### PR TITLE
fix: cleanup pos-MVP — updateState merge + sanitize word boundaries + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,17 @@ Orquestrador conecta os 3 via MCP stdio.
 
 ## Fase atual
 
-Walking skeleton (H0 concluído). Próximo: H1 (contracts) → H2 (motor-execucao) → H3 (planejador) → H4 (motor-drota) → H5 (orchestrator) → H6 (smoke) → H7 (real) → H8 (docs+PR).
+Walking skeleton H0-H6 concluído em [PR#1](https://github.com/ascendimacy/ascendimacy-motor/pull/1) (commit `fc88f39`).
+
+- H0 scaffold + workspace: ✅
+- H1 shared contracts + trace-schema: ✅
+- H2 motor-execucao (MCP + SQLite + 3 tools): ✅
+- H3 planejador (MCP + Anthropic SDK): ✅
+- H4 motor-drota (MCP + Infomaniak Mistral + scoring): ✅
+- H5 orchestrator (CLI + mcp-clients + trace-writer): ✅
+- H6 smoke test (mocks, npm run smoke): ✅
+- H7 trace Paula × Drota com LLMs reais: ✅ (Sonnet 6.1s + Infomaniak 3.4s, rubric G1-G3 verde)
+- H8 docs finais + PR: ✅ (PR#1 mergeado)
 
 ## Decisões arquiteturais (D1-D12)
 

--- a/motor-drota/src/select.ts
+++ b/motor-drota/src/select.ts
@@ -13,7 +13,8 @@ export function selectBest(scored: ScoredAction[]): ScoredAction {
 export function sanitizeMaterialization(text: string): string {
   let result = text;
   for (const word of FORBIDDEN_WORDS) {
-    result = result.replace(new RegExp(word, "gi"), "");
+    const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    result = result.replace(new RegExp(`\\b${escaped}\\b`, "gi"), "");
   }
-  return result.trim();
+  return result.replace(/\s{2,}/g, " ").trim();
 }

--- a/motor-drota/tests/sanitize.test.ts
+++ b/motor-drota/tests/sanitize.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeMaterialization } from "../src/select.js";
+
+describe("sanitizeMaterialization — word boundaries", () => {
+  it("does not cut partial words that contain a forbidden substring", () => {
+    const result = sanitizeMaterialization("o bot se adapta");
+    expect(result).toBe("o bot se adapta");
+  });
+
+  it("removes exact forbidden word and collapses spaces", () => {
+    const result = sanitizeMaterialization("isso é um playbook bom");
+    expect(result).toBe("isso é um bom");
+  });
+
+  it("removes multiple forbidden words and collapses resulting spaces", () => {
+    const result = sanitizeMaterialization("playbookId fields score alto");
+    expect(result).toBe("fields alto");
+  });
+});

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -59,9 +59,16 @@ export function getState(sessionId: string): SessionState {
 
 export function updateState(sessionId: string, delta: Partial<SessionState>): void {
   const database = getDb();
+  const current = database.prepare("SELECT * FROM sessions WHERE session_id = ?").get(sessionId) as Record<string, unknown> | undefined;
+  if (!current) return;
+  const merged = {
+    trustLevel: delta.trustLevel ?? Number(current["trust_level"]),
+    budgetRemaining: delta.budgetRemaining ?? Number(current["budget_remaining"]),
+    turn: delta.turn ?? Number(current["turn"]),
+  };
   const now = new Date().toISOString();
   database.prepare("UPDATE sessions SET trust_level = ?, budget_remaining = ?, turn = ?, updated_at = ? WHERE session_id = ?")
-    .run(delta.trustLevel ?? 0.3, delta.budgetRemaining ?? 100, delta.turn ?? 0, now, sessionId);
+    .run(merged.trustLevel, merged.budgetRemaining, merged.turn, now, sessionId);
 }
 
 export function logEvent(sessionId: string, event: EventEntry): void {

--- a/motor-execucao/tests/state-manager.test.ts
+++ b/motor-execucao/tests/state-manager.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getState, updateState, closeDb } from "../src/state-manager.js";
+
+beforeEach(() => {
+  closeDb();
+});
+
+describe("updateState — partial delta preservation", () => {
+  it("preserves trustLevel and budgetRemaining when only turn is updated", () => {
+    const sessionId = `sm-test-${Date.now()}`;
+    getState(sessionId); // cria row com defaults
+    updateState(sessionId, { trustLevel: 0.7, budgetRemaining: 80, turn: 1 });
+    updateState(sessionId, { turn: 5 }); // só turn
+    const state = getState(sessionId);
+    expect(state.turn).toBe(5);
+    expect(state.trustLevel).toBeCloseTo(0.7);
+    expect(state.budgetRemaining).toBeCloseTo(80);
+  });
+
+  it("preserves budgetRemaining and turn when only trustLevel is updated", () => {
+    const sessionId = `sm-test-${Date.now()}`;
+    getState(sessionId);
+    updateState(sessionId, { trustLevel: 0.3, budgetRemaining: 90, turn: 2 });
+    updateState(sessionId, { trustLevel: 0.6 });
+    const state = getState(sessionId);
+    expect(state.trustLevel).toBeCloseTo(0.6);
+    expect(state.budgetRemaining).toBeCloseTo(90);
+    expect(state.turn).toBe(2);
+  });
+
+  it("does not throw when session does not exist", () => {
+    const sessionId = `nonexistent-${Date.now()}`;
+    expect(() => updateState(sessionId, { turn: 1 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Handoff: [2026-04-23-cc-motor-cleanup.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/handoffs/2026-04-23-cc-motor-cleanup.md)
Ref: ascendimacy-ops#369

## Fixes

**Fix 1 — **
Lê row atual antes do UPDATE e faz merge — campos omitidos no delta preservam valor persistido. Antes:  resetava trustLevel para 0.3 e budgetRemaining para 100.

**Fix 2 — **
Adiciona  (word boundaries) + escape de meta chars + collapse de espaços duplos. Antes: regex sem  podia casar substrings dentro de palavras maiores.

**Fix 3 — **
Fase atual atualizada com H0-H6 todos ✅ e H7 ✅.

## Testes



## Escopo OUT (conforme handoff)
- Sem mudança em contracts, LLM clients, orchestrator, CI, fixtures
- H7 (LLMs reais) fora deste PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)