### PR TITLE
feat(#17 Bloco 2a): retrofit candidateActions→contentPool + status matrix como tree_nodes

### DIFF
--- a/motor-drota/src/evaluate.ts
+++ b/motor-drota/src/evaluate.ts
@@ -1,17 +1,19 @@
-import type { CandidateAction, SessionState } from "@ascendimacy/shared";
-import type { ScoredAction } from "./types.js";
+/**
+ * Evaluate — Bloco 2a.
+ *
+ * Planejador já scorou o pool. Motor-drota recebe `contentPool` pronto,
+ * precisa apenas selecionar (selectFromPool) e materializar linguisticamente.
+ *
+ * Nota: a lógica antiga `scoreActions` (multiplicava por trustWeight etc)
+ * saiu. Scoring é responsabilidade única do planejador agora.
+ */
 
-export function scoreActions(
-  candidates: CandidateAction[],
-  state: SessionState
-): ScoredAction[] {
-  return candidates.map(action => {
-    const trustWeight = state.trustLevel < 0.4 ? 1.5 : 1.0;
-    const budgetPenalty = action.estimatedSacrifice > state.budgetRemaining * 0.3 ? 0.7 : 1.0;
-    const score =
-      (action.estimatedConfidenceGain * trustWeight - action.estimatedSacrifice * 0.5) *
-      budgetPenalty *
-      (1 / action.priority);
-    return { ...action, score };
-  });
+import type { ScoredContentItem } from "@ascendimacy/shared";
+
+/**
+ * Reordena só por garantia — planejador já devolve ordenado, mas o
+ * pool pode ter sido mutado pelo MCP serialization.
+ */
+export function rankPool(pool: ScoredContentItem[]): ScoredContentItem[] {
+  return [...pool].sort((a, b) => b.score - a.score);
 }

--- a/motor-drota/src/select.ts
+++ b/motor-drota/src/select.ts
@@ -1,12 +1,24 @@
-import type { ScoredAction } from "./types.js";
+import type { ScoredContentItem } from "@ascendimacy/shared";
 
 const FORBIDDEN_WORDS = [
-  "playbook", "playbookId", "motor", "score", "candidateAction",
-  "trust_level", "budgetRemaining", "sessionId",
+  "playbook",
+  "playbookId",
+  "motor",
+  "score",
+  "candidateAction",
+  "trust_level",
+  "budgetRemaining",
+  "sessionId",
+  "contentPool",
+  "content_pool",
 ];
 
-export function selectBest(scored: ScoredAction[]): ScoredAction {
-  const sorted = [...scored].sort((a, b) => b.score - a.score);
+/** Pick o top-1 de um pool ordenado. Assume já vem sorted desc; se não, re-sorta. */
+export function selectFromPool(pool: ScoredContentItem[]): ScoredContentItem {
+  if (pool.length === 0) {
+    throw new Error("selectFromPool: empty pool");
+  }
+  const sorted = [...pool].sort((a, b) => b.score - a.score);
   return sorted[0]!;
 }
 

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -1,40 +1,83 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import type { EvaluateAndSelectInput, EvaluateAndSelectOutput } from "@ascendimacy/shared";
-import { scoreActions } from "./evaluate.js";
-import { selectBest, sanitizeMaterialization } from "./select.js";
+import type {
+  EvaluateAndSelectInput,
+  EvaluateAndSelectOutput,
+  ContentItem,
+  ScoredContentItem,
+} from "@ascendimacy/shared";
+import { rankPool } from "./evaluate.js";
+import { selectFromPool, sanitizeMaterialization } from "./select.js";
 import { callLlm, callLlmMock } from "./llm-client.js";
 
 const server = new McpServer({
   name: "motor-drota",
-  version: "0.2.0",
+  version: "0.3.0",
 });
 
-const candidateSchema = z.object({
-  playbookId: z.string(),
-  priority: z.number(),
-  rationale: z.string(),
-  estimatedSacrifice: z.number(),
-  estimatedConfidenceGain: z.number(),
+const scoredContentSchema = z.object({
+  item: z.record(z.string(), z.unknown()),
+  score: z.number(),
+  reasons: z.array(z.string()),
 });
 
-function buildDrotaPrompt(input: EvaluateAndSelectInput, selectedPlaybookId: string): string {
-  const { persona, state, contextHints, strategicRationale, candidateActions } = input;
+/**
+ * Serializa um ContentItem para o prompt do drota preservando o discriminante.
+ * v1 é hooks-only em termos de teste — outros tipos fazem fallback genérico (campos comuns).
+ * Plan v2 §4.12.
+ */
+function serializeContentItem(item: ContentItem): string {
+  const common = {
+    id: item.id,
+    type: item.type,
+    domain: item.domain,
+    casel_target: item.casel_target,
+    surprise: item.surprise,
+    age_range: item.age_range,
+    group_compatible: item.group_compatible ?? false,
+  };
+  // curiosity_hook e cultural_diamond carregam fact/bridge/quest
+  if (item.type === "curiosity_hook" || item.type === "cultural_diamond") {
+    return JSON.stringify({
+      ...common,
+      fact: item.fact,
+      bridge: item.bridge,
+      quest: item.quest,
+      sacrifice_type: item.sacrifice_type,
+      country: item.country,
+    });
+  }
+  // Demais tipos: serialização genérica com todos os campos próprios.
+  return JSON.stringify({ ...common, ...item });
+}
 
-  const personaYaml = typeof persona.profile === "object"
-    ? JSON.stringify(persona.profile, null, 2)
-    : String(persona.profile);
+function buildDrotaPrompt(
+  input: EvaluateAndSelectInput,
+  selected: ScoredContentItem,
+): string {
+  const { persona, state, contextHints, strategicRationale, contentPool, instruction_addition } = input;
+
+  const personaYaml =
+    typeof persona.profile === "object"
+      ? JSON.stringify(persona.profile, null, 2)
+      : String(persona.profile);
 
   const contextHintsJson = JSON.stringify(contextHints ?? {}, null, 2);
-  const candidateActionsJson = JSON.stringify(candidateActions, null, 2);
+  const poolSerialized = contentPool
+    .map((s) => ({ score: s.score, reasons: s.reasons, content: JSON.parse(serializeContentItem(s.item)) }));
+  const contentPoolJson = JSON.stringify(poolSerialized, null, 2);
+  const selectedJson = serializeContentItem(selected.item);
+  const instructionAdditionBody = (instruction_addition ?? "").trim();
 
-  // Detect language from contextHints, fallback to pt-br
   const language = (contextHints?.["language"] as string | undefined) ?? "pt-br";
-  const isLimitedProficiency = language.includes("limitado") || language.includes("basico") || language.includes("básico");
+  const isLimitedProficiency =
+    language.includes("limitado") ||
+    language.includes("basico") ||
+    language.includes("básico");
 
   return `[BLOCO 1 - Role]
-Você avalia ações candidatas e materializa a ação escolhida em linguagem natural para o sujeito. Você não é um assistente utilitário — você é o componente que traduz intenção estratégica em fala concreta.
+Você avalia content items candidatos e materializa o escolhido em linguagem natural para o sujeito. Você não é um assistente utilitário — você é o componente que traduz intenção estratégica em fala concreta. **NUNCA inventa conteúdo**; ancora sempre no content item selecionado.
 
 [BLOCO 2 - Dynamic content]
 <persona>
@@ -59,100 +102,140 @@ ${strategicRationale ?? ""}
 ${contextHintsJson}
 </context_hints>
 
-<candidate_actions>
-${candidateActionsJson}
-</candidate_actions>
+<content_pool>
+${contentPoolJson}
+</content_pool>
 
-<selected_playbook_id>
-${selectedPlaybookId}
-</selected_playbook_id>
+<selected_content>
+${selectedJson}
+</selected_content>
+
+<instruction_addition>
+${instructionAdditionBody}
+</instruction_addition>
 
 [BLOCO 3 - Numbered instructions]
-1. A ação selecionada é ${selectedPlaybookId}. Materialize-a em linguagem natural para ${persona.name}.
-2. A materialização DEVE respeitar todas as diretivas em <context_hints>.
-3. Se <context_hints> contém chaves 'avoid', 'evitar', ou 'alertas', esses padrões são PROIBIDOS na saída — não apareçam na fala de forma alguma.
-4. Se <context_hints> contém 'tom', 'format', 'tone', ou 'next_move', siga literalmente.
-5. Quando <context_hints> contém informação específica extraída (ex: afirmações da persona, hipóteses, intenções), USE essa informação na materialização — não gere conteúdo genérico que ignora o que foi extraído.
-6. Use o ID do playbook (ex: 'helix.ciclo.avancar_dia') APENAS como índice interno. NUNCA reproduza identificadores técnicos, dot-notation ou jargon interno na materialização. A persona não sabe que o sistema tem 'Helix', 'painel', 'ciclo.avancar_dia'.
-7. Língua: "${language}". Gere na MESMA língua. Se omitido, default pt-br.
-8. ${isLimitedProficiency ? `PROFICIÊNCIA LIMITADA: vocabulário simples, frases curtas, zero jargon, erros típicos de não-nativo (concordância de gênero, preposições), eventual interjeição na língua nativa, pausas 'hmm'.` : `Gere em ${language} fluente, natural, adequado à idade e contexto.`}
-9. Se o playbook não tem template canônico, construa a materialização PELOS HINTS (não pelo nome técnico).
+1. Materialize o <selected_content> em fala natural para ${persona.name}. Use OS CAMPOS do content (fact, bridge, quest para hooks; title, trigger para cards; etc).
+2. **Ancoragem obrigatória**: a fala deve citar/adaptar o conteúdo do item selecionado — não invente fato novo.
+3. Respeite <context_hints>. Se contém 'avoid', 'evitar' ou 'alertas', esses padrões são PROIBIDOS na saída.
+4. 'status_gates' em contextHints lista dimensões bloqueadas. Se dimensão bloqueada aparece como casel_focus, adapte tom (reparador, não desafiador).
+5. NUNCA vaze identificadores técnicos (id do content, dot-notation, 'content_pool', 'playbook') na fala.
+6. Língua: "${language}". Gere na MESMA língua.
+7. ${isLimitedProficiency ? `PROFICIÊNCIA LIMITADA: vocabulário simples, frases curtas, zero jargon, erros típicos de não-nativo.` : `Gere em ${language} fluente, natural, adequado à idade e contexto.`}
+8. Se <instruction_addition> não está vazio, incorpore-o naturalmente. Exemplos: "day 2 of 5 of chain X" → continuar arco multi-dia; "technique_hint: tribunal" → framear como debate.
 
 [BLOCO 4 - Examples]
 <example>
-<context_hints>
-{"language": "pt-br", "afirmacoes_extraidas": ["trabalho me consome", "não consigo descansar"], "avoid": ["diagnóstico emocional", "rótulos clínicos"]}
-</context_hints>
-<selected_playbook_id>reflexao.custo-beneficio</selected_playbook_id>
+<selected_content>{"id":"ling_inuit_snow","type":"curiosity_hook","fact":"Os Inuit têm 50+ palavras pra neve.","bridge":"Quantas palavras você tem pra RAIVA?","quest":"Encontre 5 palavras pro que sente agora."}</selected_content>
+<context_hints>{"language":"pt-br","mood":"receptive"}</context_hints>
 Output esperado:
-{"selectionRationale": "Reflexão sobre custo-benefício dado que persona afirmou que trabalho consome", "linguisticMaterialization": "Você mencionou que o trabalho te consome e que é difícil descansar. Vou te propor algo simples: imagina que seu tempo é um recurso limitado. Como você está distribuindo ele agora?"}
-</example>
-
-<example>
-<context_hints>
-{"language": "pt-br limitado", "avoid": ["diagnóstico emocional", "vocabulário técnico"]}
-</context_hints>
-<selected_playbook_id>icebreaker.primeiro-contato</selected_playbook_id>
-Output esperado:
-{"selectionRationale": "Primeiro contato adaptado para proficiência limitada", "linguisticMaterialization": "Oi! Como você está hoje? Pode falar simples, tudo bem."}
+{"selectionRationale":"Hook linguístico com alta surpresa, casel SA","linguisticMaterialization":"Sabia que os Inuit têm mais de 50 palavras pra neve? Cada uma indica algo diferente. Quantas palavras você tem pra RAIVA? Irritado, furioso, frustrado... Se só tem uma, como sabe o que tá sentindo? Tenta: escreve 5 palavras diferentes pro que você sente AGORA. Não vale repetir."}
 </example>
 
 [BLOCO 5 - Repeat critical]
 Lembre-se:
-- NUNCA vaze identificadores técnicos (dot-notation, nomes de playbooks) na fala ao sujeito.
-- Diretivas em <context_hints> são OBRIGATÓRIAS, não sugestões.
-- Gere na mesma língua do sujeito; adapte para proficiência limitada quando indicado.
+- **Ancoragem obrigatória** — fato/ponte/quest vêm do selected_content.
+- NUNCA vaze identificadores técnicos na fala.
+- Diretivas em <context_hints> são OBRIGATÓRIAS.
 - Retorne APENAS JSON válido, sem markdown fence.
-- JSON schema: {"selectionRationale": "string", "linguisticMaterialization": "string"}`;
+- Schema: {"selectionRationale": "string", "linguisticMaterialization": "string"}`;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-server.registerTool("evaluate_and_select", {
-  description: "Avalia candidateActions, seleciona o melhor e materializa linguisticamente",
-  inputSchema: {
-    sessionId: z.string(),
-    candidateActions: z.array(candidateSchema),
-    state: z.object({
+server.registerTool(
+  "evaluate_and_select",
+  {
+    description:
+      "Recebe contentPool scorado, seleciona top, materializa linguisticamente",
+    inputSchema: {
       sessionId: z.string(),
-      trustLevel: z.number(),
-      budgetRemaining: z.number(),
-      turn: z.number(),
-      eventLog: z.array(z.unknown()),
-    }),
-    persona: z.object({
-      id: z.string(),
-      name: z.string(),
-      age: z.number(),
-      profile: z.union([z.record(z.string(), z.unknown()), z.string()]),
-    }),
-    strategicRationale: z.string().optional().default(""),
-    contextHints: z.record(z.string(), z.unknown()).optional().default({}),
-  } as any,
-}, async (input: EvaluateAndSelectInput) => {
-  const { candidateActions, state } = input;
-  const scored = scoreActions(candidateActions, state);
-  const selected = selectBest(scored);
+      contentPool: z.array(scoredContentSchema),
+      state: z.object({
+        sessionId: z.string(),
+        trustLevel: z.number(),
+        budgetRemaining: z.number(),
+        turn: z.number(),
+        eventLog: z.array(z.unknown()),
+        statusMatrix: z.record(z.string(), z.string()).optional(),
+      }),
+      persona: z.object({
+        id: z.string(),
+        name: z.string(),
+        age: z.number(),
+        profile: z.union([z.record(z.string(), z.unknown()), z.string()]),
+      }),
+      strategicRationale: z.string().optional().default(""),
+      contextHints: z.record(z.string(), z.unknown()).optional().default({}),
+      instruction_addition: z.string().optional().default(""),
+    } as any,
+  },
+  async (input: EvaluateAndSelectInput) => {
+    const ranked = rankPool(input.contentPool);
+    if (ranked.length === 0) {
+      // Pool vazio: fallback conversacional (v2 §4.2 do plano).
+      const output: EvaluateAndSelectOutput = {
+        selectedContent: {
+          item: {
+            id: "__empty_pool__",
+            type: "curiosity_hook",
+            domain: "generic",
+            casel_target: [],
+            age_range: [0, 99],
+            surprise: 7,
+            verified: false,
+            base_score: 0,
+            fact: "",
+            bridge: "",
+            quest: "",
+            sacrifice_type: "reflect",
+          } as ContentItem,
+          score: 0,
+          reasons: ["pool_empty_fallback"],
+        },
+        selectionRationale: "Pool vazio — fallback conversacional.",
+        linguisticMaterialization:
+          "Oi! Me conta o que está passando na sua cabeça.",
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(output) }],
+      };
+    }
 
-  const useMock = process.env["USE_MOCK_LLM"] === "true" || !process.env["INFOMANIAK_API_KEY"];
-  const systemPrompt = buildDrotaPrompt(input, selected.playbookId);
-  const userMessage = `Materialize a ação selecionada em JSON.`;
-  const raw = useMock ? await callLlmMock(systemPrompt, userMessage) : await callLlm(systemPrompt, userMessage);
+    const selected = selectFromPool(ranked);
+    const useMock =
+      process.env["USE_MOCK_LLM"] === "true" ||
+      !process.env["INFOMANIAK_API_KEY"];
+    const systemPrompt = buildDrotaPrompt(input, selected);
+    const userMessage = `Materialize o content selecionado em JSON.`;
+    const raw = useMock
+      ? await callLlmMock(systemPrompt, userMessage)
+      : await callLlm(systemPrompt, userMessage);
 
-  let parsed: { selectionRationale?: string; linguisticMaterialization?: string } = {};
-  try { parsed = JSON.parse(raw); } catch { parsed = { linguisticMaterialization: raw }; }
+    let parsed: {
+      selectionRationale?: string;
+      linguisticMaterialization?: string;
+    } = {};
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      parsed = { linguisticMaterialization: raw };
+    }
 
-  const materialization = sanitizeMaterialization(parsed.linguisticMaterialization ?? "");
+    const materialization = sanitizeMaterialization(
+      parsed.linguisticMaterialization ?? "",
+    );
 
-  const output: EvaluateAndSelectOutput = {
-    selectedAction: selected,
-    selectionRationale: parsed.selectionRationale ?? selected.rationale,
-    actualSacrifice: selected.estimatedSacrifice,
-    actualConfidenceGain: selected.estimatedConfidenceGain,
-    linguisticMaterialization: materialization,
-  };
+    const output: EvaluateAndSelectOutput = {
+      selectedContent: selected,
+      selectionRationale: parsed.selectionRationale ?? "auto-select top pool",
+      linguisticMaterialization: materialization,
+    };
 
-  return { content: [{ type: "text" as const, text: JSON.stringify(output) }] };
-});
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(output) }],
+    };
+  },
+);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/motor-drota/src/types.ts
+++ b/motor-drota/src/types.ts
@@ -1,8 +1,0 @@
-export interface ScoredAction {
-  playbookId: string;
-  priority: number;
-  rationale: string;
-  estimatedSacrifice: number;
-  estimatedConfidenceGain: number;
-  score: number;
-}

--- a/motor-drota/tests/content-pool.test.ts
+++ b/motor-drota/tests/content-pool.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { rankPool } from "../src/evaluate.js";
+import { selectFromPool } from "../src/select.js";
+import type { ScoredContentItem, ContentItem } from "@ascendimacy/shared";
+
+const hook = (id: string, score: number, overrides: Partial<ContentItem> = {}): ScoredContentItem => ({
+  item: {
+    id,
+    type: "curiosity_hook",
+    domain: "linguistics",
+    casel_target: ["SA"],
+    age_range: [7, 14],
+    surprise: 9,
+    verified: true,
+    base_score: 7,
+    fact: "Os Inuit têm 50+ palavras pra neve.",
+    bridge: "Quantas palavras você tem pra RAIVA?",
+    quest: "Encontre 5 palavras pro que sente agora.",
+    sacrifice_type: "reflect",
+    ...overrides,
+  } as ContentItem,
+  score,
+  reasons: ["base_score=7"],
+});
+
+describe("rankPool + selectFromPool — v1 hooks-only (plan §4.12)", () => {
+  it("selected item always comes from pool (ancoragem)", () => {
+    const pool = [hook("h1", 7), hook("h2", 10), hook("h3", 5)];
+    const selected = selectFromPool(rankPool(pool));
+    // O selecionado DEVE ter id que existe no pool original.
+    const originalIds = pool.map((s) => s.item.id);
+    expect(originalIds).toContain(selected.item.id);
+  });
+
+  it("ScoredContentItem preserves full content item", () => {
+    const pool = [hook("h1", 9)];
+    const selected = selectFromPool(pool);
+    expect(selected.item.id).toBe("h1");
+    // Campos obrigatórios do hook preservados.
+    expect((selected.item as ContentItem & { fact: string }).fact).toBeTruthy();
+  });
+});
+
+describe("content-pool — edge cases", () => {
+  it("tied scores: first in array wins after stable sort", () => {
+    const pool = [hook("a", 7), hook("b", 7)];
+    const ranked = rankPool(pool);
+    // Stable-sort semantics: desc order preserved order for ties.
+    expect(ranked[0]!.item.id).toBe("a");
+  });
+
+  it("selectFromPool throws on empty pool (caller must fallback)", () => {
+    expect(() => selectFromPool([])).toThrow(/empty pool/);
+  });
+
+  it("group_compatible propagates in serialized item (Bloco 6 prep)", () => {
+    const pool = [hook("dyad", 9, { group_compatible: true })];
+    const selected = selectFromPool(pool);
+    expect(selected.item.group_compatible).toBe(true);
+  });
+});

--- a/motor-drota/tests/context-hints.test.ts
+++ b/motor-drota/tests/context-hints.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { sanitizeMaterialization } from "../src/select.js";
 
-// Tests for contextHints 'avoid' enforcement via sanitizeMaterialization.
-// The full pipeline test (real LLM) is covered by STS H7 re-run (v0.2 traces).
+// Testes para contextHints 'avoid' enforcement via sanitizeMaterialization.
+// Full pipeline com LLM real é coberto por STS H7 re-run.
 
 describe("contextHints avoid enforcement — sanitizeMaterialization", () => {
   it("removes playbook technical identifier from materialization", () => {
@@ -13,7 +13,6 @@ describe("contextHints avoid enforcement — sanitizeMaterialization", () => {
   });
 
   it("does not remove words that only contain a forbidden substring", () => {
-    // 'bot' is not in FORBIDDEN_WORDS, so 'robot' should not be touched
     const raw = "o bot se adapta ao robot";
     const clean = sanitizeMaterialization(raw);
     expect(clean).toBe("o bot se adapta ao robot");
@@ -28,30 +27,30 @@ describe("contextHints avoid enforcement — sanitizeMaterialization", () => {
   });
 });
 
-describe("contextHints language passthrough — prompt construction", () => {
-  it("language field propagates through EvaluateAndSelectInput interface contract", () => {
-    // Structural test: ensure the interface accepts the new fields without TypeScript errors.
-    // If this file compiles, the contract is correct.
+describe("EvaluateAndSelectInput — contract shape (contentPool + instruction_addition)", () => {
+  it("interface accepts contentPool + instruction_addition", () => {
+    // Structural test: verifica que o contract aceita os campos novos.
     type EvaluateAndSelectInput = {
       sessionId: string;
-      candidateActions: unknown[];
+      contentPool: Array<{ item: unknown; score: number; reasons: string[] }>;
       state: unknown;
       persona: unknown;
       strategicRationale: string;
       contextHints: Record<string, unknown>;
+      instruction_addition?: string;
     };
 
     const input: EvaluateAndSelectInput = {
       sessionId: "test-001",
-      candidateActions: [],
+      contentPool: [],
       state: {},
-      persona: { id: "ryo", name: "Ryo", age: 15, profile: {} },
-      strategicRationale: "Primo contato com adolescente japonês",
-      contextHints: { language: "pt-br limitado", avoid: ["diagnóstico emocional"] },
+      persona: { id: "ryo", name: "Ryo", age: 13, profile: {} },
+      strategicRationale: "Primo contato com adolescente",
+      contextHints: { language: "pt-br", status_gates: { emotional: { ok: true } } },
+      instruction_addition: "",
     };
 
-    expect(input.strategicRationale).toBe("Primo contato com adolescente japonês");
-    expect(input.contextHints["language"]).toBe("pt-br limitado");
-    expect(Array.isArray(input.contextHints["avoid"])).toBe(true);
+    expect(input.contextHints["language"]).toBe("pt-br");
+    expect(input.instruction_addition).toBe("");
   });
 });

--- a/motor-drota/tests/evaluate.test.ts
+++ b/motor-drota/tests/evaluate.test.ts
@@ -1,52 +1,58 @@
 import { describe, it, expect } from "vitest";
-import { scoreActions } from "../src/evaluate.js";
-import { selectBest, sanitizeMaterialization } from "../src/select.js";
-import type { SessionState } from "@ascendimacy/shared";
+import { rankPool } from "../src/evaluate.js";
+import { selectFromPool, sanitizeMaterialization } from "../src/select.js";
+import type { ScoredContentItem } from "@ascendimacy/shared";
 
-const mockState: SessionState = {
-  sessionId: "test-001",
-  trustLevel: 0.3,
-  budgetRemaining: 100,
-  turn: 0,
-  eventLog: [],
-};
+const makeScored = (id: string, score: number): ScoredContentItem => ({
+  item: {
+    id,
+    type: "curiosity_hook",
+    domain: "generic",
+    casel_target: ["SA"],
+    age_range: [7, 14],
+    surprise: 7,
+    verified: true,
+    base_score: 7,
+    fact: "",
+    bridge: "",
+    quest: "",
+    sacrifice_type: "reflect",
+  },
+  score,
+  reasons: [],
+});
 
-const candidates = [
-  { playbookId: "icebreaker.primeiro-contato", priority: 1, rationale: "Primeiro contato", estimatedSacrifice: 1, estimatedConfidenceGain: 4 },
-  { playbookId: "onboarding.pitch", priority: 2, rationale: "Pitch direto", estimatedSacrifice: 5, estimatedConfidenceGain: 7 },
-];
-
-describe("scoreActions", () => {
-  it("scores all candidates", () => {
-    const scored = scoreActions(candidates, mockState);
-    expect(scored).toHaveLength(2);
-    for (const s of scored) {
-      expect(typeof s.score).toBe("number");
-    }
+describe("rankPool", () => {
+  it("sorts pool by score descending", () => {
+    const pool = [makeScored("a", 3), makeScored("b", 9), makeScored("c", 5)];
+    const ranked = rankPool(pool);
+    expect(ranked.map((s) => s.item.id)).toEqual(["b", "c", "a"]);
   });
 
-  it("applies trustWeight penalty for low trust", () => {
-    const lowTrustState = { ...mockState, trustLevel: 0.2 };
-    const highTrustState = { ...mockState, trustLevel: 0.8 };
-    const lowScores = scoreActions([candidates[0]!], lowTrustState);
-    const highScores = scoreActions([candidates[0]!], highTrustState);
-    expect(lowScores[0]!.score).toBeGreaterThan(highScores[0]!.score);
+  it("does not mutate input", () => {
+    const pool = [makeScored("a", 3), makeScored("b", 9)];
+    rankPool(pool);
+    expect(pool.map((s) => s.item.id)).toEqual(["a", "b"]);
   });
 });
 
-describe("selectBest", () => {
-  it("selects action with highest score", () => {
-    const scored = scoreActions(candidates, mockState);
-    const best = selectBest(scored);
-    expect(best.playbookId).toBeTruthy();
+describe("selectFromPool", () => {
+  it("returns top-scored item", () => {
+    const pool = [makeScored("a", 3), makeScored("b", 9)];
+    const selected = selectFromPool(pool);
+    expect(selected.item.id).toBe("b");
+  });
+
+  it("throws on empty pool", () => {
+    expect(() => selectFromPool([])).toThrow();
   });
 });
 
-describe("sanitizeMaterialization", () => {
-  it("removes forbidden technical words", () => {
-    const dirty = "Oi! Este playbook vai aumentar seu trust_level.";
+describe("sanitizeMaterialization — forbidden words (Bloco 2a inclui contentPool/content_pool)", () => {
+  it("removes technical identifiers from materialization", () => {
+    const dirty = "O content_pool sugere playbook helix.";
     const clean = sanitizeMaterialization(dirty);
+    expect(clean).not.toContain("content_pool");
     expect(clean).not.toContain("playbook");
-    expect(clean).not.toContain("trust_level");
   });
 });

--- a/motor-execucao/src/executor.ts
+++ b/motor-execucao/src/executor.ts
@@ -7,7 +7,7 @@ export function executePlaybook(
   input: ExecutePlaybookInput,
   inventory: PlaybookInventory
 ): ExecutePlaybookOutput {
-  const { sessionId, playbookId, output, metadata } = input;
+  const { sessionId, playbookId, selectedContentId, output, metadata } = input;
   const playbook = getPlaybookById(inventory, playbookId);
 
   const state = getState(sessionId);
@@ -19,6 +19,7 @@ export function executePlaybook(
       output: output.slice(0, 200),
       metadata,
       playbookFound: !!playbook,
+      selectedContentId: selectedContentId ?? null,
     },
   };
 

--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -26,11 +26,12 @@ server.registerTool("execute_playbook", {
   inputSchema: {
     sessionId: z.string(),
     playbookId: z.string(),
+    selectedContentId: z.string().optional(),
     output: z.string(),
     metadata: z.record(z.string(), z.unknown()).optional().default({}),
   } as any,
-}, async ({ sessionId, playbookId, output, metadata }: { sessionId: string; playbookId: string; output: string; metadata?: Record<string, unknown> }) => {
-  const result = executePlaybook({ sessionId, playbookId, output, metadata: metadata ?? {} }, inventory);
+}, async ({ sessionId, playbookId, selectedContentId, output, metadata }: { sessionId: string; playbookId: string; selectedContentId?: string; output: string; metadata?: Record<string, unknown> }) => {
+  const result = executePlaybook({ sessionId, playbookId, selectedContentId, output, metadata: metadata ?? {} }, inventory);
   return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
 });
 

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SessionState, EventEntry } from "@ascendimacy/shared";
+import { TREE_NODES_DDL, getStatusMatrix } from "./tree-nodes.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -29,6 +30,7 @@ function getDb(dbPath?: string): Database.Database {
         playbook_id TEXT,
         data TEXT
       );
+      ${TREE_NODES_DDL}
     `);
   }
   return db;
@@ -36,19 +38,29 @@ function getDb(dbPath?: string): Database.Database {
 
 export function getState(sessionId: string): SessionState {
   const database = getDb();
-  let row = database.prepare("SELECT * FROM sessions WHERE session_id = ?").get(sessionId) as Record<string, unknown> | undefined;
+  let row = database
+    .prepare("SELECT * FROM sessions WHERE session_id = ?")
+    .get(sessionId) as Record<string, unknown> | undefined;
   if (!row) {
     const now = new Date().toISOString();
-    database.prepare("INSERT INTO sessions (session_id, trust_level, budget_remaining, turn, created_at, updated_at) VALUES (?, 0.3, 100, 0, ?, ?)").run(sessionId, now, now);
+    database
+      .prepare(
+        "INSERT INTO sessions (session_id, trust_level, budget_remaining, turn, created_at, updated_at) VALUES (?, 0.3, 100, 0, ?, ?)",
+      )
+      .run(sessionId, now, now);
     row = { session_id: sessionId, trust_level: 0.3, budget_remaining: 100, turn: 0 };
   }
-  const events = database.prepare("SELECT * FROM event_log WHERE session_id = ? ORDER BY id DESC LIMIT 20").all(sessionId) as Record<string, unknown>[];
+  const events = database
+    .prepare("SELECT * FROM event_log WHERE session_id = ? ORDER BY id DESC LIMIT 20")
+    .all(sessionId) as Record<string, unknown>[];
+  const statusMatrix = getStatusMatrix(database, sessionId);
   return {
     sessionId,
     trustLevel: Number(row["trust_level"]),
     budgetRemaining: Number(row["budget_remaining"]),
     turn: Number(row["turn"]),
-    eventLog: events.map(e => ({
+    statusMatrix,
+    eventLog: events.map((e) => ({
       timestamp: String(e["timestamp"]),
       type: String(e["type"]),
       playbookId: e["playbook_id"] ? String(e["playbook_id"]) : undefined,
@@ -59,7 +71,9 @@ export function getState(sessionId: string): SessionState {
 
 export function updateState(sessionId: string, delta: Partial<SessionState>): void {
   const database = getDb();
-  const current = database.prepare("SELECT * FROM sessions WHERE session_id = ?").get(sessionId) as Record<string, unknown> | undefined;
+  const current = database
+    .prepare("SELECT * FROM sessions WHERE session_id = ?")
+    .get(sessionId) as Record<string, unknown> | undefined;
   if (!current) return;
   const merged = {
     trustLevel: delta.trustLevel ?? Number(current["trust_level"]),
@@ -67,16 +81,36 @@ export function updateState(sessionId: string, delta: Partial<SessionState>): vo
     turn: delta.turn ?? Number(current["turn"]),
   };
   const now = new Date().toISOString();
-  database.prepare("UPDATE sessions SET trust_level = ?, budget_remaining = ?, turn = ?, updated_at = ? WHERE session_id = ?")
+  database
+    .prepare(
+      "UPDATE sessions SET trust_level = ?, budget_remaining = ?, turn = ?, updated_at = ? WHERE session_id = ?",
+    )
     .run(merged.trustLevel, merged.budgetRemaining, merged.turn, now, sessionId);
 }
 
 export function logEvent(sessionId: string, event: EventEntry): void {
   const database = getDb();
-  database.prepare("INSERT INTO event_log (session_id, timestamp, type, playbook_id, data) VALUES (?, ?, ?, ?, ?)")
-    .run(sessionId, event.timestamp, event.type, event.playbookId ?? null, JSON.stringify(event.data));
+  database
+    .prepare(
+      "INSERT INTO event_log (session_id, timestamp, type, playbook_id, data) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run(
+      sessionId,
+      event.timestamp,
+      event.type,
+      event.playbookId ?? null,
+      JSON.stringify(event.data),
+    );
+}
+
+/** Exposed para consumidores (tree-nodes, testes). */
+export function getDbInstance(): Database.Database {
+  return getDb();
 }
 
 export function closeDb(): void {
-  if (db) { db.close(); db = null; }
+  if (db) {
+    db.close();
+    db = null;
+  }
 }

--- a/motor-execucao/src/tree-nodes.ts
+++ b/motor-execucao/src/tree-nodes.ts
@@ -1,0 +1,230 @@
+/**
+ * tree_nodes SQLite CRUD + status matrix hydration.
+ *
+ * Espelho simplificado de `kids_tree_nodes` da ebrota (§17 FOUNDATION / tree.js).
+ * Bloco 2a usa só zone='status'; zonas raiz/tronco/galho/folha entram em C-005.
+ *
+ * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.C v2 (override Jun).
+ */
+
+import type Database from "better-sqlite3";
+import type {
+  StatusMatrix,
+  StatusValue,
+  TreeNode,
+  TreeNodeZone,
+} from "@ascendimacy/shared";
+import { transition, isStatusValue, defaultMatrix } from "@ascendimacy/shared";
+
+export const TREE_NODES_DDL = `
+CREATE TABLE IF NOT EXISTS tree_nodes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  zone TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT,
+  source TEXT NOT NULL DEFAULT 'engine',
+  state TEXT NOT NULL DEFAULT 'seed',
+  sensitivity TEXT NOT NULL DEFAULT 'free',
+  urgency INTEGER NOT NULL DEFAULT 1,
+  importance INTEGER NOT NULL DEFAULT 1,
+  half_life_days INTEGER,
+  last_active_at TEXT,
+  cooldown_until TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(session_id, zone, key)
+);
+`;
+
+interface TreeNodeRow {
+  id: number;
+  session_id: string;
+  zone: string;
+  key: string;
+  value: string | null;
+  source: string;
+  state: string;
+  sensitivity: string;
+  urgency: number;
+  importance: number;
+  half_life_days: number | null;
+  last_active_at: string | null;
+  cooldown_until: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToNode(row: TreeNodeRow): TreeNode {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    zone: row.zone as TreeNodeZone,
+    key: row.key,
+    value: row.value,
+    source: row.source,
+    state: row.state as TreeNode["state"],
+    sensitivity: row.sensitivity as TreeNode["sensitivity"],
+    urgency: row.urgency,
+    importance: row.importance,
+    halfLifeDays: row.half_life_days,
+    lastActiveAt: row.last_active_at,
+    cooldownUntil: row.cooldown_until,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export interface UpsertNodeInput {
+  sessionId: string;
+  zone: TreeNodeZone;
+  key: string;
+  value: string | null;
+  source?: string;
+  state?: TreeNode["state"];
+  sensitivity?: TreeNode["sensitivity"];
+  urgency?: number;
+  importance?: number;
+  halfLifeDays?: number | null;
+  now?: string;
+}
+
+export function upsertNode(
+  db: Database.Database,
+  input: UpsertNodeInput,
+): TreeNode {
+  const now = input.now ?? new Date().toISOString();
+  db.prepare(
+    `INSERT INTO tree_nodes
+     (session_id, zone, key, value, source, state, sensitivity, urgency, importance,
+      half_life_days, last_active_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(session_id, zone, key) DO UPDATE SET
+       value = excluded.value,
+       source = excluded.source,
+       state = excluded.state,
+       sensitivity = excluded.sensitivity,
+       urgency = excluded.urgency,
+       importance = excluded.importance,
+       half_life_days = excluded.half_life_days,
+       last_active_at = excluded.last_active_at,
+       updated_at = excluded.updated_at`,
+  ).run(
+    input.sessionId,
+    input.zone,
+    input.key,
+    input.value,
+    input.source ?? "engine",
+    input.state ?? "seed",
+    input.sensitivity ?? "free",
+    input.urgency ?? 1,
+    input.importance ?? 1,
+    input.halfLifeDays ?? null,
+    now,
+    now,
+    now,
+  );
+  const row = db
+    .prepare(
+      `SELECT * FROM tree_nodes WHERE session_id = ? AND zone = ? AND key = ?`,
+    )
+    .get(input.sessionId, input.zone, input.key) as TreeNodeRow;
+  return rowToNode(row);
+}
+
+export interface GetNodesOptions {
+  zone?: TreeNodeZone;
+  source?: string;
+}
+
+export function getNodes(
+  db: Database.Database,
+  sessionId: string,
+  opts: GetNodesOptions = {},
+): TreeNode[] {
+  const clauses: string[] = ["session_id = ?"];
+  const args: (string | number)[] = [sessionId];
+  if (opts.zone) {
+    clauses.push("zone = ?");
+    args.push(opts.zone);
+  }
+  if (opts.source) {
+    clauses.push("source = ?");
+    args.push(opts.source);
+  }
+  const rows = db
+    .prepare(`SELECT * FROM tree_nodes WHERE ${clauses.join(" AND ")}`)
+    .all(...args) as TreeNodeRow[];
+  return rows.map(rowToNode);
+}
+
+/**
+ * Coleta todos os nodes zone='status' e monta a StatusMatrix.
+ * Preenche dimensões ausentes com default (baia) para evitar buracos.
+ */
+export function getStatusMatrix(
+  db: Database.Database,
+  sessionId: string,
+): StatusMatrix {
+  const rows = db
+    .prepare(
+      `SELECT key, value FROM tree_nodes WHERE session_id = ? AND zone = 'status'`,
+    )
+    .all(sessionId) as Array<{ key: string; value: string | null }>;
+  const fromDb: StatusMatrix = {};
+  for (const r of rows) {
+    if (isStatusValue(r.value)) {
+      fromDb[r.key] = r.value;
+    }
+  }
+  // Merge com default para garantir presença das dimensões canônicas.
+  return { ...defaultMatrix(), ...fromDb };
+}
+
+export interface ApplyStatusTransitionResult {
+  dimension: string;
+  target: StatusValue;
+  applied: StatusValue;
+  accepted: boolean;
+  reason: string;
+}
+
+/**
+ * Aplica uma transição no nó de status da dimensão — respeita a invariante
+ * brejo → baia → pasto em 2 camadas: (1) tipo via `transition` pura,
+ * (2) persistência via upsert.
+ */
+export function applyStatusTransition(
+  db: Database.Database,
+  sessionId: string,
+  dimension: string,
+  target: StatusValue,
+  now?: string,
+): ApplyStatusTransitionResult {
+  const current = (() => {
+    const row = db
+      .prepare(
+        `SELECT value FROM tree_nodes WHERE session_id = ? AND zone = 'status' AND key = ?`,
+      )
+      .get(sessionId, dimension) as { value: string | null } | undefined;
+    if (!row) return undefined;
+    return isStatusValue(row.value) ? row.value : undefined;
+  })();
+  const result = transition(current, target);
+  upsertNode(db, {
+    sessionId,
+    zone: "status",
+    key: dimension,
+    value: result.applied,
+    source: "engine",
+    state: "done",
+    now,
+  });
+  return {
+    dimension,
+    target,
+    applied: result.applied,
+    accepted: result.accepted,
+    reason: result.reason,
+  };
+}

--- a/motor-execucao/tests/state-manager.test.ts
+++ b/motor-execucao/tests/state-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { getState, updateState, closeDb } from "../src/state-manager.js";
+import { getState, updateState, closeDb, getDbInstance } from "../src/state-manager.js";
+import { applyStatusTransition } from "../src/tree-nodes.js";
 
 beforeEach(() => {
   closeDb();
@@ -31,5 +32,37 @@ describe("updateState — partial delta preservation", () => {
   it("does not throw when session does not exist", () => {
     const sessionId = `nonexistent-${Date.now()}`;
     expect(() => updateState(sessionId, { turn: 1 })).not.toThrow();
+  });
+});
+
+describe("getState — hydrates statusMatrix (Bloco 2a)", () => {
+  it("new session comes with default matrix (all baia)", () => {
+    const sessionId = `sm-new-${Date.now()}`;
+    const state = getState(sessionId);
+    expect(state.statusMatrix).toBeDefined();
+    expect(state.statusMatrix!["emotional"]).toBe("baia");
+    expect(state.statusMatrix!["social_with_ebrota"]).toBe("baia");
+  });
+
+  it("persisted status transitions are reflected in next getState", () => {
+    const sessionId = `sm-persist-${Date.now()}`;
+    getState(sessionId); // creates row
+    const db = getDbInstance();
+    applyStatusTransition(db, sessionId, "emotional", "brejo");
+    applyStatusTransition(db, sessionId, "cognitive_math", "pasto");
+    const reloaded = getState(sessionId);
+    expect(reloaded.statusMatrix!["emotional"]).toBe("brejo");
+    expect(reloaded.statusMatrix!["cognitive_math"]).toBe("pasto");
+  });
+
+  it("different sessions do not leak statusMatrix", () => {
+    const a = `sm-a-${Date.now()}`;
+    const b = `sm-b-${Date.now()}-other`;
+    getState(a);
+    getState(b);
+    const db = getDbInstance();
+    applyStatusTransition(db, a, "emotional", "brejo");
+    expect(getState(a).statusMatrix!["emotional"]).toBe("brejo");
+    expect(getState(b).statusMatrix!["emotional"]).toBe("baia");
   });
 });

--- a/motor-execucao/tests/tree-nodes.test.ts
+++ b/motor-execucao/tests/tree-nodes.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  TREE_NODES_DDL,
+  upsertNode,
+  getNodes,
+  getStatusMatrix,
+  applyStatusTransition,
+} from "../src/tree-nodes.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(TREE_NODES_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("tree_nodes CRUD", () => {
+  it("upsert inserts a new node", () => {
+    const node = upsertNode(db, {
+      sessionId: "s1",
+      zone: "status",
+      key: "emotional",
+      value: "baia",
+    });
+    expect(node.sessionId).toBe("s1");
+    expect(node.zone).toBe("status");
+    expect(node.key).toBe("emotional");
+    expect(node.value).toBe("baia");
+    expect(node.state).toBe("seed");
+  });
+
+  it("upsert is idempotent on UNIQUE(session_id, zone, key)", () => {
+    upsertNode(db, { sessionId: "s1", zone: "status", key: "emotional", value: "baia" });
+    upsertNode(db, { sessionId: "s1", zone: "status", key: "emotional", value: "pasto", state: "done" });
+    const nodes = getNodes(db, "s1", { zone: "status" });
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]!.value).toBe("pasto");
+    expect(nodes[0]!.state).toBe("done");
+  });
+
+  it("different (zone, key) create distinct rows", () => {
+    upsertNode(db, { sessionId: "s1", zone: "status", key: "emotional", value: "baia" });
+    upsertNode(db, { sessionId: "s1", zone: "status", key: "cognitive_math", value: "baia" });
+    expect(getNodes(db, "s1", { zone: "status" })).toHaveLength(2);
+  });
+
+  it("different sessions are isolated", () => {
+    upsertNode(db, { sessionId: "s1", zone: "status", key: "emotional", value: "brejo" });
+    upsertNode(db, { sessionId: "s2", zone: "status", key: "emotional", value: "pasto" });
+    expect(getStatusMatrix(db, "s1")["emotional"]).toBe("brejo");
+    expect(getStatusMatrix(db, "s2")["emotional"]).toBe("pasto");
+  });
+});
+
+describe("getStatusMatrix — hydration", () => {
+  it("returns default baia for dimensions not persisted", () => {
+    const matrix = getStatusMatrix(db, "new_session");
+    expect(matrix["emotional"]).toBe("baia");
+    expect(matrix["social_with_ebrota"]).toBe("baia");
+  });
+
+  it("overrides default with persisted values", () => {
+    upsertNode(db, { sessionId: "s1", zone: "status", key: "emotional", value: "pasto" });
+    const matrix = getStatusMatrix(db, "s1");
+    expect(matrix["emotional"]).toBe("pasto");
+    // other canonical dims still baia
+    expect(matrix["social_with_ebrota"]).toBe("baia");
+  });
+
+  it("ignores nodes with non-StatusValue payload (defensive)", () => {
+    upsertNode(db, { sessionId: "s1", zone: "status", key: "weird", value: "lake" });
+    const matrix = getStatusMatrix(db, "s1");
+    expect(matrix["weird"]).toBeUndefined();
+  });
+});
+
+describe("applyStatusTransition — enforces invariant brejo→baia→pasto", () => {
+  it("first write accepts any value", () => {
+    const r = applyStatusTransition(db, "s1", "emotional", "brejo");
+    expect(r.applied).toBe("brejo");
+    expect(r.accepted).toBe(true);
+    expect(getStatusMatrix(db, "s1")["emotional"]).toBe("brejo");
+  });
+
+  it("brejo → pasto is rejected, forced to baia and persisted as baia", () => {
+    applyStatusTransition(db, "s1", "emotional", "brejo");
+    const r = applyStatusTransition(db, "s1", "emotional", "pasto");
+    expect(r.accepted).toBe(false);
+    expect(r.applied).toBe("baia");
+    expect(getStatusMatrix(db, "s1")["emotional"]).toBe("baia");
+  });
+
+  it("pasto → brejo is rejected, forced to baia", () => {
+    applyStatusTransition(db, "s1", "cognitive_math", "pasto");
+    const r = applyStatusTransition(db, "s1", "cognitive_math", "brejo");
+    expect(r.accepted).toBe(false);
+    expect(r.applied).toBe("baia");
+  });
+
+  it("brejo → baia → pasto is accepted in 2 steps", () => {
+    applyStatusTransition(db, "s1", "emotional", "brejo");
+    const r1 = applyStatusTransition(db, "s1", "emotional", "baia");
+    expect(r1.accepted).toBe(true);
+    const r2 = applyStatusTransition(db, "s1", "emotional", "pasto");
+    expect(r2.accepted).toBe(true);
+    expect(getStatusMatrix(db, "s1")["emotional"]).toBe("pasto");
+  });
+
+  it("no-op when target === current", () => {
+    applyStatusTransition(db, "s1", "emotional", "baia");
+    const r = applyStatusTransition(db, "s1", "emotional", "baia");
+    expect(r.accepted).toBe(true);
+    expect(r.reason).toBe("no_op");
+  });
+});

--- a/orchestrator/src/mcp-clients.ts
+++ b/orchestrator/src/mcp-clients.ts
@@ -74,37 +74,84 @@ function createMockClients(): McpClients {
 function getMockResponse(service: string, tool: string, args?: Record<string, unknown>): string {
   if (service === "planejador" && tool === "plan_turn") {
     return JSON.stringify({
-      strategicRationale: "Mock: contexto inicial.",
-      candidateActions: [
-        { playbookId: "icebreaker.primeiro-contato", priority: 1, rationale: "Primeiro contato", estimatedSacrifice: 1, estimatedConfidenceGain: 4 },
-        { playbookId: "onboarding.apresentacao-produto", priority: 2, rationale: "Apresentar produto", estimatedSacrifice: 2, estimatedConfidenceGain: 3 },
+      strategicRationale: "Mock: contexto inicial, foco em receptividade.",
+      contentPool: [
+        {
+          item: {
+            id: "ling_inuit_snow",
+            type: "curiosity_hook",
+            domain: "linguistics",
+            casel_target: ["SA"],
+            age_range: [7, 14],
+            surprise: 9,
+            verified: true,
+            base_score: 7,
+            fact: "Os Inuit têm 50+ palavras pra neve.",
+            bridge: "Quantas palavras você tem pra raiva?",
+            quest: "Encontre 5 palavras pro que sente agora.",
+            sacrifice_type: "reflect",
+          },
+          score: 9,
+          reasons: ["base_score=7", "surprise_bonus=+4"],
+        },
       ],
-      contextHints: { language: "pt-br" },
+      contextHints: { language: "pt-br", status_gates: { emotional: { ok: true } } },
     });
   }
   if (service === "motor-drota" && tool === "evaluate_and_select") {
-    // Accept strategicRationale and contextHints from args (ignored in mock, but validated here)
     const _strategicRationale = (args?.["strategicRationale"] as string | undefined) ?? "";
     const _contextHints = (args?.["contextHints"] as Record<string, unknown> | undefined) ?? {};
-    void _strategicRationale; void _contextHints;
+    const _instructionAddition = (args?.["instruction_addition"] as string | undefined) ?? "";
+    void _strategicRationale; void _contextHints; void _instructionAddition;
+    const contentPool = (args?.["contentPool"] as unknown[] | undefined) ?? [];
+    const first = contentPool[0] as { item?: { id?: string }; score?: number; reasons?: string[] } | undefined;
+    const selectedItem = first?.item ?? {
+      id: "mock_fallback",
+      type: "curiosity_hook",
+      domain: "generic",
+      casel_target: ["SA"],
+      age_range: [0, 99],
+      surprise: 7,
+      verified: true,
+      base_score: 7,
+      fact: "",
+      bridge: "",
+      quest: "",
+      sacrifice_type: "reflect",
+    };
     return JSON.stringify({
-      selectedAction: { playbookId: "icebreaker.primeiro-contato", priority: 1, rationale: "Melhor score", estimatedSacrifice: 1, estimatedConfidenceGain: 4, score: 6 },
-      selectionRationale: "Mock: icebreaker tem maior score.",
-      actualSacrifice: 1,
-      actualConfidenceGain: 4,
-      linguisticMaterialization: "Olá! Que bom ter você aqui. Como posso ajudar hoje?",
+      selectedContent: { item: selectedItem, score: first?.score ?? 0, reasons: first?.reasons ?? [] },
+      selectionRationale: "Mock: top do pool.",
+      linguisticMaterialization: "Olá! Que bom ter você aqui. Posso te contar algo que pode te surpreender?",
     });
   }
   if (service === "motor-execucao" && tool === "get_state") {
     const sessionId = (args?.["sessionId"] as string) ?? "mock-session";
-    return JSON.stringify({ sessionId, trustLevel: 0.3, budgetRemaining: 100, turn: 0, eventLog: [] });
+    return JSON.stringify({
+      sessionId,
+      trustLevel: 0.3,
+      budgetRemaining: 100,
+      turn: 0,
+      eventLog: [],
+      statusMatrix: {
+        emotional: "baia",
+        social_with_ebrota: "baia",
+        social_with_parent: "baia",
+        social_with_sibling: "baia",
+      },
+    });
   }
   if (service === "motor-execucao" && tool === "execute_playbook") {
     const sessionId = (args?.["sessionId"] as string) ?? "mock-session";
     return JSON.stringify({
       success: true,
       newState: { sessionId, trustLevel: 0.34, budgetRemaining: 99, turn: 1, eventLog: [] },
-      eventLogged: { timestamp: new Date().toISOString(), type: "playbook_executed", playbookId: "icebreaker.primeiro-contato", data: {} },
+      eventLogged: {
+        timestamp: new Date().toISOString(),
+        type: "playbook_executed",
+        playbookId: "default",
+        data: { selectedContentId: args?.["selectedContentId"] ?? "" },
+      },
     });
   }
   return JSON.stringify({ ok: true });

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -87,7 +87,7 @@ export async function runTurn(
     service: "planejador",
     timestamp: new Date().toISOString(),
     durationMs: Date.now() - t1,
-    input: { incomingMessage: message, candidateCount: plan.candidateActions.length },
+    input: { incomingMessage: message, poolSize: plan.contentPool.length },
     output: plan as unknown as Record<string, unknown>,
   });
 
@@ -96,11 +96,12 @@ export async function runTurn(
     name: "evaluate_and_select",
     arguments: {
       sessionId,
-      candidateActions: plan.candidateActions,
+      contentPool: plan.contentPool,
       state,
       persona,
       strategicRationale: plan.strategicRationale,
       contextHints: plan.contextHints,
+      instruction_addition: "",
     },
   });
   const drota = parseToolText<import("@ascendimacy/shared").EvaluateAndSelectOutput>(drotaResult);
@@ -108,21 +109,33 @@ export async function runTurn(
     service: "motor-drota",
     timestamp: new Date().toISOString(),
     durationMs: Date.now() - t2,
-    input: { candidateCount: plan.candidateActions.length },
+    input: { poolSize: plan.contentPool.length },
     output: drota as unknown as Record<string, unknown>,
   });
 
   const t3 = Date.now();
+  // v1 usa playbookId = inventory[0] como deploy profile default.
+  // Plan §2.A v2: playbookId é session profile, não mais action-id.
+  const deployProfileId = inventory[0]?.id ?? "default";
   const execResult = await clients.motorExecucao.callTool({
     name: "execute_playbook",
-    arguments: { sessionId, playbookId: drota.selectedAction.playbookId, output: drota.linguisticMaterialization, metadata: {} },
+    arguments: {
+      sessionId,
+      playbookId: deployProfileId,
+      selectedContentId: drota.selectedContent?.item?.id ?? "",
+      output: drota.linguisticMaterialization,
+      metadata: {},
+    },
   });
   const exec = parseToolText<import("@ascendimacy/shared").ExecutePlaybookOutput>(execResult);
   turnEntries.push({
     service: "motor-execucao",
     timestamp: new Date().toISOString(),
     durationMs: Date.now() - t3,
-    input: { playbookId: drota.selectedAction.playbookId },
+    input: {
+      playbookId: deployProfileId,
+      selectedContentId: drota.selectedContent?.item?.id ?? "",
+    },
     output: exec as unknown as Record<string, unknown>,
   });
 

--- a/planejador/src/child-profile.ts
+++ b/planejador/src/child-profile.ts
@@ -1,0 +1,62 @@
+/**
+ * Adaptador PersonaDef + SessionState → ChildScoringProfile.
+ *
+ * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.A v2.
+ *
+ * v1 é conservador: usa campos do perfil estático quando presentes,
+ * preenche defaults sem inventar. engagement_by_type e recent_hook_domains
+ * serão populados em Bloco 3 (trace schema completo).
+ */
+
+import type {
+  ChildScoringProfile,
+  PersonaDef,
+  SessionState,
+} from "@ascendimacy/shared";
+
+/**
+ * Deriva profile de scoring a partir dos dados disponíveis.
+ * turn=0 → tudo vazio (cold start). turn>=1 → começa a popular via state/history.
+ */
+export function personaToChildProfile(
+  persona: PersonaDef,
+  _state: SessionState,
+): ChildScoringProfile {
+  const profile = (persona.profile ?? {}) as Record<string, unknown>;
+
+  // domain_ranking pode vir do profile estático se fixture declarar.
+  const rawRanking = profile["domain_ranking"];
+  const domainRanking =
+    rawRanking && typeof rawRanking === "object"
+      ? (rawRanking as Record<string, { score: number }>)
+      : undefined;
+
+  // recent_hook_domains derivamos do eventLog em Bloco 3 (trace schema).
+  // Por ora, vazio — cold start seguro.
+  const recentHookDomains: string[] = [];
+
+  const cycleDay = typeof profile["cycle_day"] === "number"
+    ? (profile["cycle_day"] as number)
+    : undefined;
+
+  return {
+    age: persona.age,
+    domain_ranking: domainRanking,
+    recent_hook_domains: recentHookDomains,
+    cycle_day: cycleDay,
+    cycle_phase: cyclePhaseFor(cycleDay),
+  };
+}
+
+/** Mapeia cycle_day → cycle_phase conforme BRIDGING_PLAYBOOK linhas 2700-2715. */
+export function cyclePhaseFor(
+  day: number | undefined,
+): ChildScoringProfile["cycle_phase"] | undefined {
+  if (typeof day !== "number") return undefined;
+  if (day >= 1 && day <= 3) return "rapport";
+  if (day >= 4 && day <= 7) return "building";
+  if (day >= 8 && day <= 10) return "peak";
+  if (day >= 11 && day <= 14) return "consolidation";
+  if (day >= 15 && day <= 18) return "buffer";
+  return undefined;
+}

--- a/planejador/src/llm-client.ts
+++ b/planejador/src/llm-client.ts
@@ -9,12 +9,15 @@ function getClient(): Anthropic {
   return client;
 }
 
-export async function callLlm(systemPrompt: string, userMessage: string): Promise<string> {
+export async function callLlm(
+  systemPrompt: string,
+  userMessage: string,
+): Promise<string> {
   const c = getClient();
   const model = process.env["PLANEJADOR_MODEL"] ?? "claude-sonnet-4-6";
   const response = await c.messages.create({
     model,
-    max_tokens: 400,
+    max_tokens: 200,
     system: systemPrompt,
     messages: [{ role: "user", content: userMessage }],
   });
@@ -23,13 +26,16 @@ export async function callLlm(systemPrompt: string, userMessage: string): Promis
   return block.text;
 }
 
-export async function callLlmMock(_systemPrompt: string, _userMessage: string): Promise<string> {
+/**
+ * Mock: planejador Bloco 2a devolve só rationale + hints.
+ * Scoring de conteúdo é determinístico, fora do LLM.
+ */
+export async function callLlmMock(
+  _systemPrompt: string,
+  _userMessage: string,
+): Promise<string> {
   return JSON.stringify({
-    strategicRationale: "Mock: contexto inicial, usuário se apresentou. Foco em receptividade.",
-    candidateActions: [
-      { playbookId: "icebreaker.primeiro-contato", priority: 1, rationale: "Primeira interação", estimatedSacrifice: 1, estimatedConfidenceGain: 4 },
-      { playbookId: "onboarding.apresentacao-produto", priority: 2, rationale: "Momento certo para apresentar", estimatedSacrifice: 2, estimatedConfidenceGain: 3 },
-    ],
-    contextHints: { mood: "receptive", urgency: "low" },
+    strategicRationale: "Mock: contexto inicial, foco em receptividade.",
+    contextHints: { language: "pt-br", mood: "receptive", urgency: "low" },
   });
 }

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -1,68 +1,118 @@
-import type { PlanTurnInput, PlanTurnOutput, CandidateAction } from "@ascendimacy/shared";
+/**
+ * Planejador — deixa de nomear playbook-ação-unitária.
+ * Agora: scora o pool (via scoreItem de @ascendimacy/shared) e devolve top 1-5.
+ *
+ * LLM é consultada APENAS para strategicRationale e contextHints
+ * (detecção de língua + ajuste tonal). O scoring é determinístico.
+ *
+ * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.A v2.
+ */
+
+import type {
+  PlanTurnInput,
+  PlanTurnOutput,
+  ScoredContentItem,
+} from "@ascendimacy/shared";
+import {
+  scorePool,
+  allGates,
+  pickFocusDimension,
+  caselTargetsFor,
+  defaultMatrix,
+} from "@ascendimacy/shared";
 import { callLlm, callLlmMock } from "./llm-client.js";
+import { loadSeedPool, buildPool } from "./pool-builder.js";
+import { personaToChildProfile } from "./child-profile.js";
+
+/** Quantos items do pool passamos ao drota (top-K). */
+export const TOP_K_POOL = 5;
+
+/** Caminho do seed pode ser sobrescrito via env para testes. */
+function seedPath(): string | undefined {
+  return process.env["CONTENT_SEED_PATH"];
+}
 
 function buildSystemPrompt(input: PlanTurnInput): string {
-  const { persona, adquirente, inventory, state } = input;
-  const inventoryList = inventory
-    .map(p => `- ${p.id}: ${p.title} (sacrifício estimado: ${p.estimatedSacrifice}, confiança estimada: +${p.estimatedConfidenceGain})`)
-    .join("\n");
+  const { persona, state, incomingMessage } = input;
+  return `Você é o Planejador do motor Ascendimacy. Seu papel é AUXILIAR de compositor:
+o scoring de content items é determinístico (feito no código). Você só emite:
 
-  return `Você é o Planejador do motor Ascendimacy. Seu papel é estratégico: dado o contexto do sujeito e o estado da sessão, escolha 2-5 playbooks candidatos em ordem de prioridade.
+1. strategicRationale (≤80 chars) — 1 frase sobre o momento da sessão.
+2. contextHints — dicas de composição (language, tom, avoid, etc).
 
-SUJEITO: ${persona.name}, ${persona.age} anos
+SUJEITO: ${persona.name}, ${persona.age} anos.
 Perfil: ${JSON.stringify(persona.profile, null, 2)}
+Estado: trust=${state.trustLevel.toFixed(2)}, turn=${state.turn}, budget=${state.budgetRemaining}
+Mensagem: "${incomingMessage}"
 
-ADQUIRENTE (defaults de contexto):
-${JSON.stringify(adquirente.defaults, null, 2)}
+Detecte a língua do sujeito (ex: 'pt-br', 'pt-br limitado', 'pt-br basico', 'ja', 'en'). Se o perfil indica falante não-nativo (ex: japonês aprendendo pt-br), use 'pt-br limitado'.
 
-ESTADO DA SESSÃO:
-- Trust level: ${state.trustLevel.toFixed(2)}
-- Budget restante: ${state.budgetRemaining}
-- Turno: ${state.turn}
+Responda APENAS JSON COMPACTO:
+{"strategicRationale":"string ≤80 chars","contextHints":{"language":"pt-br","mood":"receptive","urgency":"low"}}`;
+}
 
-PLAYBOOKS DISPONÍVEIS:
-${inventoryList}
+interface LlmRationale {
+  strategicRationale: string;
+  contextHints: Record<string, unknown>;
+}
 
-Responda APENAS com JSON COMPACTO (sem newlines extras). Máximo 2 candidateActions. strategicRationale max 80 chars. Formato:
-{
-  "strategicRationale": "string com raciocínio estratégico",
-  "candidateActions": [
-    {
-      "playbookId": "id do playbook",
-      "priority": 1,
-      "rationale": "por que este playbook agora",
-      "estimatedSacrifice": 0,
-      "estimatedConfidenceGain": 0
-    }
-  ],
-  "contextHints": {
-    "language": "detectar da mensagem e perfil — valores: 'pt-br', 'pt-br limitado', 'pt-br basico', 'ja', 'en', etc."
+function parseRationale(raw: string): LlmRationale {
+  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
+  try {
+    const parsed = JSON.parse(cleaned) as {
+      strategicRationale?: string;
+      contextHints?: Record<string, unknown>;
+    };
+    return {
+      strategicRationale: parsed.strategicRationale ?? "",
+      contextHints: parsed.contextHints ?? {},
+    };
+  } catch {
+    return { strategicRationale: "", contextHints: { language: "pt-br" } };
   }
 }
 
-Instrução adicional: detecte a língua e proficiência do sujeito com base na mensagem recebida e no perfil. Registre em contextHints.language. Se o perfil indica falante não-nativo de pt-br (ex: japonês aprendendo), use 'pt-br limitado'. Se a mensagem está em outra língua, use essa língua. Default: 'pt-br'.`;
-}
-
-function parseOutput(raw: string): PlanTurnOutput {
-  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
-  const parsed = JSON.parse(cleaned) as {
-    strategicRationale?: string;
-    candidateActions?: CandidateAction[];
-    contextHints?: Record<string, unknown>;
-  };
-  return {
-    strategicRationale: parsed.strategicRationale ?? "",
-    candidateActions: parsed.candidateActions ?? [],
-    contextHints: parsed.contextHints ?? {},
-  };
-}
-
 export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
-  const useMock = process.env["USE_MOCK_LLM"] === "true" || !process.env["ANTHROPIC_API_KEY"];
+  // 1. Scoring determinístico do pool.
+  const rawPool = loadSeedPool(seedPath());
+  const eligible = buildPool(rawPool, {
+    age: input.persona.age,
+    sessionMode: "1v1", // Bloco 6 adotará 'joint' para dyad
+  });
+  const child = personaToChildProfile(input.persona, input.state);
+  const statusMatrix = input.state.statusMatrix ?? defaultMatrix();
+  const focusDim = pickFocusDimension(statusMatrix);
+  const caselTargets = focusDim ? caselTargetsFor(focusDim) : [];
+  const scored = scorePool(eligible, child, {
+    now: new Date().toISOString(),
+    casel_focus: caselTargets[0] as ScoredContentItem["item"]["casel_target"][number] | undefined,
+  });
+  const topK = scored.slice(0, TOP_K_POOL);
+
+  // 2. LLM consulta para rationale + contextHints.
+  const useMock =
+    process.env["USE_MOCK_LLM"] === "true" ||
+    !process.env["ANTHROPIC_API_KEY"];
   const systemPrompt = buildSystemPrompt(input);
-  const userMessage = `Mensagem recebida do sujeito: "${input.incomingMessage}"\n\nGere o plano estratégico.`;
+  const userMessage = `Emita o JSON com rationale + hints.`;
   const raw = useMock
     ? await callLlmMock(systemPrompt, userMessage)
     : await callLlm(systemPrompt, userMessage);
-  return parseOutput(raw);
+  const rationale = parseRationale(raw);
+
+  // 3. Injeta status_gates + casel_focus em contextHints.
+  const contextHints: Record<string, unknown> = {
+    ...rationale.contextHints,
+    status_gates: allGates(statusMatrix),
+  };
+  if (focusDim) {
+    contextHints["casel_focus_dimension"] = focusDim;
+    contextHints["casel_focus_targets"] = caselTargets;
+  }
+
+  return {
+    strategicRationale: rationale.strategicRationale,
+    contentPool: topK,
+    contextHints,
+  };
 }

--- a/planejador/src/pool-builder.ts
+++ b/planejador/src/pool-builder.ts
@@ -1,0 +1,71 @@
+/**
+ * Pool builder — carrega o seed de content items e aplica elegibilidade.
+ *
+ * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.A v2.
+ * Referência pro filtro: ebrota/src/kids/tree.js:159-169 (prioritizedNodes).
+ *
+ * Função pura — I/O de disco isolado em `loadSeedPool`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ContentItem } from "@ascendimacy/shared";
+import { isContentItem } from "@ascendimacy/shared";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Caminho default do seed (relativo ao repo root). */
+export const DEFAULT_SEED_PATH = join(
+  __dirname,
+  "../../content/hooks/seed.json",
+);
+
+/** Carrega pool do disco. Throws se arquivo ausente ou malformado. */
+export function loadSeedPool(path?: string): ContentItem[] {
+  const target = path ?? DEFAULT_SEED_PATH;
+  const raw = readFileSync(target, "utf-8");
+  const parsed = JSON.parse(raw) as unknown[];
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Seed at ${target} is not an array`);
+  }
+  return parsed.filter(isContentItem);
+}
+
+export interface PoolFilterOptions {
+  /** Idade da criança — gate duro; items fora da faixa caem fora. */
+  age: number;
+  /**
+   * Modo da sessão. Se `joint`, só items com `group_compatible=true`.
+   * v1 default é `1v1` (Bloco 6 adotará `joint`).
+   */
+  sessionMode?: "1v1" | "joint" | "cross_sibling";
+  /**
+   * Filtro de sensibilidade — v1 permite só sensitivity=free.
+   * Ver plan v2 §4.11 (refusal tracking é Bloco 3+).
+   */
+  allowProtected?: boolean;
+}
+
+/**
+ * Aplica elegibilidade estática sobre o pool. NÃO scora.
+ * Scoring é responsabilidade do `scoreItem` de @ascendimacy/shared.
+ */
+export function buildPool(
+  pool: ContentItem[],
+  opts: PoolFilterOptions,
+): ContentItem[] {
+  return pool.filter((item) => {
+    // Idade — gate duro.
+    if (opts.age < item.age_range[0] || opts.age > item.age_range[1]) {
+      return false;
+    }
+    // Joint mode exige group_compatible.
+    if (opts.sessionMode === "joint" && !item.group_compatible) {
+      return false;
+    }
+    // Bloco 2a v1 assume todos os items do seed são sensitivity=free implícito.
+    // Refusal tracking (cooldown em nó refused) é Bloco 3+.
+    return true;
+  });
+}

--- a/planejador/src/server.ts
+++ b/planejador/src/server.ts
@@ -6,24 +6,55 @@ import type { PlanTurnInput } from "@ascendimacy/shared";
 
 const server = new McpServer({
   name: "planejador",
-  version: "0.1.0",
+  version: "0.3.0",
 });
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-server.registerTool("plan_turn", {
-  description: "Gera plano estratégico para o turno: recebe estado + mensagem, retorna candidateActions",
-  inputSchema: {
-    sessionId: z.string(),
-    persona: z.object({ id: z.string(), name: z.string(), age: z.number(), profile: z.record(z.string(), z.unknown()) }),
-    adquirente: z.object({ id: z.string(), name: z.string(), defaults: z.record(z.string(), z.unknown()) }),
-    inventory: z.array(z.object({ id: z.string(), title: z.string(), category: z.string(), estimatedSacrifice: z.number(), estimatedConfidenceGain: z.number() })),
-    state: z.object({ sessionId: z.string(), trustLevel: z.number(), budgetRemaining: z.number(), turn: z.number(), eventLog: z.array(z.unknown()) }),
-    incomingMessage: z.string(),
-  } as any,
-}, async (input: PlanTurnInput) => {
-  const output = await planTurn(input);
-  return { content: [{ type: "text" as const, text: JSON.stringify(output) }] };
-});
+server.registerTool(
+  "plan_turn",
+  {
+    description:
+      "Gera plano do turno: scora content pool, devolve top 1-5 + rationale + contextHints",
+    inputSchema: {
+      sessionId: z.string(),
+      persona: z.object({
+        id: z.string(),
+        name: z.string(),
+        age: z.number(),
+        profile: z.record(z.string(), z.unknown()),
+      }),
+      adquirente: z.object({
+        id: z.string(),
+        name: z.string(),
+        defaults: z.record(z.string(), z.unknown()),
+      }),
+      inventory: z.array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          category: z.string(),
+          estimatedSacrifice: z.number(),
+          estimatedConfidenceGain: z.number(),
+        }),
+      ),
+      state: z.object({
+        sessionId: z.string(),
+        trustLevel: z.number(),
+        budgetRemaining: z.number(),
+        turn: z.number(),
+        eventLog: z.array(z.unknown()),
+        statusMatrix: z.record(z.string(), z.string()).optional(),
+      }),
+      incomingMessage: z.string(),
+    } as any,
+  },
+  async (input: PlanTurnInput) => {
+    const output = await planTurn(input);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(output) }],
+    };
+  },
+);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/planejador/tests/child-profile.test.ts
+++ b/planejador/tests/child-profile.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { personaToChildProfile, cyclePhaseFor } from "../src/child-profile.js";
+import type { PersonaDef, SessionState } from "@ascendimacy/shared";
+
+const makePersona = (overrides: Partial<PersonaDef> = {}): PersonaDef => ({
+  id: "ryo",
+  name: "Ryo",
+  age: 13,
+  profile: {},
+  ...overrides,
+});
+
+const emptyState: SessionState = {
+  sessionId: "s1",
+  trustLevel: 0.3,
+  budgetRemaining: 100,
+  turn: 0,
+  eventLog: [],
+};
+
+describe("personaToChildProfile", () => {
+  it("uses persona.age", () => {
+    const p = personaToChildProfile(makePersona({ age: 11 }), emptyState);
+    expect(p.age).toBe(11);
+  });
+
+  it("extracts domain_ranking from profile when present", () => {
+    const persona = makePersona({
+      profile: { domain_ranking: { biology: { score: 4 } } },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.domain_ranking?.["biology"]).toEqual({ score: 4 });
+  });
+
+  it("omits domain_ranking when profile doesn't declare", () => {
+    const p = personaToChildProfile(makePersona(), emptyState);
+    expect(p.domain_ranking).toBeUndefined();
+  });
+
+  it("propagates cycle_day from profile and derives cycle_phase", () => {
+    const persona = makePersona({ profile: { cycle_day: 5 } });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.cycle_day).toBe(5);
+    expect(p.cycle_phase).toBe("building");
+  });
+
+  it("recent_hook_domains is empty in v1 (Bloco 3 fills)", () => {
+    const p = personaToChildProfile(makePersona(), emptyState);
+    expect(p.recent_hook_domains).toEqual([]);
+  });
+});
+
+describe("cyclePhaseFor", () => {
+  it("maps 1-3 → rapport", () => {
+    expect(cyclePhaseFor(1)).toBe("rapport");
+    expect(cyclePhaseFor(3)).toBe("rapport");
+  });
+  it("maps 4-7 → building", () => {
+    expect(cyclePhaseFor(4)).toBe("building");
+    expect(cyclePhaseFor(7)).toBe("building");
+  });
+  it("maps 8-10 → peak", () => {
+    expect(cyclePhaseFor(8)).toBe("peak");
+    expect(cyclePhaseFor(10)).toBe("peak");
+  });
+  it("maps 11-14 → consolidation", () => {
+    expect(cyclePhaseFor(14)).toBe("consolidation");
+  });
+  it("maps 15-18 → buffer", () => {
+    expect(cyclePhaseFor(18)).toBe("buffer");
+  });
+  it("undefined outside 1-18 or undefined input", () => {
+    expect(cyclePhaseFor(undefined)).toBeUndefined();
+    expect(cyclePhaseFor(0)).toBeUndefined();
+    expect(cyclePhaseFor(19)).toBeUndefined();
+  });
+});

--- a/planejador/tests/plan.test.ts
+++ b/planejador/tests/plan.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { planTurn } from "../src/plan.js";
 
 process.env["USE_MOCK_LLM"] = "true";
@@ -12,10 +12,10 @@ const mockState = {
 };
 
 const mockPersona = {
-  id: "paula-mendes",
-  name: "Paula Mendes",
-  age: 34,
-  profile: { occupation: "analista_financeira", city: "Sao_Paulo" },
+  id: "ryo",
+  name: "Ryo",
+  age: 13,
+  profile: { interests: ["dragon_ball"] },
 };
 
 const mockAdquirente = {
@@ -25,12 +25,15 @@ const mockAdquirente = {
 };
 
 const mockInventory = [
-  { id: "icebreaker.primeiro-contato", title: "Icebreaker", category: "onboarding", estimatedSacrifice: 1, estimatedConfidenceGain: 4 },
-  { id: "onboarding.apresentacao-produto", title: "Apresentação produto", category: "onboarding", estimatedSacrifice: 2, estimatedConfidenceGain: 3 },
+  { id: "kids.helix.session", title: "Helix session", category: "kids", estimatedSacrifice: 1, estimatedConfidenceGain: 4 },
 ];
 
-describe("planTurn", () => {
-  it("returns candidateActions with at least 1 action (mock)", async () => {
+beforeAll(() => {
+  // Garante que o seed padrão é encontrado pelos testes — caminho relativo do ESM.
+});
+
+describe("planTurn — Bloco 2a (contentPool)", () => {
+  it("returns contentPool (not candidateActions)", async () => {
     const output = await planTurn({
       sessionId: "test-001",
       persona: mockPersona,
@@ -39,11 +42,12 @@ describe("planTurn", () => {
       state: mockState,
       incomingMessage: "oi, tudo bem?",
     });
-    expect(output.candidateActions.length).toBeGreaterThan(0);
+    expect(Array.isArray(output.contentPool)).toBe(true);
+    expect(output.contentPool.length).toBeGreaterThan(0);
     expect(output.strategicRationale).toBeTruthy();
   });
 
-  it("each candidateAction has required fields", async () => {
+  it("each ScoredContentItem has item + score + reasons", async () => {
     const output = await planTurn({
       sessionId: "test-001",
       persona: mockPersona,
@@ -52,11 +56,47 @@ describe("planTurn", () => {
       state: mockState,
       incomingMessage: "quero saber mais",
     });
-    for (const action of output.candidateActions) {
-      expect(action.playbookId).toBeTruthy();
-      expect(typeof action.priority).toBe("number");
-      expect(typeof action.estimatedSacrifice).toBe("number");
-      expect(typeof action.estimatedConfidenceGain).toBe("number");
+    for (const scored of output.contentPool) {
+      expect(scored.item).toBeDefined();
+      expect(typeof scored.score).toBe("number");
+      expect(Array.isArray(scored.reasons)).toBe(true);
     }
+  });
+
+  it("contentPool is bounded by TOP_K_POOL (5)", async () => {
+    const output = await planTurn({
+      sessionId: "test-001",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "me conta algo legal",
+    });
+    expect(output.contentPool.length).toBeLessThanOrEqual(5);
+  });
+
+  it("injects status_gates in contextHints", async () => {
+    const output = await planTurn({
+      sessionId: "test-001",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["status_gates"]).toBeDefined();
+  });
+
+  it("injects casel_focus_dimension derived from status matrix", async () => {
+    const output = await planTurn({
+      sessionId: "test-001",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: { ...mockState, statusMatrix: { emotional: "brejo", social_with_ebrota: "baia" } },
+      incomingMessage: "oi",
+    });
+    // emotional=brejo deve vir primeiro pela ordem de prioridade
+    expect(output.contextHints["casel_focus_dimension"]).toBe("emotional");
   });
 });

--- a/planejador/tests/pool-builder.test.ts
+++ b/planejador/tests/pool-builder.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { loadSeedPool, buildPool } from "../src/pool-builder.js";
+import type { ContentItem } from "@ascendimacy/shared";
+
+const makeHook = (overrides: Partial<ContentItem> = {}): ContentItem =>
+  ({
+    id: "h1",
+    type: "curiosity_hook",
+    domain: "biology",
+    casel_target: ["SA"],
+    age_range: [7, 14],
+    surprise: 8,
+    verified: true,
+    base_score: 7,
+    fact: "f",
+    bridge: "b",
+    quest: "q",
+    sacrifice_type: "reflect",
+    ...overrides,
+  }) as ContentItem;
+
+describe("loadSeedPool", () => {
+  it("loads at least 1 content item from default seed", () => {
+    const pool = loadSeedPool();
+    expect(pool.length).toBeGreaterThan(0);
+  });
+  it("all loaded items pass isContentItem", () => {
+    const pool = loadSeedPool();
+    // Each should have required fields.
+    for (const item of pool.slice(0, 5)) {
+      expect(typeof item.id).toBe("string");
+      expect(typeof item.type).toBe("string");
+      expect(Array.isArray(item.casel_target)).toBe(true);
+    }
+  });
+});
+
+describe("buildPool — age gate (v2, A.1.2 slot)", () => {
+  it("includes items where age fits the range", () => {
+    const pool = [
+      makeHook({ id: "fits", age_range: [7, 14] }),
+      makeHook({ id: "too_old", age_range: [15, 18] }),
+      makeHook({ id: "too_young", age_range: [3, 5] }),
+    ];
+    const built = buildPool(pool, { age: 10 });
+    expect(built.map((i) => i.id)).toEqual(["fits"]);
+  });
+
+  it("respects edge cases (age === min)", () => {
+    const pool = [makeHook({ id: "edge", age_range: [10, 12] })];
+    expect(buildPool(pool, { age: 10 })[0]?.id).toBe("edge");
+    expect(buildPool(pool, { age: 12 })[0]?.id).toBe("edge");
+    expect(buildPool(pool, { age: 13 })).toHaveLength(0);
+  });
+});
+
+describe("buildPool — group_compatible filter (Bloco 6 prep)", () => {
+  it("1v1 mode includes all age-eligible items regardless of group_compatible", () => {
+    const pool = [
+      makeHook({ id: "individual", group_compatible: false }),
+      makeHook({ id: "dyad_ok", group_compatible: true }),
+      makeHook({ id: "no_flag" }), // group_compatible undefined
+    ];
+    const built = buildPool(pool, { age: 10, sessionMode: "1v1" });
+    expect(built.map((i) => i.id).sort()).toEqual(["dyad_ok", "individual", "no_flag"]);
+  });
+
+  it("joint mode drops items without group_compatible=true", () => {
+    const pool = [
+      makeHook({ id: "individual", group_compatible: false }),
+      makeHook({ id: "dyad_ok", group_compatible: true }),
+      makeHook({ id: "no_flag" }),
+    ];
+    const built = buildPool(pool, { age: 10, sessionMode: "joint" });
+    expect(built.map((i) => i.id)).toEqual(["dyad_ok"]);
+  });
+});
+
+describe("buildPool — refusal tracking is Bloco 3+ (v2, §4.11)", () => {
+  it("does NOT filter based on any 'refused' marker in v1", () => {
+    // Marca ausente — pool-builder v1 não se importa.
+    const pool = [makeHook({ id: "normal" })];
+    const built = buildPool(pool, { age: 10 });
+    expect(built.map((i) => i.id)).toEqual(["normal"]);
+  });
+});

--- a/shared/src/content-item.ts
+++ b/shared/src/content-item.ts
@@ -70,6 +70,14 @@ export interface ContentItemBase {
   verified: boolean;
   base_score: number;
 
+  /**
+   * Elegibilidade para joint/dyad sessions (Bloco 6 #17).
+   * Bloco 2a adiciona o campo com default `false` para evitar migration
+   * futura no schema. Pool-builder v1 não filtra por isso — consumo é
+   * Bloco 6+. Plan §2.A v2, A.1.1.
+   */
+  group_compatible?: boolean;
+
   /** Dinâmico por criança — resultante do histórico de uso. */
   times_used?: number;
   last_used_at?: string | null;

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -1,6 +1,11 @@
-import type { CandidateAction, SessionState, PersonaDef, AdquirenteDef, PlaybookIndex, EventEntry } from "./types.js";
-
-export type { CandidateAction };
+import type { ContentItem, ScoredContentItem } from "./content-item.js";
+import type {
+  SessionState,
+  PersonaDef,
+  AdquirenteDef,
+  PlaybookIndex,
+  EventEntry,
+} from "./types.js";
 
 export interface PlanTurnInput {
   sessionId: string;
@@ -13,30 +18,41 @@ export interface PlanTurnInput {
 
 export interface PlanTurnOutput {
   strategicRationale: string;
-  candidateActions: CandidateAction[];
+  /**
+   * Top 1-5 items scorados do pool.
+   * Substitui `candidateActions` (removido Bloco 2a).
+   */
+  contentPool: ScoredContentItem[];
   contextHints: Record<string, unknown>;
 }
 
 export interface EvaluateAndSelectInput {
   sessionId: string;
-  candidateActions: CandidateAction[];
+  contentPool: ScoredContentItem[];
   state: SessionState;
   persona: PersonaDef;
   strategicRationale: string;
   contextHints: Record<string, unknown>;
+  /**
+   * Slot para continuidade multi-dia / technique hints (Bloco 3/5).
+   * Bloco 2a sempre passa string vazia ou omite. Ver plano v2 A.2.
+   */
+  instruction_addition?: string;
 }
 
 export interface EvaluateAndSelectOutput {
-  selectedAction: CandidateAction;
+  /** Item escolhido do pool (com score + reasons preservados). */
+  selectedContent: ScoredContentItem;
   selectionRationale: string;
-  actualSacrifice: number;
-  actualConfidenceGain: number;
   linguisticMaterialization: string;
 }
 
 export interface ExecutePlaybookInput {
   sessionId: string;
+  /** Deploy profile (e.g. "kids.session" / "drota.session"). */
   playbookId: string;
+  /** Id do content item materializado, se houve — para trace + updates. */
+  selectedContentId?: string;
   output: string;
   metadata: Record<string, unknown>;
 }
@@ -46,3 +62,6 @@ export interface ExecutePlaybookOutput {
   newState: SessionState;
   eventLogged: EventEntry;
 }
+
+/** Re-export conveniente para consumidores. */
+export type { ContentItem, ScoredContentItem };

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -3,3 +3,5 @@ export * from "./contracts.js";
 export * from "./trace-schema.js";
 export * from "./content-item.js";
 export * from "./scorer.js";
+export * from "./tree-node.js";
+export * from "./status-matrix.js";

--- a/shared/src/scorer.ts
+++ b/shared/src/scorer.ts
@@ -51,6 +51,19 @@ export interface ChildScoringProfile {
   domain_ranking?: Record<string, DomainRankEntry>;
   recent_hook_domains?: string[];
   engagement_by_type?: Partial<Record<ContentItemType, number>>;
+
+  /**
+   * Dia no ciclo helix de 18 dias (1-18). Bloco 2a adiciona o slot;
+   * scorer v1 não consome. Referência: BRIDGING_PLAYBOOK.MD linhas 2700-2715
+   * (distribuição de técnicas por fase). Plan §2.A v2, A.1.2.
+   */
+  cycle_day?: number;
+
+  /**
+   * Fase derivada do cycle_day. Bloco 3 pode modular pesos por fase.
+   *   rapport (1-3), building (4-7), peak (8-10), consolidation (11-14), buffer (15-18)
+   */
+  cycle_phase?: "rapport" | "building" | "peak" | "consolidation" | "buffer";
 }
 
 export interface ScoringContext {

--- a/shared/src/status-matrix.ts
+++ b/shared/src/status-matrix.ts
@@ -1,0 +1,201 @@
+/**
+ * Status matrix — dimensões × valores (brejo/baia/pasto).
+ *
+ * Persistência: tabela `tree_nodes` com `zone='status'` e `key=<dimension>`
+ * (override Jun 2026-04-24 sobre plano §4.7 v1 — ver plano v2 §2.C).
+ *
+ * Invariantes:
+ *   - Nunca pular brejo → pasto direto (precisa passar por baia).
+ *   - emotional=brejo bloqueia emit de challenge em qualquer outra dimensão.
+ *
+ * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.C + §4 (v2).
+ * Referência: ebrota/src/kids/tree.js (padrão), FOUNDATION §17 (conceito).
+ */
+
+export const STATUS_VALUES = ["brejo", "baia", "pasto"] as const;
+export type StatusValue = (typeof STATUS_VALUES)[number];
+
+/**
+ * Matrix é Record<dimension-key, StatusValue>. Dimension-keys são
+ * strings semânticas (ver CANONICAL_DIMENSIONS) — não fixamos tipo
+ * porque cognitive_<subject> e linguistic_<lang> são abertas.
+ */
+export type StatusMatrix = Record<string, StatusValue>;
+
+/** Dimensões canônicas v1 — ordem define prioridade de CASEL focus. */
+export const CANONICAL_DIMENSIONS = [
+  "emotional",
+  "social_with_ebrota",
+  "social_with_parent",
+  "social_with_sibling",
+  // cognitive_<subject> e linguistic_<lang> são abertas; exemplo só:
+  "cognitive_math",
+  "cognitive_science",
+  "linguistic_ja",
+  "linguistic_pt_br",
+] as const;
+
+export function isStatusValue(v: unknown): v is StatusValue {
+  return typeof v === "string" && STATUS_VALUES.includes(v as StatusValue);
+}
+
+/** Matrix default (tudo baia) — usado em turn 1 sem onboarding. */
+export function defaultMatrix(): StatusMatrix {
+  const m: StatusMatrix = {};
+  for (const dim of CANONICAL_DIMENSIONS) {
+    m[dim] = "baia";
+  }
+  return m;
+}
+
+/** Retorna `true` se todas as entradas da matrix são StatusValue válidas. */
+export function isStatusMatrix(v: unknown): v is StatusMatrix {
+  if (!v || typeof v !== "object") return false;
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof k !== "string" || k.length === 0) return false;
+    if (!isStatusValue(val)) return false;
+  }
+  return true;
+}
+
+/**
+ * Resultado de uma tentativa de transição.
+ * - applied: o valor efetivamente aplicado (pode divergir do target se inválido)
+ * - accepted: true se o target foi aceito; false se foi ajustado pela invariante
+ * - reason: string legível (para logs e trace)
+ */
+export interface TransitionResult {
+  applied: StatusValue;
+  accepted: boolean;
+  reason: string;
+}
+
+/**
+ * Aplica uma transição respeitando a invariante brejo → baia → pasto.
+ *
+ * Regras:
+ *   - undefined (primeira medição) → target aceito.
+ *   - target === current → no-op aceito.
+ *   - brejo → pasto: rejeitado, força baia.
+ *   - pasto → brejo: rejeitado, força baia (mesma invariante reversa —
+ *     fica mais forte pela sugestão da spec: transições não pulam).
+ *   - demais transições (baia→brejo, baia→pasto, brejo→baia, pasto→baia): aceitas.
+ */
+export function transition(
+  current: StatusValue | undefined,
+  target: StatusValue,
+): TransitionResult {
+  if (current === undefined) {
+    return { applied: target, accepted: true, reason: "first_set" };
+  }
+  if (current === target) {
+    return { applied: target, accepted: true, reason: "no_op" };
+  }
+  const pair = `${current}->${target}`;
+  if (pair === "brejo->pasto" || pair === "pasto->brejo") {
+    return {
+      applied: "baia",
+      accepted: false,
+      reason: `invariant_skip (${pair}) — forced baia`,
+    };
+  }
+  return { applied: target, accepted: true, reason: `transition ${pair}` };
+}
+
+export interface GateResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Pode emitir challenge para `dimension` dado o estado atual da matrix?
+ *
+ * Invariantes:
+ *   - emotional=brejo → bloqueia TODAS as dimensões não-emotional.
+ *   - dimension=brejo → desafio suave only (ok=false com reason).
+ *   - dimension=baia → ok.
+ *   - dimension=pasto → ok.
+ *   - dimension ausente na matrix → tratado como default(baia) → ok.
+ */
+export function canEmitChallenge(
+  matrix: StatusMatrix,
+  dimension: string,
+): GateResult {
+  const emotional = matrix["emotional"];
+  if (emotional === "brejo" && dimension !== "emotional") {
+    return { ok: false, reason: "emotional_brejo_blocks_all" };
+  }
+  const current = matrix[dimension] ?? "baia";
+  if (current === "brejo") {
+    return { ok: false, reason: `${dimension}_brejo_needs_repair` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Devolve status_gates map para injetar em contextHints.
+ * Chave: dimension. Valor: GateResult.
+ */
+export function allGates(matrix: StatusMatrix): Record<string, GateResult> {
+  const out: Record<string, GateResult> = {};
+  for (const dim of Object.keys(matrix)) {
+    out[dim] = canEmitChallenge(matrix, dim);
+  }
+  return out;
+}
+
+/**
+ * Escolhe a dimensão de CASEL focus.
+ *
+ * Ordem de prioridade (v2, plano §4.9):
+ *   1. Qualquer dimensão em brejo (mais crítico primeiro).
+ *   2. Qualquer dimensão em baia.
+ *   3. Pasto (último recurso — tudo fluindo).
+ *
+ * Dentro do mesmo status, a ordem segue CANONICAL_DIMENSIONS:
+ *   emotional → social_with_ebrota → social_with_parent → social_with_sibling
+ *     → cognitive_* → linguistic_*
+ *
+ * Retorna string (key) ou undefined se matrix vazia.
+ */
+export function pickFocusDimension(matrix: StatusMatrix): string | undefined {
+  const entries = Object.entries(matrix);
+  if (entries.length === 0) return undefined;
+
+  const byPriority = [...entries].sort(([aKey, aVal], [bKey, bVal]) => {
+    const order: Record<StatusValue, number> = { brejo: 0, baia: 1, pasto: 2 };
+    const diff = order[aVal] - order[bVal];
+    if (diff !== 0) return diff;
+    return canonicalOrder(aKey) - canonicalOrder(bKey);
+  });
+
+  return byPriority[0]?.[0];
+}
+
+function canonicalOrder(key: string): number {
+  const idx = (CANONICAL_DIMENSIONS as readonly string[]).indexOf(key);
+  if (idx >= 0) return idx;
+  // Keys abertas (cognitive_<x>, linguistic_<x>) vão para o final.
+  if (key.startsWith("cognitive_")) return 100;
+  if (key.startsWith("linguistic_")) return 200;
+  return 500;
+}
+
+/** Mapa dimensão → CASEL dimension(s) (plano §4.9 v2). */
+export const CASEL_FROM_DIMENSION: Record<string, string[]> = {
+  emotional: ["SA", "SM"],
+  social_with_ebrota: ["REL"],
+  social_with_parent: ["SOC", "REL"],
+  social_with_sibling: ["SOC", "REL"],
+};
+
+/**
+ * Devolve as CASEL dimensions associadas a uma dimension key.
+ * cognitive_* → DM; linguistic_* → REL.
+ */
+export function caselTargetsFor(dimension: string): string[] {
+  if (CASEL_FROM_DIMENSION[dimension]) return CASEL_FROM_DIMENSION[dimension];
+  if (dimension.startsWith("cognitive_")) return ["DM"];
+  if (dimension.startsWith("linguistic_")) return ["REL"];
+  return [];
+}

--- a/shared/src/trace-schema.ts
+++ b/shared/src/trace-schema.ts
@@ -1,4 +1,5 @@
-import type { CandidateAction, EventEntry } from "./types.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { EventEntry } from "./types.js";
 
 export interface TraceEntry {
   service: "planejador" | "motor-drota" | "motor-execucao";

--- a/shared/src/tree-node.ts
+++ b/shared/src/tree-node.ts
@@ -1,0 +1,65 @@
+/**
+ * Tree node — unidade de persistência genérica do motor canônico.
+ *
+ * Inspirado em `ebrota/src/kids/tree.js` (§17 FOUNDATION, "Árvore Viva"),
+ * porém minimalista no v1: é usado só para status matrix em Bloco 2a.
+ * Zonas raiz/tronco/galho/folha virão em C-005 (migração da árvore).
+ *
+ * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.C (v2).
+ * Referência: ebrota/src/kids/tree.js:6-41 (constantes).
+ */
+
+export const TREE_NODE_ZONES = [
+  "status",
+  "raiz",
+  "tronco",
+  "galho",
+  "folha",
+] as const;
+export type TreeNodeZone = (typeof TREE_NODE_ZONES)[number];
+
+export const NODE_STATES = [
+  "seed",
+  "done",
+  "partial",
+  "empty",
+  "warning",
+  "refused",
+  "review",
+  "muted",
+] as const;
+export type NodeState = (typeof NODE_STATES)[number];
+
+export const SENSITIVITIES = ["free", "conversation", "protected"] as const;
+export type Sensitivity = (typeof SENSITIVITIES)[number];
+
+/** Node fields as persisted (subset mirror of kids_tree_nodes). */
+export interface TreeNode {
+  id?: number;
+  sessionId: string;
+  zone: TreeNodeZone;
+  key: string;
+  value: string | null;
+  source: string;
+  state: NodeState;
+  sensitivity: Sensitivity;
+  urgency: number;
+  importance: number;
+  halfLifeDays: number | null;
+  lastActiveAt: string | null;
+  cooldownUntil: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function isTreeNodeZone(v: unknown): v is TreeNodeZone {
+  return typeof v === "string" && TREE_NODE_ZONES.includes(v as TreeNodeZone);
+}
+
+export function isNodeState(v: unknown): v is NodeState {
+  return typeof v === "string" && NODE_STATES.includes(v as NodeState);
+}
+
+export function isSensitivity(v: unknown): v is Sensitivity {
+  return typeof v === "string" && SENSITIVITIES.includes(v as Sensitivity);
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,3 +1,5 @@
+import type { StatusMatrix } from "./status-matrix.js";
+
 export interface PersonaDef {
   id: string;
   name: string;
@@ -25,6 +27,8 @@ export interface SessionState {
   budgetRemaining: number;
   eventLog: EventEntry[];
   turn: number;
+  /** Hidratado por motor-execucao a partir de tree_nodes (zone='status'). */
+  statusMatrix?: StatusMatrix;
 }
 
 export interface EventEntry {
@@ -32,12 +36,4 @@ export interface EventEntry {
   type: string;
   playbookId?: string;
   data: Record<string, unknown>;
-}
-
-export interface CandidateAction {
-  playbookId: string;
-  priority: number;
-  rationale: string;
-  estimatedSacrifice: number;
-  estimatedConfidenceGain: number;
 }

--- a/shared/tests/status-matrix.test.ts
+++ b/shared/tests/status-matrix.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  transition,
+  canEmitChallenge,
+  allGates,
+  defaultMatrix,
+  pickFocusDimension,
+  caselTargetsFor,
+  isStatusValue,
+  isStatusMatrix,
+  CANONICAL_DIMENSIONS,
+} from "../src/status-matrix.js";
+import type { StatusMatrix } from "../src/status-matrix.js";
+
+describe("StatusValue guards", () => {
+  it("accepts brejo, baia, pasto", () => {
+    expect(isStatusValue("brejo")).toBe(true);
+    expect(isStatusValue("baia")).toBe(true);
+    expect(isStatusValue("pasto")).toBe(true);
+  });
+  it("rejects other strings", () => {
+    expect(isStatusValue("lake")).toBe(false);
+    expect(isStatusValue("")).toBe(false);
+    expect(isStatusValue(null)).toBe(false);
+  });
+});
+
+describe("defaultMatrix", () => {
+  it("returns baia for all canonical dimensions", () => {
+    const m = defaultMatrix();
+    for (const dim of CANONICAL_DIMENSIONS) {
+      expect(m[dim]).toBe("baia");
+    }
+  });
+  it("isStatusMatrix accepts defaultMatrix", () => {
+    expect(isStatusMatrix(defaultMatrix())).toBe(true);
+  });
+});
+
+describe("transition — invariant brejo→baia→pasto", () => {
+  it("first_set: undefined current accepts any target", () => {
+    const r = transition(undefined, "brejo");
+    expect(r.accepted).toBe(true);
+    expect(r.applied).toBe("brejo");
+    expect(r.reason).toBe("first_set");
+  });
+  it("no_op: current equals target", () => {
+    const r = transition("baia", "baia");
+    expect(r.accepted).toBe(true);
+    expect(r.applied).toBe("baia");
+  });
+  it("rejects brejo → pasto (forces baia)", () => {
+    const r = transition("brejo", "pasto");
+    expect(r.accepted).toBe(false);
+    expect(r.applied).toBe("baia");
+    expect(r.reason).toMatch(/invariant_skip/);
+  });
+  it("rejects pasto → brejo (forces baia)", () => {
+    const r = transition("pasto", "brejo");
+    expect(r.accepted).toBe(false);
+    expect(r.applied).toBe("baia");
+  });
+  it("accepts brejo → baia", () => {
+    const r = transition("brejo", "baia");
+    expect(r.accepted).toBe(true);
+    expect(r.applied).toBe("baia");
+  });
+  it("accepts baia → pasto", () => {
+    const r = transition("baia", "pasto");
+    expect(r.accepted).toBe(true);
+    expect(r.applied).toBe("pasto");
+  });
+  it("accepts baia → brejo (degradation allowed)", () => {
+    const r = transition("baia", "brejo");
+    expect(r.accepted).toBe(true);
+    expect(r.applied).toBe("brejo");
+  });
+  it("accepts pasto → baia (stepping down)", () => {
+    const r = transition("pasto", "baia");
+    expect(r.accepted).toBe(true);
+    expect(r.applied).toBe("baia");
+  });
+});
+
+describe("canEmitChallenge", () => {
+  it("allows when all baia", () => {
+    const m = defaultMatrix();
+    expect(canEmitChallenge(m, "cognitive_math")).toEqual({ ok: true });
+  });
+  it("blocks all dimensions when emotional=brejo (except emotional itself)", () => {
+    const m: StatusMatrix = { ...defaultMatrix(), emotional: "brejo" };
+    expect(canEmitChallenge(m, "cognitive_math").ok).toBe(false);
+    expect(canEmitChallenge(m, "social_with_parent").ok).toBe(false);
+    // emotional itself — blocked because brejo-in-dim rule
+    expect(canEmitChallenge(m, "emotional").ok).toBe(false);
+  });
+  it("blocks dimension-specific brejo", () => {
+    const m: StatusMatrix = { ...defaultMatrix(), cognitive_math: "brejo" };
+    const r = canEmitChallenge(m, "cognitive_math");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/cognitive_math/);
+  });
+  it("treats missing dimension as baia (ok)", () => {
+    const m: StatusMatrix = {};
+    expect(canEmitChallenge(m, "cognitive_novel").ok).toBe(true);
+  });
+});
+
+describe("allGates", () => {
+  it("emits one entry per dimension in matrix", () => {
+    const m: StatusMatrix = { emotional: "baia", cognitive_math: "pasto" };
+    const gates = allGates(m);
+    expect(Object.keys(gates).sort()).toEqual(["cognitive_math", "emotional"]);
+    expect(gates["emotional"]?.ok).toBe(true);
+  });
+});
+
+describe("pickFocusDimension — priority order", () => {
+  it("picks brejo over baia over pasto", () => {
+    const m: StatusMatrix = {
+      emotional: "pasto",
+      social_with_ebrota: "brejo",
+      cognitive_math: "baia",
+    };
+    expect(pickFocusDimension(m)).toBe("social_with_ebrota");
+  });
+  it("within same status, follows CANONICAL_DIMENSIONS order (emotional wins)", () => {
+    const m: StatusMatrix = {
+      emotional: "brejo",
+      social_with_ebrota: "brejo",
+      cognitive_math: "brejo",
+    };
+    expect(pickFocusDimension(m)).toBe("emotional");
+  });
+  it("social_with_ebrota comes before social_with_parent", () => {
+    const m: StatusMatrix = {
+      social_with_parent: "brejo",
+      social_with_ebrota: "brejo",
+    };
+    expect(pickFocusDimension(m)).toBe("social_with_ebrota");
+  });
+  it("undefined for empty matrix", () => {
+    expect(pickFocusDimension({})).toBeUndefined();
+  });
+});
+
+describe("caselTargetsFor", () => {
+  it("emotional → SA+SM", () => {
+    expect(caselTargetsFor("emotional")).toEqual(["SA", "SM"]);
+  });
+  it("social_with_parent → SOC+REL", () => {
+    expect(caselTargetsFor("social_with_parent")).toEqual(["SOC", "REL"]);
+  });
+  it("cognitive_<any> → DM", () => {
+    expect(caselTargetsFor("cognitive_math")).toEqual(["DM"]);
+    expect(caselTargetsFor("cognitive_novel_subject")).toEqual(["DM"]);
+  });
+  it("linguistic_<any> → REL", () => {
+    expect(caselTargetsFor("linguistic_ja")).toEqual(["REL"]);
+  });
+  it("unknown → empty", () => {
+    expect(caselTargetsFor("random")).toEqual([]);
+  });
+});

--- a/shared/tests/tree-node.test.ts
+++ b/shared/tests/tree-node.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  isTreeNodeZone,
+  isNodeState,
+  isSensitivity,
+  TREE_NODE_ZONES,
+  NODE_STATES,
+  SENSITIVITIES,
+} from "../src/tree-node.js";
+
+describe("TreeNode zones", () => {
+  it("accepts canonical zones", () => {
+    for (const z of TREE_NODE_ZONES) {
+      expect(isTreeNodeZone(z)).toBe(true);
+    }
+  });
+  it("rejects unknown strings", () => {
+    expect(isTreeNodeZone("root")).toBe(false);
+    expect(isTreeNodeZone("")).toBe(false);
+    expect(isTreeNodeZone(42)).toBe(false);
+  });
+  it("includes status zone (Bloco 2a)", () => {
+    expect(TREE_NODE_ZONES).toContain("status");
+  });
+});
+
+describe("NodeState guard", () => {
+  it("accepts all 8 canonical states", () => {
+    for (const s of NODE_STATES) {
+      expect(isNodeState(s)).toBe(true);
+    }
+    expect(NODE_STATES.length).toBe(8);
+  });
+  it("rejects invalid states", () => {
+    expect(isNodeState("active")).toBe(false);
+  });
+});
+
+describe("Sensitivity guard", () => {
+  it("accepts free|conversation|protected", () => {
+    for (const s of SENSITIVITIES) {
+      expect(isSensitivity(s)).toBe(true);
+    }
+  });
+  it("rejects others", () => {
+    expect(isSensitivity("public")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Refs

- Handoff v2: [docs/handoffs/2026-04-24-cc-bloco2-plan.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/handoffs/2026-04-24-cc-bloco2-plan.md)
- Memos: [docs/insights/2026-04-24-*.md](https://github.com/ascendimacy/ascendimacy-ops/tree/main/docs/insights)
- Issue umbrella: [ascendimacy-ops#17](https://github.com/ascendimacy/ascendimacy-ops/issues/17) (eBrota Kids v1)

## O que foi feito

Bloco 2a do handoff #17: retrofit do contrato planejador↔drota + primeira iteração da status matrix, aplicando os 7 ajustes do apêndice do plano + A.2 (`instruction_addition`) + override do Jun sobre persistência (status matrix como rows em `tree_nodes`, não coluna JSON).

### Retrofit de contrato
- `PlanTurnOutput.candidateActions` → `contentPool: ScoredContentItem[]`
- `EvaluateAndSelectInput.candidateActions` → `contentPool` + `instruction_addition?`
- `EvaluateAndSelectOutput.selectedAction` → `selectedContent: ScoredContentItem`
- `ExecutePlaybookInput.selectedContentId?` novo
- `CandidateAction` **removido** (plan §4.1 — clean break)

### Shared (7 ajustes do apêndice aplicados)
- `ContentItem.group_compatible?: boolean` (A.1.1, prep Bloco 6)
- `ChildScoringProfile.cycle_day?` + `cycle_phase?` (A.1.2, slot pro scorer)
- Nomenclatura `social_with_parent|_sibling|_ebrota` (A.1.3)
- Novo `shared/src/tree-node.ts` — tipos + guards
- Novo `shared/src/status-matrix.ts` — invariante `brejo→baia→pasto`, `canEmitChallenge`, `pickFocusDimension` com ordem prioritária v2
- Remove `CandidateAction` (§4.1)
- `SessionState.statusMatrix?` agora hidratado por motor-execucao

### Planejador (scoring determinístico + LLM só pra rationale)
- Novo `pool-builder.ts` (age gate + sessionMode filter — joint mode exige group_compatible)
- Novo `child-profile.ts` (persona → ChildScoringProfile, cycle_day→phase)
- `plan.ts` reescrito: `scoreItem` sobre seed, LLM só pra strategicRationale+contextHints
- Injeta `status_gates` + `casel_focus_dimension` em contextHints

### Motor-drota (ancoragem obrigatória)
- Prompt: `<content_pool>` + `<instruction_addition>` substituem `<candidate_actions>`
- Instrução 2: "Ancoragem obrigatória — fala cita/adapta content selecionado"
- Fallback conversacional quando pool vazio (§4.2)
- `forbidden_words` ganha `contentPool`/`content_pool`
- v1 é hooks-only (§4.12) — outros tipos fazem fallback genérico na serialização

### Motor-execução (override Jun: status matrix como tree nodes)
- Nova tabela `tree_nodes (session × zone × key UNIQUE)` em `tree-nodes.ts`
- `upsertNode`, `getNodes`, `getStatusMatrix` (com default baia), `applyStatusTransition` (enforça invariante na persistência)
- `state-manager.ts` faz DDL aditiva + `getState` hidrata `statusMatrix` automático
- Zonas `raiz/tronco/galho/folha` definidas mas não populadas (C-005 virá)

### Orchestrator + mocks
- Propaga `contentPool` + `instruction_addition`
- `deployProfileId` = `inventory[0]` (playbookId agora é session profile, não action-id)
- Mocks atualizados para novo schema

## Resultados

### npm run build
✅ limpo nos 5 packages

### npm run test (132 testes verdes — meta 130)

| Package | Testes | Delta |
|---|---|---|
| shared | 66 | +33 (tree-node × 7, status-matrix × 26) |
| planejador | 24 | +21 (pool-builder × 7, child-profile × 11, plan × 5) |
| motor-drota | 18 | +6 (content-pool × 5, evaluate rewritten, context-hints updated) |
| motor-execucao | 22 | +15 (tree-nodes × 12, state-manager × 3) |
| orchestrator | 2 | ✓ |

### npm run smoke
✅ Rubric G1-G3 verde (motor-execucao → planejador → motor-drota → motor-execucao)

## Decisões principais

- **Status matrix como tree_nodes** (não coluna JSON) — override Jun sobre plano v1 §4.7. Unifica storage com C-005 futuro.
- **v1 é hooks-only** (§4.12) — outros 6 tipos de ContentItem aceitos pelo schema mas não populados; serialização faz fallback genérico.
- **Refusal tracking é Bloco 3+** (§4.11) — pool-builder v1 não filtra por state=refused cooldown.
- **`instruction_addition` slot** — sempre string vazia em v1; Bloco 3/5 vão popular com "day 2 of 5 of chain X" ou "technique_hint: tribunal".

## Débitos explícitos (Bloco 3+)

- Content items não-hook (seeds + testes full serialization)
- Zonas tree raiz/tronco/galho/folha (C-005)
- Half-life temporal real no scorer (hoje é por `last_used_at` só)
- Bullying check para joint sessions (Bloco 6)
- `ACADEMIC_BRIDGE_MAP` do BRIDGING_PLAYBOOK para Bloco 4 onboarding

## Como testar

```bash
cd ascendimacy-motor
npm install
npm run build
npm run test   # 132 verdes esperados
npm run smoke  # Rubric G1-G3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)