### PR TITLE
feat(#17 Bloco 2b): mixin withGardnerProgram — 5 semanas × 3 fases

### DIFF
--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -157,6 +157,7 @@ server.registerTool(
         turn: z.number(),
         eventLog: z.array(z.unknown()),
         statusMatrix: z.record(z.string(), z.string()).optional(),
+        gardnerProgram: z.record(z.string(), z.unknown()).optional(),
       }),
       persona: z.object({
         id: z.string(),

--- a/motor-execucao/src/gardner-program.ts
+++ b/motor-execucao/src/gardner-program.ts
@@ -1,0 +1,248 @@
+/**
+ * kids_gardner_program — estado persistido do programa Dual Helix de 5 semanas.
+ *
+ * Spec:
+ *   - ascendimacy-ops/docs/fundamentos/ebrota-kids-fundamentos.md §6
+ *   - ascendimacy-ops/docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md §4.2-4.3
+ *
+ * Schema: 1 row por sessão (session_id UNIQUE). Reflete estado "onde estamos"
+ * no arco de 5 semanas; não é log de eventos (o event_log cuida disso).
+ */
+
+import type Database from "better-sqlite3";
+import type { GardnerProgramState, ProgramPhase } from "@ascendimacy/shared";
+import { nextPhase, isAssessmentReady } from "@ascendimacy/shared";
+import type { GardnerAssessment } from "@ascendimacy/shared";
+
+export const GARDNER_PROGRAM_DDL = `
+CREATE TABLE IF NOT EXISTS kids_gardner_program (
+  session_id TEXT PRIMARY KEY,
+  current_week INTEGER,
+  current_day INTEGER NOT NULL DEFAULT 1,
+  current_phase TEXT,
+  paused INTEGER NOT NULL DEFAULT 0,
+  paused_reason TEXT,
+  phases_completed INTEGER NOT NULL DEFAULT 0,
+  consecutive_missed_milestones INTEGER NOT NULL DEFAULT 0,
+  started_at TEXT,
+  updated_at TEXT NOT NULL
+);
+`;
+
+interface ProgramRow {
+  session_id: string;
+  current_week: number | null;
+  current_day: number;
+  current_phase: string | null;
+  paused: number;
+  paused_reason: string | null;
+  phases_completed: number;
+  consecutive_missed_milestones: number;
+  started_at: string | null;
+  updated_at: string;
+}
+
+function rowToState(row: ProgramRow): GardnerProgramState {
+  return {
+    current_week: row.current_week,
+    current_day: row.current_day,
+    current_phase: (row.current_phase as ProgramPhase | null) ?? null,
+    paused: row.paused === 1,
+    paused_reason: row.paused_reason ?? undefined,
+    phases_completed: row.phases_completed,
+    consecutive_missed_milestones: row.consecutive_missed_milestones,
+    started_at: row.started_at ?? undefined,
+    updated_at: row.updated_at,
+  };
+}
+
+/**
+ * Estado default de um programa que ainda não foi iniciado (sem row).
+ * `current_week=null` + `current_phase=null` indica "pré-programa".
+ */
+export function defaultProgramState(now: string): GardnerProgramState {
+  return {
+    current_week: null,
+    current_day: 1,
+    current_phase: null,
+    paused: false,
+    phases_completed: 0,
+    consecutive_missed_milestones: 0,
+    updated_at: now,
+  };
+}
+
+/**
+ * Lê o estado atual do programa pra uma sessão.
+ * Se ainda não houver row, retorna defaultProgramState.
+ */
+export function getProgramState(
+  db: Database.Database,
+  sessionId: string,
+): GardnerProgramState {
+  const row = db
+    .prepare("SELECT * FROM kids_gardner_program WHERE session_id = ?")
+    .get(sessionId) as ProgramRow | undefined;
+  if (!row) return defaultProgramState(new Date().toISOString());
+  return rowToState(row);
+}
+
+/**
+ * Inicia o programa — cria row se ausente, define week=1 phase=1.
+ * No-op se já está iniciado (current_week !== null).
+ * Exige assessment pronto (min 3 sessões) — caller deve checar antes.
+ */
+export function startProgram(
+  db: Database.Database,
+  sessionId: string,
+  now?: string,
+): GardnerProgramState {
+  const ts = now ?? new Date().toISOString();
+  const existing = getProgramState(db, sessionId);
+  if (existing.current_week !== null) return existing;
+  db.prepare(
+    `INSERT INTO kids_gardner_program
+      (session_id, current_week, current_day, current_phase, paused,
+       phases_completed, consecutive_missed_milestones, started_at, updated_at)
+     VALUES (?, 1, 1, 'exploration_in_strength', 0, 0, 0, ?, ?)
+     ON CONFLICT(session_id) DO UPDATE SET
+       current_week = 1,
+       current_day = 1,
+       current_phase = 'exploration_in_strength',
+       paused = 0,
+       paused_reason = NULL,
+       phases_completed = 0,
+       started_at = COALESCE(kids_gardner_program.started_at, excluded.started_at),
+       updated_at = excluded.updated_at`,
+  ).run(sessionId, ts, ts);
+  return getProgramState(db, sessionId);
+}
+
+/**
+ * Avança programa pela próxima fase (usa `nextPhase` puro do shared).
+ * Throws se programa pausado — caller deve resumir antes.
+ */
+export function advanceProgram(
+  db: Database.Database,
+  sessionId: string,
+  now?: string,
+): GardnerProgramState {
+  const ts = now ?? new Date().toISOString();
+  const current = getProgramState(db, sessionId);
+  if (current.paused) {
+    throw new Error("advanceProgram: program is paused; resume first");
+  }
+  const next = nextPhase(current);
+  upsertProgram(db, sessionId, next, ts);
+  return getProgramState(db, sessionId);
+}
+
+/** Pausa explicitamente (motivo livre). */
+export function pauseProgram(
+  db: Database.Database,
+  sessionId: string,
+  reason: string,
+  now?: string,
+): GardnerProgramState {
+  const ts = now ?? new Date().toISOString();
+  const current = getProgramState(db, sessionId);
+  upsertProgram(db, sessionId, { ...current, paused: true, paused_reason: reason }, ts);
+  return getProgramState(db, sessionId);
+}
+
+/** Resume programa pausado. */
+export function resumeProgram(
+  db: Database.Database,
+  sessionId: string,
+  now?: string,
+): GardnerProgramState {
+  const ts = now ?? new Date().toISOString();
+  const current = getProgramState(db, sessionId);
+  upsertProgram(
+    db,
+    sessionId,
+    { ...current, paused: false, paused_reason: undefined },
+    ts,
+  );
+  return getProgramState(db, sessionId);
+}
+
+/** Incrementa milestones faltantes — dispara pause parental se ≥2. */
+export function recordMissedMilestone(
+  db: Database.Database,
+  sessionId: string,
+  now?: string,
+): GardnerProgramState {
+  const ts = now ?? new Date().toISOString();
+  const current = getProgramState(db, sessionId);
+  const next = current.consecutive_missed_milestones + 1;
+  const shouldPause = next >= 2;
+  upsertProgram(
+    db,
+    sessionId,
+    {
+      ...current,
+      consecutive_missed_milestones: next,
+      paused: shouldPause ? true : current.paused,
+      paused_reason: shouldPause ? "missed_milestones" : current.paused_reason,
+    },
+    ts,
+  );
+  return getProgramState(db, sessionId);
+}
+
+/** Reseta o contador de milestones faltantes (após fase completada). */
+export function resetMissedMilestones(
+  db: Database.Database,
+  sessionId: string,
+  now?: string,
+): void {
+  const ts = now ?? new Date().toISOString();
+  const current = getProgramState(db, sessionId);
+  upsertProgram(
+    db,
+    sessionId,
+    { ...current, consecutive_missed_milestones: 0 },
+    ts,
+  );
+}
+
+function upsertProgram(
+  db: Database.Database,
+  sessionId: string,
+  state: GardnerProgramState,
+  ts: string,
+): void {
+  db.prepare(
+    `INSERT INTO kids_gardner_program
+      (session_id, current_week, current_day, current_phase, paused, paused_reason,
+       phases_completed, consecutive_missed_milestones, started_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(session_id) DO UPDATE SET
+       current_week = excluded.current_week,
+       current_day = excluded.current_day,
+       current_phase = excluded.current_phase,
+       paused = excluded.paused,
+       paused_reason = excluded.paused_reason,
+       phases_completed = excluded.phases_completed,
+       consecutive_missed_milestones = excluded.consecutive_missed_milestones,
+       started_at = COALESCE(kids_gardner_program.started_at, excluded.started_at),
+       updated_at = excluded.updated_at`,
+  ).run(
+    sessionId,
+    state.current_week ?? null,
+    state.current_day,
+    state.current_phase ?? null,
+    state.paused ? 1 : 0,
+    state.paused_reason ?? null,
+    state.phases_completed,
+    state.consecutive_missed_milestones,
+    state.started_at ?? ts,
+    ts,
+  );
+}
+
+/** Helper: verifica se assessment pronto (delega pro shared). */
+export function canActivate(assessment: GardnerAssessment | undefined): boolean {
+  return isAssessmentReady(assessment);
+}

--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -2,8 +2,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { loadInventory } from "./loader.js";
-import { getState, logEvent } from "./state-manager.js";
+import { getState, logEvent, getDbInstance } from "./state-manager.js";
 import { executePlaybook } from "./executor.js";
+import {
+  startProgram,
+  advanceProgram,
+  pauseProgram,
+  resumeProgram,
+} from "./gardner-program.js";
 
 const inventory = loadInventory();
 
@@ -33,6 +39,38 @@ server.registerTool("execute_playbook", {
 }, async ({ sessionId, playbookId, selectedContentId, output, metadata }: { sessionId: string; playbookId: string; selectedContentId?: string; output: string; metadata?: Record<string, unknown> }) => {
   const result = executePlaybook({ sessionId, playbookId, selectedContentId, output, metadata: metadata ?? {} }, inventory);
   return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
+});
+
+server.registerTool("gardner_program_start", {
+  description: "Inicia programa Gardner 5 semanas (week=1, phase=exploration). Caller deve ter verificado assessment pronto (min 3 sessões).",
+  inputSchema: { sessionId: z.string() } as any,
+}, async ({ sessionId }: { sessionId: string }) => {
+  const state = startProgram(getDbInstance(), sessionId);
+  return { content: [{ type: "text" as const, text: JSON.stringify(state) }] };
+});
+
+server.registerTool("gardner_program_advance", {
+  description: "Avança programa Gardner pela próxima fase (1→2→3→week+1 phase1). Throws se pausado.",
+  inputSchema: { sessionId: z.string() } as any,
+}, async ({ sessionId }: { sessionId: string }) => {
+  const state = advanceProgram(getDbInstance(), sessionId);
+  return { content: [{ type: "text" as const, text: JSON.stringify(state) }] };
+});
+
+server.registerTool("gardner_program_pause", {
+  description: "Pausa programa Gardner com motivo (ex: emotional_brejo, child_request, missed_milestones).",
+  inputSchema: { sessionId: z.string(), reason: z.string() } as any,
+}, async ({ sessionId, reason }: { sessionId: string; reason: string }) => {
+  const state = pauseProgram(getDbInstance(), sessionId, reason);
+  return { content: [{ type: "text" as const, text: JSON.stringify(state) }] };
+});
+
+server.registerTool("gardner_program_resume", {
+  description: "Retoma programa Gardner pausado.",
+  inputSchema: { sessionId: z.string() } as any,
+}, async ({ sessionId }: { sessionId: string }) => {
+  const state = resumeProgram(getDbInstance(), sessionId);
+  return { content: [{ type: "text" as const, text: JSON.stringify(state) }] };
 });
 
 server.registerTool("log_event", {

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -3,6 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SessionState, EventEntry } from "@ascendimacy/shared";
 import { TREE_NODES_DDL, getStatusMatrix } from "./tree-nodes.js";
+import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -31,6 +32,7 @@ function getDb(dbPath?: string): Database.Database {
         data TEXT
       );
       ${TREE_NODES_DDL}
+      ${GARDNER_PROGRAM_DDL}
     `);
   }
   return db;
@@ -54,12 +56,14 @@ export function getState(sessionId: string): SessionState {
     .prepare("SELECT * FROM event_log WHERE session_id = ? ORDER BY id DESC LIMIT 20")
     .all(sessionId) as Record<string, unknown>[];
   const statusMatrix = getStatusMatrix(database, sessionId);
+  const gardnerProgram = getProgramState(database, sessionId);
   return {
     sessionId,
     trustLevel: Number(row["trust_level"]),
     budgetRemaining: Number(row["budget_remaining"]),
     turn: Number(row["turn"]),
     statusMatrix,
+    gardnerProgram,
     eventLog: events.map((e) => ({
       timestamp: String(e["timestamp"]),
       type: String(e["type"]),

--- a/motor-execucao/tests/gardner-program.test.ts
+++ b/motor-execucao/tests/gardner-program.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  GARDNER_PROGRAM_DDL,
+  getProgramState,
+  startProgram,
+  advanceProgram,
+  pauseProgram,
+  resumeProgram,
+  recordMissedMilestone,
+  resetMissedMilestones,
+} from "../src/gardner-program.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(GARDNER_PROGRAM_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("gardner-program CRUD", () => {
+  it("getProgramState de sessão nova retorna default (pré-programa)", () => {
+    const s = getProgramState(db, "new");
+    expect(s.current_week).toBeNull();
+    expect(s.current_phase).toBeNull();
+    expect(s.paused).toBe(false);
+    expect(s.phases_completed).toBe(0);
+  });
+
+  it("startProgram inicia week 1 phase 1", () => {
+    const s = startProgram(db, "s1");
+    expect(s.current_week).toBe(1);
+    expect(s.current_phase).toBe("exploration_in_strength");
+    expect(s.paused).toBe(false);
+  });
+
+  it("startProgram é idempotente (não reseta se já iniciado)", () => {
+    startProgram(db, "s1");
+    advanceProgram(db, "s1"); // phase 1 → 2
+    const s = startProgram(db, "s1");
+    expect(s.current_phase).toBe("translation_via_weakness");
+  });
+
+  it("advanceProgram progride phase 1→2→3→week2 phase1", () => {
+    startProgram(db, "s1");
+    const p2 = advanceProgram(db, "s1");
+    expect(p2.current_phase).toBe("translation_via_weakness");
+    const p3 = advanceProgram(db, "s1");
+    expect(p3.current_phase).toBe("presentation");
+    const w2 = advanceProgram(db, "s1");
+    expect(w2.current_week).toBe(2);
+    expect(w2.current_phase).toBe("exploration_in_strength");
+  });
+
+  it("advanceProgram throws quando pausado", () => {
+    startProgram(db, "s1");
+    pauseProgram(db, "s1", "test");
+    expect(() => advanceProgram(db, "s1")).toThrow(/paused/);
+  });
+
+  it("pauseProgram marca paused + reason", () => {
+    startProgram(db, "s1");
+    const s = pauseProgram(db, "s1", "emotional_brejo");
+    expect(s.paused).toBe(true);
+    expect(s.paused_reason).toBe("emotional_brejo");
+  });
+
+  it("resumeProgram limpa paused + reason", () => {
+    startProgram(db, "s1");
+    pauseProgram(db, "s1", "emotional_brejo");
+    const s = resumeProgram(db, "s1");
+    expect(s.paused).toBe(false);
+    expect(s.paused_reason).toBeUndefined();
+  });
+
+  it("recordMissedMilestone incrementa contador; 2 consecutivos pausa", () => {
+    startProgram(db, "s1");
+    const s1 = recordMissedMilestone(db, "s1");
+    expect(s1.consecutive_missed_milestones).toBe(1);
+    expect(s1.paused).toBe(false);
+    const s2 = recordMissedMilestone(db, "s1");
+    expect(s2.consecutive_missed_milestones).toBe(2);
+    expect(s2.paused).toBe(true);
+    expect(s2.paused_reason).toBe("missed_milestones");
+  });
+
+  it("resetMissedMilestones zera contador", () => {
+    startProgram(db, "s1");
+    recordMissedMilestone(db, "s1");
+    resetMissedMilestones(db, "s1");
+    const s = getProgramState(db, "s1");
+    expect(s.consecutive_missed_milestones).toBe(0);
+  });
+
+  it("sessões isoladas — estado de s1 não vaza pra s2", () => {
+    startProgram(db, "s1");
+    advanceProgram(db, "s1");
+    const s2 = getProgramState(db, "s2");
+    expect(s2.current_week).toBeNull();
+  });
+});

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -101,7 +101,7 @@ export async function runTurn(
       persona,
       strategicRationale: plan.strategicRationale,
       contextHints: plan.contextHints,
-      instruction_addition: "",
+      instruction_addition: plan.instruction_addition ?? "",
     },
   });
   const drota = parseToolText<import("@ascendimacy/shared").EvaluateAndSelectOutput>(drotaResult);

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -5,13 +5,18 @@
  * LLM é consultada APENAS para strategicRationale e contextHints
  * (detecção de língua + ajuste tonal). O scoring é determinístico.
  *
- * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.A v2.
+ * Bloco 2b adiciona: composição de `instruction_addition` via
+ * `withGardnerProgram` se programa ativo e assessment pronto.
+ *
+ * Spec: docs/handoffs/2026-04-24-cc-bloco2-plan.md §2.A v2 + Bloco 2b.
  */
 
 import type {
   PlanTurnInput,
   PlanTurnOutput,
   ScoredContentItem,
+  GardnerAssessment,
+  GardnerProgramState,
 } from "@ascendimacy/shared";
 import {
   scorePool,
@@ -19,6 +24,10 @@ import {
   pickFocusDimension,
   caselTargetsFor,
   defaultMatrix,
+  composeInstructionAddition,
+  isAssessmentReady,
+  pairForWeek,
+  shouldPauseProgram,
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock } from "./llm-client.js";
 import { loadSeedPool, buildPool } from "./pool-builder.js";
@@ -72,6 +81,52 @@ function parseRationale(raw: string): LlmRationale {
   }
 }
 
+/**
+ * Se há programa ativo + assessment pronto + matrix não-pausável,
+ * compõe a string instruction_addition que vai pro drota.
+ * Retorna string vazia caso contrário.
+ */
+function buildGardnerInstruction(input: PlanTurnInput): {
+  text: string;
+  pauseReason?: string;
+  active: boolean;
+} {
+  const program = input.state.gardnerProgram;
+  if (!program || program.current_week === null || program.current_phase === null) {
+    return { text: "", active: false };
+  }
+  if (program.paused) {
+    return { text: "", active: false, pauseReason: program.paused_reason ?? "paused" };
+  }
+
+  // Assessment vem via persona.profile.gardner_assessment em v1 (fixture pattern).
+  const profile = (input.persona.profile ?? {}) as Record<string, unknown>;
+  const rawAssessment = profile["gardner_assessment"] as GardnerAssessment | undefined;
+  if (!isAssessmentReady(rawAssessment)) {
+    return { text: "", active: false, pauseReason: "assessment_not_ready" };
+  }
+
+  // Pausa automática se matrix sinaliza brejo afetivo.
+  const matrix = input.state.statusMatrix ?? defaultMatrix();
+  const pause = shouldPauseProgram(matrix);
+  if (pause.paused) {
+    return { text: "", active: false, pauseReason: pause.reason };
+  }
+
+  const pair = pairForWeek(program.current_week, rawAssessment!);
+  if (!pair) return { text: "", active: false, pauseReason: "no_pair" };
+
+  const text = composeInstructionAddition({
+    week_number: program.current_week,
+    day_in_week: program.current_day,
+    strength_channel: pair.strength,
+    weakness_channel: pair.weakness,
+    phase: program.current_phase,
+    multi_channel: pair.multi_channel,
+  });
+  return { text, active: true };
+}
+
 export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   // 1. Scoring determinístico do pool.
   const rawPool = loadSeedPool(seedPath());
@@ -100,7 +155,10 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     : await callLlm(systemPrompt, userMessage);
   const rationale = parseRationale(raw);
 
-  // 3. Injeta status_gates + casel_focus em contextHints.
+  // 3. Composição do mixin withGardnerProgram se ativo.
+  const gardnerInstruction = buildGardnerInstruction(input);
+
+  // 4. Injeta status_gates + casel_focus + gardner meta em contextHints.
   const contextHints: Record<string, unknown> = {
     ...rationale.contextHints,
     status_gates: allGates(statusMatrix),
@@ -109,10 +167,21 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     contextHints["casel_focus_dimension"] = focusDim;
     contextHints["casel_focus_targets"] = caselTargets;
   }
+  if (input.state.gardnerProgram?.current_week) {
+    contextHints["gardner_program_active"] = gardnerInstruction.active;
+    contextHints["gardner_current_week"] = input.state.gardnerProgram.current_week;
+    if (gardnerInstruction.pauseReason) {
+      contextHints["gardner_pause_reason"] = gardnerInstruction.pauseReason;
+    }
+  }
 
   return {
     strategicRationale: rationale.strategicRationale,
     contentPool: topK,
     contextHints,
+    instruction_addition: gardnerInstruction.text,
   };
 }
+
+/** Exposto para testes. */
+export { buildGardnerInstruction };

--- a/planejador/src/server.ts
+++ b/planejador/src/server.ts
@@ -44,6 +44,7 @@ server.registerTool(
         turn: z.number(),
         eventLog: z.array(z.unknown()),
         statusMatrix: z.record(z.string(), z.string()).optional(),
+        gardnerProgram: z.record(z.string(), z.unknown()).optional(),
       }),
       incomingMessage: z.string(),
     } as any,

--- a/planejador/tests/gardner-integration.test.ts
+++ b/planejador/tests/gardner-integration.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import { buildGardnerInstruction, planTurn } from "../src/plan.js";
+import type {
+  GardnerAssessment,
+  GardnerProgramState,
+  PersonaDef,
+  SessionState,
+  StatusMatrix,
+} from "@ascendimacy/shared";
+
+process.env["USE_MOCK_LLM"] = "true";
+
+const assessment: GardnerAssessment = {
+  top: ["linguistic", "logical_mathematical", "spatial", "interpersonal"],
+  bottom: ["musical", "bodily_kinesthetic", "naturalist", "existential"],
+  sessions_observed: 3,
+};
+
+function makePersona(overrides: Partial<PersonaDef> = {}): PersonaDef {
+  return {
+    id: "ryo",
+    name: "Ryo",
+    age: 13,
+    profile: { gardner_assessment: assessment },
+    ...overrides,
+  };
+}
+
+const baseProgram: GardnerProgramState = {
+  current_week: 1,
+  current_day: 1,
+  current_phase: "exploration_in_strength",
+  paused: false,
+  phases_completed: 0,
+  consecutive_missed_milestones: 0,
+};
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: "s1",
+    trustLevel: 0.3,
+    budgetRemaining: 100,
+    turn: 0,
+    eventLog: [],
+    statusMatrix: { emotional: "baia" },
+    ...overrides,
+  };
+}
+
+const adquirente = { id: "jun", name: "Jun", defaults: {} };
+const inventory = [
+  { id: "kids.helix.session", title: "Helix", category: "kids", estimatedSacrifice: 1, estimatedConfidenceGain: 4 },
+];
+
+describe("buildGardnerInstruction — integração pura", () => {
+  it("retorna active=false quando programa não iniciado", () => {
+    const r = buildGardnerInstruction({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+    });
+    expect(r.active).toBe(false);
+    expect(r.text).toBe("");
+  });
+
+  it("retorna texto composto quando programa ativo + assessment pronto", () => {
+    const r = buildGardnerInstruction({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState({ gardnerProgram: baseProgram }),
+      incomingMessage: "oi",
+    });
+    expect(r.active).toBe(true);
+    expect(r.text).toContain("semana 1/5");
+    expect(r.text).toContain("Fase 1");
+  });
+
+  it("pausa automaticamente quando emotional=brejo (reusa canEmitChallenge)", () => {
+    const brejoMatrix: StatusMatrix = { emotional: "brejo" };
+    const r = buildGardnerInstruction({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState({ gardnerProgram: baseProgram, statusMatrix: brejoMatrix }),
+      incomingMessage: "oi",
+    });
+    expect(r.active).toBe(false);
+    expect(r.pauseReason).toBe("emotional_brejo");
+  });
+
+  it("não compõe quando assessment não pronto (min 3 sessões)", () => {
+    const persona = makePersona({
+      profile: {
+        gardner_assessment: { ...assessment, sessions_observed: 2 },
+      },
+    });
+    const r = buildGardnerInstruction({
+      sessionId: "s1",
+      persona,
+      adquirente,
+      inventory,
+      state: makeState({ gardnerProgram: baseProgram }),
+      incomingMessage: "oi",
+    });
+    expect(r.active).toBe(false);
+    expect(r.pauseReason).toBe("assessment_not_ready");
+  });
+
+  it("não compõe quando programa já pausado", () => {
+    const r = buildGardnerInstruction({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState({
+        gardnerProgram: { ...baseProgram, paused: true, paused_reason: "child_request" },
+      }),
+      incomingMessage: "oi",
+    });
+    expect(r.active).toBe(false);
+    expect(r.pauseReason).toBe("child_request");
+  });
+
+  it("texto difere entre 3 fases da mesma semana", () => {
+    const make = (phase: GardnerProgramState["current_phase"]) =>
+      buildGardnerInstruction({
+        sessionId: "s1",
+        persona: makePersona(),
+        adquirente,
+        inventory,
+        state: makeState({ gardnerProgram: { ...baseProgram, current_phase: phase } }),
+        incomingMessage: "oi",
+      }).text;
+
+    const t1 = make("exploration_in_strength");
+    const t2 = make("translation_via_weakness");
+    const t3 = make("presentation");
+    expect(t1).not.toBe(t2);
+    expect(t2).not.toBe(t3);
+    expect(t1).not.toBe(t3);
+  });
+});
+
+describe("planTurn — emite instruction_addition quando programa ativo", () => {
+  it("instruction_addition não-vazio quando programa ativo + matrix ok", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState({ gardnerProgram: baseProgram }),
+      incomingMessage: "oi",
+    });
+    expect(out.instruction_addition).toBeTruthy();
+    expect(out.instruction_addition).toContain("semana");
+  });
+
+  it("instruction_addition vazia quando programa pausado por brejo", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState({
+        gardnerProgram: baseProgram,
+        statusMatrix: { emotional: "brejo" },
+      }),
+      incomingMessage: "oi",
+    });
+    expect(out.instruction_addition).toBe("");
+    expect(out.contextHints["gardner_pause_reason"]).toBe("emotional_brejo");
+  });
+
+  it("contextHints.gardner_program_active reflete estado real", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState({ gardnerProgram: baseProgram }),
+      incomingMessage: "oi",
+    });
+    expect(out.contextHints["gardner_program_active"]).toBe(true);
+    expect(out.contextHints["gardner_current_week"]).toBe(1);
+  });
+
+  it("instruction_addition vazia quando programa não iniciado", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+    });
+    expect(out.instruction_addition).toBe("");
+  });
+});

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -24,6 +24,11 @@ export interface PlanTurnOutput {
    */
   contentPool: ScoredContentItem[];
   contextHints: Record<string, unknown>;
+  /**
+   * Composed pelo planejador quando mixin ativo (ex: withGardnerProgram).
+   * Repassado para `EvaluateAndSelectInput.instruction_addition` (Bloco 2b).
+   */
+  instruction_addition?: string;
 }
 
 export interface EvaluateAndSelectInput {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -5,3 +5,4 @@ export * from "./content-item.js";
 export * from "./scorer.js";
 export * from "./tree-node.js";
 export * from "./status-matrix.js";
+export * from "./mixins/with-gardner-program.js";

--- a/shared/src/mixins/with-gardner-program.ts
+++ b/shared/src/mixins/with-gardner-program.ts
@@ -1,0 +1,224 @@
+/**
+ * withGardnerProgram — mixin pedagógico de 5 semanas com padrão triádico
+ * força-ensina-fraqueza.
+ *
+ * Spec:
+ *   - ascendimacy-ops/docs/fundamentos/ebrota-kids-fundamentos.md §6
+ *   - ascendimacy-ops/docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md §4.2-4.3
+ *
+ * Estrutura:
+ *   Semana 1: Top#1 ensina Bottom#1
+ *   Semana 2: Top#2 ensina Bottom#2
+ *   Semana 3: Top#3 ensina Bottom#3
+ *   Semana 4: Top#4 ensina Bottom#4
+ *   Semana 5: combinação múltipla — arremate
+ *
+ * 3 fases por semana (em ordem):
+ *   1. exploration_in_strength (off-screen)
+ *   2. translation_via_weakness (on-screen)
+ *   3. presentation (off-screen — audiência real)
+ *
+ * Invariantes:
+ *   - Assessment Gardner exige min 3 sessões antes de ativar (D-firme #8)
+ *   - Programa pausa em emotional=brejo (canEmitChallenge)
+ *   - Criança pode pedir pausa a qualquer momento
+ */
+
+import type { GardnerChannel } from "../content-item.js";
+import { canEmitChallenge } from "../status-matrix.js";
+import type { StatusMatrix } from "../status-matrix.js";
+
+export const PROGRAM_PHASES = [
+  "exploration_in_strength",
+  "translation_via_weakness",
+  "presentation",
+] as const;
+export type ProgramPhase = (typeof PROGRAM_PHASES)[number];
+
+/** Assessment Gardner — ranking parcial dos 9 canais. */
+export interface GardnerAssessment {
+  /** Top 4+ canais por rank, mais forte primeiro. */
+  top: GardnerChannel[];
+  /** Bottom 4+ canais por rank, mais fraco primeiro. */
+  bottom: GardnerChannel[];
+  /** Quantas sessões produziram esse ranking. min 3 pra ativar programa. */
+  sessions_observed: number;
+}
+
+/** Estado persistido do programa em andamento. */
+export interface GardnerProgramState {
+  /** Se undefined, programa nunca iniciou; se null, pausado. */
+  current_week: number | null;
+  current_day: number;
+  current_phase: ProgramPhase | null;
+  paused: boolean;
+  paused_reason?: string;
+  /** count de fases completadas (week × phase). */
+  phases_completed: number;
+  /** Milestones consecutivos não entregues (pause-revisão parental). */
+  consecutive_missed_milestones: number;
+  started_at?: string;
+  updated_at?: string;
+}
+
+/** min de sessões antes de liberar programa. */
+export const MIN_SESSIONS_FOR_ASSESSMENT = 3;
+
+/** Total de semanas do programa. */
+export const PROGRAM_LENGTH_WEEKS = 5;
+
+/** Milestones consecutivos faltantes que disparam pause parental. */
+export const MISSED_MILESTONES_TO_PAUSE = 2;
+
+/** `true` se o assessment tem dados suficientes pra ativar programa. */
+export function isAssessmentReady(a: GardnerAssessment | undefined): boolean {
+  if (!a) return false;
+  if (a.sessions_observed < MIN_SESSIONS_FOR_ASSESSMENT) return false;
+  if (a.top.length < 1 || a.bottom.length < 1) return false;
+  return true;
+}
+
+export interface ChannelPair {
+  strength: GardnerChannel;
+  weakness: GardnerChannel;
+  multi_channel: boolean;
+}
+
+/**
+ * Retorna o par força×fraqueza da semana conforme tabela §4.2:
+ *   semana 1 → Top#1 × Bottom#1
+ *   ...
+ *   semana 4 → Top#4 × Bottom#4
+ *   semana 5 → multi-channel (arremate) — usa Top#1 + Bottom#1 como base + flag
+ */
+export function pairForWeek(
+  week: number,
+  assessment: GardnerAssessment,
+): ChannelPair | null {
+  if (week < 1 || week > PROGRAM_LENGTH_WEEKS) return null;
+  if (!isAssessmentReady(assessment)) return null;
+
+  const rank = week === 5 ? 0 : week - 1;
+  const strength = assessment.top[rank] ?? assessment.top[0]!;
+  const weakness = assessment.bottom[rank] ?? assessment.bottom[0]!;
+  return {
+    strength,
+    weakness,
+    multi_channel: week === 5,
+  };
+}
+
+/**
+ * Fase → descrição localizável usada no instruction_addition.
+ */
+const PHASE_LABEL: Record<ProgramPhase, string> = {
+  exploration_in_strength: "exploração na força (off-screen)",
+  translation_via_weakness: "tradução via fraqueza (tela)",
+  presentation: "apresentação para audiência real (off-screen)",
+};
+
+export interface ComposeInstructionInput {
+  week_number: number;
+  day_in_week: number;
+  strength_channel: GardnerChannel;
+  weakness_channel: GardnerChannel;
+  phase: ProgramPhase;
+  multi_channel?: boolean;
+}
+
+/**
+ * Compõe o conteúdo pra `EvaluateAndSelectInput.instruction_addition`.
+ * String de 3-6 linhas para o drota incorporar no bloco 2 do prompt.
+ *
+ * Diferente por fase — CADA fase produz instrução distinta:
+ *   1. exploration: pede artifact bruto no canal forte
+ *   2. translation: pede conversão usando canal fraco
+ *   3. presentation: convida apresentação pra audiência real
+ */
+export function composeInstructionAddition(input: ComposeInstructionInput): string {
+  const { week_number, day_in_week, strength_channel, weakness_channel, phase, multi_channel } = input;
+  const header = multi_channel
+    ? `[programa dual-helix | semana ${week_number}/5 — arremate multi-canal | dia ${day_in_week}]`
+    : `[programa dual-helix | semana ${week_number}/5 | dia ${day_in_week}]`;
+  const pair = multi_channel
+    ? `Força principal: ${strength_channel} (+ combinar outros canais do top). Fraqueza a trabalhar: ${weakness_channel}.`
+    : `Força da semana: ${strength_channel}. Fraqueza a trabalhar: ${weakness_channel}.`;
+
+  const phaseInstruction = (() => {
+    switch (phase) {
+      case "exploration_in_strength":
+        return `Fase 1 — ${PHASE_LABEL.exploration_in_strength}. Peça material bruto (rabiscos, notas, áudios, fotos — qualquer formato) produzido no canal ${strength_channel}. Isto não é desafio de tela: o artefato existe físico. Sua fala deve convidar produção autêntica, sem julgar qualidade.`;
+      case "translation_via_weakness":
+        return `Fase 2 — ${PHASE_LABEL.translation_via_weakness}. Convide a criança a CONVERTER o material da fase 1 usando canal ${weakness_channel}. A fraqueza é ponte, não treino isolado — sua função é ser o único caminho pra expressar o que a força criou.`;
+      case "presentation":
+        return `Fase 3 — ${PHASE_LABEL.presentation}. Incentive que o artefato final seja apresentado pra uma audiência real (irmão, responsável, amigo). Enfatize que não há nota nem score — só o ato de mostrar pra alguém importante.`;
+    }
+  })();
+
+  return [header, pair, phaseInstruction].join("\n");
+}
+
+/**
+ * Decide se o programa deve pausar AGORA dada a status matrix.
+ * Reusa `canEmitChallenge` pra enforçar a invariante emotional=brejo.
+ */
+export interface PauseDecision {
+  paused: boolean;
+  reason?: string;
+}
+
+export function shouldPauseProgram(matrix: StatusMatrix): PauseDecision {
+  const gate = canEmitChallenge(matrix, "cognitive_math");
+  if (!gate.ok && gate.reason === "emotional_brejo_blocks_all") {
+    return { paused: true, reason: "emotional_brejo" };
+  }
+  // Brejo no próprio emotional (gate bloqueia a dimensão alvo) também pausa.
+  const emotional = matrix["emotional"];
+  if (emotional === "brejo") {
+    return { paused: true, reason: "emotional_brejo" };
+  }
+  return { paused: false };
+}
+
+/**
+ * Avança fase: phase 1 → 2, 2 → 3, 3 → week+1 phase 1.
+ * Week 5 phase 3 → programa completo (retorna `null` em current_phase).
+ */
+export function nextPhase(state: GardnerProgramState): GardnerProgramState {
+  if (state.paused) return state;
+  const { current_week, current_phase } = state;
+  if (current_week === null || current_phase === null) {
+    // Primeiro turno — inicia week 1 phase 1.
+    return {
+      ...state,
+      current_week: 1,
+      current_phase: "exploration_in_strength",
+      phases_completed: 0,
+    };
+  }
+  const idx = PROGRAM_PHASES.indexOf(current_phase);
+  const newPhasesCompleted = state.phases_completed + 1;
+  if (idx < PROGRAM_PHASES.length - 1) {
+    return {
+      ...state,
+      current_phase: PROGRAM_PHASES[idx + 1]!,
+      phases_completed: newPhasesCompleted,
+    };
+  }
+  // Última fase da semana — avança semana.
+  if (current_week >= PROGRAM_LENGTH_WEEKS) {
+    // Programa completo.
+    return {
+      ...state,
+      current_phase: null,
+      current_week: null,
+      phases_completed: newPhasesCompleted,
+    };
+  }
+  return {
+    ...state,
+    current_week: current_week + 1,
+    current_phase: "exploration_in_strength",
+    phases_completed: newPhasesCompleted,
+  };
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,4 +1,5 @@
 import type { StatusMatrix } from "./status-matrix.js";
+import type { GardnerProgramState } from "./mixins/with-gardner-program.js";
 
 export interface PersonaDef {
   id: string;
@@ -29,6 +30,8 @@ export interface SessionState {
   turn: number;
   /** Hidratado por motor-execucao a partir de tree_nodes (zone='status'). */
   statusMatrix?: StatusMatrix;
+  /** Estado do programa Gardner 5 semanas (Bloco 2b). */
+  gardnerProgram?: GardnerProgramState;
 }
 
 export interface EventEntry {

--- a/shared/tests/with-gardner-program.test.ts
+++ b/shared/tests/with-gardner-program.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+  composeInstructionAddition,
+  isAssessmentReady,
+  pairForWeek,
+  shouldPauseProgram,
+  nextPhase,
+  PROGRAM_PHASES,
+  PROGRAM_LENGTH_WEEKS,
+  MIN_SESSIONS_FOR_ASSESSMENT,
+} from "../src/mixins/with-gardner-program.js";
+import type {
+  GardnerAssessment,
+  GardnerProgramState,
+} from "../src/mixins/with-gardner-program.js";
+import type { StatusMatrix } from "../src/status-matrix.js";
+
+const assessment: GardnerAssessment = {
+  top: ["linguistic", "logical_mathematical", "spatial", "interpersonal"],
+  bottom: ["musical", "bodily_kinesthetic", "naturalist", "existential"],
+  sessions_observed: 3,
+};
+
+describe("isAssessmentReady", () => {
+  it("accepts assessment with ≥3 sessions + top/bottom populated", () => {
+    expect(isAssessmentReady(assessment)).toBe(true);
+  });
+  it("rejects undefined", () => {
+    expect(isAssessmentReady(undefined)).toBe(false);
+  });
+  it("rejects <3 sessions", () => {
+    expect(isAssessmentReady({ ...assessment, sessions_observed: 2 })).toBe(false);
+  });
+  it("rejects empty top", () => {
+    expect(isAssessmentReady({ ...assessment, top: [] })).toBe(false);
+  });
+  it("MIN_SESSIONS é 3", () => {
+    expect(MIN_SESSIONS_FOR_ASSESSMENT).toBe(3);
+  });
+});
+
+describe("pairForWeek — tabela §4.2", () => {
+  it("semana 1 → Top#1 × Bottom#1", () => {
+    const p = pairForWeek(1, assessment);
+    expect(p).toEqual({
+      strength: "linguistic",
+      weakness: "musical",
+      multi_channel: false,
+    });
+  });
+  it("semana 2 → Top#2 × Bottom#2", () => {
+    const p = pairForWeek(2, assessment);
+    expect(p!.strength).toBe("logical_mathematical");
+    expect(p!.weakness).toBe("bodily_kinesthetic");
+  });
+  it("semana 5 é arremate multi-canal", () => {
+    const p = pairForWeek(5, assessment);
+    expect(p!.multi_channel).toBe(true);
+    expect(p!.strength).toBe("linguistic"); // volta pro Top#1
+  });
+  it("retorna null pra semana fora de 1-5", () => {
+    expect(pairForWeek(0, assessment)).toBeNull();
+    expect(pairForWeek(6, assessment)).toBeNull();
+  });
+  it("retorna null se assessment não pronto", () => {
+    expect(pairForWeek(1, { ...assessment, sessions_observed: 1 })).toBeNull();
+  });
+  it("PROGRAM_LENGTH_WEEKS é 5", () => {
+    expect(PROGRAM_LENGTH_WEEKS).toBe(5);
+  });
+});
+
+describe("composeInstructionAddition — cada fase produz instrução distinta", () => {
+  const base = {
+    week_number: 1,
+    day_in_week: 2,
+    strength_channel: "linguistic" as const,
+    weakness_channel: "musical" as const,
+  };
+
+  it("fase 1 exploration menciona off-screen + produção autêntica", () => {
+    const out = composeInstructionAddition({ ...base, phase: "exploration_in_strength" });
+    expect(out).toContain("Fase 1");
+    expect(out).toContain("semana 1/5");
+    expect(out).toContain("dia 2");
+    expect(out).toMatch(/linguistic/);
+    expect(out).toMatch(/musical/);
+  });
+
+  it("fase 2 translation menciona conversão via canal fraco", () => {
+    const out = composeInstructionAddition({ ...base, phase: "translation_via_weakness" });
+    expect(out).toContain("Fase 2");
+    expect(out).toMatch(/converter|CONVERTER/i);
+  });
+
+  it("fase 3 presentation menciona audiência real", () => {
+    const out = composeInstructionAddition({ ...base, phase: "presentation" });
+    expect(out).toContain("Fase 3");
+    expect(out).toMatch(/audiência|audiencia/i);
+  });
+
+  it("as 3 fases produzem outputs diferentes entre si", () => {
+    const t1 = composeInstructionAddition({ ...base, phase: "exploration_in_strength" });
+    const t2 = composeInstructionAddition({ ...base, phase: "translation_via_weakness" });
+    const t3 = composeInstructionAddition({ ...base, phase: "presentation" });
+    expect(t1).not.toBe(t2);
+    expect(t2).not.toBe(t3);
+    expect(t1).not.toBe(t3);
+  });
+
+  it("multi_channel=true muda o header para 'arremate multi-canal'", () => {
+    const out = composeInstructionAddition({
+      ...base,
+      week_number: 5,
+      phase: "exploration_in_strength",
+      multi_channel: true,
+    });
+    expect(out).toMatch(/arremate multi-canal/);
+  });
+
+  it("PROGRAM_PHASES tem 3 fases na ordem correta", () => {
+    expect(PROGRAM_PHASES).toEqual([
+      "exploration_in_strength",
+      "translation_via_weakness",
+      "presentation",
+    ]);
+  });
+});
+
+describe("shouldPauseProgram — invariante emotional=brejo", () => {
+  it("retorna paused=true quando emotional=brejo", () => {
+    const m: StatusMatrix = { emotional: "brejo" };
+    const r = shouldPauseProgram(m);
+    expect(r.paused).toBe(true);
+    expect(r.reason).toBe("emotional_brejo");
+  });
+  it("retorna paused=false com matrix saudável (baia/pasto)", () => {
+    const m: StatusMatrix = { emotional: "baia", cognitive_math: "pasto" };
+    expect(shouldPauseProgram(m).paused).toBe(false);
+  });
+  it("não pausa só por cognitive brejo (só emotional bloqueia)", () => {
+    const m: StatusMatrix = { emotional: "baia", cognitive_math: "brejo" };
+    expect(shouldPauseProgram(m).paused).toBe(false);
+  });
+  it("matrix vazia não pausa", () => {
+    expect(shouldPauseProgram({}).paused).toBe(false);
+  });
+});
+
+describe("nextPhase — transição de fases e semanas", () => {
+  const initial: GardnerProgramState = {
+    current_week: null,
+    current_day: 1,
+    current_phase: null,
+    paused: false,
+    phases_completed: 0,
+    consecutive_missed_milestones: 0,
+  };
+
+  it("estado inicial pula pra week 1 phase 1", () => {
+    const n = nextPhase(initial);
+    expect(n.current_week).toBe(1);
+    expect(n.current_phase).toBe("exploration_in_strength");
+  });
+
+  it("phase 1 → phase 2 (mesma semana)", () => {
+    const s: GardnerProgramState = {
+      ...initial,
+      current_week: 1,
+      current_phase: "exploration_in_strength",
+    };
+    const n = nextPhase(s);
+    expect(n.current_week).toBe(1);
+    expect(n.current_phase).toBe("translation_via_weakness");
+    expect(n.phases_completed).toBe(1);
+  });
+
+  it("phase 3 → week+1 phase 1", () => {
+    const s: GardnerProgramState = {
+      ...initial,
+      current_week: 2,
+      current_phase: "presentation",
+      phases_completed: 5,
+    };
+    const n = nextPhase(s);
+    expect(n.current_week).toBe(3);
+    expect(n.current_phase).toBe("exploration_in_strength");
+  });
+
+  it("week 5 phase 3 → programa completo (week/phase=null)", () => {
+    const s: GardnerProgramState = {
+      ...initial,
+      current_week: 5,
+      current_phase: "presentation",
+      phases_completed: 14,
+    };
+    const n = nextPhase(s);
+    expect(n.current_week).toBeNull();
+    expect(n.current_phase).toBeNull();
+    expect(n.phases_completed).toBe(15);
+  });
+
+  it("no-op quando pausado", () => {
+    const s: GardnerProgramState = {
+      ...initial,
+      current_week: 1,
+      current_phase: "exploration_in_strength",
+      paused: true,
+    };
+    const n = nextPhase(s);
+    expect(n.current_phase).toBe("exploration_in_strength");
+  });
+});


### PR DESCRIPTION
## Refs

- Handoff: [docs/handoffs/2026-04-24-cc-bloco2-plan.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/handoffs/2026-04-24-cc-bloco2-plan.md) §2.B
- Spec §6: [docs/fundamentos/ebrota-kids-fundamentos.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/fundamentos/ebrota-kids-fundamentos.md)
- Paper §4.2-4.3: [docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md)
- Base: motor#10 merged (`93523b7`)

## O que foi feito

Mixin `withGardnerProgram` conforme 4 requisitos (a-d):

**(a) Composer puro** — `shared/src/mixins/with-gardner-program.ts`
- Input: `{ week_number, day_in_week, strength_channel, weakness_channel, phase, multi_channel? }`
- Output: string 3-6 linhas pra `EvaluateAndSelectInput.instruction_addition`
- CADA fase produz texto distinto:
  - `exploration_in_strength` — material bruto off-screen
  - `translation_via_weakness` — conversão on-screen
  - `presentation` — audiência real off-screen
- Helpers: `pairForWeek`, `isAssessmentReady`, `nextPhase`, `shouldPauseProgram`

**(b) State tracking** — `motor-execucao/src/gardner-program.ts`
- DDL: `kids_gardner_program (session_id PK, week, day, phase, paused, reason, phases_completed, missed_milestones, ...)`
- `getProgramState`, `startProgram`, `advanceProgram` (throws se pausado), `pauseProgram`, `resumeProgram`, `recordMissedMilestone` (auto-pausa ao chegar em 2)
- 4 MCP tools expostas: `gardner_program_{start,advance,pause,resume}`
- `SessionState.gardnerProgram?` hidratado automaticamente em `getState`

**(c) Planejador consulta estado + popula instruction_addition**
- `plan.ts` ganha `buildGardnerInstruction(input)` que checa ativo + assessment pronto + matrix saudável antes de compor
- `PlanTurnOutput.instruction_addition?` novo (passthrough pra drota via orchestrator)
- `contextHints` ganha `gardner_program_active`, `gardner_current_week`, `gardner_pause_reason`

**(d) Invariante pausa em emotional=brejo**
- `shouldPauseProgram(matrix)` reusa `canEmitChallenge` do `shared/src/status-matrix.ts` — retorna `{paused:true, reason:'emotional_brejo'}` se bloqueio detectado
- Planejador aplica o gate antes de compor; se pausa, emite `instruction_addition: ""` e sinaliza via `contextHints.gardner_pause_reason`

## Resultados

### npm run build
✅ limpo nos 5 packages

### npm run test — 178 testes verdes (+46 sobre Bloco 2a)

| Package | Testes | Delta | Foco |
|---|---|---|---|
| shared | 92 | +26 | `with-gardner-program.test.ts` — pairForWeek × 6, compose × 6, pause invariant × 4, nextPhase × 5, assessment gate × 5 |
| planejador | 34 | +10 | `gardner-integration.test.ts` — 3 fases compose diferente, pausa brejo, assessment not_ready, pausa explícita, integração com `planTurn` |
| motor-drota | 18 | — | |
| motor-execucao | 32 | +10 | `gardner-program.test.ts` — CRUD + advance + pause/resume + missed-milestones auto-pause + isolamento de sessões |
| orchestrator | 2 | — | |

### npm run smoke
✅ Rubric G1-G3 verde

## Decisões de design

- **Mixin vive em `shared/src/mixins/`** — é pura composição de string, consumida por planejador; não precisa de runtime em motor-execucao. State CRUD fica separado em `motor-execucao/src/gardner-program.ts`.
- **Assessment vem de `persona.profile.gardner_assessment`** em v1 (fixture pattern, igual ao `domain_ranking` existente). Bloco 4 (onboarding parental) popula real.
- **Multi-channel semana 5** — base simples: volta ao Top#1×Bottom#1 + flag `multi_channel=true` no header. Compositor pode iterar em Bloco 3+.
- **Advance explícito via MCP tool**, não automático no execute_playbook — mantém separação limpa (executor registra evento, caller decide avançar programa).

## Débitos explícitos (Bloco 3+)

- Fixture real Ryo/Kei com assessment pós-onboarding (Bloco 4 produz)
- Lógica "sessão programa" vs "sessão livre" — quando chamar advance?
- Contador de `current_day` não auto-incrementa; caller decide quando virar dia
- STS traces v0.4 cobrindo programa ativo (Bloco 3 scope)

## Como testar

```bash
cd ascendimacy-motor
npm install
npm run build
npm run test   # 178 verdes
npm run smoke  # Rubric G1-G3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)