### PR TITLE
feat(#17 Bloco 3): observabilidade completa — trace v0.3 + weekly-report

### DIFF
--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -139,12 +139,37 @@ export async function runTurn(
     output: exec as unknown as Record<string, unknown>,
   });
 
+  // v0.3: enriquece o turn com snapshots e resumos.
+  const selectedItem = drota.selectedContent?.item;
+  const selectedSummary = selectedItem
+    ? {
+        id: String(selectedItem.id),
+        type: String(selectedItem.type),
+        score: Number(drota.selectedContent.score ?? 0),
+        domain: String(selectedItem.domain ?? ""),
+        surprise: Number(selectedItem.surprise ?? 0),
+        sacrifice_type: (selectedItem as { sacrifice_type?: string }).sacrifice_type,
+      }
+    : undefined;
+
+  const gardnerChannelsObserved =
+    (selectedItem as { gardner_channels?: import("@ascendimacy/shared").GardnerChannel[] } | undefined)?.gardner_channels;
+  const caselTargetsTouched = (selectedItem as { casel_target?: import("@ascendimacy/shared").CaselDimension[] } | undefined)?.casel_target;
+
   appendTurn(trace, {
     turnNumber: state.turn,
     sessionId,
+    timestamp: new Date().toISOString(),
     incomingMessage: message,
     entries: turnEntries,
     finalResponse: drota.linguisticMaterialization,
+    statusSnapshot: state.statusMatrix,
+    gardnerProgramSnapshot: state.gardnerProgram,
+    selectedContent: selectedSummary,
+    gardnerChannelsObserved,
+    caselTargetsTouched,
+    instructionAdditionApplied: (plan.instruction_addition ?? "") || undefined,
+    flags: { anomalies: [], warnings: [] },
   });
 
   const tracePath = saveTrace(trace, tracesDir);

--- a/orchestrator/src/trace-writer.ts
+++ b/orchestrator/src/trace-writer.ts
@@ -3,8 +3,12 @@ import { join } from "node:path";
 import type { SessionTrace, TurnTrace } from "@ascendimacy/shared";
 import { createSessionTrace } from "@ascendimacy/shared";
 
-export function initTrace(sessionId: string, persona: string): SessionTrace {
-  return createSessionTrace(sessionId, persona);
+export function initTrace(
+  sessionId: string,
+  persona: string,
+  personaAge?: number,
+): SessionTrace {
+  return createSessionTrace(sessionId, persona, personaAge);
 }
 
 export function appendTurn(trace: SessionTrace, turn: TurnTrace): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "planejador",
         "motor-drota",
         "motor-execucao",
-        "orchestrator"
+        "orchestrator",
+        "weekly-report"
       ],
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -122,6 +123,10 @@
     },
     "node_modules/@ascendimacy/shared": {
       "resolved": "shared",
+      "link": true
+    },
+    "node_modules/@ascendimacy/weekly-report": {
+      "resolved": "weekly-report",
       "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -944,6 +949,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -985,6 +999,16 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.13.9.tgz",
+      "integrity": "sha512-RDG8Yb1zT7I01FfpwK7nMSA433XWpblMqSCtA5vJlSyavWZb303HUYPCel6JTiDDFqwGLvtAnYbH8N/e0Cb89g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1176,6 +1200,22 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1191,6 +1231,21 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1267,6 +1322,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1308,6 +1381,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1376,6 +1467,15 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1467,6 +1567,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1512,6 +1618,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -1519,6 +1657,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -1547,6 +1719,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -1612,6 +1790,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-object-atoms": {
@@ -1878,6 +2076,38 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -1982,6 +2212,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -2055,6 +2294,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2195,6 +2458,20 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -2213,11 +2490,176 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
@@ -2231,6 +2673,73 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2246,6 +2755,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -2277,6 +2793,25 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",
@@ -2579,6 +3114,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2677,6 +3257,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2722,6 +3308,19 @@
         "node": "*"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.2.tgz",
+      "integrity": "sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2756,6 +3355,23 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.10",
@@ -2926,6 +3542,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2934,6 +3570,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -3016,6 +3658,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3077,6 +3736,38 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -3276,6 +3967,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3348,6 +4052,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3389,6 +4099,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3451,6 +4167,32 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -3666,6 +4408,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3779,6 +4579,20 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "*",
+        "typescript": "*",
+        "vitest": "*"
+      }
+    },
+    "weekly-report": {
+      "name": "@ascendimacy/weekly-report",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ascendimacy/shared": "*",
+        "pdfkit": "^0.15.0"
+      },
+      "devDependencies": {
+        "@types/node": "*",
+        "@types/pdfkit": "^0.13.0",
         "typescript": "*",
         "vitest": "*"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Motor canonico Ascendimacy - 3 servicos agênticos via MCP",
-  "workspaces": ["shared","planejador","motor-drota","motor-execucao","orchestrator"],
+  "workspaces": ["shared","planejador","motor-drota","motor-execucao","orchestrator","weekly-report"],
   "scripts": {
     "build": "npm run build -ws",
     "test": "npm run test -ws",

--- a/shared/src/trace-schema.ts
+++ b/shared/src/trace-schema.ts
@@ -1,5 +1,26 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { EventEntry } from "./types.js";
+/**
+ * Trace schema — Bloco 3 (#17) observabilidade completa.
+ *
+ * Spec: ascendimacy-ops/docs/fundamentos/ebrota-kids-observabilidade.md §2.
+ * Handoff: docs/handoffs/2026-04-24-cc-bloco2-plan.md + Bloco 3.
+ *
+ * v0.1.0 → v0.3.0 — TurnTrace enriquecida com:
+ *   - statusSnapshot (matrix completa do turn)
+ *   - gardnerProgramSnapshot (week/day/phase/paused)
+ *   - selectedContent (id, type, score) para replay
+ *   - gardnerChannelsObserved + caselTargetsTouched
+ *   - sacrificeSpent + screenSeconds
+ *   - instructionAdditionApplied (echo do string injetado no drota)
+ *   - statusTransitions + flags.anomalies/warnings
+ *
+ * Todos os campos v0.3 são OPCIONAIS — traces antigos continuam válidos.
+ */
+
+import type { StatusMatrix, StatusValue } from "./status-matrix.js";
+import type { GardnerProgramState } from "./mixins/with-gardner-program.js";
+import type { GardnerChannel, CaselDimension, ContentItemType } from "./content-item.js";
+
+export const TRACE_SCHEMA_VERSION = "0.3.0";
 
 export interface TraceEntry {
   service: "planejador" | "motor-drota" | "motor-execucao";
@@ -9,17 +30,67 @@ export interface TraceEntry {
   output: Record<string, unknown>;
 }
 
+/** Transição aplicada na status matrix dentro de um turn. */
+export interface StatusTransitionRecord {
+  dimension: string;
+  from: StatusValue | null;
+  to: StatusValue;
+  accepted: boolean;
+  reason: string;
+}
+
+export interface SelectedContentSummary {
+  id: string;
+  type: ContentItemType | string;
+  score: number;
+  domain: string;
+  surprise: number;
+  sacrifice_type?: string;
+}
+
+export interface TurnTraceFlags {
+  anomalies: string[];
+  warnings: string[];
+}
+
 export interface TurnTrace {
   turnNumber: number;
   sessionId: string;
+  /** ISO timestamp do turn (v0.3). */
+  timestamp?: string;
   incomingMessage: string;
   entries: TraceEntry[];
   finalResponse: string;
+
+  // ────── v0.3 enrichment (todos opcionais) ──────
+
+  /** Matrix status no início do turn. */
+  statusSnapshot?: StatusMatrix;
+  /** Estado do programa Gardner no início do turn. */
+  gardnerProgramSnapshot?: GardnerProgramState;
+  /** Resumo do content selecionado pelo drota. */
+  selectedContent?: SelectedContentSummary;
+  /** Canais Gardner que foram tocados no turn (derivado do content). */
+  gardnerChannelsObserved?: GardnerChannel[];
+  /** Dimensões CASEL alvo do content selecionado. */
+  caselTargetsTouched?: CaselDimension[];
+  /** Pontos de sacrifice debitados no turn. */
+  sacrificeSpent?: number;
+  /** Segundos de tela no turn. */
+  screenSeconds?: number;
+  /** Echo literal da instruction_addition injetada (debug + replay). */
+  instructionAdditionApplied?: string;
+  /** Transições de status aplicadas durante/após o turn. */
+  statusTransitions?: StatusTransitionRecord[];
+  /** Anomalias ou warnings detectados. */
+  flags?: TurnTraceFlags;
 }
 
 export interface SessionTrace {
   sessionId: string;
   persona: string;
+  /** v0.3: idade opcional pra contextualização em relatórios. */
+  personaAge?: number;
   startedAt: string;
   turns: TurnTrace[];
   meta: {
@@ -28,12 +99,17 @@ export interface SessionTrace {
   };
 }
 
-export function createSessionTrace(sessionId: string, persona: string): SessionTrace {
+export function createSessionTrace(
+  sessionId: string,
+  persona: string,
+  personaAge?: number,
+): SessionTrace {
   return {
     sessionId,
     persona,
+    personaAge,
     startedAt: new Date().toISOString(),
     turns: [],
-    meta: { schemaVersion: "1.0", motorVersion: "0.1.0" },
+    meta: { schemaVersion: TRACE_SCHEMA_VERSION, motorVersion: "0.3.0" },
   };
 }

--- a/shared/tests/trace-schema.test.ts
+++ b/shared/tests/trace-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createSessionTrace } from "../src/trace-schema.js";
+import { createSessionTrace, TRACE_SCHEMA_VERSION } from "../src/trace-schema.js";
 
 describe("createSessionTrace", () => {
   it("creates valid trace with empty turns", () => {
@@ -7,6 +7,20 @@ describe("createSessionTrace", () => {
     expect(trace.sessionId).toBe("session-001");
     expect(trace.persona).toBe("paula");
     expect(trace.turns).toHaveLength(0);
-    expect(trace.meta.schemaVersion).toBe("1.0");
+    expect(trace.meta.schemaVersion).toBe(TRACE_SCHEMA_VERSION);
+  });
+
+  it("schema version is bumped to 0.3.0 (Bloco 3)", () => {
+    expect(TRACE_SCHEMA_VERSION).toBe("0.3.0");
+  });
+
+  it("accepts optional personaAge", () => {
+    const trace = createSessionTrace("s1", "ryo", 13);
+    expect(trace.personaAge).toBe(13);
+  });
+
+  it("personaAge undefined when not provided", () => {
+    const trace = createSessionTrace("s1", "ryo");
+    expect(trace.personaAge).toBeUndefined();
   });
 });

--- a/weekly-report/fixtures/trace-v0.3-example.json
+++ b/weekly-report/fixtures/trace-v0.3-example.json
@@ -1,0 +1,47 @@
+{
+  "sessionId": "ryo-example-0001",
+  "persona": "ryo",
+  "personaAge": 13,
+  "startedAt": "2026-04-20T10:00:00.000Z",
+  "turns": [
+    {
+      "turnNumber": 0,
+      "sessionId": "ryo-example-0001",
+      "timestamp": "2026-04-20T10:00:00.000Z",
+      "incomingMessage": "oi",
+      "entries": [],
+      "finalResponse": "Olá Ryo! Sabia que os Inuit têm 50+ palavras pra neve?",
+      "statusSnapshot": {
+        "emotional": "baia",
+        "social_with_ebrota": "baia",
+        "social_with_parent": "baia",
+        "social_with_sibling": "baia"
+      },
+      "gardnerProgramSnapshot": {
+        "current_week": 1,
+        "current_day": 1,
+        "current_phase": "exploration_in_strength",
+        "paused": false,
+        "phases_completed": 0,
+        "consecutive_missed_milestones": 0,
+        "updated_at": "2026-04-20T10:00:00.000Z"
+      },
+      "selectedContent": {
+        "id": "ling_inuit_snow",
+        "type": "curiosity_hook",
+        "score": 9,
+        "domain": "linguistics",
+        "surprise": 9,
+        "sacrifice_type": "reflect"
+      },
+      "gardnerChannelsObserved": ["linguistic", "intrapersonal"],
+      "caselTargetsTouched": ["SA", "SM"],
+      "sacrificeSpent": 1,
+      "screenSeconds": 180,
+      "instructionAdditionApplied": "[programa dual-helix | semana 1/5 | dia 1]\nForça da semana: linguistic. Fraqueza a trabalhar: musical.\nFase 1 — exploração na força (off-screen)...",
+      "statusTransitions": [],
+      "flags": { "anomalies": [], "warnings": [] }
+    }
+  ],
+  "meta": { "schemaVersion": "0.3.0", "motorVersion": "0.3.0" }
+}

--- a/weekly-report/package.json
+++ b/weekly-report/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@ascendimacy/weekly-report",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@ascendimacy/shared": "*",
+    "pdfkit": "^0.15.0"
+  },
+  "devDependencies": {
+    "typescript": "*",
+    "vitest": "*",
+    "@types/node": "*",
+    "@types/pdfkit": "^0.13.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}

--- a/weekly-report/src/aggregate.ts
+++ b/weekly-report/src/aggregate.ts
@@ -1,0 +1,244 @@
+/**
+ * Aggregate — funções puras sobre SessionTrace[] → WeeklyReportData.
+ * Zero I/O, zero clock ambiente, determinístico.
+ */
+
+import type {
+  SessionTrace,
+  StatusMatrix,
+  StatusValue,
+  GardnerChannel,
+  CaselDimension,
+} from "@ascendimacy/shared";
+import { isStatusValue } from "@ascendimacy/shared";
+import type {
+  CardSummary,
+  IgnitionEvent,
+  StatusComparison,
+  AspirationSignal,
+  WeeklyReportOptions,
+  WeeklyReportData,
+  WeekRange,
+} from "./types.js";
+import { computeMetrics } from "./metrics.js";
+
+/** Derive cards (conteúdo que virou sessão) a partir dos turns. */
+export function aggregateCards(traces: SessionTrace[]): CardSummary[] {
+  const out: CardSummary[] = [];
+  for (const trace of traces) {
+    for (const turn of trace.turns) {
+      const sel = turn.selectedContent;
+      if (!sel) continue;
+      out.push({
+        content_id: sel.id,
+        content_type: sel.type,
+        domain: sel.domain,
+        casel_targets: turn.caselTargetsTouched ?? [],
+        gardner_channels: turn.gardnerChannelsObserved ?? [],
+        sacrifice_spent: turn.sacrificeSpent ?? 0,
+        turn: turn.turnNumber,
+        session_id: trace.sessionId,
+        timestamp: turn.timestamp,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Compara status matrix da semana atual (inferida do último turn)
+ * vs prev matrix (opcional). Retorna 1 entry por dimensão.
+ */
+export function compareStatusMatrices(
+  traces: SessionTrace[],
+  previous: StatusMatrix | undefined,
+): StatusComparison[] {
+  // Pega último statusSnapshot não-vazio dos traces.
+  let latest: StatusMatrix | undefined;
+  for (let i = traces.length - 1; i >= 0; i--) {
+    const t = traces[i];
+    if (!t) continue;
+    for (let j = t.turns.length - 1; j >= 0; j--) {
+      const snap = t.turns[j]?.statusSnapshot;
+      if (snap) {
+        latest = snap;
+        break;
+      }
+    }
+    if (latest) break;
+  }
+  if (!latest) return [];
+
+  const dimensions = new Set<string>([
+    ...Object.keys(latest),
+    ...(previous ? Object.keys(previous) : []),
+  ]);
+  const out: StatusComparison[] = [];
+  for (const dim of dimensions) {
+    const prev = previous?.[dim];
+    const curr = latest[dim];
+    if (!curr || !isStatusValue(curr)) continue;
+    let trend: StatusComparison["trend"];
+    if (!prev) trend = "new";
+    else if (prev === curr) trend = "stable";
+    else trend = compareTrend(prev, curr);
+    out.push({
+      dimension: dim,
+      previous: prev ?? null,
+      current: curr,
+      trend,
+    });
+  }
+  return out.sort((a, b) => a.dimension.localeCompare(b.dimension));
+}
+
+function compareTrend(prev: StatusValue, curr: StatusValue): StatusComparison["trend"] {
+  const rank: Record<StatusValue, number> = { brejo: 0, baia: 1, pasto: 2 };
+  if (rank[curr] > rank[prev]) return "improved";
+  if (rank[curr] < rank[prev]) return "worsened";
+  return "stable";
+}
+
+/**
+ * Detecta ignições — turns onde ≥3 canais Gardner × ≥2 dimensões CASEL
+ * foram simultaneamente ativados (§2.2 paper).
+ */
+export function detectIgnitions(traces: SessionTrace[]): IgnitionEvent[] {
+  const out: IgnitionEvent[] = [];
+  for (const trace of traces) {
+    for (const turn of trace.turns) {
+      const channels = turn.gardnerChannelsObserved ?? [];
+      const dims = turn.caselTargetsTouched ?? [];
+      const uniqC = uniqueGardner(channels);
+      const uniqD = uniqueCasel(dims);
+      const ignited = uniqC.length >= 3 && uniqD.length >= 2;
+      if (uniqC.length === 0 && uniqD.length === 0) continue;
+      out.push({
+        session_id: trace.sessionId,
+        turn: turn.turnNumber,
+        gardner_channels: uniqC,
+        casel_dimensions: uniqD,
+        ignited,
+      });
+    }
+  }
+  return out;
+}
+
+function uniqueGardner(arr: GardnerChannel[]): GardnerChannel[] {
+  return Array.from(new Set(arr));
+}
+
+function uniqueCasel(arr: CaselDimension[]): CaselDimension[] {
+  return Array.from(new Set(arr));
+}
+
+/**
+ * Extrai sinais de aspiração emergente — domínios/temas que aparecem em
+ * múltiplos turns. Threshold: ≥3 ocorrências.
+ */
+export function extractAspirations(traces: SessionTrace[]): AspirationSignal[] {
+  const byKey = new Map<string, {
+    occurrences: number;
+    firstTurn: number;
+    lastTurn: number;
+    contexts: string[];
+  }>();
+
+  for (const trace of traces) {
+    for (const turn of trace.turns) {
+      const sel = turn.selectedContent;
+      if (!sel) continue;
+      const key = sel.domain;
+      if (!key) continue;
+      const entry = byKey.get(key);
+      const context = sel.id;
+      if (!entry) {
+        byKey.set(key, {
+          occurrences: 1,
+          firstTurn: turn.turnNumber,
+          lastTurn: turn.turnNumber,
+          contexts: [context],
+        });
+      } else {
+        entry.occurrences += 1;
+        entry.lastTurn = turn.turnNumber;
+        if (!entry.contexts.includes(context)) entry.contexts.push(context);
+      }
+    }
+  }
+
+  const out: AspirationSignal[] = [];
+  for (const [key, entry] of byKey.entries()) {
+    if (entry.occurrences < 3) continue;
+    out.push({
+      key,
+      occurrences: entry.occurrences,
+      first_seen_turn: entry.firstTurn,
+      last_seen_turn: entry.lastTurn,
+      contexts: entry.contexts.slice(0, 5),
+    });
+  }
+  return out.sort((a, b) => b.occurrences - a.occurrences);
+}
+
+/** Pega estado Gardner do último turn disponível. */
+function latestProgramStatus(traces: SessionTrace[]): WeeklyReportData["program_status"] {
+  for (let i = traces.length - 1; i >= 0; i--) {
+    const t = traces[i];
+    if (!t) continue;
+    for (let j = t.turns.length - 1; j >= 0; j--) {
+      const snap = t.turns[j]?.gardnerProgramSnapshot;
+      if (snap) {
+        return {
+          current_week: snap.current_week,
+          current_phase: snap.current_phase,
+          paused: snap.paused,
+          paused_reason: snap.paused_reason,
+        };
+      }
+    }
+  }
+  return {
+    current_week: null,
+    current_phase: null,
+    paused: false,
+  };
+}
+
+/** Inferir range de datas a partir dos traces (min/max timestamps). */
+function deriveWeekRange(traces: SessionTrace[]): WeekRange {
+  let minTs: string | undefined;
+  let maxTs: string | undefined;
+  for (const t of traces) {
+    for (const turn of t.turns) {
+      const ts = turn.timestamp ?? t.startedAt;
+      if (!minTs || ts < minTs) minTs = ts;
+      if (!maxTs || ts > maxTs) maxTs = ts;
+    }
+  }
+  return {
+    from: minTs ?? new Date().toISOString(),
+    to: maxTs ?? new Date().toISOString(),
+  };
+}
+
+/** Entrypoint: SessionTrace[] + opts → WeeklyReportData. */
+export function aggregate(
+  traces: SessionTrace[],
+  childName: string,
+  opts: WeeklyReportOptions = {},
+): WeeklyReportData {
+  const childAge = traces.find((t) => t.personaAge !== undefined)?.personaAge ?? null;
+  return {
+    child_name: childName,
+    child_age: childAge,
+    week: opts.week_range ?? deriveWeekRange(traces),
+    program_status: latestProgramStatus(traces),
+    cards: aggregateCards(traces),
+    status_comparison: compareStatusMatrices(traces, opts.previous_matrix),
+    ignitions: detectIgnitions(traces),
+    aspirations: extractAspirations(traces),
+    metrics: computeMetrics(traces),
+  };
+}

--- a/weekly-report/src/index.ts
+++ b/weekly-report/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * @ascendimacy/weekly-report
+ * Bloco 3 #17 — relatório semanal a partir de traces v0.3.
+ *
+ * API canônica:
+ *   generateWeeklyReport(traces, childName, options?) →
+ *     { data, markdown, renderPdf() }
+ *
+ * PDF é função assíncrona — caller invoca só se quiser output binário.
+ */
+
+import type { SessionTrace } from "@ascendimacy/shared";
+import type { WeeklyReportData, WeeklyReportOptions } from "./types.js";
+import { aggregate } from "./aggregate.js";
+import { renderMarkdown } from "./markdown.js";
+import { renderPdf } from "./pdf.js";
+
+export * from "./types.js";
+export { aggregate, aggregateCards, compareStatusMatrices, detectIgnitions, extractAspirations } from "./aggregate.js";
+export { computeMetrics } from "./metrics.js";
+export { renderMarkdown } from "./markdown.js";
+export { renderPdf } from "./pdf.js";
+
+export interface GeneratedReport {
+  data: WeeklyReportData;
+  markdown: string;
+  renderPdf(): Promise<Buffer>;
+}
+
+export function generateWeeklyReport(
+  traces: SessionTrace[],
+  childName: string,
+  options: WeeklyReportOptions = {},
+): GeneratedReport {
+  const data = aggregate(traces, childName, options);
+  const markdown = renderMarkdown(data);
+  return {
+    data,
+    markdown,
+    renderPdf: () => renderPdf(data),
+  };
+}

--- a/weekly-report/src/markdown.ts
+++ b/weekly-report/src/markdown.ts
@@ -1,0 +1,161 @@
+/**
+ * Renderiza WeeklyReportData em markdown pt-BR legível.
+ * Zero dependência externa, testável por regex/asserção de conteúdo.
+ */
+
+import type {
+  WeeklyReportData,
+  StatusComparison,
+  IgnitionEvent,
+  CardSummary,
+  AspirationSignal,
+} from "./types.js";
+
+const TREND_EMOJI: Record<StatusComparison["trend"], string> = {
+  improved: "↑",
+  worsened: "↓",
+  stable: "→",
+  new: "✨",
+};
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toISOString().slice(0, 10);
+  } catch {
+    return iso;
+  }
+}
+
+function renderHeader(data: WeeklyReportData): string {
+  const ageStr = data.child_age !== null ? `${data.child_age}a` : "idade ?";
+  return [
+    `# Semana de ${data.child_name} (${ageStr})`,
+    ``,
+    `**Período:** ${formatDate(data.week.from)} → ${formatDate(data.week.to)}`,
+    ``,
+  ].join("\n");
+}
+
+function renderProgram(data: WeeklyReportData): string {
+  const p = data.program_status;
+  if (p.current_week === null) {
+    return `## Programa Dual Helix\n\nPrograma não iniciado.\n`;
+  }
+  const pauseLine = p.paused ? ` — **pausado** (${p.paused_reason ?? "sem motivo registrado"})` : "";
+  return [
+    `## Programa Dual Helix`,
+    ``,
+    `Semana ${p.current_week}/5 · fase: ${p.current_phase ?? "—"}${pauseLine}`,
+    ``,
+  ].join("\n");
+}
+
+function renderCards(cards: CardSummary[]): string {
+  if (cards.length === 0) return `## Cards recebidos\n\nNenhum card nesta semana.\n`;
+  const lines = [
+    `## Cards recebidos (${cards.length})`,
+    ``,
+    `| # | Conteúdo | Tipo | Domínio | CASEL | Gardner | Sacrifice |`,
+    `|---|---|---|---|---|---|---|`,
+  ];
+  cards.slice(0, 10).forEach((c, i) => {
+    lines.push(
+      `| ${i + 1} | ${c.content_id} | ${c.content_type} | ${c.domain} | ${c.casel_targets.join(",") || "—"} | ${c.gardner_channels.join(",") || "—"} | ${c.sacrifice_spent} |`,
+    );
+  });
+  if (cards.length > 10) lines.push(`\n*(+${cards.length - 10} outros omitidos)*`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderStatus(sc: StatusComparison[]): string {
+  if (sc.length === 0)
+    return `## Status matriz (vs semana anterior)\n\nSem dados de comparação.\n`;
+  const lines = [
+    `## Status matriz (vs semana anterior)`,
+    ``,
+    `| Dimensão | Antes | Agora | Tendência |`,
+    `|---|---|---|---|`,
+  ];
+  for (const row of sc) {
+    lines.push(
+      `| ${row.dimension} | ${row.previous ?? "—"} | ${row.current} | ${TREND_EMOJI[row.trend]} ${row.trend} |`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderIgnitions(igs: IgnitionEvent[]): string {
+  const ignited = igs.filter((i) => i.ignited);
+  if (ignited.length === 0) {
+    return `## Combinações Helix que acenderam\n\nNenhuma ignição (≥3 canais Gardner × ≥2 CASEL) nesta semana.\n`;
+  }
+  const lines = [
+    `## Combinações Helix que acenderam (${ignited.length})`,
+    ``,
+    `> Ignição = ≥3 canais Gardner × ≥2 dimensões CASEL simultâneos no mesmo turn.`,
+    ``,
+  ];
+  for (const ig of ignited.slice(0, 8)) {
+    lines.push(
+      `- Turn ${ig.turn} (${ig.session_id.slice(0, 12)}): ${ig.gardner_channels.join(" × ")} / ${ig.casel_dimensions.join(" + ")}`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderAspirations(aps: AspirationSignal[]): string {
+  if (aps.length === 0)
+    return `## Sinais de aspiração emergente\n\nSem temas recorrentes (threshold: 3+ ocorrências).\n`;
+  const lines = [
+    `## Sinais de aspiração emergente`,
+    ``,
+    `> Temas que repetiram ≥3 vezes. Não são "aspiração" ainda — são sinais a observar.`,
+    ``,
+  ];
+  for (const a of aps) {
+    lines.push(
+      `- **${a.key}** — ${a.occurrences}x (turns ${a.first_seen_turn}–${a.last_seen_turn}; ex: ${a.contexts.slice(0, 3).join(", ")})`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderMetrics(data: WeeklyReportData): string {
+  const m = data.metrics;
+  const ratio =
+    m.off_on_screen_ratio.ratio === Infinity
+      ? "∞ (tudo off-screen)"
+      : m.off_on_screen_ratio.ratio.toFixed(2);
+  return [
+    `## Métricas operacionais`,
+    ``,
+    `| Métrica | Valor |`,
+    `|---|---|`,
+    `| Turns totais | ${m.total_turns} |`,
+    `| Sessões | ${m.total_sessions} |`,
+    `| Ratio off:on screen | ${ratio} (${m.off_on_screen_ratio.off} off / ${m.off_on_screen_ratio.on} on) |`,
+    `| Sessões c/ brejo | ${m.sessions_in_brejo} |`,
+    `| Frequência de pausa do programa | ${(m.program_pause_frequency * 100).toFixed(0)}% |`,
+    `| Milestones faltantes (acumulado) | ${m.missed_milestones_total} |`,
+    `| Sacrifice médio/turn | ${m.avg_sacrifice_per_turn.toFixed(2)} |`,
+    `| Tempo de tela (s) | ${m.total_screen_seconds} |`,
+    ``,
+  ].join("\n");
+}
+
+export function renderMarkdown(data: WeeklyReportData): string {
+  return [
+    renderHeader(data),
+    renderProgram(data),
+    renderCards(data.cards),
+    renderStatus(data.status_comparison),
+    renderIgnitions(data.ignitions),
+    renderAspirations(data.aspirations),
+    renderMetrics(data),
+    `---\n\n> 🌳 Crescer para colher.\n`,
+  ].join("\n");
+}

--- a/weekly-report/src/metrics.ts
+++ b/weekly-report/src/metrics.ts
@@ -1,0 +1,104 @@
+/**
+ * Métricas operacionais conforme Bloco 3 requisito (c):
+ *   - ratio off:on screen
+ *   - sessions in brejo
+ *   - programa pause frequency
+ *   - missed milestones
+ *
+ * Função pura sobre SessionTrace[].
+ */
+
+import type { SessionTrace } from "@ascendimacy/shared";
+import type { OperationalMetrics } from "./types.js";
+
+/**
+ * Classificação off/on screen — heurística simples baseada em
+ * content type + sacrifice_type:
+ *   - content.type in {challenge, dynamic} com sacrifice_type 'act'|'create'|'observe' → off-screen
+ *   - demais → on-screen (chat)
+ *
+ * A API é uma função pura que retorna 'off' ou 'on'.
+ */
+function classifyTurnLocation(
+  contentType: string | undefined,
+  sacrificeType: string | undefined,
+): "off" | "on" {
+  const offTypes = new Set(["challenge", "dynamic", "gtd_task"]);
+  const offSacrifice = new Set(["act", "create", "observe"]);
+  if (contentType && offTypes.has(contentType)) return "off";
+  if (sacrificeType && offSacrifice.has(sacrificeType)) return "off";
+  return "on";
+}
+
+export function computeMetrics(traces: SessionTrace[]): OperationalMetrics {
+  let totalTurns = 0;
+  let off = 0;
+  let on = 0;
+  let sessionsWithBrejo = 0;
+  let pauses = 0;
+  let lastMissedMilestones = 0;
+  let sacrificeSum = 0;
+  let screenSum = 0;
+
+  const sessionIds = new Set<string>();
+
+  for (const trace of traces) {
+    sessionIds.add(trace.sessionId);
+    let sessionHadBrejo = false;
+    let sessionHadPause = false;
+    for (const turn of trace.turns) {
+      totalTurns += 1;
+      // Off/on classification.
+      const sel = turn.selectedContent;
+      const loc = classifyTurnLocation(sel?.type, sel?.sacrifice_type);
+      if (loc === "off") off += 1;
+      else on += 1;
+
+      // Brejo detection.
+      const snap = turn.statusSnapshot;
+      if (snap) {
+        for (const v of Object.values(snap)) {
+          if (v === "brejo") {
+            sessionHadBrejo = true;
+            break;
+          }
+        }
+      }
+
+      // Programa pause.
+      const prog = turn.gardnerProgramSnapshot;
+      if (prog?.paused) sessionHadPause = true;
+
+      // Sacrifice + screen seconds.
+      if (typeof turn.sacrificeSpent === "number") {
+        sacrificeSum += turn.sacrificeSpent;
+      }
+      if (typeof turn.screenSeconds === "number") {
+        screenSum += turn.screenSeconds;
+      }
+
+      // Missed milestones — usa sempre o último snapshot disponível.
+      if (prog && typeof prog.consecutive_missed_milestones === "number") {
+        lastMissedMilestones = prog.consecutive_missed_milestones;
+      }
+    }
+    if (sessionHadBrejo) sessionsWithBrejo += 1;
+    if (sessionHadPause) pauses += 1;
+  }
+
+  const totalSessions = sessionIds.size;
+  const ratio = on === 0 ? (off > 0 ? Infinity : 0) : off / on;
+
+  return {
+    total_turns: totalTurns,
+    total_sessions: totalSessions,
+    off_on_screen_ratio: { off, on, ratio },
+    sessions_in_brejo: sessionsWithBrejo,
+    program_pause_frequency:
+      totalSessions === 0 ? 0 : pauses / totalSessions,
+    missed_milestones_total: lastMissedMilestones,
+    avg_sacrifice_per_turn:
+      totalTurns === 0 ? 0 : sacrificeSum / totalTurns,
+    total_screen_seconds: screenSum,
+  };
+}

--- a/weekly-report/src/pdf.ts
+++ b/weekly-report/src/pdf.ts
@@ -1,0 +1,167 @@
+/**
+ * PDF renderer — pdfkit. Gera documento estruturado do WeeklyReportData.
+ *
+ * API retorna Buffer (ou Promise<Buffer>) — sem I/O de disco aqui.
+ * Caller decide onde escrever (ou envia por email/WhatsApp).
+ */
+
+import PDFDocument from "pdfkit";
+import type {
+  WeeklyReportData,
+  StatusComparison,
+  CardSummary,
+  IgnitionEvent,
+  AspirationSignal,
+} from "./types.js";
+
+interface PdfOptions {
+  /** Default 'A4'. */
+  size?: string;
+  /** Default 40 (pontos, ~14mm). */
+  margin?: number;
+}
+
+const TREND_SYMBOL: Record<StatusComparison["trend"], string> = {
+  improved: "↑ melhorou",
+  worsened: "↓ piorou",
+  stable: "→ estável",
+  new: "✨ novo",
+};
+
+function writeHeader(doc: PDFKit.PDFDocument, data: WeeklyReportData): void {
+  const ageStr = data.child_age !== null ? `${data.child_age} anos` : "idade ?";
+  doc.fontSize(20).text(`Semana de ${data.child_name}`, { align: "left" });
+  doc.fontSize(10).fillColor("#555").text(ageStr);
+  doc
+    .moveDown(0.3)
+    .text(`Período: ${data.week.from.slice(0, 10)} → ${data.week.to.slice(0, 10)}`);
+  doc.fillColor("black").moveDown(1);
+}
+
+function writeProgram(doc: PDFKit.PDFDocument, data: WeeklyReportData): void {
+  doc.fontSize(14).text("Programa Dual Helix");
+  doc.fontSize(10).moveDown(0.2);
+  const p = data.program_status;
+  if (p.current_week === null) {
+    doc.text("Programa não iniciado.");
+  } else {
+    const pauseNote = p.paused
+      ? ` — pausado (${p.paused_reason ?? "sem motivo"})`
+      : "";
+    doc.text(`Semana ${p.current_week}/5 · fase: ${p.current_phase ?? "—"}${pauseNote}`);
+  }
+  doc.moveDown(1);
+}
+
+function writeCards(doc: PDFKit.PDFDocument, cards: CardSummary[]): void {
+  doc.fontSize(14).text(`Cards recebidos (${cards.length})`);
+  doc.fontSize(9).moveDown(0.2);
+  if (cards.length === 0) {
+    doc.text("Nenhum card nesta semana.");
+  } else {
+    for (const c of cards.slice(0, 12)) {
+      const line = `• ${c.content_id} [${c.content_type}] dom:${c.domain} CASEL:${c.casel_targets.join(",") || "—"} Gardner:${c.gardner_channels.join(",") || "—"} sac:${c.sacrifice_spent}`;
+      doc.text(line);
+    }
+    if (cards.length > 12) doc.text(`… +${cards.length - 12} outros`);
+  }
+  doc.moveDown(1);
+}
+
+function writeStatus(doc: PDFKit.PDFDocument, sc: StatusComparison[]): void {
+  doc.fontSize(14).text("Status matriz (vs semana anterior)");
+  doc.fontSize(9).moveDown(0.2);
+  if (sc.length === 0) {
+    doc.text("Sem dados de comparação.");
+  } else {
+    for (const row of sc) {
+      doc.text(
+        `• ${row.dimension}: ${row.previous ?? "—"} → ${row.current} (${TREND_SYMBOL[row.trend]})`,
+      );
+    }
+  }
+  doc.moveDown(1);
+}
+
+function writeIgnitions(doc: PDFKit.PDFDocument, igs: IgnitionEvent[]): void {
+  const ignited = igs.filter((i) => i.ignited);
+  doc.fontSize(14).text(`Combinações Helix que acenderam (${ignited.length})`);
+  doc.fontSize(9).moveDown(0.2);
+  if (ignited.length === 0) {
+    doc.text("Nenhuma ignição (≥3 canais Gardner × ≥2 CASEL).");
+  } else {
+    for (const ig of ignited.slice(0, 10)) {
+      doc.text(
+        `• turn ${ig.turn} — ${ig.gardner_channels.join("×")} / ${ig.casel_dimensions.join("+")}`,
+      );
+    }
+  }
+  doc.moveDown(1);
+}
+
+function writeAspirations(doc: PDFKit.PDFDocument, aps: AspirationSignal[]): void {
+  doc.fontSize(14).text("Sinais de aspiração emergente");
+  doc.fontSize(9).moveDown(0.2);
+  if (aps.length === 0) {
+    doc.text("Sem temas recorrentes.");
+  } else {
+    for (const a of aps) {
+      doc.text(
+        `• ${a.key} — ${a.occurrences}x (turns ${a.first_seen_turn}–${a.last_seen_turn})`,
+      );
+    }
+  }
+  doc.moveDown(1);
+}
+
+function writeMetrics(doc: PDFKit.PDFDocument, data: WeeklyReportData): void {
+  const m = data.metrics;
+  doc.fontSize(14).text("Métricas operacionais");
+  doc.fontSize(9).moveDown(0.2);
+  const ratio =
+    m.off_on_screen_ratio.ratio === Infinity
+      ? "∞ (tudo off)"
+      : m.off_on_screen_ratio.ratio.toFixed(2);
+  doc.text(`Turns totais: ${m.total_turns}`);
+  doc.text(`Sessões: ${m.total_sessions}`);
+  doc.text(
+    `Ratio off:on screen: ${ratio} (${m.off_on_screen_ratio.off} off / ${m.off_on_screen_ratio.on} on)`,
+  );
+  doc.text(`Sessões com brejo: ${m.sessions_in_brejo}`);
+  doc.text(
+    `Frequência de pausa do programa: ${(m.program_pause_frequency * 100).toFixed(0)}%`,
+  );
+  doc.text(`Milestones faltantes acumulados: ${m.missed_milestones_total}`);
+  doc.text(`Sacrifice médio/turn: ${m.avg_sacrifice_per_turn.toFixed(2)}`);
+  doc.text(`Tempo de tela total (s): ${m.total_screen_seconds}`);
+  doc.moveDown(1);
+}
+
+/** Renderiza o relatório como Buffer PDF. */
+export function renderPdf(
+  data: WeeklyReportData,
+  opts: PdfOptions = {},
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDFDocument({ size: opts.size ?? "A4", margin: opts.margin ?? 40 });
+      const chunks: Buffer[] = [];
+      doc.on("data", (chunk: Buffer) => chunks.push(chunk));
+      doc.on("end", () => resolve(Buffer.concat(chunks)));
+      doc.on("error", reject);
+
+      writeHeader(doc, data);
+      writeProgram(doc, data);
+      writeCards(doc, data.cards);
+      writeStatus(doc, data.status_comparison);
+      writeIgnitions(doc, data.ignitions);
+      writeAspirations(doc, data.aspirations);
+      writeMetrics(doc, data);
+
+      doc.fontSize(8).fillColor("#888").moveDown(1).text("🌳 Crescer para colher.");
+      doc.end();
+    } catch (err) {
+      reject(err as Error);
+    }
+  });
+}

--- a/weekly-report/src/types.ts
+++ b/weekly-report/src/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Tipos de saída do weekly-report — aggregate + metrics + render.
+ *
+ * Spec: ascendimacy-ops/docs/fundamentos/ebrota-kids-observabilidade.md
+ * Handoff #17 Bloco 3.
+ */
+
+import type {
+  GardnerChannel,
+  CaselDimension,
+  StatusMatrix,
+  StatusValue,
+} from "@ascendimacy/shared";
+
+export interface WeekRange {
+  /** ISO date (inclusive). */
+  from: string;
+  /** ISO date (exclusive). */
+  to: string;
+}
+
+export interface CardSummary {
+  content_id: string;
+  content_type: string;
+  domain: string;
+  casel_targets: CaselDimension[];
+  gardner_channels: GardnerChannel[];
+  sacrifice_spent: number;
+  turn: number;
+  session_id: string;
+  timestamp?: string;
+}
+
+export interface StatusComparison {
+  dimension: string;
+  previous: StatusValue | null;
+  current: StatusValue;
+  trend: "improved" | "worsened" | "stable" | "new";
+}
+
+/** Combinação de canais Gardner × dimensões CASEL ativados numa sessão. */
+export interface IgnitionEvent {
+  session_id: string;
+  turn: number;
+  gardner_channels: GardnerChannel[];
+  casel_dimensions: CaselDimension[];
+  /** Score de ignição: ≥3 canais + ≥2 dimensões (§2.2 paper). */
+  ignited: boolean;
+}
+
+/** Métrica de sinal emergente — o que repete pode virar aspiração. */
+export interface AspirationSignal {
+  key: string;
+  occurrences: number;
+  first_seen_turn: number;
+  last_seen_turn: number;
+  contexts: string[];
+}
+
+export interface OperationalMetrics {
+  total_turns: number;
+  total_sessions: number;
+  off_on_screen_ratio: { off: number; on: number; ratio: number };
+  sessions_in_brejo: number;
+  program_pause_frequency: number;
+  missed_milestones_total: number;
+  avg_sacrifice_per_turn: number;
+  total_screen_seconds: number;
+}
+
+export interface WeeklyReportData {
+  child_name: string;
+  child_age: number | null;
+  week: WeekRange;
+  program_status: {
+    current_week: number | null;
+    current_phase: string | null;
+    paused: boolean;
+    paused_reason?: string;
+  };
+  cards: CardSummary[];
+  status_comparison: StatusComparison[];
+  ignitions: IgnitionEvent[];
+  aspirations: AspirationSignal[];
+  metrics: OperationalMetrics;
+}
+
+export interface WeeklyReportOptions {
+  /** Status matrix da semana anterior — pra comparação. */
+  previous_matrix?: StatusMatrix;
+  /** Range de datas; se omitido, tenta derivar dos traces. */
+  week_range?: WeekRange;
+}

--- a/weekly-report/tests/aggregate.test.ts
+++ b/weekly-report/tests/aggregate.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from "vitest";
+import type {
+  SessionTrace,
+  StatusMatrix,
+  TurnTrace,
+  GardnerChannel,
+  CaselDimension,
+} from "@ascendimacy/shared";
+import {
+  aggregate,
+  aggregateCards,
+  compareStatusMatrices,
+  detectIgnitions,
+  extractAspirations,
+} from "../src/aggregate.js";
+
+function turn(overrides: Partial<TurnTrace> = {}): TurnTrace {
+  return {
+    turnNumber: 0,
+    sessionId: "s1",
+    incomingMessage: "x",
+    entries: [],
+    finalResponse: "y",
+    ...overrides,
+  };
+}
+
+function trace(id: string, turns: TurnTrace[], age?: number): SessionTrace {
+  return {
+    sessionId: id,
+    persona: "ryo",
+    personaAge: age,
+    startedAt: "2026-04-20T10:00:00.000Z",
+    turns,
+    meta: { schemaVersion: "0.3.0", motorVersion: "0.3.0" },
+  };
+}
+
+describe("aggregateCards", () => {
+  it("extracts one card per turn with selectedContent", () => {
+    const t = trace("s1", [
+      turn({ selectedContent: { id: "h1", type: "curiosity_hook", score: 7, domain: "biology", surprise: 8 } }),
+      turn({ turnNumber: 1, selectedContent: { id: "h2", type: "curiosity_hook", score: 8, domain: "physics", surprise: 9 } }),
+      turn({ turnNumber: 2 }),
+    ]);
+    const cards = aggregateCards([t]);
+    expect(cards).toHaveLength(2);
+    expect(cards[0]!.content_id).toBe("h1");
+    expect(cards[1]!.content_id).toBe("h2");
+  });
+
+  it("propagates CASEL and Gardner from trace fields", () => {
+    const t = trace("s1", [
+      turn({
+        selectedContent: { id: "h1", type: "curiosity_hook", score: 7, domain: "biology", surprise: 8 },
+        caselTargetsTouched: ["SA", "DM"] as CaselDimension[],
+        gardnerChannelsObserved: ["linguistic", "logical_mathematical"] as GardnerChannel[],
+        sacrificeSpent: 4,
+      }),
+    ]);
+    const card = aggregateCards([t])[0]!;
+    expect(card.casel_targets).toEqual(["SA", "DM"]);
+    expect(card.gardner_channels).toEqual(["linguistic", "logical_mathematical"]);
+    expect(card.sacrifice_spent).toBe(4);
+  });
+});
+
+describe("compareStatusMatrices", () => {
+  const prev: StatusMatrix = { emotional: "brejo", cognitive_math: "baia" };
+  const currSnap: StatusMatrix = { emotional: "baia", cognitive_math: "baia", cognitive_novel: "pasto" };
+  const t = trace("s1", [turn({ statusSnapshot: currSnap })]);
+
+  it("marks improved when current > previous in rank", () => {
+    const cmp = compareStatusMatrices([t], prev);
+    const emotional = cmp.find((c) => c.dimension === "emotional");
+    expect(emotional?.trend).toBe("improved");
+  });
+
+  it("marks stable when equal", () => {
+    const cmp = compareStatusMatrices([t], prev);
+    const cm = cmp.find((c) => c.dimension === "cognitive_math");
+    expect(cm?.trend).toBe("stable");
+  });
+
+  it("marks new when dimension missing in previous", () => {
+    const cmp = compareStatusMatrices([t], prev);
+    const novel = cmp.find((c) => c.dimension === "cognitive_novel");
+    expect(novel?.trend).toBe("new");
+  });
+
+  it("returns empty when no snapshot available", () => {
+    const empty = trace("s1", [turn({})]);
+    expect(compareStatusMatrices([empty], prev)).toEqual([]);
+  });
+
+  it("marks worsened when current < previous", () => {
+    const downSnap: StatusMatrix = { emotional: "brejo" };
+    const tDown = trace("s1", [turn({ statusSnapshot: downSnap })]);
+    const prev2: StatusMatrix = { emotional: "pasto" };
+    const cmp = compareStatusMatrices([tDown], prev2);
+    expect(cmp[0]!.trend).toBe("worsened");
+  });
+});
+
+describe("detectIgnitions", () => {
+  it("marks ignited=true when ≥3 channels + ≥2 CASEL", () => {
+    const t = trace("s1", [
+      turn({
+        gardnerChannelsObserved: ["linguistic", "logical_mathematical", "spatial"] as GardnerChannel[],
+        caselTargetsTouched: ["SA", "DM"] as CaselDimension[],
+      }),
+    ]);
+    const igs = detectIgnitions([t]);
+    expect(igs[0]!.ignited).toBe(true);
+  });
+
+  it("marks ignited=false with <3 channels", () => {
+    const t = trace("s1", [
+      turn({
+        gardnerChannelsObserved: ["linguistic", "logical_mathematical"] as GardnerChannel[],
+        caselTargetsTouched: ["SA", "DM"] as CaselDimension[],
+      }),
+    ]);
+    const igs = detectIgnitions([t]);
+    expect(igs[0]!.ignited).toBe(false);
+  });
+
+  it("deduplicates channels and dimensions", () => {
+    const t = trace("s1", [
+      turn({
+        gardnerChannelsObserved: ["linguistic", "linguistic", "linguistic", "linguistic"] as GardnerChannel[],
+        caselTargetsTouched: ["SA", "SA"] as CaselDimension[],
+      }),
+    ]);
+    const igs = detectIgnitions([t]);
+    expect(igs[0]!.gardner_channels).toHaveLength(1);
+    expect(igs[0]!.ignited).toBe(false);
+  });
+});
+
+describe("extractAspirations", () => {
+  it("extracts domains with ≥3 occurrences", () => {
+    const turns: TurnTrace[] = [];
+    for (let i = 0; i < 3; i++) {
+      turns.push(turn({
+        turnNumber: i,
+        selectedContent: { id: `h${i}`, type: "curiosity_hook", score: 7, domain: "biology", surprise: 8 },
+      }));
+    }
+    turns.push(turn({
+      turnNumber: 3,
+      selectedContent: { id: "h9", type: "curiosity_hook", score: 7, domain: "physics", surprise: 8 },
+    }));
+    const t = trace("s1", turns);
+    const aps = extractAspirations([t]);
+    expect(aps).toHaveLength(1);
+    expect(aps[0]!.key).toBe("biology");
+    expect(aps[0]!.occurrences).toBe(3);
+  });
+
+  it("skips domains below threshold", () => {
+    const turns: TurnTrace[] = [];
+    for (let i = 0; i < 2; i++) {
+      turns.push(turn({
+        turnNumber: i,
+        selectedContent: { id: `h${i}`, type: "curiosity_hook", score: 7, domain: "biology", surprise: 8 },
+      }));
+    }
+    const aps = extractAspirations([trace("s1", turns)]);
+    expect(aps).toHaveLength(0);
+  });
+});
+
+describe("aggregate — end-to-end", () => {
+  it("produces WeeklyReportData with all sections", () => {
+    const t = trace("s1", [
+      turn({
+        selectedContent: { id: "h1", type: "curiosity_hook", score: 7, domain: "biology", surprise: 8 },
+        statusSnapshot: { emotional: "baia" },
+        gardnerProgramSnapshot: {
+          current_week: 2,
+          current_day: 3,
+          current_phase: "translation_via_weakness",
+          paused: false,
+          phases_completed: 3,
+          consecutive_missed_milestones: 0,
+        },
+      }),
+    ], 13);
+    const data = aggregate([t], "Ryo");
+    expect(data.child_name).toBe("Ryo");
+    expect(data.child_age).toBe(13);
+    expect(data.program_status.current_week).toBe(2);
+    expect(data.cards).toHaveLength(1);
+    expect(data.metrics.total_turns).toBe(1);
+  });
+
+  it("accepts week_range override", () => {
+    const data = aggregate([], "Ryo", {
+      week_range: { from: "2026-04-20", to: "2026-04-26" },
+    });
+    expect(data.week.from).toBe("2026-04-20");
+    expect(data.week.to).toBe("2026-04-26");
+  });
+});

--- a/weekly-report/tests/integration.test.ts
+++ b/weekly-report/tests/integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { SessionTrace } from "@ascendimacy/shared";
+import { generateWeeklyReport } from "../src/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("generateWeeklyReport — fixture v0.3", () => {
+  const fixturePath = join(__dirname, "../fixtures/trace-v0.3-example.json");
+  const trace = JSON.parse(readFileSync(fixturePath, "utf-8")) as SessionTrace;
+
+  it("aceita fixture v0.3 do shared trace schema (STS integration point)", () => {
+    expect(trace.meta.schemaVersion).toBe("0.3.0");
+    expect(trace.turns[0]!.statusSnapshot).toBeDefined();
+    expect(trace.turns[0]!.gardnerProgramSnapshot).toBeDefined();
+    expect(trace.turns[0]!.selectedContent).toBeDefined();
+  });
+
+  it("generateWeeklyReport produz data + markdown", () => {
+    const report = generateWeeklyReport([trace], "Ryo");
+    expect(report.data.child_name).toBe("Ryo");
+    expect(report.data.child_age).toBe(13);
+    expect(report.data.cards).toHaveLength(1);
+    expect(report.markdown).toContain("Ryo");
+    expect(report.markdown).toContain("ling_inuit_snow");
+  });
+
+  it("renderPdf produz buffer PDF válido a partir da fixture", async () => {
+    const report = generateWeeklyReport([trace], "Ryo");
+    const buf = await report.renderPdf();
+    expect(buf.slice(0, 5).toString("ascii")).toBe("%PDF-");
+  }, 10_000);
+});

--- a/weekly-report/tests/markdown.test.ts
+++ b/weekly-report/tests/markdown.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { renderMarkdown } from "../src/markdown.js";
+import type { WeeklyReportData } from "../src/types.js";
+
+function baseData(overrides: Partial<WeeklyReportData> = {}): WeeklyReportData {
+  return {
+    child_name: "Ryo",
+    child_age: 13,
+    week: { from: "2026-04-20T00:00:00Z", to: "2026-04-26T23:59:59Z" },
+    program_status: { current_week: 2, current_phase: "translation_via_weakness", paused: false },
+    cards: [],
+    status_comparison: [],
+    ignitions: [],
+    aspirations: [],
+    metrics: {
+      total_turns: 0,
+      total_sessions: 0,
+      off_on_screen_ratio: { off: 0, on: 0, ratio: 0 },
+      sessions_in_brejo: 0,
+      program_pause_frequency: 0,
+      missed_milestones_total: 0,
+      avg_sacrifice_per_turn: 0,
+      total_screen_seconds: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("renderMarkdown — header + program", () => {
+  it("renderiza nome + idade + período", () => {
+    const md = renderMarkdown(baseData());
+    expect(md).toContain("Semana de Ryo (13a)");
+    expect(md).toContain("2026-04-20");
+    expect(md).toContain("2026-04-26");
+  });
+
+  it("mostra status programa ativo", () => {
+    const md = renderMarkdown(baseData());
+    expect(md).toContain("Semana 2/5");
+    expect(md).toContain("translation_via_weakness");
+  });
+
+  it("indica programa pausado com motivo", () => {
+    const md = renderMarkdown(baseData({
+      program_status: {
+        current_week: 1,
+        current_phase: "exploration_in_strength",
+        paused: true,
+        paused_reason: "emotional_brejo",
+      },
+    }));
+    expect(md).toContain("**pausado**");
+    expect(md).toContain("emotional_brejo");
+  });
+
+  it("mostra 'não iniciado' quando programa ausente", () => {
+    const md = renderMarkdown(baseData({
+      program_status: { current_week: null, current_phase: null, paused: false },
+    }));
+    expect(md).toContain("Programa não iniciado");
+  });
+});
+
+describe("renderMarkdown — cards", () => {
+  it("renderiza tabela com cards", () => {
+    const md = renderMarkdown(baseData({
+      cards: [
+        {
+          content_id: "h1", content_type: "curiosity_hook",
+          domain: "biology", casel_targets: ["SA"], gardner_channels: ["linguistic"],
+          sacrifice_spent: 2, turn: 0, session_id: "s1",
+        },
+      ],
+    }));
+    expect(md).toContain("Cards recebidos (1)");
+    expect(md).toContain("| 1 | h1 | curiosity_hook | biology | SA | linguistic | 2 |");
+  });
+
+  it("mostra 'nenhum card' quando vazio", () => {
+    const md = renderMarkdown(baseData());
+    expect(md).toContain("Nenhum card");
+  });
+});
+
+describe("renderMarkdown — status comparison", () => {
+  it("renderiza trend com emojis", () => {
+    const md = renderMarkdown(baseData({
+      status_comparison: [
+        { dimension: "emotional", previous: "brejo", current: "baia", trend: "improved" },
+      ],
+    }));
+    expect(md).toContain("improved");
+    expect(md).toContain("↑");
+  });
+});
+
+describe("renderMarkdown — ignitions + aspirations", () => {
+  it("renderiza só ignições (ignited=true)", () => {
+    const md = renderMarkdown(baseData({
+      ignitions: [
+        { session_id: "s1", turn: 0, gardner_channels: ["linguistic"], casel_dimensions: ["SA"], ignited: false },
+        { session_id: "s1", turn: 1, gardner_channels: ["linguistic", "logical_mathematical", "spatial"], casel_dimensions: ["SA", "DM"], ignited: true },
+      ],
+    }));
+    expect(md).toContain("Combinações Helix que acenderam (1)");
+    expect(md).toContain("Turn 1");
+  });
+
+  it("renderiza aspirações com contagem", () => {
+    const md = renderMarkdown(baseData({
+      aspirations: [
+        { key: "biology", occurrences: 5, first_seen_turn: 0, last_seen_turn: 10, contexts: ["h1", "h2"] },
+      ],
+    }));
+    expect(md).toContain("biology");
+    expect(md).toContain("5x");
+  });
+});
+
+describe("renderMarkdown — métricas", () => {
+  it("renderiza todas as métricas operacionais", () => {
+    const md = renderMarkdown(baseData({
+      metrics: {
+        total_turns: 10,
+        total_sessions: 2,
+        off_on_screen_ratio: { off: 3, on: 7, ratio: 3 / 7 },
+        sessions_in_brejo: 1,
+        program_pause_frequency: 0.5,
+        missed_milestones_total: 1,
+        avg_sacrifice_per_turn: 2.3,
+        total_screen_seconds: 900,
+      },
+    }));
+    expect(md).toContain("Turns totais | 10");
+    expect(md).toContain("Sessões c/ brejo | 1");
+    expect(md).toContain("50%");
+  });
+
+  it("formata ratio infinito como ∞", () => {
+    const md = renderMarkdown(baseData({
+      metrics: {
+        total_turns: 1, total_sessions: 1,
+        off_on_screen_ratio: { off: 1, on: 0, ratio: Infinity },
+        sessions_in_brejo: 0, program_pause_frequency: 0,
+        missed_milestones_total: 0, avg_sacrifice_per_turn: 0,
+        total_screen_seconds: 0,
+      },
+    }));
+    expect(md).toContain("∞");
+  });
+});

--- a/weekly-report/tests/metrics.test.ts
+++ b/weekly-report/tests/metrics.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import type {
+  SessionTrace,
+  StatusMatrix,
+  GardnerProgramState,
+  TurnTrace,
+} from "@ascendimacy/shared";
+import { computeMetrics } from "../src/metrics.js";
+
+function turn(overrides: Partial<TurnTrace> = {}): TurnTrace {
+  return {
+    turnNumber: 0,
+    sessionId: "s1",
+    incomingMessage: "x",
+    entries: [],
+    finalResponse: "y",
+    ...overrides,
+  };
+}
+
+function trace(id: string, turns: TurnTrace[]): SessionTrace {
+  return {
+    sessionId: id,
+    persona: "ryo",
+    startedAt: "2026-04-20T10:00:00.000Z",
+    turns,
+    meta: { schemaVersion: "0.3.0", motorVersion: "0.3.0" },
+  };
+}
+
+describe("computeMetrics — off/on screen ratio", () => {
+  it("classifies curiosity_hook reflect as on-screen", () => {
+    const t = trace("s1", [
+      turn({
+        selectedContent: {
+          id: "h",
+          type: "curiosity_hook",
+          score: 7,
+          domain: "x",
+          surprise: 8,
+          sacrifice_type: "reflect",
+        },
+      }),
+    ]);
+    const m = computeMetrics([t]);
+    expect(m.off_on_screen_ratio.on).toBe(1);
+    expect(m.off_on_screen_ratio.off).toBe(0);
+  });
+
+  it("classifies challenge/dynamic/gtd_task as off-screen", () => {
+    const t = trace("s1", [
+      turn({ turnNumber: 0, selectedContent: { id: "c1", type: "challenge", score: 7, domain: "x", surprise: 8 } }),
+      turn({ turnNumber: 1, selectedContent: { id: "d1", type: "dynamic", score: 7, domain: "x", surprise: 8 } }),
+      turn({ turnNumber: 2, selectedContent: { id: "t1", type: "gtd_task", score: 7, domain: "x", surprise: 8 } }),
+    ]);
+    const m = computeMetrics([t]);
+    expect(m.off_on_screen_ratio.off).toBe(3);
+    expect(m.off_on_screen_ratio.on).toBe(0);
+  });
+
+  it("sacrifice_type act/create/observe force off-screen", () => {
+    const t = trace("s1", [
+      turn({ selectedContent: { id: "a", type: "curiosity_hook", score: 7, domain: "x", surprise: 8, sacrifice_type: "act" } }),
+    ]);
+    const m = computeMetrics([t]);
+    expect(m.off_on_screen_ratio.off).toBe(1);
+  });
+
+  it("ratio=0 when no off-screen", () => {
+    const t = trace("s1", [turn({ selectedContent: { id: "h", type: "curiosity_hook", score: 7, domain: "x", surprise: 8, sacrifice_type: "reflect" } })]);
+    expect(computeMetrics([t]).off_on_screen_ratio.ratio).toBe(0);
+  });
+
+  it("ratio=Infinity quando tudo off-screen", () => {
+    const t = trace("s1", [turn({ selectedContent: { id: "c", type: "challenge", score: 7, domain: "x", surprise: 8 } })]);
+    expect(computeMetrics([t]).off_on_screen_ratio.ratio).toBe(Infinity);
+  });
+});
+
+describe("computeMetrics — sessions in brejo", () => {
+  it("counts 1 when any turn tem dimensão brejo", () => {
+    const matrix: StatusMatrix = { emotional: "brejo" };
+    const t = trace("s1", [turn({ statusSnapshot: matrix })]);
+    expect(computeMetrics([t]).sessions_in_brejo).toBe(1);
+  });
+
+  it("counts 0 quando todas dimensões são baia/pasto", () => {
+    const matrix: StatusMatrix = { emotional: "baia", cognitive_math: "pasto" };
+    const t = trace("s1", [turn({ statusSnapshot: matrix })]);
+    expect(computeMetrics([t]).sessions_in_brejo).toBe(0);
+  });
+
+  it("não conta mesma sessão duas vezes", () => {
+    const matrix: StatusMatrix = { emotional: "brejo" };
+    const t = trace("s1", [
+      turn({ turnNumber: 0, statusSnapshot: matrix }),
+      turn({ turnNumber: 1, statusSnapshot: matrix }),
+    ]);
+    expect(computeMetrics([t]).sessions_in_brejo).toBe(1);
+  });
+});
+
+describe("computeMetrics — program pause frequency", () => {
+  it("conta pauses por sessão", () => {
+    const paused: GardnerProgramState = {
+      current_week: 1,
+      current_day: 1,
+      current_phase: "exploration_in_strength",
+      paused: true,
+      paused_reason: "emotional_brejo",
+      phases_completed: 0,
+      consecutive_missed_milestones: 0,
+    };
+    const notPaused: GardnerProgramState = { ...paused, paused: false };
+    const t1 = trace("s1", [turn({ gardnerProgramSnapshot: paused })]);
+    const t2 = trace("s2", [turn({ gardnerProgramSnapshot: notPaused })]);
+    const m = computeMetrics([t1, t2]);
+    expect(m.program_pause_frequency).toBe(0.5);
+  });
+
+  it("frequency=0 quando nenhuma sessão", () => {
+    expect(computeMetrics([]).program_pause_frequency).toBe(0);
+  });
+});
+
+describe("computeMetrics — missed milestones", () => {
+  it("usa último snapshot", () => {
+    const prog = (n: number): GardnerProgramState => ({
+      current_week: 1,
+      current_day: 1,
+      current_phase: "exploration_in_strength",
+      paused: false,
+      phases_completed: 0,
+      consecutive_missed_milestones: n,
+    });
+    const t = trace("s1", [
+      turn({ turnNumber: 0, gardnerProgramSnapshot: prog(0) }),
+      turn({ turnNumber: 1, gardnerProgramSnapshot: prog(2) }),
+    ]);
+    expect(computeMetrics([t]).missed_milestones_total).toBe(2);
+  });
+});
+
+describe("computeMetrics — totals", () => {
+  it("soma sacrifice + screen seconds", () => {
+    const t = trace("s1", [
+      turn({ turnNumber: 0, sacrificeSpent: 2, screenSeconds: 60 }),
+      turn({ turnNumber: 1, sacrificeSpent: 3, screenSeconds: 120 }),
+    ]);
+    const m = computeMetrics([t]);
+    expect(m.total_turns).toBe(2);
+    expect(m.avg_sacrifice_per_turn).toBe(2.5);
+    expect(m.total_screen_seconds).toBe(180);
+  });
+
+  it("traces vazios retornam métricas zero", () => {
+    const m = computeMetrics([]);
+    expect(m.total_turns).toBe(0);
+    expect(m.total_sessions).toBe(0);
+    expect(m.avg_sacrifice_per_turn).toBe(0);
+  });
+});

--- a/weekly-report/tests/pdf.test.ts
+++ b/weekly-report/tests/pdf.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { renderPdf } from "../src/pdf.js";
+import type { WeeklyReportData } from "../src/types.js";
+
+const minimalData: WeeklyReportData = {
+  child_name: "Ryo",
+  child_age: 13,
+  week: { from: "2026-04-20T00:00:00Z", to: "2026-04-26T23:59:59Z" },
+  program_status: { current_week: 2, current_phase: "translation_via_weakness", paused: false },
+  cards: [
+    {
+      content_id: "h1",
+      content_type: "curiosity_hook",
+      domain: "biology",
+      casel_targets: ["SA"],
+      gardner_channels: ["linguistic"],
+      sacrifice_spent: 2,
+      turn: 0,
+      session_id: "s1",
+    },
+  ],
+  status_comparison: [
+    { dimension: "emotional", previous: "brejo", current: "baia", trend: "improved" },
+  ],
+  ignitions: [],
+  aspirations: [
+    { key: "biology", occurrences: 4, first_seen_turn: 0, last_seen_turn: 3, contexts: ["h1"] },
+  ],
+  metrics: {
+    total_turns: 5,
+    total_sessions: 2,
+    off_on_screen_ratio: { off: 2, on: 3, ratio: 2 / 3 },
+    sessions_in_brejo: 0,
+    program_pause_frequency: 0,
+    missed_milestones_total: 0,
+    avg_sacrifice_per_turn: 1.8,
+    total_screen_seconds: 600,
+  },
+};
+
+describe("renderPdf", () => {
+  it("gera um Buffer com magic bytes PDF (%PDF-)", async () => {
+    const buf = await renderPdf(minimalData);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.length).toBeGreaterThan(500);
+    const header = buf.slice(0, 5).toString("ascii");
+    expect(header).toBe("%PDF-");
+  }, 10_000);
+
+  it("inclui EOF marker no final", async () => {
+    const buf = await renderPdf(minimalData);
+    const tail = buf.slice(-16).toString("ascii");
+    expect(tail).toMatch(/%%EOF/);
+  }, 10_000);
+
+  it("dados vazios ainda produzem PDF válido", async () => {
+    const empty: WeeklyReportData = {
+      ...minimalData,
+      cards: [],
+      status_comparison: [],
+      ignitions: [],
+      aspirations: [],
+      metrics: {
+        total_turns: 0, total_sessions: 0,
+        off_on_screen_ratio: { off: 0, on: 0, ratio: 0 },
+        sessions_in_brejo: 0, program_pause_frequency: 0,
+        missed_milestones_total: 0, avg_sacrifice_per_turn: 0,
+        total_screen_seconds: 0,
+      },
+    };
+    const buf = await renderPdf(empty);
+    expect(buf.slice(0, 5).toString("ascii")).toBe("%PDF-");
+  }, 10_000);
+});

--- a/weekly-report/tsconfig.build.json
+++ b/weekly-report/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}

--- a/weekly-report/tsconfig.json
+++ b/weekly-report/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/weekly-report/vitest.config.ts
+++ b/weekly-report/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Refs

- Spec: [docs/fundamentos/ebrota-kids-observabilidade.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/fundamentos/ebrota-kids-observabilidade.md)
- Handoff mãe #17: [docs/handoffs/2026-04-24-cc-ebrota-kids-v1-handoff-17.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/handoffs/2026-04-24-cc-ebrota-kids-v1-handoff-17.md)
- Base: motor#11 merged (`012678f`)

## Cobertura dos 4 requisitos

| Req | Implementação |
|---|---|
| **(a)** Trace schema v0.3 | `shared/src/trace-schema.ts` bumpa para `0.3.0`. `TurnTrace` ganha: statusSnapshot, gardnerProgramSnapshot (week/day/phase/pause_reason), selectedContent, gardnerChannelsObserved, caselTargetsTouched, sacrificeSpent, screenSeconds, instructionAdditionApplied, statusTransitions, flags. Todos opcionais — backwards-compat. Orchestrator popula via snapshot do SessionState + drota output. |
| **(b)** PDF semanal generator | Novo package `weekly-report/`: `aggregate` (cards, status vs semana anterior, ignitions Helix ≥3×≥2, aspirações ≥3 ocorrências), `markdown` (7 seções pt-BR), `pdf` (pdfkit, Buffer). API: `generateWeeklyReport(traces, name, opts)` retorna `{ data, markdown, renderPdf() }`. |
| **(c)** Métricas operacionais | `weekly-report/src/metrics.ts` computa: off:on screen ratio (heurística content.type + sacrifice_type), sessions_in_brejo, program_pause_frequency, missed_milestones_total, avg_sacrifice_per_turn, total_screen_seconds. |
| **(d)** Integration point STS v0.4 | Schema v0.3 exportado de `@ascendimacy/shared` com `TRACE_SCHEMA_VERSION` const. Fixture `weekly-report/fixtures/trace-v0.3-example.json` cobrindo todos os campos enriched — STS consome como reference trace. `integration.test.ts` valida parse round-trip. |

## Resultados

### npm run build
✅ 6 packages limpos (pdfkit + @types/pdfkit instalados)

### npm run test — 225 testes verdes (+47 sobre Bloco 2b)

| Package | Testes | Delta | Cobertura |
|---|---|---|---|
| shared | 95 | +3 | trace-schema bump v0.3 + personaAge |
| **weekly-report (NOVO)** | **44** | +44 | aggregate × 14, metrics × 13, markdown × 11, pdf × 3 (magic bytes + EOF), integration × 3 (fixture round-trip) |
| planejador | 34 | — | |
| motor-drota | 18 | — | |
| motor-execucao | 32 | — | |
| orchestrator | 2 | — | |

### npm run smoke
✅ Rubric G1-G3 verde — trace v0.3 escrito em disco com todos os campos novos

## Decisões de design

- **`weekly-report` é workspace novo** (Jun sugeriu "motor-execucao ou novo package" — novo é melhor: contrato claro, reuso em STS, não acopla com persistence layer).
- **pdfkit, não puppeteer/chrome** — lightweight (61 packages adicionados), zero runtime externo. PDF válido mas sem layout complexo; iterar pra v2 se necessário.
- **Off:on screen é heurística** — content.type + sacrifice_type. Refinar em Bloco 3+ com telemetria real de sessions.
- **Ignitions threshold**: ≥3 Gardner × ≥2 CASEL (§2.2 paper). Fixado como v1; configurável em Bloco 3+.
- **Aspirações threshold**: ≥3 ocorrências de domínio. Mais refinado virá em Bloco 3+ quando detect_branches rodar no motor.

## Débitos explícitos (Bloco 4+)

- STS harness v0.4 consome fixture e compara traces reais (fora deste PR — repo `ascendimacy-sts`)
- `sacrificeSpent` + `screenSeconds` não são populados automaticamente pelo orchestrator (falta decisão sobre quem computa — motor-drota? executor?). Campos existem no schema mas ficam 0 no smoke atual
- `statusTransitions` array fica vazio — precisa captura no executor quando aplica transição
- `detectBranches` (galhos emergentes) pra alimentar `aspirations` com maior precisão
- Dashboard HTML estático (§10 do spec item #3)

## Como testar

```bash
cd ascendimacy-motor
npm install
npm run build
npm run test    # 225 verdes esperados
npm run smoke   # Rubric G1-G3
```

Render manual do relatório:

```ts
import { generateWeeklyReport } from '@ascendimacy/weekly-report';
import fixture from './weekly-report/fixtures/trace-v0.3-example.json';
const r = generateWeeklyReport([fixture as any], 'Ryo');
console.log(r.markdown);
await r.renderPdf().then(buf => fs.writeFileSync('/tmp/semana.pdf', buf));
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)