### PR TITLE
feat(#17 Bloco 4): onboarding parental + autorização em 3 camadas

### DIFF
--- a/fixtures/parent-yuji.yaml
+++ b/fixtures/parent-yuji.yaml
@@ -1,0 +1,62 @@
+# Yuji Ochiai — parental profile fixture v1
+# Perfil do pai primário de Ryo e Kei; schema conforme shared/src/parental-profile.ts
+# Spec: ascendimacy-ops/docs/fundamentos/ebrota-kids-onboarding-parental.md §2.
+# Uso: consumido por testes + orchestrator pra simular onboarding parental em STS.
+
+id: yuji-ochiai
+name: Yuji Ochiai
+age: 42
+profile:
+  role: primary
+  parental_profile:
+    id: yuji-ochiai
+    role: primary
+    decision_profile: consultative_risk_averse
+    family_values:
+      principles:
+        - "respeito por anciãos e professores é inegociável"
+        - "vergonha pública é evitada a todo custo"
+        - "esforço importa mais que resultado"
+        - "curiosidade é celebrada, tédio não é julgado"
+      cultural_axis: japanese_brazilian
+      religious_tradition: secular
+      political_sensitivity: moderate
+    forbidden_zones:
+      - topic: political_content
+        reason: "não queremos expor a criança a temas divisivos ainda"
+      - topic: religious_proselytizing
+        reason: "respeitamos a escolha futura da criança"
+      - topic: screen_gaming_promotion
+        reason: "já limitamos games suficiente"
+    budget_constraints:
+      materials_monthly_ceiling_jpy: 3000
+      screen_time_daily_max_minutes: 90
+      screen_time_weekly_soft_ceiling: 420
+    parental_availability:
+      supervision_available_hours_per_week: 6
+      supervision_for_which_kinds_of_challenges:
+        - physical_supervised
+        - conflict_mediation
+      scale_tolerance:
+        micro: yes
+        pequeno: yes
+        medio: yes
+        grande: yes_with_review
+        monumental: yes_with_full_review_meeting
+      ready_for_dyad_sessions: true
+      ready_for_joint_sessions: true
+    parental_perception:
+      perceived_aspiration: "criatividade artística e narrativa via mangá"
+      perceived_strengths:
+        - { channel: linguistic, note: "conta histórias longas" }
+        - { channel: spatial, note: "desenha bem pra idade" }
+        - { channel: intrapersonal, note: "reflete quando desafiado" }
+      perceived_weaknesses:
+        - { channel: musical, note: "nunca demonstrou interesse musical" }
+        - { channel: naturalist, note: "indiferente a animais e natureza" }
+      concerns_current:
+        - "Ryo não quer ir à escola — 2 semanas de recusa"
+        - "passa tempo demais no celular"
+      hopes_for_next_3_months:
+        - "reconectar com o prazer de aprender"
+        - "encontrar 1 atividade que ele escolha voluntariamente"

--- a/fixtures/parent-yuko.yaml
+++ b/fixtures/parent-yuko.yaml
@@ -1,0 +1,54 @@
+# Yuko Ochiai — parental profile fixture v1
+# Perfil da mãe (secondary no contexto eBrota) de Ryo e Kei.
+# Schema conforme shared/src/parental-profile.ts.
+# Decision profile = decider_permissive: decide rápido, aprova mais que Yuji.
+
+id: yuko-ochiai
+name: Yuko Ochiai
+age: 40
+profile:
+  role: secondary
+  parental_profile:
+    id: yuko-ochiai
+    role: secondary
+    decision_profile: decider_permissive
+    family_values:
+      principles:
+        - "liberdade de escolha infantil respeitada"
+        - "erros fazem parte; julgamento envergonha"
+        - "falar sobre sentimentos não é tabu"
+      cultural_axis: japanese_brazilian
+      religious_tradition: secular
+      political_sensitivity: low
+    forbidden_zones:
+      - topic: religious_proselytizing
+        reason: "mesma razão do Yuji"
+    budget_constraints:
+      materials_monthly_ceiling_jpy: 5000
+      screen_time_daily_max_minutes: 120
+      screen_time_weekly_soft_ceiling: 600
+    parental_availability:
+      supervision_available_hours_per_week: 10
+      supervision_for_which_kinds_of_challenges:
+        - physical_supervised
+        - public_exposure_supervised
+        - conflict_mediation
+      scale_tolerance:
+        micro: yes
+        pequeno: yes
+        medio: yes
+        grande: yes
+        monumental: yes_with_review
+      ready_for_dyad_sessions: true
+      ready_for_joint_sessions: true
+    parental_perception:
+      perceived_aspiration: "socialização + expressão emocional"
+      perceived_strengths:
+        - { channel: interpersonal, note: "identifica emoção no outro rápido" }
+        - { channel: linguistic, note: "vocabulário emocional rico" }
+      perceived_weaknesses:
+        - { channel: bodily_kinesthetic, note: "coordenação ainda em desenvolvimento" }
+      concerns_current:
+        - "Ryo às vezes se isola demais"
+      hopes_for_next_3_months:
+        - "Ryo ter 1 interação social voluntária semanal"

--- a/motor-execucao/src/parent-decisions.ts
+++ b/motor-execucao/src/parent-decisions.ts
@@ -1,0 +1,153 @@
+/**
+ * kids_parent_decisions — tabela de decisões parentais por content item.
+ *
+ * Fluxo:
+ *   - Após triagem (camada 2 paper §6), o motor-drota propõe 1-2 alternativas.
+ *   - Pais veem no painel e decidem: approved | rejected | pinned.
+ *   - `pinned` vira `ContentItem.parent_pinned=true` no scorer (Bloco 1 já suporta).
+ *   - Decisões persistem por session_id + content_id (UNIQUE).
+ *
+ * Spec: paper §6 "autorização em três camadas" + fundamentos §2 forbidden_zones.
+ */
+
+import type Database from "better-sqlite3";
+
+export const PARENT_DECISION_STATUSES = [
+  "pending",
+  "approved",
+  "rejected",
+  "pinned",
+] as const;
+export type ParentDecisionStatus = (typeof PARENT_DECISION_STATUSES)[number];
+
+export const PARENT_DECISIONS_DDL = `
+CREATE TABLE IF NOT EXISTS kids_parent_decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  content_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  reason TEXT,
+  decided_at TEXT NOT NULL,
+  expires_at TEXT,
+  UNIQUE(session_id, content_id)
+);
+`;
+
+export interface ParentDecision {
+  id?: number;
+  session_id: string;
+  content_id: string;
+  status: ParentDecisionStatus;
+  reason?: string;
+  decided_at: string;
+  expires_at?: string;
+}
+
+interface DecisionRow {
+  id: number;
+  session_id: string;
+  content_id: string;
+  status: string;
+  reason: string | null;
+  decided_at: string;
+  expires_at: string | null;
+}
+
+function rowToDecision(row: DecisionRow): ParentDecision {
+  return {
+    id: row.id,
+    session_id: row.session_id,
+    content_id: row.content_id,
+    status: row.status as ParentDecisionStatus,
+    reason: row.reason ?? undefined,
+    decided_at: row.decided_at,
+    expires_at: row.expires_at ?? undefined,
+  };
+}
+
+/** Upsert de decisão (UNIQUE por session × content). */
+export function setParentDecision(
+  db: Database.Database,
+  input: Omit<ParentDecision, "id" | "decided_at"> & { decided_at?: string },
+): ParentDecision {
+  const now = input.decided_at ?? new Date().toISOString();
+  db.prepare(
+    `INSERT INTO kids_parent_decisions (session_id, content_id, status, reason, decided_at, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(session_id, content_id) DO UPDATE SET
+       status = excluded.status,
+       reason = excluded.reason,
+       decided_at = excluded.decided_at,
+       expires_at = excluded.expires_at`,
+  ).run(
+    input.session_id,
+    input.content_id,
+    input.status,
+    input.reason ?? null,
+    now,
+    input.expires_at ?? null,
+  );
+  const row = db
+    .prepare(
+      `SELECT * FROM kids_parent_decisions WHERE session_id = ? AND content_id = ?`,
+    )
+    .get(input.session_id, input.content_id) as DecisionRow;
+  return rowToDecision(row);
+}
+
+/** Lê todas as decisões de uma sessão. */
+export function listParentDecisions(
+  db: Database.Database,
+  sessionId: string,
+): ParentDecision[] {
+  const rows = db
+    .prepare("SELECT * FROM kids_parent_decisions WHERE session_id = ? ORDER BY id")
+    .all(sessionId) as DecisionRow[];
+  return rows.map(rowToDecision);
+}
+
+/** Map content_id → ParentDecision pra lookup eficiente no scorer wrapper. */
+export function getDecisionMap(
+  db: Database.Database,
+  sessionId: string,
+): Map<string, ParentDecision> {
+  const map = new Map<string, ParentDecision>();
+  for (const d of listParentDecisions(db, sessionId)) {
+    map.set(d.content_id, d);
+  }
+  return map;
+}
+
+/** Filtra rejeitados (não-expirados). Usado pelo pool-builder. */
+export function getRejectedIds(
+  db: Database.Database,
+  sessionId: string,
+  now?: string,
+): Set<string> {
+  const ts = now ?? new Date().toISOString();
+  const rows = db
+    .prepare(
+      `SELECT content_id FROM kids_parent_decisions
+       WHERE session_id = ? AND status = 'rejected'
+         AND (expires_at IS NULL OR expires_at > ?)`,
+    )
+    .all(sessionId, ts) as Array<{ content_id: string }>;
+  return new Set(rows.map((r) => r.content_id));
+}
+
+/** Retorna ids com status='pinned' não-expirados. */
+export function getPinnedIds(
+  db: Database.Database,
+  sessionId: string,
+  now?: string,
+): Set<string> {
+  const ts = now ?? new Date().toISOString();
+  const rows = db
+    .prepare(
+      `SELECT content_id FROM kids_parent_decisions
+       WHERE session_id = ? AND status = 'pinned'
+         AND (expires_at IS NULL OR expires_at > ?)`,
+    )
+    .all(sessionId, ts) as Array<{ content_id: string }>;
+  return new Set(rows.map((r) => r.content_id));
+}

--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -10,6 +10,12 @@ import {
   pauseProgram,
   resumeProgram,
 } from "./gardner-program.js";
+import {
+  setParentDecision,
+  listParentDecisions,
+  PARENT_DECISION_STATUSES,
+} from "./parent-decisions.js";
+import type { ParentDecisionStatus } from "./parent-decisions.js";
 
 const inventory = loadInventory();
 
@@ -71,6 +77,34 @@ server.registerTool("gardner_program_resume", {
 }, async ({ sessionId }: { sessionId: string }) => {
   const state = resumeProgram(getDbInstance(), sessionId);
   return { content: [{ type: "text" as const, text: JSON.stringify(state) }] };
+});
+
+server.registerTool("parent_decision_set", {
+  description: "Registra decisão parental para um content item (pending/approved/rejected/pinned).",
+  inputSchema: {
+    sessionId: z.string(),
+    contentId: z.string(),
+    status: z.enum(PARENT_DECISION_STATUSES),
+    reason: z.string().optional(),
+    expiresAt: z.string().optional(),
+  } as any,
+}, async ({ sessionId, contentId, status, reason, expiresAt }: { sessionId: string; contentId: string; status: ParentDecisionStatus; reason?: string; expiresAt?: string }) => {
+  const decision = setParentDecision(getDbInstance(), {
+    session_id: sessionId,
+    content_id: contentId,
+    status,
+    reason,
+    expires_at: expiresAt,
+  });
+  return { content: [{ type: "text" as const, text: JSON.stringify(decision) }] };
+});
+
+server.registerTool("parent_decision_list", {
+  description: "Lista todas as decisões parentais de uma sessão.",
+  inputSchema: { sessionId: z.string() } as any,
+}, async ({ sessionId }: { sessionId: string }) => {
+  const decisions = listParentDecisions(getDbInstance(), sessionId);
+  return { content: [{ type: "text" as const, text: JSON.stringify(decisions) }] };
 });
 
 server.registerTool("log_event", {

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { SessionState, EventEntry } from "@ascendimacy/shared";
 import { TREE_NODES_DDL, getStatusMatrix } from "./tree-nodes.js";
 import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
+import { PARENT_DECISIONS_DDL } from "./parent-decisions.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -33,6 +34,7 @@ function getDb(dbPath?: string): Database.Database {
       );
       ${TREE_NODES_DDL}
       ${GARDNER_PROGRAM_DDL}
+      ${PARENT_DECISIONS_DDL}
     `);
   }
   return db;

--- a/motor-execucao/tests/parent-decisions.test.ts
+++ b/motor-execucao/tests/parent-decisions.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  PARENT_DECISIONS_DDL,
+  setParentDecision,
+  listParentDecisions,
+  getDecisionMap,
+  getPinnedIds,
+  getRejectedIds,
+} from "../src/parent-decisions.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(PARENT_DECISIONS_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("parent-decisions CRUD", () => {
+  it("setParentDecision inserts new row", () => {
+    const d = setParentDecision(db, {
+      session_id: "s1",
+      content_id: "h1",
+      status: "approved",
+    });
+    expect(d.status).toBe("approved");
+    expect(d.session_id).toBe("s1");
+    expect(d.content_id).toBe("h1");
+  });
+
+  it("setParentDecision is idempotent on UNIQUE(session, content)", () => {
+    setParentDecision(db, { session_id: "s1", content_id: "h1", status: "approved" });
+    setParentDecision(db, { session_id: "s1", content_id: "h1", status: "rejected", reason: "mudei de ideia" });
+    const list = listParentDecisions(db, "s1");
+    expect(list).toHaveLength(1);
+    expect(list[0]!.status).toBe("rejected");
+    expect(list[0]!.reason).toBe("mudei de ideia");
+  });
+
+  it("different sessions are isolated", () => {
+    setParentDecision(db, { session_id: "s1", content_id: "h1", status: "pinned" });
+    setParentDecision(db, { session_id: "s2", content_id: "h1", status: "rejected" });
+    expect(listParentDecisions(db, "s1")[0]!.status).toBe("pinned");
+    expect(listParentDecisions(db, "s2")[0]!.status).toBe("rejected");
+  });
+
+  it("getDecisionMap indexes by content_id", () => {
+    setParentDecision(db, { session_id: "s1", content_id: "h1", status: "pinned" });
+    setParentDecision(db, { session_id: "s1", content_id: "h2", status: "rejected" });
+    const map = getDecisionMap(db, "s1");
+    expect(map.get("h1")?.status).toBe("pinned");
+    expect(map.get("h2")?.status).toBe("rejected");
+  });
+});
+
+describe("parent-decisions expiry", () => {
+  it("getPinnedIds filters expired", () => {
+    setParentDecision(db, {
+      session_id: "s1",
+      content_id: "h1",
+      status: "pinned",
+      expires_at: "2020-01-01T00:00:00Z",
+    });
+    setParentDecision(db, {
+      session_id: "s1",
+      content_id: "h2",
+      status: "pinned",
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    const pinned = getPinnedIds(db, "s1", "2026-04-24T00:00:00Z");
+    expect(pinned.has("h1")).toBe(false);
+    expect(pinned.has("h2")).toBe(true);
+  });
+
+  it("getRejectedIds filters expired", () => {
+    setParentDecision(db, {
+      session_id: "s1",
+      content_id: "h1",
+      status: "rejected",
+      expires_at: "2020-01-01T00:00:00Z",
+    });
+    setParentDecision(db, {
+      session_id: "s1",
+      content_id: "h2",
+      status: "rejected",
+    });
+    const rejected = getRejectedIds(db, "s1", "2026-04-24T00:00:00Z");
+    expect(rejected.has("h1")).toBe(false);
+    expect(rejected.has("h2")).toBe(true);
+  });
+
+  it("null expires_at nunca expira", () => {
+    setParentDecision(db, { session_id: "s1", content_id: "h1", status: "pinned" });
+    const pinned = getPinnedIds(db, "s1");
+    expect(pinned.has("h1")).toBe(true);
+  });
+});

--- a/planejador/src/llm-client.ts
+++ b/planejador/src/llm-client.ts
@@ -27,6 +27,27 @@ export async function callLlm(
 }
 
 /**
+ * Haiku chamado pra triagem parental (Bloco 4 #17). Reuso do client global.
+ * Modelo default `claude-haiku-4-5-20251001`. Curto (150 tokens) — rerank only.
+ */
+export async function callHaiku(
+  systemPrompt: string,
+  userMessage: string,
+): Promise<string> {
+  const c = getClient();
+  const model = process.env["HAIKU_MODEL"] ?? "claude-haiku-4-5-20251001";
+  const response = await c.messages.create({
+    model,
+    max_tokens: 150,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userMessage }],
+  });
+  const block = response.content[0];
+  if (block.type !== "text") throw new Error("Unexpected response type from Haiku");
+  return block.text;
+}
+
+/**
  * Mock: planejador Bloco 2a devolve só rationale + hints.
  * Scoring de conteúdo é determinístico, fora do LLM.
  */

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -17,6 +17,8 @@ import type {
   ScoredContentItem,
   GardnerAssessment,
   GardnerProgramState,
+  ParentalProfile,
+  ContentItem,
 } from "@ascendimacy/shared";
 import {
   scorePool,
@@ -28,8 +30,10 @@ import {
   isAssessmentReady,
   pairForWeek,
   shouldPauseProgram,
+  isParentalProfileMinimal,
+  triageForParents,
 } from "@ascendimacy/shared";
-import { callLlm, callLlmMock } from "./llm-client.js";
+import { callLlm, callLlmMock, callHaiku } from "./llm-client.js";
 import { loadSeedPool, buildPool } from "./pool-builder.js";
 import { personaToChildProfile } from "./child-profile.js";
 
@@ -127,10 +131,35 @@ function buildGardnerInstruction(input: PlanTurnInput): {
   return { text, active: true };
 }
 
+/**
+ * Aplica parent_pinned dinâmico — se persona.profile.parent_pinned_ids incluir
+ * o id do item, marca parent_pinned=true antes de scorar. Assim o scorer (Bloco 1)
+ * já respeita (PARENT_PINNED_SCORE=1000 vence tudo). Plan Bloco 4 requisito (c).
+ */
+function applyPinnedDecisions(pool: ContentItem[], persona: PlanTurnInput["persona"]): ContentItem[] {
+  const profile = (persona.profile ?? {}) as Record<string, unknown>;
+  const pinnedIds = Array.isArray(profile["parent_pinned_ids"])
+    ? new Set(profile["parent_pinned_ids"] as string[])
+    : null;
+  const rejectedIds = Array.isArray(profile["parent_rejected_ids"])
+    ? new Set(profile["parent_rejected_ids"] as string[])
+    : null;
+  if (!pinnedIds && !rejectedIds) return pool;
+  return pool
+    .filter((item) => !(rejectedIds?.has(item.id)))
+    .map((item) => {
+      if (pinnedIds?.has(item.id)) {
+        return { ...item, parent_pinned: true, pinned_until: item.pinned_until ?? null };
+      }
+      return item;
+    });
+}
+
 export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   // 1. Scoring determinístico do pool.
   const rawPool = loadSeedPool(seedPath());
-  const eligible = buildPool(rawPool, {
+  const withPinnedMarks = applyPinnedDecisions(rawPool, input.persona);
+  const eligible = buildPool(withPinnedMarks, {
     age: input.persona.age,
     sessionMode: "1v1", // Bloco 6 adotará 'joint' para dyad
   });
@@ -142,23 +171,40 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     now: new Date().toISOString(),
     casel_focus: caselTargets[0] as ScoredContentItem["item"]["casel_target"][number] | undefined,
   });
-  const topK = scored.slice(0, TOP_K_POOL);
+  let topK = scored.slice(0, TOP_K_POOL);
 
-  // 2. LLM consulta para rationale + contextHints.
-  const useMock =
+  // 2. Triagem parental (Bloco 4 #17, paper §6 camada 2).
+  //    Se persona.profile.parental_profile existir E estiver mínimo,
+  //    passa topK pelo triageForParents (rule-based ou Haiku).
+  const useMockLlm =
     process.env["USE_MOCK_LLM"] === "true" ||
     !process.env["ANTHROPIC_API_KEY"];
+  const parentalProfile = extractParentalProfile(input.persona);
+  let triageMode: "rule_based" | "haiku" | "skipped" = "skipped";
+  let triageRejectedIds: string[] = [];
+  if (isParentalProfileMinimal(parentalProfile)) {
+    const haikuCaller = useMockLlm ? undefined : callHaiku;
+    const triageResult = await triageForParents(
+      { pool: topK, profile: parentalProfile!, max_approved: TOP_K_POOL },
+      haikuCaller,
+    );
+    topK = triageResult.approved;
+    triageMode = triageResult.triage_mode;
+    triageRejectedIds = triageResult.rejected.map((r) => r.item.id);
+  }
+
+  // 3. LLM consulta para rationale + contextHints.
   const systemPrompt = buildSystemPrompt(input);
   const userMessage = `Emita o JSON com rationale + hints.`;
-  const raw = useMock
+  const raw = useMockLlm
     ? await callLlmMock(systemPrompt, userMessage)
     : await callLlm(systemPrompt, userMessage);
   const rationale = parseRationale(raw);
 
-  // 3. Composição do mixin withGardnerProgram se ativo.
+  // 4. Composição do mixin withGardnerProgram se ativo.
   const gardnerInstruction = buildGardnerInstruction(input);
 
-  // 4. Injeta status_gates + casel_focus + gardner meta em contextHints.
+  // 5. Injeta status_gates + casel_focus + gardner meta + triage meta em contextHints.
   const contextHints: Record<string, unknown> = {
     ...rationale.contextHints,
     status_gates: allGates(statusMatrix),
@@ -174,6 +220,12 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
       contextHints["gardner_pause_reason"] = gardnerInstruction.pauseReason;
     }
   }
+  if (triageMode !== "skipped") {
+    contextHints["parental_triage_mode"] = triageMode;
+    if (triageRejectedIds.length > 0) {
+      contextHints["parental_triage_rejected_ids"] = triageRejectedIds;
+    }
+  }
 
   return {
     strategicRationale: rationale.strategicRationale,
@@ -183,5 +235,13 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   };
 }
 
+/** Extrai `parental_profile` da persona (fixture pattern v1). */
+function extractParentalProfile(persona: PlanTurnInput["persona"]): ParentalProfile | undefined {
+  const profile = (persona.profile ?? {}) as Record<string, unknown>;
+  const raw = profile["parental_profile"];
+  if (!raw || typeof raw !== "object") return undefined;
+  return raw as ParentalProfile;
+}
+
 /** Exposto para testes. */
-export { buildGardnerInstruction };
+export { buildGardnerInstruction, extractParentalProfile };

--- a/planejador/tests/parental-triage-integration.test.ts
+++ b/planejador/tests/parental-triage-integration.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { planTurn, extractParentalProfile } from "../src/plan.js";
+import type {
+  ParentalProfile,
+  PersonaDef,
+  SessionState,
+} from "@ascendimacy/shared";
+
+process.env["USE_MOCK_LLM"] = "true";
+
+const yujiProfile: ParentalProfile = {
+  id: "yuji",
+  role: "primary",
+  decision_profile: "consultative_risk_averse",
+  family_values: {
+    principles: ["esforço>resultado"],
+  },
+  forbidden_zones: [
+    { topic: "politic", reason: "divisivo" },
+    { topic: "religio", reason: "respeito" },
+  ],
+  budget_constraints: { screen_time_daily_max_minutes: 90 },
+  parental_availability: {
+    scale_tolerance: { micro: "yes", pequeno: "yes", medio: "yes" },
+    ready_for_dyad_sessions: true,
+  },
+};
+
+function makePersona(overrides: Partial<PersonaDef> = {}): PersonaDef {
+  return {
+    id: "ryo",
+    name: "Ryo",
+    age: 13,
+    profile: {},
+    ...overrides,
+  };
+}
+
+const baseState: SessionState = {
+  sessionId: "s1",
+  trustLevel: 0.3,
+  budgetRemaining: 100,
+  turn: 0,
+  eventLog: [],
+  statusMatrix: { emotional: "baia" },
+};
+
+const adquirente = { id: "jun", name: "Jun", defaults: {} };
+const inventory = [
+  { id: "kids.helix.session", title: "Helix", category: "kids", estimatedSacrifice: 1, estimatedConfidenceGain: 4 },
+];
+
+describe("extractParentalProfile", () => {
+  it("extracts when persona.profile.parental_profile present", () => {
+    const persona = makePersona({ profile: { parental_profile: yujiProfile } });
+    expect(extractParentalProfile(persona)?.id).toBe("yuji");
+  });
+
+  it("undefined when ausente", () => {
+    expect(extractParentalProfile(makePersona())).toBeUndefined();
+  });
+});
+
+describe("planTurn — triagem parental integrada", () => {
+  it("contextHints sem parental_triage_mode quando parental_profile ausente", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: baseState,
+      incomingMessage: "oi",
+    });
+    expect(out.contextHints["parental_triage_mode"]).toBeUndefined();
+  });
+
+  it("adiciona contextHints.parental_triage_mode='rule_based' quando parental_profile presente e USE_MOCK_LLM", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona({ profile: { parental_profile: yujiProfile } }),
+      adquirente,
+      inventory,
+      state: baseState,
+      incomingMessage: "oi",
+    });
+    expect(out.contextHints["parental_triage_mode"]).toBe("rule_based");
+  });
+
+  it("contentPool filtrado quando forbidden_zone bate em top hook (via domain boost)", async () => {
+    const strictProfile: ParentalProfile = {
+      ...yujiProfile,
+      forbidden_zones: [
+        { topic: "linguistics", reason: "teste" },
+      ],
+    };
+    const out = await planTurn({
+      sessionId: "s1",
+      // Boost linguistics para garantir que entra no top-5.
+      persona: makePersona({
+        profile: {
+          parental_profile: strictProfile,
+          domain_ranking: { linguistics: { score: 100 } },
+        },
+      }),
+      adquirente,
+      inventory,
+      state: baseState,
+      incomingMessage: "oi",
+    });
+    // Com boost forte, linguistics hooks dominam top-5 e devem ser todos rejeitados.
+    const rejectedIds = out.contextHints["parental_triage_rejected_ids"] as string[] | undefined;
+    expect(rejectedIds).toBeDefined();
+    expect(rejectedIds!.length).toBeGreaterThan(0);
+    // Nenhum item com domain=linguistics sobrevive
+    for (const s of out.contentPool) {
+      expect(s.item.domain).not.toBe("linguistics");
+    }
+  });
+});
+
+describe("planTurn — parent_pinned via persona.profile.parent_pinned_ids", () => {
+  it("item pinned ganha score=PARENT_PINNED_SCORE e vira top-1", async () => {
+    // Pinamos um id específico do seed (sem conhecer qual, pegamos o id que a mock triage vai manter)
+    // Usamos um id do seed conhecido — ling_inuit_snow (primeiro do seed)
+    const persona = makePersona({
+      profile: {
+        parent_pinned_ids: ["ling_inuit_snow"],
+      },
+    });
+    const out = await planTurn({
+      sessionId: "s1",
+      persona,
+      adquirente,
+      inventory,
+      state: baseState,
+      incomingMessage: "oi",
+    });
+    const top = out.contentPool[0];
+    expect(top?.item.id).toBe("ling_inuit_snow");
+    expect(top?.score).toBe(1000); // PARENT_PINNED_SCORE
+  });
+
+  it("item rejected sumiu do pool", async () => {
+    const persona = makePersona({
+      profile: {
+        parent_rejected_ids: ["ling_inuit_snow"],
+      },
+    });
+    const out = await planTurn({
+      sessionId: "s1",
+      persona,
+      adquirente,
+      inventory,
+      state: baseState,
+      incomingMessage: "oi",
+    });
+    const ids = out.contentPool.map((s) => s.item.id);
+    expect(ids).not.toContain("ling_inuit_snow");
+  });
+});

--- a/shared/src/gardner-onboarding.ts
+++ b/shared/src/gardner-onboarding.ts
@@ -1,0 +1,75 @@
+/**
+ * Bridge entre onboarding parental e Gardner assessment do motor.
+ *
+ * Spec: ascendimacy-ops/docs/fundamentos/ebrota-kids-onboarding-parental.md §2.5, §6
+ *
+ * Input do onboarding: `parental_perception.perceived_strengths` + `perceived_weaknesses`.
+ * Output: `GardnerAssessment` consumível por `withGardnerProgram` (Bloco 2b).
+ *
+ * IMPORTANTE: o ranking derivado do pai é PROVISÓRIO (§6 doc: confidence ≤0.7).
+ * Os 3 primeiros assessments ativos do eBerrante com a criança sobrescrevem.
+ */
+
+import type { GardnerAssessment } from "./mixins/with-gardner-program.js";
+import type { GardnerChannel } from "./content-item.js";
+import type { PerceivedStrength } from "./parental-profile.js";
+
+const ALL_CHANNELS: GardnerChannel[] = [
+  "linguistic",
+  "logical_mathematical",
+  "spatial",
+  "musical",
+  "bodily_kinesthetic",
+  "interpersonal",
+  "intrapersonal",
+  "naturalist",
+  "existential",
+];
+
+export interface OnboardingGardnerInput {
+  perceived_strengths?: PerceivedStrength[];
+  perceived_weaknesses?: PerceivedStrength[];
+  /** Quantas sessões de onboarding completadas. Precisa ≥3 pra ativar programa. */
+  sessions_completed: number;
+}
+
+/**
+ * Converte input do onboarding parental em GardnerAssessment inicial.
+ *
+ * Estratégia:
+ *   - Top = `perceived_strengths` na ordem dada pelos pais (rank 1 = primeiro).
+ *   - Bottom = `perceived_weaknesses` na ordem dada pelos pais.
+ *   - Preenche com canais não-mencionados no meio (ordem padrão).
+ *   - `sessions_observed` vem direto do input.
+ */
+export function onboardingToGardnerAssessment(
+  input: OnboardingGardnerInput,
+): GardnerAssessment {
+  const strengths = (input.perceived_strengths ?? []).map((s) => s.channel);
+  const weaknesses = (input.perceived_weaknesses ?? []).map((s) => s.channel);
+
+  // Top: primeiro pais declararam forças, depois resto sem weaknesses.
+  const top = dedupe(strengths).slice(0, 4);
+  // Bottom: pais declararam fraquezas, depois resto sem strengths.
+  const bottom = dedupe(weaknesses).slice(0, 4);
+
+  // Se pais não deram ≥1 em cada, preencher mínimo com canais não-mencionados.
+  const mentioned = new Set<GardnerChannel>([...top, ...bottom]);
+  const untouched = ALL_CHANNELS.filter((c) => !mentioned.has(c));
+  while (top.length < 1 && untouched.length > 0) {
+    top.push(untouched.shift()!);
+  }
+  while (bottom.length < 1 && untouched.length > 0) {
+    bottom.push(untouched.pop()!);
+  }
+
+  return {
+    top,
+    bottom,
+    sessions_observed: Math.max(0, input.sessions_completed),
+  };
+}
+
+function dedupe<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,3 +6,6 @@ export * from "./scorer.js";
 export * from "./tree-node.js";
 export * from "./status-matrix.js";
 export * from "./mixins/with-gardner-program.js";
+export * from "./parental-profile.js";
+export * from "./parental-authorization.js";
+export * from "./gardner-onboarding.js";

--- a/shared/src/parental-authorization.ts
+++ b/shared/src/parental-authorization.ts
@@ -1,0 +1,247 @@
+/**
+ * Parental authorization pipeline — 3 camadas do §6 paper:
+ *   1. Divergência: eBerrante (planejador) gera 3-5 alternativas (pool).
+ *   2. Triagem: Claude Haiku filtra e rankeia pelo ParentalProfile.
+ *   3. Decisão: pais aprovam/rejeitam/pinam; parent_pinned propaga pro scorer.
+ *
+ * Este módulo contém a camada (2): filter pipeline puro + helper async
+ * pra chamada do Haiku. A camada (3) vive em motor-execucao (persistência).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md §6
+ * Handoff: Bloco 4 do #17.
+ */
+
+import type { ScoredContentItem, ContentItem } from "./content-item.js";
+import type { ParentalProfile, ForbiddenZone } from "./parental-profile.js";
+
+export interface TriageResult {
+  /** Items aprovados pela triagem (aceitáveis pra pais). */
+  approved: ScoredContentItem[];
+  /** Items rejeitados por algum gate. */
+  rejected: Array<ScoredContentItem & { reject_reason: string }>;
+  /** Se Haiku foi consultado ou só filtro rule-based. */
+  triage_mode: "rule_based" | "haiku";
+  /** Tempo de triagem em ms (pra trace). */
+  duration_ms: number;
+}
+
+export interface TriageInput {
+  pool: ScoredContentItem[];
+  profile: ParentalProfile;
+  /** Top-K máximo após triagem. Default: min(2, pool.length). */
+  max_approved?: number;
+}
+
+/**
+ * Filtro rule-based — não chama LLM. Aplica forbidden_zones, age, budget.
+ * Pode ser usado standalone OU como fallback quando Haiku indisponível.
+ */
+export function triageRuleBased(input: TriageInput): TriageResult {
+  const started = Date.now();
+  const { pool, profile } = input;
+  const maxApproved = input.max_approved ?? Math.min(2, pool.length);
+
+  const approved: ScoredContentItem[] = [];
+  const rejected: TriageResult["rejected"] = [];
+
+  for (const scored of pool) {
+    const reject = evaluateAgainstProfile(scored.item, profile);
+    if (reject) {
+      rejected.push({ ...scored, reject_reason: reject });
+    } else {
+      approved.push(scored);
+    }
+  }
+
+  approved.sort((a, b) => b.score - a.score);
+  const topApproved = approved.slice(0, maxApproved);
+  const filteredOut = approved.slice(maxApproved);
+  for (const filtered of filteredOut) {
+    rejected.push({ ...filtered, reject_reason: "below_max_approved_cutoff" });
+  }
+
+  return {
+    approved: topApproved,
+    rejected,
+    triage_mode: "rule_based",
+    duration_ms: Date.now() - started,
+  };
+}
+
+function evaluateAgainstProfile(
+  item: ContentItem,
+  profile: ParentalProfile,
+): string | null {
+  // 1. Forbidden zones — match por domain + texto livre.
+  for (const zone of profile.forbidden_zones) {
+    if (matchesForbiddenZone(item, zone)) {
+      return `forbidden_zone:${zone.topic}`;
+    }
+  }
+
+  // 2. Scale tolerance — sacrifice_type 'act'/'create' pede 'medio' tolerance no mínimo.
+  const sacrificeType = (item as ContentItem & { sacrifice_type?: string }).sacrifice_type;
+  const tolerance = profile.parental_availability.scale_tolerance;
+  if (tolerance) {
+    if (
+      (sacrificeType === "act" || sacrificeType === "create") &&
+      (tolerance.medio === "no" || tolerance.pequeno === "no")
+    ) {
+      return "scale_tolerance_blocks_act_or_create";
+    }
+  }
+
+  return null;
+}
+
+function matchesForbiddenZone(item: ContentItem, zone: ForbiddenZone): boolean {
+  const topic = zone.topic.toLowerCase();
+  const hay = [
+    item.domain ?? "",
+    (item as ContentItem & { fact?: string }).fact ?? "",
+    (item as ContentItem & { bridge?: string }).bridge ?? "",
+    (item as ContentItem & { quest?: string }).quest ?? "",
+    (item as ContentItem & { title?: string }).title ?? "",
+    (item as ContentItem & { description?: string }).description ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+  // Match naïve por substring do topic em qualquer campo textual.
+  if (hay.includes(topic)) return true;
+  // Match de dominio específico pra topics canônicos.
+  if (topic === "political_content" && /politic|political/i.test(item.domain)) return true;
+  if (topic === "religious_proselytizing" && /relig|religion|teolog/i.test(item.domain)) return true;
+  return false;
+}
+
+/**
+ * Triage via Claude Haiku — input/output estruturados, prompt curto.
+ * Assinado assincronamente; caller decide mock vs real via env.
+ *
+ * Se Haiku falhar (timeout, parse error), cai em rule_based pra resiliência.
+ */
+export interface HaikuCaller {
+  (systemPrompt: string, userMessage: string): Promise<string>;
+}
+
+export async function triageWithHaiku(
+  input: TriageInput,
+  callHaiku: HaikuCaller,
+): Promise<TriageResult> {
+  const started = Date.now();
+  const { pool, profile } = input;
+  const maxApproved = input.max_approved ?? Math.min(2, pool.length);
+
+  // Rule-based pre-filter: sempre primeiro (cheap gate). Haiku só reordena.
+  const prefilter = triageRuleBased({ ...input, max_approved: pool.length });
+  if (prefilter.approved.length === 0) {
+    return { ...prefilter, duration_ms: Date.now() - started };
+  }
+
+  const systemPrompt = buildHaikuSystemPrompt(profile);
+  const userMessage = buildHaikuUserMessage(prefilter.approved);
+
+  let parsed: { ranking: string[] } | null = null;
+  try {
+    const raw = await callHaiku(systemPrompt, userMessage);
+    parsed = parseHaikuResponse(raw);
+  } catch {
+    // Fallback silencioso pro rule_based.
+    return {
+      approved: prefilter.approved.slice(0, maxApproved),
+      rejected: [
+        ...prefilter.rejected,
+        ...prefilter.approved.slice(maxApproved).map((s) => ({
+          ...s,
+          reject_reason: "below_max_approved_cutoff",
+        })),
+      ],
+      triage_mode: "rule_based",
+      duration_ms: Date.now() - started,
+    };
+  }
+
+  if (!parsed || !Array.isArray(parsed.ranking)) {
+    return {
+      approved: prefilter.approved.slice(0, maxApproved),
+      rejected: prefilter.rejected,
+      triage_mode: "rule_based",
+      duration_ms: Date.now() - started,
+    };
+  }
+
+  const byId = new Map(prefilter.approved.map((s) => [s.item.id, s]));
+  const reordered: ScoredContentItem[] = [];
+  for (const id of parsed.ranking) {
+    const s = byId.get(id);
+    if (s) reordered.push(s);
+  }
+  // Items que Haiku omitiu — vão pro rejeitado.
+  const omittedIds = new Set(
+    prefilter.approved.map((s) => s.item.id).filter((id) => !reordered.find((r) => r.item.id === id)),
+  );
+  const rejected = [
+    ...prefilter.rejected,
+    ...Array.from(omittedIds).map((id) => {
+      const s = prefilter.approved.find((x) => x.item.id === id)!;
+      return { ...s, reject_reason: "haiku_omitted" };
+    }),
+  ];
+  const topK = reordered.slice(0, maxApproved);
+  for (const dropped of reordered.slice(maxApproved)) {
+    rejected.push({ ...dropped, reject_reason: "below_max_approved_cutoff" });
+  }
+
+  return {
+    approved: topK,
+    rejected,
+    triage_mode: "haiku",
+    duration_ms: Date.now() - started,
+  };
+}
+
+function buildHaikuSystemPrompt(profile: ParentalProfile): string {
+  const values = profile.family_values.principles.slice(0, 5).map((p) => `- ${p}`).join("\n");
+  const forbidden = profile.forbidden_zones.map((z) => `- ${z.topic}: ${z.reason}`).join("\n");
+  return `Você é um filtro parental leve. Recebe uma lista curta de propostas de conteúdo pedagógico pra criança, cada uma com id + resumo. Seu trabalho é RERANKEAR por alinhamento com os valores da família.
+
+Valores declarados:
+${values}
+
+Zonas proibidas:
+${forbidden}
+
+Output obrigatório: JSON {"ranking": ["id1", "id2", ...]}. Omita o que viola valores; não invente ids.`;
+}
+
+function buildHaikuUserMessage(pool: ScoredContentItem[]): string {
+  const entries = pool.map((s) => {
+    const it = s.item as ContentItem & { fact?: string; bridge?: string };
+    const summary = `[${it.type}] ${it.domain}: ${it.fact ?? ""} → ${it.bridge ?? ""}`.slice(0, 180);
+    return `- ${it.id}: ${summary}`;
+  });
+  return `Propostas:\n${entries.join("\n")}\n\nRerankeie.`;
+}
+
+function parseHaikuResponse(raw: string): { ranking: string[] } | null {
+  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
+  try {
+    const parsed = JSON.parse(cleaned) as { ranking?: unknown };
+    if (!Array.isArray(parsed.ranking)) return null;
+    return { ranking: parsed.ranking.filter((x): x is string => typeof x === "string") };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Dispatch entry: chama Haiku se disponível, senão rule_based.
+ * Mode controlado por env USE_MOCK_LLM — se mock, força rule_based.
+ */
+export async function triageForParents(
+  input: TriageInput,
+  callHaiku?: HaikuCaller,
+): Promise<TriageResult> {
+  if (!callHaiku) return triageRuleBased(input);
+  return triageWithHaiku(input, callHaiku);
+}

--- a/shared/src/parental-profile.ts
+++ b/shared/src/parental-profile.ts
@@ -1,0 +1,99 @@
+/**
+ * ParentalProfile — perfil dos pais coletado via onboarding parental.
+ *
+ * Spec: ascendimacy-ops/docs/fundamentos/ebrota-kids-onboarding-parental.md §2.
+ * Fonte no motor: persona.profile.parental_profile (fixture pattern v1).
+ *
+ * Bloco 4 do #17 implementa só as seções 2.2, 2.4, 2.5 (Milestone 1-3 do doc):
+ *   - family_values + forbidden_zones + budget_constraints
+ *   - parental_availability + scale_tolerance
+ *   - gardner parental observation (input pra populate GardnerAssessment)
+ */
+
+import type { GardnerChannel } from "./content-item.js";
+
+export interface FamilyValues {
+  principles: string[];
+  cultural_axis?: string;
+  religious_tradition?:
+    | "shinto_buddhist"
+    | "christian"
+    | "secular"
+    | "other";
+  political_sensitivity?: "low" | "moderate" | "high";
+}
+
+export interface ForbiddenZone {
+  topic: string;
+  reason: string;
+}
+
+export interface BudgetConstraints {
+  materials_monthly_ceiling_jpy?: number;
+  screen_time_daily_max_minutes?: number;
+  screen_time_weekly_soft_ceiling?: number;
+}
+
+export interface ParentalAvailability {
+  supervision_available_hours_per_week?: number;
+  supervision_for_which_kinds_of_challenges?: string[];
+  scale_tolerance?: {
+    micro?: "yes" | "no" | "yes_with_review";
+    pequeno?: "yes" | "no" | "yes_with_review";
+    medio?: "yes" | "no" | "yes_with_review";
+    grande?: "yes" | "no" | "yes_with_review" | "yes_with_full_review_meeting";
+    monumental?: "yes" | "no" | "yes_with_review" | "yes_with_full_review_meeting";
+  };
+  ready_for_dyad_sessions?: boolean;
+  ready_for_joint_sessions?: boolean;
+}
+
+export interface PerceivedStrength {
+  channel: GardnerChannel;
+  note?: string;
+}
+
+export interface ParentalPerception {
+  perceived_aspiration?: string;
+  perceived_strengths?: PerceivedStrength[];
+  perceived_weaknesses?: PerceivedStrength[];
+  concerns_current?: string[];
+  hopes_for_next_3_months?: string[];
+}
+
+/**
+ * Decision profile determina como o pai responde:
+ *  - consultive: consulta outro responsável antes; demora mais
+ *  - decider: decide rápido e firme
+ *  - risk_averse: nega com frequência itens grandes
+ *  - permissive: aprova quase tudo, foca em valores
+ */
+export type ParentDecisionProfile =
+  | "consultative_risk_averse"
+  | "consultative_permissive"
+  | "decider_risk_averse"
+  | "decider_permissive";
+
+export interface ParentalProfile {
+  id: string;
+  role: "primary" | "secondary";
+  decision_profile: ParentDecisionProfile;
+  family_values: FamilyValues;
+  forbidden_zones: ForbiddenZone[];
+  budget_constraints: BudgetConstraints;
+  parental_availability: ParentalAvailability;
+  parental_perception?: ParentalPerception;
+  /** Valor opcional: minutos desde onboarding; serve pra re-onboarding trimestral. */
+  onboarding_completed_at?: string;
+}
+
+/** `true` se o perfil tem o mínimo pra Milestone 1 (§9 doc). */
+export function isParentalProfileMinimal(p: ParentalProfile | undefined): boolean {
+  if (!p) return false;
+  if (!p.family_values || !Array.isArray(p.family_values.principles)) return false;
+  if (p.family_values.principles.length === 0) return false;
+  if (!p.forbidden_zones) return false;
+  if (!p.budget_constraints) return false;
+  if (!p.parental_availability) return false;
+  return true;
+}

--- a/shared/tests/gardner-onboarding.test.ts
+++ b/shared/tests/gardner-onboarding.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { onboardingToGardnerAssessment } from "../src/gardner-onboarding.js";
+import { isAssessmentReady } from "../src/mixins/with-gardner-program.js";
+
+describe("onboardingToGardnerAssessment", () => {
+  it("converts perceived strengths into top channels", () => {
+    const a = onboardingToGardnerAssessment({
+      perceived_strengths: [
+        { channel: "linguistic" },
+        { channel: "spatial" },
+        { channel: "intrapersonal" },
+      ],
+      perceived_weaknesses: [{ channel: "musical" }, { channel: "naturalist" }],
+      sessions_completed: 3,
+    });
+    expect(a.top).toEqual(["linguistic", "spatial", "intrapersonal"]);
+    expect(a.bottom).toEqual(["musical", "naturalist"]);
+    expect(a.sessions_observed).toBe(3);
+  });
+
+  it("result passes isAssessmentReady when sessions >= 3", () => {
+    const a = onboardingToGardnerAssessment({
+      perceived_strengths: [{ channel: "linguistic" }],
+      perceived_weaknesses: [{ channel: "musical" }],
+      sessions_completed: 3,
+    });
+    expect(isAssessmentReady(a)).toBe(true);
+  });
+
+  it("fails isAssessmentReady when sessions < 3", () => {
+    const a = onboardingToGardnerAssessment({
+      perceived_strengths: [{ channel: "linguistic" }],
+      perceived_weaknesses: [{ channel: "musical" }],
+      sessions_completed: 2,
+    });
+    expect(isAssessmentReady(a)).toBe(false);
+  });
+
+  it("dedupes channels mentioned twice", () => {
+    const a = onboardingToGardnerAssessment({
+      perceived_strengths: [
+        { channel: "linguistic" },
+        { channel: "linguistic" },
+        { channel: "spatial" },
+      ],
+      sessions_completed: 3,
+    });
+    expect(a.top).toEqual(["linguistic", "spatial"]);
+  });
+
+  it("falls back to untouched channels when pai não deu nada", () => {
+    const a = onboardingToGardnerAssessment({ sessions_completed: 3 });
+    expect(a.top.length).toBeGreaterThanOrEqual(1);
+    expect(a.bottom.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("negative sessions_completed clamped a 0", () => {
+    const a = onboardingToGardnerAssessment({ sessions_completed: -5 });
+    expect(a.sessions_observed).toBe(0);
+  });
+
+  it("caps top at 4 channels (tabela §4.2 de 5 semanas)", () => {
+    const a = onboardingToGardnerAssessment({
+      perceived_strengths: [
+        { channel: "linguistic" },
+        { channel: "spatial" },
+        { channel: "intrapersonal" },
+        { channel: "interpersonal" },
+        { channel: "logical_mathematical" },
+      ],
+      sessions_completed: 3,
+    });
+    expect(a.top).toHaveLength(4);
+  });
+});

--- a/shared/tests/parental-authorization.test.ts
+++ b/shared/tests/parental-authorization.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  triageRuleBased,
+  triageWithHaiku,
+  triageForParents,
+} from "../src/parental-authorization.js";
+import type { ParentalProfile } from "../src/parental-profile.js";
+import type { ContentItem, ScoredContentItem } from "../src/content-item.js";
+
+const yuji: ParentalProfile = {
+  id: "yuji",
+  role: "primary",
+  decision_profile: "consultative_risk_averse",
+  family_values: { principles: ["esforço>resultado"] },
+  forbidden_zones: [
+    { topic: "political_content", reason: "divisivo" },
+    { topic: "religious_proselytizing", reason: "respeito" },
+  ],
+  budget_constraints: { screen_time_daily_max_minutes: 90 },
+  parental_availability: {
+    scale_tolerance: { micro: "yes", pequeno: "yes", medio: "yes", grande: "yes_with_review" },
+  },
+};
+
+function hook(id: string, score: number, overrides: Partial<ContentItem> = {}): ScoredContentItem {
+  return {
+    item: {
+      id,
+      type: "curiosity_hook",
+      domain: "biology",
+      casel_target: ["SA"],
+      age_range: [7, 14],
+      surprise: 8,
+      verified: true,
+      base_score: 7,
+      fact: "",
+      bridge: "",
+      quest: "",
+      sacrifice_type: "reflect",
+      ...overrides,
+    } as ContentItem,
+    score,
+    reasons: [],
+  };
+}
+
+describe("triageRuleBased — forbidden zones", () => {
+  it("rejects item whose domain matches forbidden topic", () => {
+    const pool = [
+      hook("pol1", 9, { domain: "political", fact: "algo sobre eleição" }),
+      hook("bio1", 8, { domain: "biology" }),
+    ];
+    const r = triageRuleBased({ pool, profile: yuji, max_approved: 2 });
+    const approvedIds = r.approved.map((s) => s.item.id);
+    expect(approvedIds).toContain("bio1");
+    expect(approvedIds).not.toContain("pol1");
+    expect(r.rejected.find((x) => x.item.id === "pol1")?.reject_reason).toMatch(/political/);
+  });
+
+  it("rejects item whose fact contains forbidden topic substring", () => {
+    const pool = [
+      hook("h1", 9, { fact: "religious_proselytizing em países secularizados" }),
+    ];
+    const r = triageRuleBased({ pool, profile: yuji });
+    expect(r.approved).toHaveLength(0);
+  });
+
+  it("approves all when no forbidden zones match", () => {
+    const pool = [hook("bio1", 9), hook("bio2", 7)];
+    const r = triageRuleBased({ pool, profile: yuji });
+    expect(r.approved).toHaveLength(2);
+  });
+
+  it("trims pool to max_approved after approving", () => {
+    const pool = [hook("a", 9), hook("b", 8), hook("c", 7)];
+    const r = triageRuleBased({ pool, profile: yuji, max_approved: 2 });
+    expect(r.approved).toHaveLength(2);
+    expect(r.approved.map((s) => s.item.id)).toEqual(["a", "b"]);
+    expect(r.rejected.find((x) => x.item.id === "c")?.reject_reason).toBe("below_max_approved_cutoff");
+  });
+});
+
+describe("triageRuleBased — scale tolerance", () => {
+  it("blocks act/create when scale_tolerance says no", () => {
+    const restrictive: ParentalProfile = {
+      ...yuji,
+      parental_availability: {
+        scale_tolerance: { medio: "no", pequeno: "yes", micro: "yes" },
+      },
+    };
+    const pool = [hook("act1", 9, { sacrifice_type: "act" })];
+    const r = triageRuleBased({ pool, profile: restrictive });
+    expect(r.approved).toHaveLength(0);
+    expect(r.rejected[0]!.reject_reason).toBe("scale_tolerance_blocks_act_or_create");
+  });
+});
+
+describe("triageWithHaiku — rerank + fallback", () => {
+  it("calls Haiku and reorders according to response", async () => {
+    const pool = [hook("a", 5), hook("b", 9), hook("c", 7)];
+    const mockHaiku = async () => JSON.stringify({ ranking: ["c", "a"] });
+    const r = await triageWithHaiku({ pool, profile: yuji, max_approved: 2 }, mockHaiku);
+    expect(r.triage_mode).toBe("haiku");
+    expect(r.approved.map((s) => s.item.id)).toEqual(["c", "a"]);
+    // 'b' omitido pelo Haiku vira rejected
+    expect(r.rejected.find((x) => x.item.id === "b")?.reject_reason).toBe("haiku_omitted");
+  });
+
+  it("falls back to rule_based when Haiku throws", async () => {
+    const pool = [hook("a", 5), hook("b", 9)];
+    const broken = async () => {
+      throw new Error("timeout");
+    };
+    const r = await triageWithHaiku({ pool, profile: yuji }, broken);
+    expect(r.triage_mode).toBe("rule_based");
+    expect(r.approved.length).toBeGreaterThan(0);
+  });
+
+  it("falls back when Haiku returns unparseable", async () => {
+    const pool = [hook("a", 9)];
+    const malformed = async () => "not json at all";
+    const r = await triageWithHaiku({ pool, profile: yuji }, malformed);
+    expect(r.triage_mode).toBe("rule_based");
+  });
+});
+
+describe("triageForParents — dispatch", () => {
+  it("uses rule_based when no Haiku caller", async () => {
+    const pool = [hook("a", 9)];
+    const r = await triageForParents({ pool, profile: yuji });
+    expect(r.triage_mode).toBe("rule_based");
+  });
+
+  it("uses Haiku when caller provided", async () => {
+    const pool = [hook("a", 9)];
+    const r = await triageForParents(
+      { pool, profile: yuji },
+      async () => JSON.stringify({ ranking: ["a"] }),
+    );
+    expect(r.triage_mode).toBe("haiku");
+  });
+});

--- a/shared/tests/parental-profile.test.ts
+++ b/shared/tests/parental-profile.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { isParentalProfileMinimal } from "../src/parental-profile.js";
+import type { ParentalProfile } from "../src/parental-profile.js";
+
+const base: ParentalProfile = {
+  id: "yuji",
+  role: "primary",
+  decision_profile: "consultative_risk_averse",
+  family_values: {
+    principles: ["p1"],
+  },
+  forbidden_zones: [{ topic: "political_content", reason: "x" }],
+  budget_constraints: { screen_time_daily_max_minutes: 90 },
+  parental_availability: {
+    scale_tolerance: { medio: "yes" },
+  },
+};
+
+describe("isParentalProfileMinimal", () => {
+  it("accepts profile with all required fields", () => {
+    expect(isParentalProfileMinimal(base)).toBe(true);
+  });
+
+  it("rejects undefined", () => {
+    expect(isParentalProfileMinimal(undefined)).toBe(false);
+  });
+
+  it("rejects empty family_values.principles", () => {
+    const p = { ...base, family_values: { principles: [] } };
+    expect(isParentalProfileMinimal(p)).toBe(false);
+  });
+
+  it("rejects missing forbidden_zones", () => {
+    const p = { ...base } as Partial<ParentalProfile>;
+    delete (p as { forbidden_zones?: unknown }).forbidden_zones;
+    expect(isParentalProfileMinimal(p as ParentalProfile)).toBe(false);
+  });
+
+  it("rejects missing parental_availability", () => {
+    const p = { ...base } as Partial<ParentalProfile>;
+    delete (p as { parental_availability?: unknown }).parental_availability;
+    expect(isParentalProfileMinimal(p as ParentalProfile)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Refs

- Paper §6: [docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md)
- Fundamentos: [docs/fundamentos/ebrota-kids-onboarding-parental.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/fundamentos/ebrota-kids-onboarding-parental.md) (§2, §4.1, §6)
- Companion: **ascendimacy-sts#4** (Yuji-virtual + Yuko-virtual personas)
- Base: motor#12 merged (`7e2c02a`)

## Cobertura dos 4 requisitos

| Req | Implementação |
|---|---|
| **(a)** Yuji/Yuko personas | `fixtures/parent-yuji.yaml` (consultative_risk_averse) + `parent-yuko.yaml` (decider_permissive) no motor; **personas sintéticas pro STS em sts#4** |
| **(b)** Pipeline triagem | `shared/src/parental-authorization.ts` — `triageRuleBased` (determinístico) + `triageWithHaiku` (Haiku rerank, rule-based pre-filter + fallback silencioso); persistência em `motor-execucao/src/parent-decisions.ts` (tabela `kids_parent_decisions`, status ∈ {pending,approved,rejected,pinned}); MCP tools `parent_decision_{set,list}` |
| **(c)** parent_pinned no scorer | Scorer já respeita (Bloco 1 — PARENT_PINNED_SCORE=1000). Novo helper `applyPinnedDecisions` em `planejador/src/plan.ts` lê `persona.profile.parent_pinned_ids` / `parent_rejected_ids` e marca items antes de scorar |
| **(d)** Assessment population | `shared/src/gardner-onboarding.ts` — `onboardingToGardnerAssessment({ strengths, weaknesses, sessions })` → `GardnerAssessment` consumível por Bloco 2b |

## Pipeline completo

```
1. planejador carrega pool → applyPinnedDecisions → scorePool → top-K
2. IF persona.profile.parental_profile (mínimo):
   triageForParents(topK, profile, callHaiku?) →
     ├─ rule_based: forbidden_zones + scale_tolerance
     └─ haiku: rerank sobre rule_based pre-filtered; fallback silencioso
3. contextHints emite parental_triage_mode + _rejected_ids
4. Orchestrator passa pro drota (instruction_addition + content_pool reduzido)
```

## Resultados

### npm run build
✅ 6 packages limpos

### npm run test — 261 verdes (+36 sobre Bloco 3)

| Package | Testes | Delta |
|---|---|---|
| shared | 117 | +22 (parental-profile 5, parental-authorization 10, gardner-onboarding 7) |
| planejador | 41 | +7 (parental-triage-integration) |
| motor-drota | 18 | — |
| motor-execucao | 39 | +7 (parent-decisions CRUD + UNIQUE + expiração) |
| orchestrator | 2 | — |
| weekly-report | 44 | — |

### npm run smoke
✅ Rubric G1-G3 verde

## Decisões de design

- **Rule-based primeiro, Haiku depois** — Haiku recebe só pool já filtrado (rule-based), rerankeia. Se falhar, rule-based survive. Zero cascata de falhas.
- **Match naïve de forbidden_zone** — substring em domain+fact+bridge+quest+title+description (lowercased). Funciona pro v1; refinar em Bloco 3+ se falsos positivos/negativos incomodarem.
- **Fixture pattern via persona.profile** — `parental_profile`, `parent_pinned_ids`, `parent_rejected_ids` vivem no `PersonaDef.profile`. Bloco 7 (piloto) troca por onboarding real que popula via tools MCP.
- **Haiku model default** = `claude-haiku-4-5-20251001`. Override via `HAIKU_MODEL` env.
- **Parent_pinned.score=1000** supera qualquer casel_focus/surprise. Decisão do paper §5.4 (Bloco 1 já implementou).

## Débitos explícitos (Bloco 5+)

- Onboarding conversacional real (sessões 1-5 via WhatsApp) — Bloco 7 piloto
- Seções 2.3/2.5/2.6 do fundamentos (perceived aspiration, crisis handoff, professional integrations) — Milestone 4-5 do doc
- Re-onboarding trimestral — Milestone 5
- Telemetria de triagem (quantos rejeitados por forbidden_zone, quantos approved virando pinned) — expandir trace v0.3 pra incluir

## Como testar

```bash
cd ascendimacy-motor
npm install
npm run build
npm run test    # 261 verdes
npm run smoke   # Rubric G1-G3
```

Testar Haiku real:

```bash
HAIKU_MODEL=claude-haiku-4-5-20251001 \
ANTHROPIC_API_KEY=sk-ant-... \
USE_MOCK_LLM=false \
node -e "..."  # ver ops docs pra receipt
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)