### PR TITLE
feat(#17 Bloco 5a): card generation runtime (schema + pipeline + HMAC + PDF)

### DIFF
--- a/content/cards/archetypes-seed.json
+++ b/content/cards/archetypes-seed.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "arch_persistence_v0",
+    "name": "Persistência Atomic",
+    "narrative_template": "{child_name}, você tentou e tentou, mesmo quando queria desistir. Isso é raro. Aqui está sua carta.",
+    "casel_dimension": "SM",
+    "gardner_channel": "logical_mathematical",
+    "rarity": "rare",
+    "is_scaffold": true
+  },
+  {
+    "id": "arch_curiosity_v0",
+    "name": "Curioso do Mundo",
+    "narrative_template": "{child_name}, você ficou mais tempo numa pergunta do que a maioria fica com a resposta pronta.",
+    "casel_dimension": "SA",
+    "gardner_channel": "intrapersonal",
+    "rarity": "common",
+    "is_scaffold": true
+  },
+  {
+    "id": "arch_teacher_v0",
+    "name": "Professor Improvável",
+    "narrative_template": "{child_name}, você explicou pra alguém hoje. Não repetiu — traduziu. Quem ensina aprende duas vezes.",
+    "casel_dimension": "REL",
+    "gardner_channel": "linguistic",
+    "rarity": "epic",
+    "is_scaffold": true
+  },
+  {
+    "id": "arch_brave_small_v0",
+    "name": "Coragem Pequena",
+    "narrative_template": "{child_name}, pequenos atos. Ninguém viu, mas o motor viu. Esta é sua carta.",
+    "casel_dimension": "SM",
+    "gardner_channel": "interpersonal",
+    "rarity": "common",
+    "is_scaffold": true
+  },
+  {
+    "id": "arch_crossing_v0",
+    "name": "Travessia",
+    "narrative_template": "{child_name}, você atravessou. De brejo pra baia, de baia pra pasto. O caminho conta.",
+    "casel_dimension": "SA",
+    "gardner_channel": "existential",
+    "rarity": "legendary",
+    "is_scaffold": true
+  }
+]

--- a/motor-execucao/src/archetype-loader.ts
+++ b/motor-execucao/src/archetype-loader.ts
@@ -1,0 +1,32 @@
+/**
+ * Carrega arquétipos do content/cards/archetypes-seed.json.
+ * v1 usa scaffolds — emitCard bloqueia em env != 'test' via guard.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { CardArchetype } from "@ascendimacy/shared";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PATH = join(__dirname, "../../content/cards/archetypes-seed.json");
+
+let _cache: CardArchetype[] | null = null;
+
+export function loadArchetypes(path?: string): CardArchetype[] {
+  if (_cache && !path) return _cache;
+  const target = path ?? DEFAULT_PATH;
+  const raw = readFileSync(target, "utf-8");
+  const parsed = JSON.parse(raw) as CardArchetype[];
+  if (!path) _cache = parsed;
+  return parsed;
+}
+
+export function getArchetype(id: string, path?: string): CardArchetype | undefined {
+  return loadArchetypes(path).find((a) => a.id === id);
+}
+
+/** Clear cache (test helper). */
+export function clearArchetypeCache(): void {
+  _cache = null;
+}

--- a/motor-execucao/src/card-generation.ts
+++ b/motor-execucao/src/card-generation.ts
@@ -1,0 +1,338 @@
+/**
+ * Card generation pipeline — Bloco 5a (#17).
+ *
+ * Estágios (runtime, sem catálogo fixo):
+ *   1. detectAchievement     — scan de trace/snapshot → AchievementSignal | null
+ *   2. proposeCardSpec       — monta CardSpec a partir do signal + contexto
+ *   3. triageCardSpec        — Haiku valida (reusa infra do Bloco 4)
+ *   4. generateCardImage     — via CardImageProvider (mock v1)
+ *   5. signCardAuthenticity  — HMAC-SHA256 (secret via env)
+ *   6. emitCard              — monta EmittedCard final, aplica scaffold guard
+ *
+ * Spec: docs/fundamentos/ebrota-kids-artefatos.md §2.3 + handoff Bloco 5a.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  CardSpec,
+  EmittedCard,
+  CardArchetype,
+  CardImageProvider,
+  CaselDimension,
+  GardnerChannel,
+  StatusMatrix,
+  StatusValue,
+  ScoredContentItem,
+  ParentalProfile,
+} from "@ascendimacy/shared";
+import {
+  generateCheatCode,
+  signCardPayload,
+  buildQrPayload,
+  formatSerialNumber,
+  gardnerIcon,
+  triageForParents,
+  type HaikuCaller,
+} from "@ascendimacy/shared";
+
+/**
+ * Sinal de conquista detectado — gatilho pra propor card.
+ * Detecção é heurística: qualquer transição status → pasto conta;
+ * ou sacrifice_spent alto; ou múltiplos canais Gardner ativados (ignition).
+ */
+export interface AchievementSignal {
+  child_id: string;
+  session_id: string;
+  timestamp: string;
+  kind: "status_to_pasto" | "ignition" | "sacrifice_high";
+  context_word: string;
+  casel_dimension: CaselDimension;
+  gardner_channel: GardnerChannel;
+  achievement_summary: string;
+}
+
+export interface DetectAchievementInput {
+  child_id: string;
+  session_id: string;
+  now: string;
+  /** Snapshot atual da matrix; compare com previous_matrix pra detectar ascensão. */
+  current_matrix?: StatusMatrix;
+  previous_matrix?: StatusMatrix;
+  /** Gardner channels observados no turn atual. */
+  gardner_observed?: GardnerChannel[];
+  /** CASEL targets do content selecionado. */
+  casel_touched?: CaselDimension[];
+  /** sacrifice_spent do turn. */
+  sacrifice_spent?: number;
+  /** selected content — usado pra context_word e achievement_summary. */
+  selected_content?: ScoredContentItem;
+}
+
+export const SACRIFICE_HIGH_THRESHOLD = 15;
+export const IGNITION_CHANNELS_MIN = 3;
+export const IGNITION_DIMENSIONS_MIN = 2;
+
+/** Retorna primeiro signal detectado ou null. Ordem de prioridade: pasto > ignition > sacrifice. */
+export function detectAchievement(
+  input: DetectAchievementInput,
+): AchievementSignal | null {
+  const kind = classifyAchievement(input);
+  if (!kind) return null;
+  const casel =
+    input.casel_touched?.[0] ??
+    (input.selected_content?.item?.casel_target?.[0] as CaselDimension | undefined) ??
+    "SA";
+  const gardner =
+    input.gardner_observed?.[0] ??
+    "intrapersonal";
+  const contextWord =
+    input.selected_content?.item?.domain ?? "conquista";
+  return {
+    child_id: input.child_id,
+    session_id: input.session_id,
+    timestamp: input.now,
+    kind,
+    context_word: contextWord,
+    casel_dimension: casel,
+    gardner_channel: gardner,
+    achievement_summary: buildSummary(kind, input),
+  };
+}
+
+function classifyAchievement(input: DetectAchievementInput): AchievementSignal["kind"] | null {
+  // 1. Status matrix atingiu pasto onde antes era baia/brejo.
+  if (input.previous_matrix && input.current_matrix) {
+    for (const [dim, nowValue] of Object.entries(input.current_matrix)) {
+      const prev = input.previous_matrix[dim];
+      if (nowValue === "pasto" && prev && prev !== "pasto") {
+        return "status_to_pasto";
+      }
+    }
+  }
+  // 2. Ignição: ≥3 canais × ≥2 dims.
+  const channels = uniq(input.gardner_observed ?? []).length;
+  const dims = uniq(input.casel_touched ?? []).length;
+  if (channels >= IGNITION_CHANNELS_MIN && dims >= IGNITION_DIMENSIONS_MIN) {
+    return "ignition";
+  }
+  // 3. Sacrifice alto.
+  if ((input.sacrifice_spent ?? 0) >= SACRIFICE_HIGH_THRESHOLD) {
+    return "sacrifice_high";
+  }
+  return null;
+}
+
+function uniq<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}
+
+function buildSummary(kind: AchievementSignal["kind"], input: DetectAchievementInput): string {
+  const selId = input.selected_content?.item?.id;
+  switch (kind) {
+    case "status_to_pasto": {
+      const dim = firstDimensionToPasto(input);
+      return `dimensão ${dim ?? "?"} transicionou pra pasto${selId ? ` via ${selId}` : ""}`;
+    }
+    case "ignition":
+      return `ignição multi-canal (${input.gardner_observed?.length ?? 0} Gardner × ${input.casel_touched?.length ?? 0} CASEL)`;
+    case "sacrifice_high":
+      return `sacrifício alto (${input.sacrifice_spent} pts) em ${selId ?? "content desconhecido"}`;
+  }
+}
+
+function firstDimensionToPasto(input: DetectAchievementInput): string | null {
+  if (!input.previous_matrix || !input.current_matrix) return null;
+  for (const [dim, val] of Object.entries(input.current_matrix)) {
+    const prev = input.previous_matrix[dim];
+    if (val === "pasto" && prev && prev !== "pasto") return dim;
+  }
+  return null;
+}
+
+/** Monta CardSpec a partir do signal + archetype escolhido + sequence. */
+export function proposeCardSpec(
+  signal: AchievementSignal,
+  archetype: CardArchetype,
+  sequence: number,
+): CardSpec {
+  return {
+    archetype,
+    child_id: signal.child_id,
+    session_id: signal.session_id,
+    context_word: signal.context_word,
+    casel_dimension: signal.casel_dimension,
+    gardner_channel: signal.gardner_channel,
+    issued_at: signal.timestamp,
+    achievement_summary: signal.achievement_summary,
+    sequence,
+  };
+}
+
+/**
+ * Seleciona archetype apropriado para o signal, dentro da lista disponível.
+ * v1: match por (kind → rarity default) + casel_dimension fit. Fallback: primeiro da lista.
+ */
+export function selectArchetypeForSignal(
+  signal: AchievementSignal,
+  archetypes: CardArchetype[],
+): CardArchetype | null {
+  if (archetypes.length === 0) return null;
+  const rarityByKind: Record<AchievementSignal["kind"], string> = {
+    status_to_pasto: "legendary",
+    ignition: "epic",
+    sacrifice_high: "rare",
+  };
+  const targetRarity = rarityByKind[signal.kind];
+  // Tenta match exato casel + rarity.
+  const exact = archetypes.find(
+    (a) => a.casel_dimension === signal.casel_dimension && a.rarity === targetRarity,
+  );
+  if (exact) return exact;
+  // Tenta só rarity.
+  const byRarity = archetypes.find((a) => a.rarity === targetRarity);
+  if (byRarity) return byRarity;
+  // Fallback: primeiro.
+  return archetypes[0]!;
+}
+
+/**
+ * Triage via infra do Bloco 4 — envolve CardSpec num ScoredContentItem sintético
+ * só pra reusar `triageForParents`. v1 checa forbidden_zones no narrative + summary.
+ */
+export async function triageCardSpec(
+  spec: CardSpec,
+  profile: ParentalProfile | undefined,
+  callHaiku?: HaikuCaller,
+): Promise<{ approved: boolean; reject_reason?: string; triage_mode: string }> {
+  if (!profile) {
+    return { approved: true, triage_mode: "skipped_no_profile" };
+  }
+  const synthetic: ScoredContentItem = {
+    item: {
+      id: `card_spec_${spec.child_id}_${spec.sequence}`,
+      type: "card_catalog",
+      domain: spec.context_word,
+      casel_target: [spec.casel_dimension],
+      age_range: [0, 99],
+      surprise: 7,
+      verified: true,
+      base_score: 7,
+      title: spec.archetype.name,
+      rarity: spec.archetype.rarity,
+      trigger_conditions: [],
+      recipient_narrative_template: spec.archetype.narrative_template,
+      parent_approval_required: true,
+      description: spec.achievement_summary,
+    } as ScoredContentItem["item"],
+    score: 10,
+    reasons: ["card_spec_synthetic"],
+  };
+  const result = await triageForParents(
+    { pool: [synthetic], profile, max_approved: 1 },
+    callHaiku,
+  );
+  if (result.approved.length === 0) {
+    const rejected = result.rejected[0];
+    return {
+      approved: false,
+      reject_reason: rejected?.reject_reason ?? "unknown",
+      triage_mode: result.triage_mode,
+    };
+  }
+  return { approved: true, triage_mode: result.triage_mode };
+}
+
+/** Wrapper: gera imagem via provider. Separado pra fácil swap. */
+export async function generateCardImage(
+  spec: CardSpec,
+  provider: CardImageProvider,
+): Promise<{ image_url: string; mime: string; provider: string }> {
+  return provider.generateImage(spec);
+}
+
+/** Wrapper: HMAC signature + qr_payload. Lê secret do caller; módulo sem env. */
+export function signCardAuthenticity(
+  cardId: string,
+  childId: string,
+  issuedAt: string,
+  secret: string,
+): { signature: string; qr_payload: string } {
+  const signature = signCardPayload({
+    card_id: cardId,
+    child_id: childId,
+    issued_at: issuedAt,
+    secret,
+  });
+  const qr_payload = buildQrPayload(cardId, signature);
+  return { signature, qr_payload };
+}
+
+export interface EmitCardInput {
+  spec: CardSpec;
+  approved_at: string;
+  emitted_at: string;
+  image: { image_url: string; mime: string; provider: string };
+  secret: string;
+  /** 'test' | 'development' | 'production' — 'test' é única que permite scaffold. */
+  env: string;
+  /** Child name substituído no narrative template. */
+  child_name?: string;
+}
+
+/**
+ * Emite o card — monta EmittedCard completo com front + back + signature.
+ *
+ * GUARD: throws se `spec.archetype.is_scaffold && env !== 'test'`.
+ * Motivo: scaffolds NUNCA podem vazar pra criança real. Fica como sentinela
+ * até Bloco 5b trazer archétipos editoriais (Content Engine charter).
+ */
+export function emitCard(input: EmitCardInput): EmittedCard {
+  if (input.spec.archetype.is_scaffold && input.env !== "test") {
+    throw new Error(
+      `emitCard: archetype '${input.spec.archetype.id}' is scaffold; ` +
+        `blocked in env='${input.env}'. Awaiting Bloco 5b Content Engine curation.`,
+    );
+  }
+  const cardId = randomUUID();
+  const { signature, qr_payload } = signCardAuthenticity(
+    cardId,
+    input.spec.child_id,
+    input.spec.issued_at,
+    input.secret,
+  );
+  const cheatCode = generateCheatCode({
+    context_word: input.spec.context_word,
+    issued_at: input.spec.issued_at,
+    gardner_channel: input.spec.gardner_channel,
+    now: input.emitted_at,
+  });
+  const narrative = (input.spec.archetype.narrative_template ?? "").replace(
+    /\{child_name\}/g,
+    input.child_name ?? input.spec.child_id,
+  );
+  const emitted: EmittedCard = {
+    card_id: cardId,
+    child_id: input.spec.child_id,
+    session_id: input.spec.session_id,
+    archetype_id: input.spec.archetype.id,
+    front: {
+      image_url: input.image.image_url,
+      narrative,
+      archetype_id: input.spec.archetype.id,
+    },
+    back: {
+      template: "v1-default",
+      gardner_channel_icon: gardnerIcon(input.spec.gardner_channel),
+      casel_dimension: input.spec.casel_dimension,
+      cheat_code: cheatCode,
+      serial_number: formatSerialNumber(input.spec.child_id, input.spec.sequence),
+      qr_payload,
+    },
+    spec_snapshot: input.spec,
+    signature,
+    issued_at: input.spec.issued_at,
+    approved_at: input.approved_at,
+    emitted_at: input.emitted_at,
+  };
+  return emitted;
+}

--- a/motor-execucao/src/cards-repo.ts
+++ b/motor-execucao/src/cards-repo.ts
@@ -1,0 +1,127 @@
+/**
+ * kids_emitted_cards — persistência de cards emitidos.
+ *
+ * Spec: Handoff #17 Bloco 5a (b).
+ * Invariante: cards nunca revogados (fundamentos §8 invariante #4).
+ */
+
+import type Database from "better-sqlite3";
+import type { EmittedCard } from "@ascendimacy/shared";
+
+export const EMITTED_CARDS_DDL = `
+CREATE TABLE IF NOT EXISTS kids_emitted_cards (
+  card_id TEXT PRIMARY KEY,
+  child_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  archetype_id TEXT NOT NULL,
+  serial_number TEXT NOT NULL,
+  signature TEXT NOT NULL,
+  issued_at TEXT NOT NULL,
+  approved_at TEXT NOT NULL,
+  emitted_at TEXT NOT NULL,
+  front_json TEXT NOT NULL,
+  back_json TEXT NOT NULL,
+  spec_snapshot_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cards_by_child ON kids_emitted_cards(child_id);
+CREATE INDEX IF NOT EXISTS idx_cards_by_session ON kids_emitted_cards(session_id);
+CREATE INDEX IF NOT EXISTS idx_cards_by_emitted_at ON kids_emitted_cards(emitted_at);
+`;
+
+interface CardRow {
+  card_id: string;
+  child_id: string;
+  session_id: string;
+  archetype_id: string;
+  serial_number: string;
+  signature: string;
+  issued_at: string;
+  approved_at: string;
+  emitted_at: string;
+  front_json: string;
+  back_json: string;
+  spec_snapshot_json: string;
+}
+
+function rowToCard(row: CardRow): EmittedCard {
+  return {
+    card_id: row.card_id,
+    child_id: row.child_id,
+    session_id: row.session_id,
+    archetype_id: row.archetype_id,
+    front: JSON.parse(row.front_json),
+    back: JSON.parse(row.back_json),
+    spec_snapshot: JSON.parse(row.spec_snapshot_json),
+    signature: row.signature,
+    issued_at: row.issued_at,
+    approved_at: row.approved_at,
+    emitted_at: row.emitted_at,
+  };
+}
+
+/** Persiste um card; idempotente pelo card_id. */
+export function saveEmittedCard(db: Database.Database, card: EmittedCard): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO kids_emitted_cards
+      (card_id, child_id, session_id, archetype_id, serial_number, signature,
+       issued_at, approved_at, emitted_at, front_json, back_json, spec_snapshot_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    card.card_id,
+    card.child_id,
+    card.session_id,
+    card.archetype_id,
+    card.back.serial_number,
+    card.signature,
+    card.issued_at,
+    card.approved_at,
+    card.emitted_at,
+    JSON.stringify(card.front),
+    JSON.stringify(card.back),
+    JSON.stringify(card.spec_snapshot),
+  );
+}
+
+export function getEmittedCardsByChild(
+  db: Database.Database,
+  childId: string,
+): EmittedCard[] {
+  const rows = db
+    .prepare("SELECT * FROM kids_emitted_cards WHERE child_id = ? ORDER BY emitted_at")
+    .all(childId) as CardRow[];
+  return rows.map(rowToCard);
+}
+
+export function getEmittedCardsBySession(
+  db: Database.Database,
+  sessionId: string,
+): EmittedCard[] {
+  const rows = db
+    .prepare("SELECT * FROM kids_emitted_cards WHERE session_id = ? ORDER BY emitted_at")
+    .all(sessionId) as CardRow[];
+  return rows.map(rowToCard);
+}
+
+export function getEmittedCardsInRange(
+  db: Database.Database,
+  childId: string,
+  fromIso: string,
+  toIso: string,
+): EmittedCard[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM kids_emitted_cards
+       WHERE child_id = ? AND emitted_at >= ? AND emitted_at < ?
+       ORDER BY emitted_at`,
+    )
+    .all(childId, fromIso, toIso) as CardRow[];
+  return rows.map(rowToCard);
+}
+
+/** Próxima sequence (count + 1) por child — usado por formatSerialNumber. */
+export function getNextSequence(db: Database.Database, childId: string): number {
+  const row = db
+    .prepare("SELECT COUNT(*) AS n FROM kids_emitted_cards WHERE child_id = ?")
+    .get(childId) as { n: number };
+  return row.n + 1;
+}

--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -16,6 +16,13 @@ import {
   PARENT_DECISION_STATUSES,
 } from "./parent-decisions.js";
 import type { ParentDecisionStatus } from "./parent-decisions.js";
+import {
+  saveEmittedCard,
+  getEmittedCardsByChild,
+  getEmittedCardsBySession,
+  getEmittedCardsInRange,
+} from "./cards-repo.js";
+import type { EmittedCard } from "@ascendimacy/shared";
 
 const inventory = loadInventory();
 
@@ -105,6 +112,44 @@ server.registerTool("parent_decision_list", {
 }, async ({ sessionId }: { sessionId: string }) => {
   const decisions = listParentDecisions(getDbInstance(), sessionId);
   return { content: [{ type: "text" as const, text: JSON.stringify(decisions) }] };
+});
+
+server.registerTool("card_save", {
+  description: "Persiste EmittedCard em kids_emitted_cards (idempotente pelo card_id). Caller monta o card via pipeline shared.",
+  inputSchema: {
+    card: z.record(z.string(), z.unknown()),
+  } as any,
+}, async ({ card }: { card: EmittedCard }) => {
+  saveEmittedCard(getDbInstance(), card);
+  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, card_id: card.card_id }) }] };
+});
+
+server.registerTool("card_list_by_child", {
+  description: "Lista todos os cards emitidos de uma criança, ordem emitted_at.",
+  inputSchema: { childId: z.string() } as any,
+}, async ({ childId }: { childId: string }) => {
+  const cards = getEmittedCardsByChild(getDbInstance(), childId);
+  return { content: [{ type: "text" as const, text: JSON.stringify(cards) }] };
+});
+
+server.registerTool("card_list_by_session", {
+  description: "Lista cards emitidos em uma sessão.",
+  inputSchema: { sessionId: z.string() } as any,
+}, async ({ sessionId }: { sessionId: string }) => {
+  const cards = getEmittedCardsBySession(getDbInstance(), sessionId);
+  return { content: [{ type: "text" as const, text: JSON.stringify(cards) }] };
+});
+
+server.registerTool("card_list_in_range", {
+  description: "Lista cards de uma criança emitidos em [fromIso, toIso). Usado pelo weekly-report.",
+  inputSchema: {
+    childId: z.string(),
+    fromIso: z.string(),
+    toIso: z.string(),
+  } as any,
+}, async ({ childId, fromIso, toIso }: { childId: string; fromIso: string; toIso: string }) => {
+  const cards = getEmittedCardsInRange(getDbInstance(), childId, fromIso, toIso);
+  return { content: [{ type: "text" as const, text: JSON.stringify(cards) }] };
 });
 
 server.registerTool("log_event", {

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -5,6 +5,7 @@ import type { SessionState, EventEntry } from "@ascendimacy/shared";
 import { TREE_NODES_DDL, getStatusMatrix } from "./tree-nodes.js";
 import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
 import { PARENT_DECISIONS_DDL } from "./parent-decisions.js";
+import { EMITTED_CARDS_DDL } from "./cards-repo.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -35,6 +36,7 @@ function getDb(dbPath?: string): Database.Database {
       ${TREE_NODES_DDL}
       ${GARDNER_PROGRAM_DDL}
       ${PARENT_DECISIONS_DDL}
+      ${EMITTED_CARDS_DDL}
     `);
   }
   return db;

--- a/motor-execucao/tests/card-generation.test.ts
+++ b/motor-execucao/tests/card-generation.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectAchievement,
+  proposeCardSpec,
+  selectArchetypeForSignal,
+  triageCardSpec,
+  generateCardImage,
+  signCardAuthenticity,
+  emitCard,
+  SACRIFICE_HIGH_THRESHOLD,
+  IGNITION_CHANNELS_MIN,
+} from "../src/card-generation.js";
+import {
+  MockCardImageProvider,
+  verifyCardSignature,
+} from "@ascendimacy/shared";
+import type { CardArchetype, ParentalProfile } from "@ascendimacy/shared";
+import { loadArchetypes } from "../src/archetype-loader.js";
+
+const SECRET = "test-secret-very-secret-0000";
+const NOW = "2026-04-24T12:00:00Z";
+
+const allArchetypes: CardArchetype[] = loadArchetypes();
+
+// Forçamos um archetype NÃO-scaffold pra testar path feliz em env != test.
+const nonScaffoldArchetype: CardArchetype = {
+  id: "arch_test_real",
+  name: "Test Real",
+  narrative_template: "{child_name}, bom trabalho.",
+  casel_dimension: "SM",
+  gardner_channel: "logical_mathematical",
+  rarity: "rare",
+  is_scaffold: false,
+};
+
+describe("detectAchievement", () => {
+  it("retorna null sem sinais", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("detecta status_to_pasto quando dim passou de baia→pasto", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      previous_matrix: { cognitive_math: "baia" },
+      current_matrix: { cognitive_math: "pasto" },
+    });
+    expect(r?.kind).toBe("status_to_pasto");
+  });
+
+  it("não detecta quando dim já estava pasto", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      previous_matrix: { emotional: "pasto" },
+      current_matrix: { emotional: "pasto" },
+    });
+    expect(r).toBeNull();
+  });
+
+  it("detecta ignition com ≥3 Gardner × ≥2 CASEL", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      gardner_observed: ["linguistic", "logical_mathematical", "spatial"],
+      casel_touched: ["SA", "DM"],
+    });
+    expect(r?.kind).toBe("ignition");
+  });
+
+  it("não detecta ignition com <3 canais", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      gardner_observed: ["linguistic", "logical_mathematical"],
+      casel_touched: ["SA", "DM"],
+    });
+    expect(r).toBeNull();
+  });
+
+  it("detecta sacrifice_high", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      sacrifice_spent: SACRIFICE_HIGH_THRESHOLD + 1,
+    });
+    expect(r?.kind).toBe("sacrifice_high");
+  });
+
+  it("prioriza pasto > ignition > sacrifice", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      previous_matrix: { cognitive_math: "baia" },
+      current_matrix: { cognitive_math: "pasto" },
+      gardner_observed: ["linguistic", "logical_mathematical", "spatial"],
+      casel_touched: ["SA", "DM"],
+      sacrifice_spent: 20,
+    });
+    expect(r?.kind).toBe("status_to_pasto");
+  });
+});
+
+describe("selectArchetypeForSignal", () => {
+  const archetypes = allArchetypes;
+  it("prefere match casel+rarity", () => {
+    const signal = {
+      child_id: "ryo",
+      session_id: "s1",
+      timestamp: NOW,
+      kind: "ignition" as const,
+      context_word: "x",
+      casel_dimension: "REL" as const,
+      gardner_channel: "linguistic" as const,
+      achievement_summary: "x",
+    };
+    const a = selectArchetypeForSignal(signal, archetypes);
+    // ignition → epic → arch_teacher (REL+epic no seed)
+    expect(a?.id).toBe("arch_teacher_v0");
+  });
+
+  it("fallback pra rarity quando casel não bate", () => {
+    const signal = {
+      child_id: "ryo",
+      session_id: "s1",
+      timestamp: NOW,
+      kind: "status_to_pasto" as const,
+      context_word: "x",
+      casel_dimension: "DM" as const,
+      gardner_channel: "linguistic" as const,
+      achievement_summary: "x",
+    };
+    // status_to_pasto → legendary; seed tem arch_crossing legendary com SA
+    const a = selectArchetypeForSignal(signal, archetypes);
+    expect(a?.rarity).toBe("legendary");
+  });
+
+  it("retorna null com archetypes vazio", () => {
+    const signal = {
+      child_id: "ryo",
+      session_id: "s1",
+      timestamp: NOW,
+      kind: "ignition" as const,
+      context_word: "x",
+      casel_dimension: "SA" as const,
+      gardner_channel: "linguistic" as const,
+      achievement_summary: "x",
+    };
+    expect(selectArchetypeForSignal(signal, [])).toBeNull();
+  });
+});
+
+describe("triageCardSpec (reuso do Bloco 4 triageForParents)", () => {
+  const profile: ParentalProfile = {
+    id: "yuji",
+    role: "primary",
+    decision_profile: "consultative_risk_averse",
+    family_values: { principles: ["x"] },
+    forbidden_zones: [{ topic: "violence", reason: "teste" }],
+    budget_constraints: {},
+    parental_availability: {},
+  };
+
+  it("approved=true quando profile ausente (skip)", async () => {
+    const spec = proposeCardSpec(
+      {
+        child_id: "r",
+        session_id: "s",
+        timestamp: NOW,
+        kind: "ignition",
+        context_word: "biology",
+        casel_dimension: "SA",
+        gardner_channel: "linguistic",
+        achievement_summary: "summary",
+      },
+      nonScaffoldArchetype,
+      1,
+    );
+    const r = await triageCardSpec(spec, undefined);
+    expect(r.approved).toBe(true);
+    expect(r.triage_mode).toBe("skipped_no_profile");
+  });
+
+  it("rejeita quando summary contém forbidden topic", async () => {
+    const spec = proposeCardSpec(
+      {
+        child_id: "r",
+        session_id: "s",
+        timestamp: NOW,
+        kind: "ignition",
+        context_word: "violence_topic",
+        casel_dimension: "SA",
+        gardner_channel: "linguistic",
+        achievement_summary: "cena de violence forte",
+      },
+      nonScaffoldArchetype,
+      1,
+    );
+    const r = await triageCardSpec(spec, profile);
+    expect(r.approved).toBe(false);
+    expect(r.reject_reason).toMatch(/violence/);
+  });
+});
+
+describe("generateCardImage + signCardAuthenticity", () => {
+  it("generateCardImage devolve data URL", async () => {
+    const spec = proposeCardSpec(
+      {
+        child_id: "r",
+        session_id: "s",
+        timestamp: NOW,
+        kind: "ignition",
+        context_word: "biology",
+        casel_dimension: "SA",
+        gardner_channel: "linguistic",
+        achievement_summary: "x",
+      },
+      nonScaffoldArchetype,
+      1,
+    );
+    const img = await generateCardImage(spec, new MockCardImageProvider());
+    expect(img.image_url).toMatch(/^data:image\/png/);
+  });
+
+  it("signCardAuthenticity produz signature verificável", () => {
+    const { signature, qr_payload } = signCardAuthenticity(
+      "abc-123",
+      "ryo",
+      NOW,
+      SECRET,
+    );
+    expect(signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(qr_payload).toContain(signature);
+    expect(
+      verifyCardSignature({
+        card_id: "abc-123",
+        child_id: "ryo",
+        issued_at: NOW,
+        secret: SECRET,
+        signature,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("emitCard — pipeline end-to-end + scaffold guard", () => {
+  const signal = {
+    child_id: "ryo",
+    session_id: "s1",
+    timestamp: "2026-04-24T10:00:00Z",
+    kind: "ignition" as const,
+    context_word: "biology",
+    casel_dimension: "SA" as const,
+    gardner_channel: "linguistic" as const,
+    achievement_summary: "ignição multi-canal",
+  };
+
+  it("emite card completo com env=test mesmo com scaffold", async () => {
+    const scaffoldArchetype = allArchetypes[0]!; // arch_persistence_v0 (is_scaffold: true)
+    expect(scaffoldArchetype.is_scaffold).toBe(true);
+    const spec = proposeCardSpec(signal, scaffoldArchetype, 1);
+    const image = await new MockCardImageProvider().generateImage(spec);
+    const card = emitCard({
+      spec,
+      approved_at: "2026-04-24T11:00:00Z",
+      emitted_at: "2026-04-24T12:00:00Z",
+      image,
+      secret: SECRET,
+      env: "test",
+      child_name: "Ryo",
+    });
+    expect(card.card_id).toBeTruthy();
+    expect(card.front.image_url).toBe(image.image_url);
+    expect(card.front.narrative).toContain("Ryo");
+    expect(card.back.serial_number).toBe("#ryo-001");
+    expect(card.back.template).toBe("v1-default");
+    expect(card.back.cheat_code).toContain("biology");
+    expect(card.signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(card.issued_at).toBe(signal.timestamp);
+    expect(card.approved_at).toBe("2026-04-24T11:00:00Z");
+    expect(card.emitted_at).toBe("2026-04-24T12:00:00Z");
+  });
+
+  it("GUARD: throws quando scaffold + env='production'", async () => {
+    const scaffold = allArchetypes[0]!;
+    const spec = proposeCardSpec(signal, scaffold, 1);
+    const image = await new MockCardImageProvider().generateImage(spec);
+    expect(() =>
+      emitCard({
+        spec,
+        approved_at: "2026-04-24T11:00:00Z",
+        emitted_at: "2026-04-24T12:00:00Z",
+        image,
+        secret: SECRET,
+        env: "production",
+      }),
+    ).toThrow(/scaffold/);
+  });
+
+  it("GUARD: throws quando scaffold + env='development'", async () => {
+    const scaffold = allArchetypes[0]!;
+    const spec = proposeCardSpec(signal, scaffold, 1);
+    const image = await new MockCardImageProvider().generateImage(spec);
+    expect(() =>
+      emitCard({
+        spec,
+        approved_at: "x",
+        emitted_at: "y",
+        image,
+        secret: SECRET,
+        env: "development",
+      }),
+    ).toThrow(/scaffold/);
+  });
+
+  it("archetype NÃO-scaffold emite em qualquer env", async () => {
+    const spec = proposeCardSpec(signal, nonScaffoldArchetype, 42);
+    const image = await new MockCardImageProvider().generateImage(spec);
+    const card = emitCard({
+      spec,
+      approved_at: "2026-04-24T11:00:00Z",
+      emitted_at: "2026-04-24T12:00:00Z",
+      image,
+      secret: SECRET,
+      env: "production",
+    });
+    expect(card.card_id).toBeTruthy();
+    expect(card.back.serial_number).toBe("#ryo-042");
+  });
+
+  it("signature é verificável com o secret", async () => {
+    const spec = proposeCardSpec(signal, nonScaffoldArchetype, 1);
+    const image = await new MockCardImageProvider().generateImage(spec);
+    const card = emitCard({
+      spec,
+      approved_at: "2026-04-24T11:00:00Z",
+      emitted_at: "2026-04-24T12:00:00Z",
+      image,
+      secret: SECRET,
+      env: "production",
+    });
+    expect(
+      verifyCardSignature({
+        card_id: card.card_id,
+        child_id: card.child_id,
+        issued_at: card.issued_at,
+        secret: SECRET,
+        signature: card.signature,
+      }),
+    ).toBe(true);
+  });
+
+  it("3 marcas temporais distintas: issued < approved < emitted", async () => {
+    const spec = proposeCardSpec(
+      { ...signal, timestamp: "2026-04-24T10:00:00Z" },
+      nonScaffoldArchetype,
+      1,
+    );
+    const image = await new MockCardImageProvider().generateImage(spec);
+    const card = emitCard({
+      spec,
+      approved_at: "2026-04-24T11:30:00Z",
+      emitted_at: "2026-04-25T08:00:00Z",
+      image,
+      secret: SECRET,
+      env: "test",
+    });
+    expect(new Date(card.issued_at).getTime()).toBeLessThan(
+      new Date(card.approved_at).getTime(),
+    );
+    expect(new Date(card.approved_at).getTime()).toBeLessThan(
+      new Date(card.emitted_at).getTime(),
+    );
+  });
+});

--- a/motor-execucao/tests/cards-repo.test.ts
+++ b/motor-execucao/tests/cards-repo.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  EMITTED_CARDS_DDL,
+  saveEmittedCard,
+  getEmittedCardsByChild,
+  getEmittedCardsBySession,
+  getEmittedCardsInRange,
+  getNextSequence,
+} from "../src/cards-repo.js";
+import type { EmittedCard } from "@ascendimacy/shared";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(EMITTED_CARDS_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function makeCard(overrides: Partial<EmittedCard> = {}): EmittedCard {
+  return {
+    card_id: "c1",
+    child_id: "ryo",
+    session_id: "s1",
+    archetype_id: "arch_1",
+    front: { image_url: "data:x", narrative: "n", archetype_id: "arch_1" },
+    back: {
+      template: "v1-default",
+      gardner_channel_icon: "✍️",
+      casel_dimension: "SA",
+      cheat_code: "test · hoje · ✍️",
+      serial_number: "#ryo-001",
+      qr_payload: "https://ebrota.app/v/c1?sig=abc",
+    },
+    spec_snapshot: {
+      archetype: { id: "arch_1", name: "x", narrative_template: "x", casel_dimension: "SA", gardner_channel: "linguistic", rarity: "common", is_scaffold: false },
+      child_id: "ryo",
+      session_id: "s1",
+      context_word: "test",
+      casel_dimension: "SA",
+      gardner_channel: "linguistic",
+      issued_at: "2026-04-24T10:00:00Z",
+      achievement_summary: "x",
+      sequence: 1,
+    },
+    signature: "sig",
+    issued_at: "2026-04-24T10:00:00Z",
+    approved_at: "2026-04-24T11:00:00Z",
+    emitted_at: "2026-04-24T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("cards-repo CRUD", () => {
+  it("saveEmittedCard + getEmittedCardsByChild round-trip", () => {
+    saveEmittedCard(db, makeCard());
+    const cards = getEmittedCardsByChild(db, "ryo");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]!.card_id).toBe("c1");
+  });
+
+  it("saveEmittedCard é idempotente (same card_id sobrescreve)", () => {
+    saveEmittedCard(db, makeCard({ card_id: "c1", emitted_at: "2026-04-24T12:00:00Z" }));
+    saveEmittedCard(db, makeCard({ card_id: "c1", emitted_at: "2026-04-25T12:00:00Z" }));
+    const cards = getEmittedCardsByChild(db, "ryo");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]!.emitted_at).toBe("2026-04-25T12:00:00Z");
+  });
+
+  it("getEmittedCardsBySession filtra por session", () => {
+    saveEmittedCard(db, makeCard({ card_id: "c1", session_id: "s1" }));
+    saveEmittedCard(db, makeCard({ card_id: "c2", session_id: "s2" }));
+    expect(getEmittedCardsBySession(db, "s1")).toHaveLength(1);
+    expect(getEmittedCardsBySession(db, "s2")).toHaveLength(1);
+  });
+
+  it("getEmittedCardsInRange inclui [from, to) — half-open", () => {
+    saveEmittedCard(db, makeCard({ card_id: "c1", emitted_at: "2026-04-24T10:00:00Z" }));
+    saveEmittedCard(db, makeCard({ card_id: "c2", emitted_at: "2026-04-24T12:00:00Z" }));
+    saveEmittedCard(db, makeCard({ card_id: "c3", emitted_at: "2026-04-25T10:00:00Z" }));
+    const r = getEmittedCardsInRange(db, "ryo", "2026-04-24T00:00:00Z", "2026-04-25T00:00:00Z");
+    expect(r.map((c) => c.card_id).sort()).toEqual(["c1", "c2"]);
+  });
+
+  it("different children are isolated", () => {
+    saveEmittedCard(db, makeCard({ card_id: "c1", child_id: "ryo" }));
+    saveEmittedCard(db, makeCard({ card_id: "c2", child_id: "kei" }));
+    expect(getEmittedCardsByChild(db, "ryo")).toHaveLength(1);
+    expect(getEmittedCardsByChild(db, "kei")).toHaveLength(1);
+  });
+
+  it("getNextSequence conta cards existentes + 1", () => {
+    expect(getNextSequence(db, "ryo")).toBe(1);
+    saveEmittedCard(db, makeCard({ card_id: "c1", child_id: "ryo" }));
+    expect(getNextSequence(db, "ryo")).toBe(2);
+    saveEmittedCard(db, makeCard({ card_id: "c2", child_id: "ryo" }));
+    expect(getNextSequence(db, "ryo")).toBe(3);
+  });
+});

--- a/shared/src/card-authenticity.ts
+++ b/shared/src/card-authenticity.ts
@@ -1,0 +1,59 @@
+/**
+ * Card authenticity — HMAC-SHA256 signature + QR payload builder.
+ *
+ * Spec: Handoff #17 Bloco 5a (c).
+ *
+ * Formato:
+ *   payload = `{card_id}:{child_id}:{issued_at}`
+ *   signature = HMAC-SHA256(payload, secret)
+ *   qr_url = `https://ebrota.app/v/{card_id}?sig={signature}`
+ *
+ * Secret lido da env `EBROTA_CARD_SECRET` no caller; este módulo só faz
+ * crypto pura (testável sem env). Nunca logar o secret.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const QR_BASE_URL = "https://ebrota.app/v";
+
+export interface SignPayloadInput {
+  card_id: string;
+  child_id: string;
+  issued_at: string;
+  secret: string;
+}
+
+/** Monta string canônica pra assinar. Formato é contrato — não mudar sem bump de versão. */
+export function buildCanonicalPayload(input: Omit<SignPayloadInput, "secret">): string {
+  return `${input.card_id}:${input.child_id}:${input.issued_at}`;
+}
+
+/** Gera HMAC-SHA256 hex do payload canônico. */
+export function signCardPayload(input: SignPayloadInput): string {
+  if (!input.secret || input.secret.length < 8) {
+    throw new Error("signCardPayload: secret too short (min 8 chars)");
+  }
+  const canonical = buildCanonicalPayload(input);
+  return createHmac("sha256", input.secret).update(canonical).digest("hex");
+}
+
+export interface VerifyInput extends SignPayloadInput {
+  signature: string;
+}
+
+/** Compara assinaturas em tempo constante pra evitar timing attack. */
+export function verifyCardSignature(input: VerifyInput): boolean {
+  try {
+    const expected = signCardPayload(input);
+    if (expected.length !== input.signature.length) return false;
+    return timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(input.signature, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+/** URL completa com sig query-string. Idempotente. */
+export function buildQrPayload(cardId: string, signature: string): string {
+  const encoded = encodeURIComponent(cardId);
+  return `${QR_BASE_URL}/${encoded}?sig=${signature}`;
+}

--- a/shared/src/card-catalog.ts
+++ b/shared/src/card-catalog.ts
@@ -1,0 +1,121 @@
+/**
+ * Card emission schema — Bloco 5a (#17).
+ *
+ * Runtime-generated cards, NÃO catálogo fixo. Arquétipos são scaffolds
+ * placeholder até Bloco 5b (Content Engine charter em docs/specs/).
+ *
+ * Spec:
+ *   - paper §8.2 — Cartas
+ *   - fundamentos/ebrota-kids-artefatos.md §2
+ *   - Handoff #17 Bloco 5a (runtime generation, sem catálogo)
+ *
+ * Conceitos:
+ *   - Archetype = scaffold (template de card); v1 tem 3-5 placeholders
+ *   - CardSpec = proposta do planejador antes de triagem parental
+ *   - EmittedCard = instância final persistida (com front/back/HMAC/QR)
+ */
+
+import type { CaselDimension, GardnerChannel, CardRarity } from "./content-item.js";
+
+/** Template do verso — v1 só um. */
+export const CARD_BACK_TEMPLATES = ["v1-default"] as const;
+export type CardBackTemplate = (typeof CARD_BACK_TEMPLATES)[number];
+
+/**
+ * Scaffold de arquétipo — placeholder editorial.
+ * Real (curated) entra via content-engine em Bloco 5b.
+ * `is_scaffold: true` é o guard-flag que bloqueia emissão em produção.
+ */
+export interface CardArchetype {
+  id: string;
+  name: string;
+  narrative_template: string;
+  casel_dimension: CaselDimension;
+  gardner_channel: GardnerChannel;
+  rarity: CardRarity;
+  /** CRITICAL: se true, emitCard lança em env !== 'test'. */
+  is_scaffold: boolean;
+}
+
+/** Frente do card — lado visível "bonito". */
+export interface CardFront {
+  image_url: string;
+  narrative: string;
+  archetype_id: string;
+}
+
+/** Verso do card — dados semânticos pra leitura humana + validação. */
+export interface CardBack {
+  template: CardBackTemplate;
+  gardner_channel_icon: string;
+  casel_dimension: CaselDimension;
+  /** 3 palavras-chave separadas por ' · ' — ver `generateCheatCode`. */
+  cheat_code: string;
+  /** Formato: `#{childId}-{sequence:3}` (3 dígitos). */
+  serial_number: string;
+  /** URL completa com HMAC; pode ser embutida em QR. */
+  qr_payload: string;
+}
+
+/**
+ * CardSpec = proposta gerada pelo eBerrante antes de triagem+aprovação.
+ * Carrega contexto bruto usado pra compor front/back no final.
+ */
+export interface CardSpec {
+  archetype: CardArchetype;
+  child_id: string;
+  session_id: string;
+  context_word: string;
+  casel_dimension: CaselDimension;
+  gardner_channel: GardnerChannel;
+  /** Quando a conquista aconteceu (detectada no trace). */
+  issued_at: string;
+  /** Evidência — resumo do que o eBerrante observou. */
+  achievement_summary: string;
+  /** Sequência monotônica por criança (caller provê — ex: count de cards emitidos+1). */
+  sequence: number;
+}
+
+/**
+ * EmittedCard = instância persistida após aprovação e emissão in-game.
+ * 3 marcas temporais (d):
+ *   - issued_at: evento de conquista no trace
+ *   - approved_at: pais aprovaram
+ *   - emitted_at: drota narrou pra criança
+ */
+export interface EmittedCard {
+  card_id: string;
+  child_id: string;
+  session_id: string;
+  archetype_id: string;
+  front: CardFront;
+  back: CardBack;
+  spec_snapshot: CardSpec;
+  signature: string;
+  issued_at: string;
+  approved_at: string;
+  emitted_at: string;
+}
+
+/** Gardner channel → icon/ideograma usado no verso + cheat code. */
+export const GARDNER_CHANNEL_ICON: Record<GardnerChannel, string> = {
+  linguistic: "✍️",
+  logical_mathematical: "💡",
+  spatial: "🧭",
+  musical: "🎵",
+  bodily_kinesthetic: "🏃",
+  interpersonal: "🫂",
+  intrapersonal: "🔮",
+  naturalist: "🌿",
+  existential: "🌌",
+};
+
+export function gardnerIcon(channel: GardnerChannel): string {
+  return GARDNER_CHANNEL_ICON[channel];
+}
+
+/** Formata serial: `#{childId}-{sequence:3}` (3 dígitos zero-padded). */
+export function formatSerialNumber(childId: string, sequence: number): string {
+  const padded = String(sequence).padStart(3, "0");
+  return `#${childId}-${padded}`;
+}

--- a/shared/src/card-cheat-code.ts
+++ b/shared/src/card-cheat-code.ts
@@ -1,0 +1,59 @@
+/**
+ * Cheat code — 3 palavras-chave determinísticas.
+ *
+ * Spec: Handoff #17 Bloco 5a (d).
+ *
+ * Componentes (sep: ' · '):
+ *   1. Word evocativa — slug do contexto (context_word do CardSpec)
+ *   2. Data relativa — 'hoje' | 'ontem' | 'semana' | 'mês' | ISO date
+ *   3. Emoji/ideograma do canal Gardner
+ *
+ * Determinístico: dado (context_word, issued_at, now, gardner_channel) idênticos,
+ * produz a mesma string. Chamada em test com `now` injetado.
+ */
+
+import type { GardnerChannel } from "./content-item.js";
+import { gardnerIcon } from "./card-catalog.js";
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+export interface CheatCodeInput {
+  context_word: string;
+  issued_at: string;
+  gardner_channel: GardnerChannel;
+  /** Relógio injetado pra determinismo nos testes. */
+  now: string;
+}
+
+/** Slug de uma word — lowercase, espaços → _, preserva unicode sem acentos. */
+export function slugify(word: string): string {
+  return word
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/\s+/g, "_")
+    .replace(/[^\p{L}\p{N}_-]/gu, "")
+    .slice(0, 32);
+}
+
+/** Converte diferença temporal em label pt-BR. */
+export function relativeDateLabel(issuedAt: string, now: string): string {
+  const deltaMs = new Date(now).getTime() - new Date(issuedAt).getTime();
+  if (deltaMs < 0) return "futuro";
+  const days = deltaMs / DAY_MS;
+  if (days < 1) return "hoje";
+  if (days < 2) return "ontem";
+  if (days < 7) return "semana";
+  if (days < 30) return "mês";
+  // Para mais antigo, devolve ISO date (determinístico).
+  return new Date(issuedAt).toISOString().slice(0, 10);
+}
+
+/** Gera o cheat code de 3 partes. */
+export function generateCheatCode(input: CheatCodeInput): string {
+  const word = slugify(input.context_word) || "conquista";
+  const dateLabel = relativeDateLabel(input.issued_at, input.now);
+  const icon = gardnerIcon(input.gardner_channel);
+  return `${word} · ${dateLabel} · ${icon}`;
+}

--- a/shared/src/card-image-provider.ts
+++ b/shared/src/card-image-provider.ts
@@ -1,0 +1,52 @@
+/**
+ * CardImageProvider — interface pluggable para geração de imagem do card.
+ *
+ * Spec: Handoff #17 Bloco 5a (f).
+ *
+ * v1 só tem MockCardImageProvider. Provider real (Stable Diffusion / DALL-E /
+ * Replicate / etc.) é débito pra Bloco 6 ou 7 via content-engine.
+ *
+ * Mock é determinístico: dado o mesmo spec → mesma URL base64. Fácil de testar
+ * e rodar em CI sem API key.
+ */
+
+import { createHash } from "node:crypto";
+import type { CardSpec } from "./card-catalog.js";
+
+export interface GeneratedImage {
+  image_url: string;
+  mime: string;
+  /** Informacional: 'mock' | 'dalle' | 'sd' | ... */
+  provider: string;
+}
+
+export interface CardImageProvider {
+  readonly name: string;
+  generateImage(spec: CardSpec): Promise<GeneratedImage>;
+}
+
+/**
+ * Mock — gera data URL base64 de 1×1 px PNG transparente com hash do spec
+ * como fragmento. Determinístico; serve como placeholder verificável.
+ */
+export class MockCardImageProvider implements CardImageProvider {
+  readonly name = "mock";
+
+  async generateImage(spec: CardSpec): Promise<GeneratedImage> {
+    const canonical = [
+      spec.archetype.id,
+      spec.child_id,
+      spec.session_id,
+      spec.issued_at,
+      spec.context_word,
+      spec.casel_dimension,
+      spec.gardner_channel,
+    ].join(":");
+    const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+    // 1×1 transparent PNG base64 + hash como fragmento determinístico.
+    const placeholderBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+    const url = `data:image/png;base64,${placeholderBase64}#${hash}`;
+    return { image_url: url, mime: "image/png", provider: this.name };
+  }
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -9,3 +9,7 @@ export * from "./mixins/with-gardner-program.js";
 export * from "./parental-profile.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
+export * from "./card-catalog.js";
+export * from "./card-authenticity.js";
+export * from "./card-cheat-code.js";
+export * from "./card-image-provider.js";

--- a/shared/tests/card-authenticity.test.ts
+++ b/shared/tests/card-authenticity.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  signCardPayload,
+  verifyCardSignature,
+  buildQrPayload,
+  buildCanonicalPayload,
+  QR_BASE_URL,
+} from "../src/card-authenticity.js";
+
+const secret = "test-secret-at-least-8-chars";
+
+describe("buildCanonicalPayload", () => {
+  it("joins fields com ':'", () => {
+    const p = buildCanonicalPayload({
+      card_id: "abc",
+      child_id: "ryo",
+      issued_at: "2026-04-24T00:00:00Z",
+    });
+    expect(p).toBe("abc:ryo:2026-04-24T00:00:00Z");
+  });
+});
+
+describe("signCardPayload", () => {
+  it("produces deterministic hex signature", () => {
+    const sig1 = signCardPayload({
+      card_id: "abc",
+      child_id: "ryo",
+      issued_at: "2026-04-24T00:00:00Z",
+      secret,
+    });
+    const sig2 = signCardPayload({
+      card_id: "abc",
+      child_id: "ryo",
+      issued_at: "2026-04-24T00:00:00Z",
+      secret,
+    });
+    expect(sig1).toBe(sig2);
+    expect(sig1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("different secret → different signature", () => {
+    const s1 = signCardPayload({ card_id: "a", child_id: "b", issued_at: "c", secret: "seeeecret1" });
+    const s2 = signCardPayload({ card_id: "a", child_id: "b", issued_at: "c", secret: "seeeecret2" });
+    expect(s1).not.toBe(s2);
+  });
+
+  it("throws when secret too short", () => {
+    expect(() =>
+      signCardPayload({ card_id: "a", child_id: "b", issued_at: "c", secret: "short" }),
+    ).toThrow(/secret too short/);
+  });
+});
+
+describe("verifyCardSignature", () => {
+  it("verifies own signature", () => {
+    const sig = signCardPayload({ card_id: "a", child_id: "b", issued_at: "c", secret });
+    expect(
+      verifyCardSignature({ card_id: "a", child_id: "b", issued_at: "c", secret, signature: sig }),
+    ).toBe(true);
+  });
+
+  it("rejects tampered card_id", () => {
+    const sig = signCardPayload({ card_id: "a", child_id: "b", issued_at: "c", secret });
+    expect(
+      verifyCardSignature({ card_id: "x", child_id: "b", issued_at: "c", secret, signature: sig }),
+    ).toBe(false);
+  });
+
+  it("rejects tampered signature", () => {
+    const sig = signCardPayload({ card_id: "a", child_id: "b", issued_at: "c", secret });
+    const tampered = sig.slice(0, -2) + "00";
+    expect(
+      verifyCardSignature({ card_id: "a", child_id: "b", issued_at: "c", secret, signature: tampered }),
+    ).toBe(false);
+  });
+
+  it("rejects different secret", () => {
+    const sig = signCardPayload({ card_id: "a", child_id: "b", issued_at: "c", secret });
+    expect(
+      verifyCardSignature({
+        card_id: "a", child_id: "b", issued_at: "c",
+        secret: "other-seeeecret",
+        signature: sig,
+      }),
+    ).toBe(false);
+  });
+
+  it("malformed signature hex returns false (no throw)", () => {
+    expect(
+      verifyCardSignature({
+        card_id: "a", child_id: "b", issued_at: "c", secret,
+        signature: "not-hex",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildQrPayload", () => {
+  it("builds URL with card_id + sig query", () => {
+    const url = buildQrPayload("abc-123", "deadbeef");
+    expect(url).toBe(`${QR_BASE_URL}/abc-123?sig=deadbeef`);
+  });
+
+  it("url-encodes card_id", () => {
+    const url = buildQrPayload("id with spaces", "xyz");
+    expect(url).toContain("id%20with%20spaces");
+  });
+});

--- a/shared/tests/card-catalog.test.ts
+++ b/shared/tests/card-catalog.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatSerialNumber,
+  gardnerIcon,
+  GARDNER_CHANNEL_ICON,
+  CARD_BACK_TEMPLATES,
+} from "../src/card-catalog.js";
+
+describe("formatSerialNumber", () => {
+  it("pads sequence to 3 digits", () => {
+    expect(formatSerialNumber("ryo", 1)).toBe("#ryo-001");
+    expect(formatSerialNumber("ryo", 42)).toBe("#ryo-042");
+    expect(formatSerialNumber("ryo", 137)).toBe("#ryo-137");
+  });
+  it("does not truncate sequence > 999", () => {
+    expect(formatSerialNumber("ryo", 1234)).toBe("#ryo-1234");
+  });
+});
+
+describe("gardnerIcon", () => {
+  it("maps all 9 channels", () => {
+    expect(Object.keys(GARDNER_CHANNEL_ICON)).toHaveLength(9);
+    expect(gardnerIcon("linguistic")).toBe("✍️");
+    expect(gardnerIcon("logical_mathematical")).toBe("💡");
+    expect(gardnerIcon("existential")).toBe("🌌");
+  });
+});
+
+describe("CARD_BACK_TEMPLATES", () => {
+  it("v1 has exactly one template", () => {
+    expect(CARD_BACK_TEMPLATES).toEqual(["v1-default"]);
+  });
+});

--- a/shared/tests/card-cheat-code.test.ts
+++ b/shared/tests/card-cheat-code.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateCheatCode,
+  slugify,
+  relativeDateLabel,
+} from "../src/card-cheat-code.js";
+
+describe("slugify", () => {
+  it("lowercases + strips accents", () => {
+    expect(slugify("Ação Aérea")).toBe("acao_aerea");
+  });
+  it("replaces spaces with underscores", () => {
+    expect(slugify("tres palavras aqui")).toBe("tres_palavras_aqui");
+  });
+  it("strips punctuation", () => {
+    expect(slugify("hello, world!")).toBe("hello_world");
+  });
+  it("clamps at 32 chars", () => {
+    const long = "a".repeat(50);
+    expect(slugify(long).length).toBe(32);
+  });
+  it("preserves unicode letters (japanese ok)", () => {
+    expect(slugify("学習")).toBe("学習");
+  });
+});
+
+describe("relativeDateLabel", () => {
+  const now = "2026-04-24T12:00:00Z";
+  it("< 1 day = hoje", () => {
+    expect(relativeDateLabel("2026-04-24T01:00:00Z", now)).toBe("hoje");
+  });
+  it("1-2 days = ontem", () => {
+    expect(relativeDateLabel("2026-04-23T11:00:00Z", now)).toBe("ontem");
+  });
+  it("2-7 days = semana", () => {
+    expect(relativeDateLabel("2026-04-20T12:00:00Z", now)).toBe("semana");
+  });
+  it(">=7 days < 30 = mês", () => {
+    expect(relativeDateLabel("2026-04-15T12:00:00Z", now)).toBe("mês");
+  });
+  it(">=30 days = ISO date", () => {
+    expect(relativeDateLabel("2025-12-01T12:00:00Z", now)).toBe("2025-12-01");
+  });
+  it("future issued_at returns 'futuro'", () => {
+    expect(relativeDateLabel("2027-01-01T00:00:00Z", now)).toBe("futuro");
+  });
+});
+
+describe("generateCheatCode", () => {
+  const now = "2026-04-24T12:00:00Z";
+  it("3 parts separated by ' · '", () => {
+    const code = generateCheatCode({
+      context_word: "persistence",
+      issued_at: "2026-04-24T10:00:00Z",
+      gardner_channel: "logical_mathematical",
+      now,
+    });
+    expect(code.split(" · ")).toHaveLength(3);
+  });
+  it("deterministic given same inputs", () => {
+    const c1 = generateCheatCode({
+      context_word: "persistence",
+      issued_at: "2026-04-24T10:00:00Z",
+      gardner_channel: "logical_mathematical",
+      now,
+    });
+    const c2 = generateCheatCode({
+      context_word: "persistence",
+      issued_at: "2026-04-24T10:00:00Z",
+      gardner_channel: "logical_mathematical",
+      now,
+    });
+    expect(c1).toBe(c2);
+  });
+  it("word normalizado (lowercase + accent strip)", () => {
+    const code = generateCheatCode({
+      context_word: "Coragem Pequena",
+      issued_at: "2026-04-24T10:00:00Z",
+      gardner_channel: "linguistic",
+      now,
+    });
+    expect(code.startsWith("coragem_pequena ·")).toBe(true);
+  });
+  it("includes gardner icon", () => {
+    const code = generateCheatCode({
+      context_word: "x",
+      issued_at: "2026-04-24T10:00:00Z",
+      gardner_channel: "musical",
+      now,
+    });
+    expect(code).toContain("🎵");
+  });
+  it("fallback 'conquista' when context_word reduz a empty slug", () => {
+    const code = generateCheatCode({
+      context_word: "!!!",
+      issued_at: "2026-04-24T10:00:00Z",
+      gardner_channel: "spatial",
+      now,
+    });
+    expect(code.startsWith("conquista ·")).toBe(true);
+  });
+});

--- a/shared/tests/card-image-provider.test.ts
+++ b/shared/tests/card-image-provider.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { MockCardImageProvider } from "../src/card-image-provider.js";
+import type { CardSpec, CardArchetype } from "../src/card-catalog.js";
+
+const archetype: CardArchetype = {
+  id: "arch_test",
+  name: "Test",
+  narrative_template: "x",
+  casel_dimension: "SA",
+  gardner_channel: "linguistic",
+  rarity: "common",
+  is_scaffold: true,
+};
+
+const baseSpec: CardSpec = {
+  archetype,
+  child_id: "ryo",
+  session_id: "s1",
+  context_word: "curiosity",
+  casel_dimension: "SA",
+  gardner_channel: "linguistic",
+  issued_at: "2026-04-24T10:00:00Z",
+  achievement_summary: "summary",
+  sequence: 1,
+};
+
+describe("MockCardImageProvider", () => {
+  const provider = new MockCardImageProvider();
+
+  it("returns data URL with image/png mime", async () => {
+    const r = await provider.generateImage(baseSpec);
+    expect(r.mime).toBe("image/png");
+    expect(r.image_url).toMatch(/^data:image\/png;base64,/);
+    expect(r.provider).toBe("mock");
+  });
+
+  it("deterministic — same spec → same URL", async () => {
+    const r1 = await provider.generateImage(baseSpec);
+    const r2 = await provider.generateImage(baseSpec);
+    expect(r1.image_url).toBe(r2.image_url);
+  });
+
+  it("different spec → different URL fragment (hash muda)", async () => {
+    const r1 = await provider.generateImage(baseSpec);
+    const r2 = await provider.generateImage({ ...baseSpec, context_word: "diferente" });
+    expect(r1.image_url).not.toBe(r2.image_url);
+  });
+});

--- a/weekly-report/src/aggregate.ts
+++ b/weekly-report/src/aggregate.ts
@@ -9,10 +9,12 @@ import type {
   StatusValue,
   GardnerChannel,
   CaselDimension,
+  EmittedCard,
 } from "@ascendimacy/shared";
 import { isStatusValue } from "@ascendimacy/shared";
 import type {
   CardSummary,
+  EmittedCardSummary,
   IgnitionEvent,
   StatusComparison,
   AspirationSignal,
@@ -223,6 +225,26 @@ function deriveWeekRange(traces: SessionTrace[]): WeekRange {
   };
 }
 
+/** Converte EmittedCard em summary pro relatório. */
+export function summarizeEmittedCard(card: EmittedCard): EmittedCardSummary {
+  return {
+    card_id: card.card_id,
+    archetype_id: card.archetype_id,
+    title: card.spec_snapshot.archetype.name,
+    narrative: card.front.narrative,
+    image_url: card.front.image_url,
+    rarity: card.spec_snapshot.archetype.rarity,
+    cheat_code: card.back.cheat_code,
+    serial_number: card.back.serial_number,
+    qr_payload: card.back.qr_payload,
+    casel_dimension: card.back.casel_dimension,
+    gardner_channel_icon: card.back.gardner_channel_icon,
+    issued_at: card.issued_at,
+    approved_at: card.approved_at,
+    emitted_at: card.emitted_at,
+  };
+}
+
 /** Entrypoint: SessionTrace[] + opts → WeeklyReportData. */
 export function aggregate(
   traces: SessionTrace[],
@@ -230,12 +252,14 @@ export function aggregate(
   opts: WeeklyReportOptions = {},
 ): WeeklyReportData {
   const childAge = traces.find((t) => t.personaAge !== undefined)?.personaAge ?? null;
+  const emittedCards = (opts.emitted_cards ?? []).map(summarizeEmittedCard);
   return {
     child_name: childName,
     child_age: childAge,
     week: opts.week_range ?? deriveWeekRange(traces),
     program_status: latestProgramStatus(traces),
     cards: aggregateCards(traces),
+    emitted_cards: emittedCards,
     status_comparison: compareStatusMatrices(traces, opts.previous_matrix),
     ignitions: detectIgnitions(traces),
     aspirations: extractAspirations(traces),

--- a/weekly-report/src/index.ts
+++ b/weekly-report/src/index.ts
@@ -16,7 +16,7 @@ import { renderMarkdown } from "./markdown.js";
 import { renderPdf } from "./pdf.js";
 
 export * from "./types.js";
-export { aggregate, aggregateCards, compareStatusMatrices, detectIgnitions, extractAspirations } from "./aggregate.js";
+export { aggregate, aggregateCards, compareStatusMatrices, detectIgnitions, extractAspirations, summarizeEmittedCard } from "./aggregate.js";
 export { computeMetrics } from "./metrics.js";
 export { renderMarkdown } from "./markdown.js";
 export { renderPdf } from "./pdf.js";

--- a/weekly-report/src/markdown.ts
+++ b/weekly-report/src/markdown.ts
@@ -8,6 +8,7 @@ import type {
   StatusComparison,
   IgnitionEvent,
   CardSummary,
+  EmittedCardSummary,
   AspirationSignal,
 } from "./types.js";
 
@@ -147,10 +148,34 @@ function renderMetrics(data: WeeklyReportData): string {
   ].join("\n");
 }
 
+function renderEmittedCards(ems: EmittedCardSummary[] | undefined): string {
+  const list = ems ?? [];
+  if (list.length === 0) {
+    return `## 🏆 Cartas recebidas\n\nNenhuma carta emitida nesta semana.\n`;
+  }
+  const lines = [`## 🏆 Cartas recebidas (${list.length})`, ``];
+  for (const c of list) {
+    lines.push(`### ${c.title} · ${c.rarity.toUpperCase()}`);
+    lines.push(``);
+    lines.push(`![${c.title}](${c.image_url})`);
+    lines.push(``);
+    lines.push(`> ${c.narrative}`);
+    lines.push(``);
+    lines.push(`**Verso:** ${c.gardner_channel_icon} · ${c.casel_dimension} · serial \`${c.serial_number}\``);
+    lines.push(``);
+    lines.push(`**Cheat code:** \`${c.cheat_code}\``);
+    lines.push(``);
+    lines.push(`[QR / verificar autenticidade](${c.qr_payload})`);
+    lines.push(``);
+  }
+  return lines.join("\n");
+}
+
 export function renderMarkdown(data: WeeklyReportData): string {
   return [
     renderHeader(data),
     renderProgram(data),
+    renderEmittedCards(data.emitted_cards),
     renderCards(data.cards),
     renderStatus(data.status_comparison),
     renderIgnitions(data.ignitions),

--- a/weekly-report/src/pdf.ts
+++ b/weekly-report/src/pdf.ts
@@ -10,6 +10,7 @@ import type {
   WeeklyReportData,
   StatusComparison,
   CardSummary,
+  EmittedCardSummary,
   IgnitionEvent,
   AspirationSignal,
 } from "./types.js";
@@ -49,6 +50,40 @@ function writeProgram(doc: PDFKit.PDFDocument, data: WeeklyReportData): void {
       ? ` — pausado (${p.paused_reason ?? "sem motivo"})`
       : "";
     doc.text(`Semana ${p.current_week}/5 · fase: ${p.current_phase ?? "—"}${pauseNote}`);
+  }
+  doc.moveDown(1);
+}
+
+function writeEmittedCards(doc: PDFKit.PDFDocument, ems: EmittedCardSummary[] | undefined): void {
+  const list = ems ?? [];
+  doc.fontSize(14).text(`🏆 Cartas recebidas (${list.length})`);
+  doc.fontSize(9).moveDown(0.2);
+  if (list.length === 0) {
+    doc.text("Nenhuma carta emitida nesta semana.");
+  } else {
+    for (const c of list) {
+      doc.moveDown(0.4);
+      doc.fontSize(11).fillColor("black").text(`${c.title} · ${c.rarity.toUpperCase()}`);
+      doc.fontSize(9).fillColor("#333");
+      // Front image placeholder — pdfkit suporta data: URL via Buffer.
+      try {
+        const match = c.image_url.match(/^data:image\/(png|jpeg);base64,([A-Za-z0-9+/=]+)/);
+        if (match && match[2]) {
+          const buf = Buffer.from(match[2], "base64");
+          doc.image(buf, { width: 80 });
+        } else {
+          doc.text(`[img: ${c.image_url.slice(0, 60)}…]`);
+        }
+      } catch {
+        doc.text(`[img unavailable]`);
+      }
+      doc.fontSize(9).text(`"${c.narrative}"`, { indent: 0 });
+      doc.fontSize(8).fillColor("#555");
+      doc.text(`Verso: ${c.gardner_channel_icon}  ${c.casel_dimension}  serial ${c.serial_number}`);
+      doc.text(`Cheat code: ${c.cheat_code}`);
+      doc.fillColor("#1c5fb0").fontSize(7).text(c.qr_payload, { link: c.qr_payload, underline: true });
+      doc.fillColor("black");
+    }
   }
   doc.moveDown(1);
 }
@@ -152,6 +187,7 @@ export function renderPdf(
 
       writeHeader(doc, data);
       writeProgram(doc, data);
+      writeEmittedCards(doc, data.emitted_cards);
       writeCards(doc, data.cards);
       writeStatus(doc, data.status_comparison);
       writeIgnitions(doc, data.ignitions);

--- a/weekly-report/src/types.ts
+++ b/weekly-report/src/types.ts
@@ -68,6 +68,24 @@ export interface OperationalMetrics {
   total_screen_seconds: number;
 }
 
+/** Resumo de um EmittedCard para o relatório semanal (Bloco 5a). */
+export interface EmittedCardSummary {
+  card_id: string;
+  archetype_id: string;
+  title: string;
+  narrative: string;
+  image_url: string;
+  rarity: string;
+  cheat_code: string;
+  serial_number: string;
+  qr_payload: string;
+  casel_dimension: string;
+  gardner_channel_icon: string;
+  issued_at: string;
+  approved_at: string;
+  emitted_at: string;
+}
+
 export interface WeeklyReportData {
   child_name: string;
   child_age: number | null;
@@ -79,6 +97,8 @@ export interface WeeklyReportData {
     paused_reason?: string;
   };
   cards: CardSummary[];
+  /** Cards emitidos na semana (Bloco 5a). */
+  emitted_cards: EmittedCardSummary[];
   status_comparison: StatusComparison[];
   ignitions: IgnitionEvent[];
   aspirations: AspirationSignal[];
@@ -90,4 +110,6 @@ export interface WeeklyReportOptions {
   previous_matrix?: StatusMatrix;
   /** Range de datas; se omitido, tenta derivar dos traces. */
   week_range?: WeekRange;
+  /** EmittedCards da semana (opcional — vem do caller que consulta motor-execucao). */
+  emitted_cards?: import("@ascendimacy/shared").EmittedCard[];
 }

--- a/weekly-report/tests/emitted-cards.test.ts
+++ b/weekly-report/tests/emitted-cards.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { generateWeeklyReport, summarizeEmittedCard } from "../src/index.js";
+import type { EmittedCard, SessionTrace } from "@ascendimacy/shared";
+
+const emittedCard: EmittedCard = {
+  card_id: "c-uuid-1",
+  child_id: "ryo",
+  session_id: "s1",
+  archetype_id: "arch_curiosity_v0",
+  front: {
+    image_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+    narrative: "Ryo, você ficou curioso.",
+    archetype_id: "arch_curiosity_v0",
+  },
+  back: {
+    template: "v1-default",
+    gardner_channel_icon: "🔮",
+    casel_dimension: "SA",
+    cheat_code: "curiosity · hoje · 🔮",
+    serial_number: "#ryo-001",
+    qr_payload: "https://ebrota.app/v/c-uuid-1?sig=abc",
+  },
+  spec_snapshot: {
+    archetype: {
+      id: "arch_curiosity_v0",
+      name: "Curioso do Mundo",
+      narrative_template: "x",
+      casel_dimension: "SA",
+      gardner_channel: "intrapersonal",
+      rarity: "common",
+      is_scaffold: true,
+    },
+    child_id: "ryo",
+    session_id: "s1",
+    context_word: "curiosity",
+    casel_dimension: "SA",
+    gardner_channel: "intrapersonal",
+    issued_at: "2026-04-24T10:00:00Z",
+    achievement_summary: "x",
+    sequence: 1,
+  },
+  signature: "sig",
+  issued_at: "2026-04-24T10:00:00Z",
+  approved_at: "2026-04-24T11:00:00Z",
+  emitted_at: "2026-04-24T12:00:00Z",
+};
+
+const emptyTrace: SessionTrace = {
+  sessionId: "s1",
+  persona: "ryo",
+  startedAt: "2026-04-24T10:00:00Z",
+  turns: [],
+  meta: { schemaVersion: "0.3.0", motorVersion: "0.3.0" },
+};
+
+describe("summarizeEmittedCard", () => {
+  it("extrai title + narrative + cheat code + qr", () => {
+    const s = summarizeEmittedCard(emittedCard);
+    expect(s.title).toBe("Curioso do Mundo");
+    expect(s.narrative).toBe("Ryo, você ficou curioso.");
+    expect(s.cheat_code).toBe("curiosity · hoje · 🔮");
+    expect(s.qr_payload).toContain("ebrota.app");
+    expect(s.rarity).toBe("common");
+  });
+});
+
+describe("generateWeeklyReport — emitted_cards section", () => {
+  it("markdown inclui 'Cartas recebidas' com imagem + cheat + QR link", () => {
+    const report = generateWeeklyReport([emptyTrace], "Ryo", {
+      emitted_cards: [emittedCard],
+    });
+    expect(report.markdown).toContain("Cartas recebidas (1)");
+    expect(report.markdown).toContain("Curioso do Mundo");
+    expect(report.markdown).toContain("curiosity · hoje · 🔮");
+    expect(report.markdown).toContain("ebrota.app");
+    expect(report.markdown).toContain("![Curioso do Mundo]");
+  });
+
+  it("markdown mostra 'Nenhuma carta' quando vazio", () => {
+    const report = generateWeeklyReport([emptyTrace], "Ryo");
+    expect(report.markdown).toContain("Nenhuma carta");
+  });
+
+  it("PDF binário gerado com front image embutida", async () => {
+    const report = generateWeeklyReport([emptyTrace], "Ryo", {
+      emitted_cards: [emittedCard],
+    });
+    const buf = await report.renderPdf();
+    expect(buf.slice(0, 5).toString("ascii")).toBe("%PDF-");
+    // PDF deve conter ao menos alguns bytes extras comparado ao empty
+    const emptyReport = generateWeeklyReport([emptyTrace], "Ryo");
+    const emptyBuf = await emptyReport.renderPdf();
+    expect(buf.length).toBeGreaterThan(emptyBuf.length);
+  }, 10_000);
+
+  it("aggregate.emitted_cards array preserva ordem", () => {
+    const report = generateWeeklyReport([emptyTrace], "Ryo", {
+      emitted_cards: [emittedCard, { ...emittedCard, card_id: "c2", emitted_at: "2026-04-25T12:00:00Z" }],
+    });
+    expect(report.data.emitted_cards).toHaveLength(2);
+    expect(report.data.emitted_cards[0]!.card_id).toBe("c-uuid-1");
+    expect(report.data.emitted_cards[1]!.card_id).toBe("c2");
+  });
+});


### PR DESCRIPTION
## Refs

- Paper §8.2: [docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-24-ebrota-learning-mechanics-paper.md)
- Fundamentos: [docs/fundamentos/ebrota-kids-artefatos.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/fundamentos/ebrota-kids-artefatos.md)
- Bloco 5b charter (thread separada): [docs/specs/2026-04-24-content-engine-charter.md](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-24-content-engine-charter.md)
- Base: motor#13 merged (`68788ae`)

## Direção

**Cards gerados em runtime, não catálogo fixo.** Bloco 5a entrega arquitetura completa (schema + pipeline + HMAC + PDF) usando arquétipos placeholder marcados `is_scaffold: true`. Catálogo editorial real vem em Bloco 5b (Content Engine).

## Cobertura dos 8 itens

| Item | Entrega |
|---|---|
| **(a)** Schema expandido | `shared/src/card-catalog.ts` — CardArchetype + CardFront + CardBack + CardSpec + EmittedCard + formatSerialNumber + gardnerIcon (9 canais) |
| **(b)** Pipeline | `motor-execucao/src/card-generation.ts` — detectAchievement → proposeCardSpec → triageCardSpec → generateCardImage → signCardAuthenticity → emitCard (6 funções isoladas) |
| **(c)** QR payload | `shared/src/card-authenticity.ts` — HMAC-SHA256 de `{card_id}:{child_id}:{issued_at}`; `verifyCardSignature` usa `timingSafeEqual`; QR_BASE_URL = `https://ebrota.app/v` |
| **(d)** Cheat code | `shared/src/card-cheat-code.ts` — `{slug} · {relative_date} · {gardner_icon}`; determinístico; slugify preserva unicode |
| **(e)** Weekly-report | `aggregate.summarizeEmittedCard` + `renderMarkdown` (seção "🏆 Cartas recebidas") + `renderPdf` (embute data URL base64 via `doc.image(buffer)`) |
| **(f)** CardImageProvider | Interface + `MockCardImageProvider` determinístico; provider real é débito Bloco 6/7 |
| **(g)** Scaffolds | `content/cards/archetypes-seed.json` com 5 placeholders `is_scaffold: true`; loader com cache em motor-execucao |
| **(h)** Scaffold guard | `emitCard()` throws se `archetype.is_scaffold && env !== 'test'` — mensagem aponta pra Bloco 5b |

## 3 marcas temporais (item d do handoff)

- `issued_at` — quando a conquista foi detectada no trace
- `approved_at` — pais aprovaram (triagem)
- `emitted_at` — drota narrou pra criança in-game

Assimétrico por design: pais aprovam ANTES, criança recebe DEPOIS.

## Persistência

`kids_emitted_cards (card_id PK, child_id, session_id, archetype_id, serial_number, signature, issued_at, approved_at, emitted_at, front_json, back_json, spec_snapshot_json)` + índices por child/session/emitted_at.

MCP tools: `card_save`, `card_list_by_child`, `card_list_by_session`, `card_list_in_range`.

**Auto-hook no orchestrator NÃO está incluído em v1** — emission é manual via MCP, caller decide quando chamar detectAchievement. Bloco 6 (dyad) ou 7 (piloto) pode fazer o wiring.

## Resultados

### npm run build
✅ 6 packages

### npm run test — 326 testes verdes (+65 sobre Bloco 4)

| Package | Testes | Delta |
|---|---|---|
| shared | 151 | +34 (card-catalog 4, card-authenticity 11, card-cheat-code 12, card-image-provider 3 + ajustes) |
| motor-execucao | 65 | +26 (card-generation 17, cards-repo 6) |
| weekly-report | 49 | +5 (emitted-cards incl. PDF front image embed) |
| outros | 61 | — |

Cobertura explícita dos 7 itens pedidos:
- ✅ schema
- ✅ pipeline e2e com mock (scaffold forçado em env=test pra testar path feliz)
- ✅ triagem (approved=true sem profile, rejected quando forbidden_zone bate)
- ✅ cheat code determinístico
- ✅ HMAC valida (sign/verify round-trip + tampered card_id/signature/secret rejected)
- ✅ PDF renderiza front (base64 embed) + back (cheat code + QR link)
- ✅ scaffold-guard bloqueia em env production/development

### npm run smoke
✅ Rubric G1-G3

## Env vars

- `EBROTA_CARD_SECRET` — HMAC secret. Min 8 chars (throws se menor). Caller (motor-execucao ao emitir) lê da env; módulo shared recebe como param pra ser testável.

## Decisões de design

- **Pipeline em funções separadas**, não classe — cada estágio é função pura testável em isolamento. Composição fica no caller.
- **`triageCardSpec` envolve CardSpec num ScoredContentItem sintético** pra reusar `triageForParents` do Bloco 4 (forbidden_zones, Haiku opcional). Sem duplicação de lógica parental.
- **MockCardImageProvider determinístico** via SHA-256 do canonical spec — permite snapshot testing.
- **5 scaffolds** cobrem kinds ignition (epic), status_to_pasto (legendary), sacrifice_high (rare) + fallbacks common.
- **Guard em `emitCard`**, não em `proposeCardSpec` — propose + triage podem rodar com scaffolds em todas envs (útil pra debug), só a emissão final é bloqueada.

## Débitos (Bloco 5b+)

- Arquétipos editoriais reais (Bloco 5b thread content-engine)
- Provider de imagem real (DALL-E / Stable Diffusion)
- Auto-hook no orchestrator pra detectAchievement pós-turn
- Fine-tune do scoring do Haiku pra triage de cards (diferente de content items)
- i18n pra cheat code labels ('hoje'/'ontem' pt-BR only hoje)

## Como testar

```bash
cd ascendimacy-motor
npm install
npm run build
npm run test    # 326 verdes
npm run smoke   # Rubric G1-G3
```

Render manual:
```ts
import { generateWeeklyReport } from '@ascendimacy/weekly-report';
import { emitCard, MockCardImageProvider, proposeCardSpec, signCardAuthenticity } from '@ascendimacy/shared';
// ... ver testes em weekly-report/tests/emitted-cards.test.ts pra receita
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)