### PR TITLE
feat(motor#18 Bloco 7 prep): kind crossing + prev_matrix snapshot + inventário enriquecido

### DIFF
--- a/content/hooks/seed.json
+++ b/content/hooks/seed.json
@@ -17,7 +17,12 @@
     "bridge": "Quantas palavras você tem pra RAIVA? Irritado, furioso, frustrado... Se só tem 1, como sabe o que tá sentindo?",
     "quest": "Tenta encontrar 5 palavras diferentes pro que sente AGORA. Não vale repetir.",
     "sacrifice_type": "reflect",
-    "country": "🇨🇦 Ártico"
+    "country": "🇨🇦 Ártico",
+    "gardner_channels": [
+      "linguistic",
+      "intrapersonal"
+    ],
+    "sacrifice_amount": 8
   },
   {
     "id": "ling_pirahã_numbers",
@@ -44,7 +49,8 @@
     "type": "curiosity_hook",
     "domain": "linguistics",
     "casel_target": [
-      "SA"
+      "SA",
+      "REL"
     ],
     "age_range": [
       7,
@@ -57,14 +63,22 @@
     "bridge": "Qual silêncio você sente mais? O pesado ou o bonito? Quando cada um aparece?",
     "quest": "Amanhã presta atenção nos silêncios. Anota: quantos foram pesados? Quantos foram bonitos?",
     "sacrifice_type": "reflect",
-    "country": "🇯🇵 Japão"
+    "country": "🇯🇵 Japão",
+    "gardner_channels": [
+      "linguistic",
+      "intrapersonal",
+      "musical"
+    ],
+    "sacrifice_amount": 6
   },
   {
     "id": "ling_greek_love",
     "type": "curiosity_hook",
     "domain": "linguistics",
     "casel_target": [
-      "SA"
+      "SA",
+      "REL",
+      "SOC"
     ],
     "age_range": [
       7,
@@ -77,7 +91,14 @@
     "bridge": "E você — que tipo de amor sente pelo Kei? Pelo pai? Pelo Dragon Ball? É o mesmo amor?",
     "quest": "Classifica 3 amores da tua vida nos tipos gregos. Me conta qual é cada um.",
     "sacrifice_type": "reflect",
-    "country": "🇬🇷 Grécia"
+    "country": "🇬🇷 Grécia",
+    "gardner_channels": [
+      "linguistic",
+      "interpersonal",
+      "intrapersonal",
+      "existential"
+    ],
+    "sacrifice_amount": 18
   },
   {
     "id": "ling_whistled_language",
@@ -144,7 +165,8 @@
     "type": "curiosity_hook",
     "domain": "biology",
     "casel_target": [
-      "SA"
+      "SA",
+      "SM"
     ],
     "age_range": [
       7,
@@ -157,14 +179,20 @@
     "bridge": "Se você tivesse 3 corações — 1 pra família, 1 pra amigos, 1 pra você — qual bate mais forte?",
     "quest": "Desenha ou descreve: qual dos 3 \"corações\" tá mais cansado essa semana?",
     "sacrifice_type": "reflect",
-    "country": "🌊 Oceano"
+    "country": "🌊 Oceano",
+    "gardner_channels": [
+      "naturalist",
+      "spatial",
+      "intrapersonal"
+    ],
+    "sacrifice_amount": 8
   },
   {
     "id": "bio_trees_communicate",
     "type": "curiosity_hook",
     "domain": "biology",
     "casel_target": [
-      "SOC"
+      "REL"
     ],
     "age_range": [
       7,
@@ -177,14 +205,21 @@
     "bridge": "As árvores avisam as vizinhas do perigo. Você — avisa quando alguém perto tá em perigo? Ou espera?",
     "quest": "Essa semana, se perceber que alguém tá com dificuldade, avisa ou ajuda ANTES que peça.",
     "sacrifice_type": "reflect",
-    "country": "🌳 Floresta"
+    "country": "🌳 Floresta",
+    "gardner_channels": [
+      "naturalist",
+      "interpersonal"
+    ],
+    "sacrifice_amount": 7
   },
   {
     "id": "bio_dolphin_names",
     "type": "curiosity_hook",
     "domain": "biology",
     "casel_target": [
-      "SA"
+      "SA",
+      "REL",
+      "SM"
     ],
     "age_range": [
       7,
@@ -197,7 +232,14 @@
     "bridge": "Os golfinhos fazem luto repetindo o nome do amigo. Quando você perde alguém ou algo importante, como expressa?",
     "quest": "Pensa em algo que perdeu (pessoa, momento, fase). O que faria pra \"assobiar o nome\" dele?",
     "sacrifice_type": "expose",
-    "country": "🌊 Oceano"
+    "country": "🌊 Oceano",
+    "gardner_channels": [
+      "linguistic",
+      "naturalist",
+      "interpersonal",
+      "intrapersonal"
+    ],
+    "sacrifice_amount": 16
   },
   {
     "id": "bio_elephant_mirror",
@@ -224,7 +266,8 @@
     "type": "curiosity_hook",
     "domain": "biology",
     "casel_target": [
-      "DM"
+      "REL",
+      "SOC"
     ],
     "age_range": [
       7,
@@ -237,7 +280,13 @@
     "bridge": "A formiga se sacrifica pelo grupo. No Dragon Ball, Vegeta fez a mesma coisa contra o Buu. Quando é certo se sacrificar? E quando é demais?",
     "quest": "Pensa numa vez que abriu mão de algo por alguém. Valeu a pena? Faria de novo?",
     "sacrifice_type": "reflect",
-    "country": "🐜 Global"
+    "country": "🐜 Global",
+    "gardner_channels": [
+      "naturalist",
+      "interpersonal",
+      "existential"
+    ],
+    "sacrifice_amount": 19
   },
   {
     "id": "bio_caterpillar_dissolve",
@@ -284,7 +333,8 @@
     "type": "curiosity_hook",
     "domain": "physiology",
     "casel_target": [
-      "SA"
+      "SA",
+      "SM"
     ],
     "age_range": [
       7,
@@ -297,7 +347,13 @@
     "bridge": "Já sentiu algo na barriga antes de uma decisão? Medo, ansiedade, empolgação? Seu intestino tava te AVISANDO.",
     "quest": "Presta atenção na barriga amanhã antes de uma decisão. Ela \"disse\" algo? Registra.",
     "sacrifice_type": "observe",
-    "country": "🧠 Corpo"
+    "country": "🧠 Corpo",
+    "gardner_channels": [
+      "bodily_kinesthetic",
+      "intrapersonal",
+      "naturalist"
+    ],
+    "sacrifice_amount": 10
   },
   {
     "id": "phys_tears_different",
@@ -444,7 +500,7 @@
     "type": "curiosity_hook",
     "domain": "physics",
     "casel_target": [
-      "SOC"
+      "SA"
     ],
     "age_range": [
       7,
@@ -457,7 +513,12 @@
     "bridge": "Observar muda a realidade. Quando você presta atenção em alguém, a pessoa muda o comportamento. Você já é influência.",
     "quest": "Observa alguém com atenção por 1 minuto (sem ser creepy). A pessoa muda o comportamento? Como?",
     "sacrifice_type": "observe",
-    "country": "⚛️ Física"
+    "country": "⚛️ Física",
+    "gardner_channels": [
+      "logical_mathematical",
+      "intrapersonal"
+    ],
+    "sacrifice_amount": 6
   },
   {
     "id": "phys_butterfly_effect",
@@ -644,7 +705,8 @@
     "type": "curiosity_hook",
     "domain": "history",
     "casel_target": [
-      "SM"
+      "REL",
+      "SOC"
     ],
     "age_range": [
       7,
@@ -657,7 +719,13 @@
     "bridge": "Mandela perdoou quem o prendeu por 27 anos. Não porque o carcereiro merecia — porque Mandela se recusava a carregar aquele peso.",
     "quest": "Carregar rancor é como beber veneno e esperar que o outro morra. Tem algo que pode soltar essa semana?",
     "sacrifice_type": "reflect",
-    "country": "🇿🇦 África do Sul"
+    "country": "🇿🇦 África do Sul",
+    "gardner_channels": [
+      "interpersonal",
+      "intrapersonal",
+      "existential"
+    ],
+    "sacrifice_amount": 22
   },
   {
     "id": "hist_viking_democracy",
@@ -704,7 +772,9 @@
     "type": "curiosity_hook",
     "domain": "psychology",
     "casel_target": [
-      "SM"
+      "SM",
+      "DM",
+      "SA"
     ],
     "age_range": [
       7,
@@ -717,7 +787,13 @@
     "bridge": "Esperar é difícil. Mas a habilidade de esperar prevê sucesso mais que inteligência.",
     "quest": "Escolhe algo que quer (doce, jogo, celular). Espera 10 min antes de pegar. O que sentiu enquanto esperava?",
     "sacrifice_type": "act",
-    "country": "🇺🇸 Stanford"
+    "country": "🇺🇸 Stanford",
+    "gardner_channels": [
+      "logical_mathematical",
+      "intrapersonal",
+      "interpersonal"
+    ],
+    "sacrifice_amount": 14
   },
   {
     "id": "psych_bystander",
@@ -844,7 +920,8 @@
     "type": "curiosity_hook",
     "domain": "culture",
     "casel_target": [
-      "SM"
+      "REL",
+      "SOC"
     ],
     "age_range": [
       7,
@@ -857,7 +934,12 @@
     "bridge": "Parar não é perder tempo. É criar espaço pra pensar. As melhores ideias vêm quando para.",
     "quest": "Faz um \"fika\" — 10 min de pausa com alguém. Sem celular. Só conversa e algo pra beber.",
     "sacrifice_type": "act",
-    "country": "🇸🇪 Suécia"
+    "country": "🇸🇪 Suécia",
+    "gardner_channels": [
+      "interpersonal",
+      "intrapersonal"
+    ],
+    "sacrifice_amount": 5
   },
   {
     "id": "cult_navajo_laughter",
@@ -944,7 +1026,9 @@
     "type": "curiosity_hook",
     "domain": "mythology",
     "casel_target": [
-      "SA"
+      "SA",
+      "SM",
+      "REL"
     ],
     "age_range": [
       7,
@@ -957,14 +1041,21 @@
     "bridge": "Suas rachaduras não são defeito. São história. O que te quebrou pode ser exatamente o que te faz mais valioso.",
     "quest": "Pensa numa \"rachadura\" tua — algo que te machucou. Se cobrisse de ouro, como ficaria? Me conta.",
     "sacrifice_type": "expose",
-    "country": "🇯🇵 Japão"
+    "country": "🇯🇵 Japão",
+    "gardner_channels": [
+      "spatial",
+      "intrapersonal",
+      "existential"
+    ],
+    "sacrifice_amount": 12
   },
   {
     "id": "myth_phoenix",
     "type": "curiosity_hook",
     "domain": "mythology",
     "casel_target": [
-      "SA"
+      "SA",
+      "SM"
     ],
     "age_range": [
       7,
@@ -977,7 +1068,13 @@
     "bridge": "Toda cultura inventou um pássaro que morre e renasce. Porque toda cultura precisa acreditar que recomeçar é possível.",
     "quest": "Já \"morreu e renasceu\" em algo? Mudou de escola, perdeu amigo, fase ruim que passou? Conta esse renascimento.",
     "sacrifice_type": "reflect",
-    "country": "🌍 Global"
+    "country": "🌍 Global",
+    "gardner_channels": [
+      "spatial",
+      "existential",
+      "intrapersonal"
+    ],
+    "sacrifice_amount": 9
   },
   {
     "id": "myth_odin_eye",
@@ -1084,7 +1181,8 @@
     "type": "curiosity_hook",
     "domain": "theology",
     "casel_target": [
-      "SA"
+      "SA",
+      "REL"
     ],
     "age_range": [
       7,
@@ -1097,7 +1195,12 @@
     "bridge": "Pra aprender, precisa esvaziar. Se já \"sabe tudo\", nada novo entra.",
     "quest": "Sobre que assunto você tá \"com a xícara cheia\"? Tenta ouvir alguém que pensa DIFERENTE sem interromper.",
     "sacrifice_type": "reflect",
-    "country": "🇯🇵 Zen"
+    "country": "🇯🇵 Zen",
+    "gardner_channels": [
+      "intrapersonal",
+      "existential"
+    ],
+    "sacrifice_amount": 17
   },
   {
     "id": "theo_sufi_elephant",

--- a/motor-execucao/src/card-generation.ts
+++ b/motor-execucao/src/card-generation.ts
@@ -21,7 +21,6 @@ import type {
   CaselDimension,
   GardnerChannel,
   StatusMatrix,
-  StatusValue,
   ScoredContentItem,
   ParentalProfile,
 } from "@ascendimacy/shared";
@@ -38,13 +37,14 @@ import {
 /**
  * Sinal de conquista detectado — gatilho pra propor card.
  * Detecção é heurística: qualquer transição status → pasto conta;
- * ou sacrifice_spent alto; ou múltiplos canais Gardner ativados (ignition).
+ * ou sacrifice_spent alto; ou múltiplos canais Gardner ativados (ignition);
+ * ou crossing brejo→baia (Bloco 7 prep — recovery transition).
  */
 export interface AchievementSignal {
   child_id: string;
   session_id: string;
   timestamp: string;
-  kind: "status_to_pasto" | "ignition" | "sacrifice_high";
+  kind: "status_to_pasto" | "ignition" | "sacrifice_high" | "crossing";
   context_word: string;
   casel_dimension: CaselDimension;
   gardner_channel: GardnerChannel;
@@ -119,6 +119,17 @@ function classifyAchievement(input: DetectAchievementInput): AchievementSignal["
   if ((input.sacrifice_spent ?? 0) >= SACRIFICE_HIGH_THRESHOLD) {
     return "sacrifice_high";
   }
+  // 4. Crossing brejo→baia (recovery transition; Bloco 7 prep).
+  //    Precedência mais baixa pra não roubar status_to_pasto (qualquer→pasto)
+  //    nem ignition/sacrifice. Só ativa se nenhum dos 3 acima detectou.
+  if (input.previous_matrix && input.current_matrix) {
+    for (const [dim, nowValue] of Object.entries(input.current_matrix)) {
+      const prev = input.previous_matrix[dim];
+      if (prev === "brejo" && nowValue === "baia") {
+        return "crossing";
+      }
+    }
+  }
   return null;
 }
 
@@ -137,7 +148,20 @@ function buildSummary(kind: AchievementSignal["kind"], input: DetectAchievementI
       return `ignição multi-canal (${input.gardner_observed?.length ?? 0} Gardner × ${input.casel_touched?.length ?? 0} CASEL)`;
     case "sacrifice_high":
       return `sacrifício alto (${input.sacrifice_spent} pts) em ${selId ?? "content desconhecido"}`;
+    case "crossing": {
+      const dim = firstDimensionBrejoToBaia(input);
+      return `dimensão ${dim ?? "?"} atravessou brejo→baia (recovery)${selId ? ` via ${selId}` : ""}`;
+    }
   }
+}
+
+function firstDimensionBrejoToBaia(input: DetectAchievementInput): string | null {
+  if (!input.previous_matrix || !input.current_matrix) return null;
+  for (const [dim, val] of Object.entries(input.current_matrix)) {
+    const prev = input.previous_matrix[dim];
+    if (prev === "brejo" && val === "baia") return dim;
+  }
+  return null;
 }
 
 function firstDimensionToPasto(input: DetectAchievementInput): string | null {
@@ -181,6 +205,9 @@ export function selectArchetypeForSignal(
     status_to_pasto: "legendary",
     ignition: "epic",
     sacrifice_high: "rare",
+    // crossing reaproveita arch_crossing_v0 (legendary) — narrativa
+    // "atravessou de brejo pra baia, baia pra pasto" cobre ambos os kinds.
+    crossing: "legendary",
   };
   const targetRarity = rarityByKind[signal.kind];
   // Tenta match exato casel + rarity.

--- a/motor-execucao/tests/card-generation.test.ts
+++ b/motor-execucao/tests/card-generation.test.ts
@@ -110,6 +110,55 @@ describe("detectAchievement", () => {
     });
     expect(r?.kind).toBe("status_to_pasto");
   });
+
+  // ─── crossing kind (Bloco 7 prep — recovery transition) ───
+  it("detecta crossing quando dim passou de brejo→baia", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      previous_matrix: { emotional: "brejo" },
+      current_matrix: { emotional: "baia" },
+    });
+    expect(r?.kind).toBe("crossing");
+    expect(r?.achievement_summary).toContain("emotional");
+    expect(r?.achievement_summary).toContain("brejo→baia");
+  });
+
+  it("baia→pasto retorna status_to_pasto (precedência sobre crossing)", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      previous_matrix: { emotional: "baia" },
+      current_matrix: { emotional: "pasto" },
+    });
+    expect(r?.kind).toBe("status_to_pasto");
+  });
+
+  it("brejo→pasto retorna status_to_pasto (jump direto, não crossing)", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      previous_matrix: { emotional: "brejo" },
+      current_matrix: { emotional: "pasto" },
+    });
+    expect(r?.kind).toBe("status_to_pasto");
+  });
+
+  it("crossing perde pra ignition se ambos qualificam", () => {
+    const r = detectAchievement({
+      child_id: "ryo",
+      session_id: "s1",
+      now: NOW,
+      previous_matrix: { emotional: "brejo" },
+      current_matrix: { emotional: "baia" },
+      gardner_observed: ["linguistic", "logical_mathematical", "spatial"],
+      casel_touched: ["SA", "DM"],
+    });
+    expect(r?.kind).toBe("ignition");
+  });
 });
 
 describe("selectArchetypeForSignal", () => {

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -185,10 +185,32 @@ export async function runTurn(
   const gardnerChannelsObserved =
     (selectedItem as { gardner_channels?: import("@ascendimacy/shared").GardnerChannel[] } | undefined)?.gardner_channels;
   const caselTargetsTouched = (selectedItem as { casel_target?: import("@ascendimacy/shared").CaselDimension[] } | undefined)?.casel_target;
+  // Bloco 7 prep — sacrifice_amount agora vem do item selecionado (antes hardcoded 0).
+  const sacrificeSpent = Number(
+    (selectedItem as { sacrifice_amount?: number } | undefined)?.sacrifice_amount ?? 0,
+  );
 
   // ─── Bloco 5a auto-hook — detectAchievement + emit (motor#17) ───────
   // Runs APÓS execute_playbook. Se signal não-null, dispara pipeline.
   // Latency budget: < 100ms extra (detect ~5ms; emit_card ~20-50ms via mocks).
+  //
+  // Bloco 7 prep (motor#18) — re-fetch state após execute_playbook pra capturar
+  // matrix atualizada pelo turn. Comparada com snapshot pré-turno (state.statusMatrix
+  // tirado lá no topo do runTurn) habilita detecção de transições status_to_pasto +
+  // crossing.
+  const prevStatusMatrix = state.statusMatrix ? { ...state.statusMatrix } : undefined;
+  let currentStatusMatrix = state.statusMatrix;
+  try {
+    const newStateResult = await clients.motorExecucao.callTool({
+      name: "get_state",
+      arguments: { sessionId },
+    });
+    const newState = parseToolText<import("@ascendimacy/shared").SessionState>(newStateResult);
+    currentStatusMatrix = newState.statusMatrix ?? currentStatusMatrix;
+  } catch {
+    // Se re-fetch falhar, mantém prev=curr (comportamento pré-#18).
+  }
+
   let emittedCardId: string | undefined;
   let cardEmissionSkipReason: string | undefined;
   const t4 = Date.now();
@@ -198,11 +220,11 @@ export async function runTurn(
       arguments: {
         childId: persona.id,
         sessionId,
-        currentMatrix: state.statusMatrix ?? {},
-        previousMatrix: state.statusMatrix ?? {}, // sem snapshot pré-turno em v1
+        currentMatrix: currentStatusMatrix ?? {},
+        previousMatrix: prevStatusMatrix ?? {},
         gardnerObserved: gardnerChannelsObserved ?? [],
         caselTouched: caselTargetsTouched ?? [],
-        sacrificeSpent: 0, // sem campo dedicado em selectedContent v1
+        sacrificeSpent,
         selectedContent: drota.selectedContent ?? {},
       },
     });

--- a/shared/src/content-item.ts
+++ b/shared/src/content-item.ts
@@ -78,6 +78,14 @@ export interface ContentItemBase {
    */
   group_compatible?: boolean;
 
+  /**
+   * Quantidade de "sacrifício" (esforço/exposição) que o item pede.
+   * Range típico: 5-25. Items com valor ≥ SACRIFICE_HIGH_THRESHOLD (15)
+   * disparam signal `sacrifice_high` em detectAchievement quando
+   * selecionados. Bloco 7 prep — antes era hardcoded 0.
+   */
+  sacrifice_amount?: number;
+
   /** Dinâmico por criança — resultante do histórico de uso. */
   times_used?: number;
   last_used_at?: string | null;


### PR DESCRIPTION
## Contexto

Após motor#17 + sts#8 mergeados, nagareyama-30d ainda emitia 0 cards. sts#8 expôs que o auto-hook estava firing corretamente — todos os turns gravavam `cardEmissionSkipReason: \"no_signal\"`. Investigação revelou 3 bloqueios coordenados upstream:

1. Mock content pool sem `gardner_channels` arrays + items single-CASEL → ignition (≥3 ch × ≥2 dim) nunca batia
2. Orchestrator hardcoda `previousMatrix = state.statusMatrix` (igual ao current) → status_to_pasto nunca firava
3. Brejo→baia (recovery) não tinha kind dedicado — só baia→pasto / brejo→pasto disparavam status_to_pasto

Este PR resolve os 3 em coordenação.

## Fix 1 — Inventário enriquecido

`content/hooks/seed.json` — 15 items selecionados estrategicamente recebem:
- `gardner_channels: GardnerChannel[]` (2-4 canais plausíveis)
- `casel_target` expandido pra ≥2 dims em 12 items
- `sacrifice_amount: number` (5-22, com 5 items ≥15)

Critério atendido:
- ≥4 ignition-capable: **10 items** ✓
- ≥3 sacrifice-high-capable: **5 items** ✓
- ≥6 multi-casel: **12 items** ✓

Itens pesados:
| ID | gardner_channels | casel_target | sacrifice |
|---|---|---|---|
| `ling_greek_love` | linguistic + interpersonal + intrapersonal + existential | SA, REL, SOC | 18 |
| `bio_dolphin_names` | linguistic + naturalist + interpersonal + intrapersonal | SA, REL, SM | 16 |
| `hist_mandela_forgave` | interpersonal + intrapersonal + existential | REL, SOC | 22 |
| `bio_ant_sacrifice` | naturalist + interpersonal + existential | REL, SOC | 19 |
| `psych_marshmallow` | logical_mathematical + intrapersonal + interpersonal | SM, DM, SA | 14 |

`shared/src/content-item.ts:ContentItemBase` ganha campo `sacrifice_amount?: number` opcional — schema-compatible com items legados.

## Fix 2 — prev_matrix snapshot em `orchestrator.runTurn`

Antes (motor#17, [orchestrator.ts:202](orchestrator/src/orchestrator.ts#L202)):
\`\`\`ts
previousMatrix: state.statusMatrix ?? {}, // sem snapshot pré-turno em v1
\`\`\`

Agora:
1. Snapshot `prevStatusMatrix = { ...state.statusMatrix }` ANTES de execute_playbook
2. Re-fetch state via `get_state` APÓS execute pra capturar matrix atualizada
3. Passa prev (snapshot) + curr (re-fetched) pro detect_achievement

Try/catch envolve o re-fetch — falha mantém prev=curr (degrade gracioso, sem panic).

`sacrificeSpent` agora vem de `selectedItem.sacrifice_amount ?? 0` (antes hardcoded 0). Sacrifice_high pode firar quando item selecionado tem amount ≥ 15.

## Fix 3 — Kind `crossing`

Novo `AchievementSignal[\"kind\"]: \"crossing\"` detecta brejo→baia (recovery transition).

Precedência: `status_to_pasto > ignition > sacrifice_high > crossing`. Crossing só ativa se nenhum dos 3 acima detectou.

Mapeamento archetype:
- `crossing` → `arch_crossing_v0` (legendary, scaffold)
- `status_to_pasto` → `arch_crossing_v0` também (compartilham — narrative cobre ambos)

Decisão explícita: NÃO criar `arch_step_forward_v0` separado pra evitar archetype proliferation. A narrative \"atravessou de brejo pra baia, de baia pra pasto\" funciona pros dois.

## Tests

4 novos em `motor-execucao/tests/card-generation.test.ts`:

1. `prev=brejo, curr=baia` → kind `crossing`, summary contém \"emotional\" + \"brejo→baia\"
2. `prev=baia, curr=pasto` → kind `status_to_pasto` (precedência sobre crossing)
3. `prev=brejo, curr=pasto` → kind `status_to_pasto` (jump direto)
4. `crossing` perde pra `ignition` se ambos qualificam

**Total motor: 385 verde** (era 381). Build clean.

## Companion PR (sts#9)

Mirror em `ascendimacy-sts/orchestrator/src/motor-client.ts:runMotorTurn`:
- prev_matrix snapshot + re-fetch (mesmo padrão)
- pull `sacrifice_amount` de `selectedItem`
- passa `previousMatrix` + atualizado `sacrificeSpent` pro detect_achievement MCP tool

Será aberto imediatamente após este PR.

## Test plan

- [x] motor build clean
- [x] motor tests 385 verde
- [x] criterio inventory: ≥4 ignition-capable + ≥3 sacrifice-high
- [x] crossing tests (4 novos)
- [ ] companion sts#9 aberto
- [ ] smoke-3d --real-llm com motor real → ≥1 card emitido
- [ ] nagareyama-30d --real-llm → ≥3 cards (alvo 3-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)