### PR TITLE
feat(motor#20): LLM robustness — timeouts + retries + classifier + tests faltantes

### DIFF
--- a/motor-drota/src/llm-client.ts
+++ b/motor-drota/src/llm-client.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { getLlmTimeoutMs, getLlmMaxRetries } from "@ascendimacy/shared";
 
 let client: OpenAI | null = null;
 
@@ -31,14 +32,22 @@ export async function callLlm(systemPrompt: string, userMessage: string): Promis
   const isReasoningModel = /kimi|deepseek-r|o1|o3|reason/i.test(model);
   const maxTokens = isReasoningModel ? 4096 : 2048;
 
-  const response = await c.chat.completions.create({
-    model,
-    messages: [
-      { role: "system", content: systemPrompt },
-      { role: "user", content: userMessage },
-    ],
-    max_tokens: maxTokens,
-  });
+  // motor#20: timeout + retries explícitos.
+  // OpenAI SDK retries 408/409/429/5xx automaticamente.
+  const response = await c.chat.completions.create(
+    {
+      model,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userMessage },
+      ],
+      max_tokens: maxTokens,
+    },
+    {
+      timeout: getLlmTimeoutMs("drota"),
+      maxRetries: getLlmMaxRetries("drota"),
+    },
+  );
 
   const msg = response.choices[0]?.message;
   const content = msg?.content ?? "";

--- a/motor-drota/tests/llm-client.test.ts
+++ b/motor-drota/tests/llm-client.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests do motor-drota llm-client (motor#19 + motor#20).
+ *
+ * Cobre:
+ *   - LlmCallResult shape — motor#19
+ *   - max_tokens=2048 default + 4096 pra reasoning models — motor#19
+ *   - Captura campo `reasoning` (Infomaniak Kimi/DeepSeek-R1) — motor#19
+ *   - Timeout 90s default + maxRetries — motor#20
+ *
+ * Mocka openai SDK.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const captured: { params?: unknown; options?: unknown } = {};
+let mockResponse: unknown = null;
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      chat = {
+        completions: {
+          create: async (params: unknown, options?: unknown) => {
+            captured.params = params;
+            captured.options = options;
+            return mockResponse;
+          },
+        },
+      };
+    },
+  };
+});
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  captured.params = undefined;
+  captured.options = undefined;
+  mockResponse = null;
+  delete process.env["MOTOR_DROTA_MODEL"];
+  delete process.env["ASC_LLM_TIMEOUT_DROTA"];
+  process.env["INFOMANIAK_API_KEY"] = "test-key";
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+});
+
+describe("motor-drota.callLlm — motor#19 + motor#20", () => {
+  it("retorna LlmCallResult com content + tokens", async () => {
+    mockResponse = {
+      choices: [{ message: { content: "Hello" } }],
+      usage: { prompt_tokens: 100, completion_tokens: 50 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.content).toBe("Hello");
+    expect(r.tokens.in).toBe(100);
+    expect(r.tokens.out).toBe(50);
+    expect(r.reasoning).toBeUndefined();
+  });
+
+  it("captura reasoning de message.reasoning (Kimi K2.5/DeepSeek-R1)", async () => {
+    mockResponse = {
+      choices: [{ message: { content: "Final answer", reasoning: "Let me think step by step..." } }],
+      usage: { prompt_tokens: 100, completion_tokens: 50 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.content).toBe("Final answer");
+    expect(r.reasoning).toBe("Let me think step by step...");
+  });
+
+  it("max_tokens=2048 pra modelo non-reasoning (mistral3)", async () => {
+    process.env["MOTOR_DROTA_MODEL"] = "mistral3";
+    mockResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.params as { max_tokens: number }).max_tokens).toBe(2048);
+  });
+
+  it("max_tokens=4096 pra Kimi K2.5 (heurística reasoning)", async () => {
+    process.env["MOTOR_DROTA_MODEL"] = "moonshotai/Kimi-K2.5";
+    mockResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.params as { max_tokens: number }).max_tokens).toBe(4096);
+  });
+
+  it("max_tokens=4096 pra DeepSeek-R1", async () => {
+    process.env["MOTOR_DROTA_MODEL"] = "deepseek-r1";
+    mockResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.params as { max_tokens: number }).max_tokens).toBe(4096);
+  });
+
+  it("content null → fallback '{}'", async () => {
+    mockResponse = {
+      choices: [{ message: { content: null } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.content).toBe("{}");
+  });
+
+  it("timeout default 90s (drota)", async () => {
+    mockResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.options as { timeout: number }).timeout).toBe(90_000);
+  });
+
+  it("ASC_LLM_TIMEOUT_DROTA override (motor#20)", async () => {
+    process.env["ASC_LLM_TIMEOUT_DROTA"] = "30";
+    mockResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.options as { timeout: number }).timeout).toBe(30_000);
+  });
+
+  it("maxRetries=2 default (drota — fail-fast em reasoning)", async () => {
+    mockResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.options as { maxRetries: number }).maxRetries).toBe(2);
+  });
+});

--- a/planejador/src/llm-client.ts
+++ b/planejador/src/llm-client.ts
@@ -1,5 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
-import { isDebugModeEnabled } from "@ascendimacy/shared";
+import { isDebugModeEnabled, getLlmTimeoutMs, getLlmMaxRetries } from "@ascendimacy/shared";
 
 let client: Anthropic | null = null;
 
@@ -44,7 +44,12 @@ export async function callLlm(
     };
   }
 
-  const response = await c.messages.create(params);
+  // motor#20: timeout + retries explícitos pra evitar hang (Kimi-like 54min travamento).
+  // SDK Anthropic retries 408/409/429/5xx + network errors automaticamente.
+  const response = await c.messages.create(params, {
+    timeout: getLlmTimeoutMs("planejador"),
+    maxRetries: getLlmMaxRetries("planejador"),
+  });
 
   let content = "";
   let reasoning: string | undefined;
@@ -87,12 +92,18 @@ export async function callHaiku(
 ): Promise<LlmCallResult> {
   const c = getClient();
   const model = process.env["HAIKU_MODEL"] ?? "claude-haiku-4-5-20251001";
-  const response = await c.messages.create({
-    model,
-    max_tokens: 512,
-    system: systemPrompt,
-    messages: [{ role: "user", content: userMessage }],
-  });
+  const response = await c.messages.create(
+    {
+      model,
+      max_tokens: 512,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+    },
+    {
+      timeout: getLlmTimeoutMs("haiku-triage"),
+      maxRetries: getLlmMaxRetries("haiku-triage"),
+    },
+  );
   let content = "";
   for (const block of response.content) {
     if (block.type === "text") content += block.text;

--- a/planejador/tests/llm-client.test.ts
+++ b/planejador/tests/llm-client.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests do planejador llm-client (motor#19 + motor#20).
+ *
+ * Cobre:
+ *   - LlmCallResult shape (content, reasoning, tokens) — motor#19
+ *   - max_tokens=2048 — motor#19 (era 200 pré-#19)
+ *   - Extended thinking ON em debug mode — motor#19
+ *   - Timeout/maxRetries forwarded pra SDK — motor#20
+ *   - Múltiplos blocks (text + thinking) tratados corretamente
+ *   - Auth error com mensagem clara
+ *
+ * Mocka @anthropic-ai/sdk via vi.mock pra não bater na API real.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Captura de params passados pra messages.create — preenchido pelos tests
+const captured: { params?: unknown; options?: unknown } = {};
+let mockResponse: unknown = null;
+let mockThrow: unknown = null;
+
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: async (params: unknown, options?: unknown) => {
+          captured.params = params;
+          captured.options = options;
+          if (mockThrow) throw mockThrow;
+          return mockResponse;
+        },
+      };
+    },
+  };
+});
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  captured.params = undefined;
+  captured.options = undefined;
+  mockResponse = null;
+  mockThrow = null;
+  delete process.env["ASC_DEBUG_MODE"];
+  delete process.env["ASC_LLM_TIMEOUT_PLANEJADOR"];
+  delete process.env["ASC_LLM_MAX_RETRIES_PLANEJADOR"];
+  process.env["ANTHROPIC_API_KEY"] = "test-key";
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+});
+
+describe("planejador.callLlm — motor#19 + motor#20", () => {
+  it("retorna LlmCallResult shape com content + tokens", async () => {
+    mockResponse = {
+      content: [{ type: "text", text: "Hello world" }],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("system", "user");
+    expect(r.content).toBe("Hello world");
+    expect(r.tokens.in).toBe(100);
+    expect(r.tokens.out).toBe(50);
+    expect(r.tokens.reasoning).toBe(0);
+    expect(r.reasoning).toBeUndefined();
+  });
+
+  it("max_tokens=2048 (motor#19 bump)", async () => {
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.params as { max_tokens: number }).max_tokens).toBe(2048);
+  });
+
+  it("thinking OFF por default (debug mode off)", async () => {
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.params as { thinking?: unknown }).thinking).toBeUndefined();
+  });
+
+  it("thinking ON com budget 1024 em debug mode", async () => {
+    process.env["ASC_DEBUG_MODE"] = "true";
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    const thinking = (captured.params as { thinking?: { type: string; budget_tokens: number } }).thinking;
+    expect(thinking).toEqual({ type: "enabled", budget_tokens: 1024 });
+  });
+
+  it("captura reasoning de blocks type=thinking", async () => {
+    mockResponse = {
+      content: [
+        { type: "thinking", thinking: "I should help the user..." },
+        { type: "text", text: "Response text" },
+      ],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.content).toBe("Response text");
+    expect(r.reasoning).toBe("I should help the user...");
+  });
+
+  it("timeout default 30s passado pra SDK options (motor#20)", async () => {
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.options as { timeout: number }).timeout).toBe(30_000);
+  });
+
+  it("ASC_LLM_TIMEOUT_PLANEJADOR override aplicado (motor#20)", async () => {
+    process.env["ASC_LLM_TIMEOUT_PLANEJADOR"] = "120";
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.options as { timeout: number }).timeout).toBe(120_000);
+  });
+
+  it("maxRetries=3 default (motor#20)", async () => {
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.options as { maxRetries: number }).maxRetries).toBe(3);
+  });
+
+  it("throw quando response sem text block", async () => {
+    mockResponse = { content: [], usage: { input_tokens: 1, output_tokens: 1 } };
+    const { callLlm } = await import("../src/llm-client.js");
+    await expect(callLlm("s", "u")).rejects.toThrow(/no text block/);
+  });
+});
+
+describe("planejador.callHaiku — motor#19 + motor#20", () => {
+  it("max_tokens=512 (motor#19 bump 150→512)", async () => {
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callHaiku } = await import("../src/llm-client.js");
+    await callHaiku("s", "u");
+    expect((captured.params as { max_tokens: number }).max_tokens).toBe(512);
+  });
+
+  it("timeout 15s (haiku-triage default)", async () => {
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callHaiku } = await import("../src/llm-client.js");
+    await callHaiku("s", "u");
+    expect((captured.options as { timeout: number }).timeout).toBe(15_000);
+  });
+
+  it("thinking OFF mesmo em debug mode (Haiku é safety-critical determinístico)", async () => {
+    process.env["ASC_DEBUG_MODE"] = "true";
+    mockResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callHaiku } = await import("../src/llm-client.js");
+    await callHaiku("s", "u");
+    expect((captured.params as { thinking?: unknown }).thinking).toBeUndefined();
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -15,3 +15,4 @@ export * from "./card-cheat-code.js";
 export * from "./card-image-provider.js";
 export * from "./bullying-check.js";
 export * from "./debug-logger.js";
+export * from "./llm-config.js";

--- a/shared/src/llm-config.ts
+++ b/shared/src/llm-config.ts
@@ -1,0 +1,127 @@
+/**
+ * LLM robustness config — timeouts + retries compartilhados por todos os callsites.
+ *
+ * Motor#20 spec: docs/specs/... (inline aqui).
+ *
+ * Defaults conservadores pra evitar hang (Kimi K2.5 travou 54min na sessão).
+ * Override via env var por step ou global.
+ */
+
+/** Timeouts default em ms, por step. */
+export const LLM_TIMEOUT_DEFAULTS: Record<string, number> = {
+  // Sonnet 4.6 planejador — prompts moderados, reasoning budget 1024
+  planejador: 30_000,
+  // Haiku 4.5 rerank — prompts curtos
+  "haiku-triage": 15_000,
+  // Haiku 4.5 bullying check
+  "haiku-bullying": 15_000,
+  // Infomaniak reasoning models (Kimi K2.5, DeepSeek-R1) — reasoning chains longas
+  drota: 90_000,
+  // Sonnet 4.6 persona-simulator
+  "persona-sim": 30_000,
+};
+
+/** MaxRetries default por step. */
+export const LLM_MAX_RETRIES_DEFAULTS: Record<string, number> = {
+  planejador: 3,
+  "haiku-triage": 2, // rerank é recuperável via rule_based fallback — menos retries
+  "haiku-bullying": 2,
+  drota: 2, // reasoning model retry é caro, fail-fast é melhor
+  "persona-sim": 3,
+};
+
+/**
+ * Timeout em ms pra um step específico.
+ *
+ * Ordem de precedência:
+ * 1. ASC_LLM_TIMEOUT_<STEP_UPPER> (ex: ASC_LLM_TIMEOUT_DROTA=120)
+ * 2. ASC_LLM_TIMEOUT_SECONDS (global override)
+ * 3. LLM_TIMEOUT_DEFAULTS[step]
+ * 4. 30_000 (fallback)
+ */
+export function getLlmTimeoutMs(step: string): number {
+  const normalized = step.toUpperCase().replace(/-/g, "_");
+  const perStep = process.env[`ASC_LLM_TIMEOUT_${normalized}`];
+  if (perStep) {
+    const n = Number.parseInt(perStep, 10);
+    if (!Number.isNaN(n) && n > 0) return n * 1000;
+  }
+  const global = process.env["ASC_LLM_TIMEOUT_SECONDS"];
+  if (global) {
+    const n = Number.parseInt(global, 10);
+    if (!Number.isNaN(n) && n > 0) return n * 1000;
+  }
+  return LLM_TIMEOUT_DEFAULTS[step] ?? 30_000;
+}
+
+/**
+ * MaxRetries pra um step específico.
+ *
+ * Ordem de precedência:
+ * 1. ASC_LLM_MAX_RETRIES_<STEP_UPPER>
+ * 2. ASC_LLM_MAX_RETRIES (global)
+ * 3. LLM_MAX_RETRIES_DEFAULTS[step]
+ * 4. 2 (fallback)
+ */
+export function getLlmMaxRetries(step: string): number {
+  const normalized = step.toUpperCase().replace(/-/g, "_");
+  const perStep = process.env[`ASC_LLM_MAX_RETRIES_${normalized}`];
+  if (perStep) {
+    const n = Number.parseInt(perStep, 10);
+    if (!Number.isNaN(n) && n >= 0) return n;
+  }
+  const global = process.env["ASC_LLM_MAX_RETRIES"];
+  if (global) {
+    const n = Number.parseInt(global, 10);
+    if (!Number.isNaN(n) && n >= 0) return n;
+  }
+  return LLM_MAX_RETRIES_DEFAULTS[step] ?? 2;
+}
+
+/**
+ * Classifica erro de LLM pra decisão de retry/fail-fast.
+ * Anthropic/OpenAI SDKs jogam errors com status HTTP numérico.
+ */
+export function classifyLlmError(err: unknown): {
+  status: number | null;
+  retriable: boolean;
+  class: string;
+} {
+  if (err == null || typeof err !== "object") {
+    return { status: null, retriable: false, class: "UnknownError" };
+  }
+  const e = err as { status?: number; name?: string; message?: string };
+  const status = typeof e.status === "number" ? e.status : null;
+  const name = e.name ?? "Error";
+
+  // Timeout detection (AbortError from SDK timeouts)
+  if (name === "AbortError" || (e.message ?? "").includes("timeout")) {
+    return { status, retriable: false, class: "TimeoutError" };
+  }
+  // Auth / permission — fail fast
+  if (status === 401 || status === 403) {
+    return { status, retriable: false, class: "AuthError" };
+  }
+  // Bad request — fail fast
+  if (status === 400) {
+    return { status, retriable: false, class: "BadRequestError" };
+  }
+  // Rate limit — retry
+  if (status === 429) {
+    return { status, retriable: true, class: "RateLimitError" };
+  }
+  // Server errors — retry
+  if (status != null && status >= 500 && status < 600) {
+    return { status, retriable: true, class: "ServerError" };
+  }
+  // Network / fetch errors — retry cautiously
+  if (name === "FetchError" || (e.message ?? "").includes("ECONN") || (e.message ?? "").includes("ENOTFOUND")) {
+    return { status, retriable: true, class: "NetworkError" };
+  }
+  // OpenAI SDK length-finish (cobra caracterıstico)
+  if ((e.message ?? "").includes("Could not parse response content as the length limit")) {
+    return { status, retriable: false, class: "LengthFinishError" };
+  }
+  // Default: fail fast
+  return { status, retriable: false, class: name };
+}

--- a/shared/tests/llm-config.test.ts
+++ b/shared/tests/llm-config.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests do llm-config (motor#20) — robustness primitives.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getLlmTimeoutMs,
+  getLlmMaxRetries,
+  classifyLlmError,
+  LLM_TIMEOUT_DEFAULTS,
+  LLM_MAX_RETRIES_DEFAULTS,
+} from "../src/llm-config.js";
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith("ASC_LLM_")) delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith("ASC_LLM_")) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(ORIG_ENV)) {
+    if (k.startsWith("ASC_LLM_")) process.env[k] = v;
+  }
+});
+
+describe("getLlmTimeoutMs", () => {
+  it("retorna default quando sem env override", () => {
+    expect(getLlmTimeoutMs("planejador")).toBe(LLM_TIMEOUT_DEFAULTS["planejador"]);
+    expect(getLlmTimeoutMs("drota")).toBe(LLM_TIMEOUT_DEFAULTS["drota"]);
+  });
+
+  it("respeita ASC_LLM_TIMEOUT_<STEP> em segundos", () => {
+    process.env["ASC_LLM_TIMEOUT_DROTA"] = "120";
+    expect(getLlmTimeoutMs("drota")).toBe(120_000);
+  });
+
+  it("converte step com hífen pra underscore no env var", () => {
+    process.env["ASC_LLM_TIMEOUT_HAIKU_TRIAGE"] = "20";
+    expect(getLlmTimeoutMs("haiku-triage")).toBe(20_000);
+  });
+
+  it("ASC_LLM_TIMEOUT_SECONDS aplica globalmente como fallback", () => {
+    process.env["ASC_LLM_TIMEOUT_SECONDS"] = "60";
+    expect(getLlmTimeoutMs("planejador")).toBe(60_000);
+    expect(getLlmTimeoutMs("drota")).toBe(60_000);
+  });
+
+  it("per-step override beats global", () => {
+    process.env["ASC_LLM_TIMEOUT_SECONDS"] = "60";
+    process.env["ASC_LLM_TIMEOUT_DROTA"] = "180";
+    expect(getLlmTimeoutMs("drota")).toBe(180_000);
+    expect(getLlmTimeoutMs("planejador")).toBe(60_000);
+  });
+
+  it("step desconhecido → 30s fallback", () => {
+    expect(getLlmTimeoutMs("unknown-step")).toBe(30_000);
+  });
+
+  it("env var inválido (não numérico) → ignora e usa default", () => {
+    process.env["ASC_LLM_TIMEOUT_DROTA"] = "abc";
+    expect(getLlmTimeoutMs("drota")).toBe(LLM_TIMEOUT_DEFAULTS["drota"]);
+  });
+
+  it("env var negativo → ignora e usa default", () => {
+    process.env["ASC_LLM_TIMEOUT_DROTA"] = "-5";
+    expect(getLlmTimeoutMs("drota")).toBe(LLM_TIMEOUT_DEFAULTS["drota"]);
+  });
+});
+
+describe("getLlmMaxRetries", () => {
+  it("retorna default por step", () => {
+    expect(getLlmMaxRetries("planejador")).toBe(LLM_MAX_RETRIES_DEFAULTS["planejador"]);
+    expect(getLlmMaxRetries("drota")).toBe(LLM_MAX_RETRIES_DEFAULTS["drota"]);
+  });
+
+  it("respeita override per-step", () => {
+    process.env["ASC_LLM_MAX_RETRIES_DROTA"] = "5";
+    expect(getLlmMaxRetries("drota")).toBe(5);
+  });
+
+  it("aceita 0 retries", () => {
+    process.env["ASC_LLM_MAX_RETRIES_PLANEJADOR"] = "0";
+    expect(getLlmMaxRetries("planejador")).toBe(0);
+  });
+
+  it("step desconhecido → 2 fallback", () => {
+    expect(getLlmMaxRetries("unknown")).toBe(2);
+  });
+});
+
+describe("classifyLlmError", () => {
+  it("AbortError ou message contém 'timeout' → TimeoutError, não retriable", () => {
+    const e = Object.assign(new Error("Request timeout"), { name: "AbortError" });
+    const r = classifyLlmError(e);
+    expect(r.class).toBe("TimeoutError");
+    expect(r.retriable).toBe(false);
+  });
+
+  it("status 401 → AuthError, não retriable", () => {
+    const r = classifyLlmError({ status: 401, name: "Error" });
+    expect(r.class).toBe("AuthError");
+    expect(r.retriable).toBe(false);
+  });
+
+  it("status 403 → AuthError", () => {
+    const r = classifyLlmError({ status: 403 });
+    expect(r.class).toBe("AuthError");
+    expect(r.retriable).toBe(false);
+  });
+
+  it("status 400 → BadRequestError, não retriable", () => {
+    const r = classifyLlmError({ status: 400 });
+    expect(r.class).toBe("BadRequestError");
+    expect(r.retriable).toBe(false);
+  });
+
+  it("status 429 → RateLimitError, retriable", () => {
+    const r = classifyLlmError({ status: 429 });
+    expect(r.class).toBe("RateLimitError");
+    expect(r.retriable).toBe(true);
+  });
+
+  it("status 500-599 → ServerError, retriable", () => {
+    expect(classifyLlmError({ status: 500 }).retriable).toBe(true);
+    expect(classifyLlmError({ status: 503 }).retriable).toBe(true);
+    expect(classifyLlmError({ status: 599 }).retriable).toBe(true);
+  });
+
+  it("ECONN/ENOTFOUND/FetchError → NetworkError, retriable", () => {
+    expect(classifyLlmError({ message: "ECONNRESET" }).retriable).toBe(true);
+    expect(classifyLlmError({ name: "FetchError", message: "fetch failed" }).retriable).toBe(true);
+  });
+
+  it("LengthFinish error não retriable (problema de prompt, não transient)", () => {
+    const e = { message: "Could not parse response content as the length limit was reached" };
+    const r = classifyLlmError(e);
+    expect(r.class).toBe("LengthFinishError");
+    expect(r.retriable).toBe(false);
+  });
+
+  it("erro nulo/undefined → UnknownError", () => {
+    expect(classifyLlmError(null).class).toBe("UnknownError");
+    expect(classifyLlmError(undefined).class).toBe("UnknownError");
+  });
+
+  it("erro 4xx genérico (não auth/bad/rate-limit) → fail fast", () => {
+    const r = classifyLlmError({ status: 404 });
+    expect(r.retriable).toBe(false);
+  });
+});


### PR DESCRIPTION
Endurece chamadas LLM antes de rodar nagareyama-30d real-llm. Resolve dois gaps abertos pós-motor#19:

1. **Hang risk**: Kimi K2.5 travou 54min na sessão. Sem timeout explícito, scenario de 30 dias pode hangear indefinidamente.
2. **Tests faltantes**: motor#19 mudou shape de retorno + bumpou max_tokens + adicionou thinking — sem unit tests novos. Comportamento "funciona" só por leitura de código.

## shared/src/llm-config.ts (novo)

Primitiva compartilhada:

\`\`\`ts
getLlmTimeoutMs(step) → ms     // 30s/90s/15s defaults + env overrides
getLlmMaxRetries(step) → number // 2-3 defaults + env overrides
classifyLlmError(err) → { status, retriable, class }
\`\`\`

| Step | Timeout | Retries | Razão |
|---|---|---|---|
| planejador | 30s | 3 | Sonnet rápido, retry generoso |
| drota | **90s** | 2 | Reasoning chains longas (Kimi K2.5 ~20-30s) |
| haiku-triage | 15s | 2 | Curto, rule_based fallback existe |
| persona-sim | 30s | 3 | Sonnet com history pode ser longa |

Env overrides: \`ASC_LLM_TIMEOUT_<STEP>\` (segundos), \`ASC_LLM_MAX_RETRIES_<STEP>\`, ou globais \`ASC_LLM_TIMEOUT_SECONDS\` / \`ASC_LLM_MAX_RETRIES\`.

\`classifyLlmError\` separa retriable (5xx, 429, network) de fail-fast (auth, bad request, timeout, length-finish).

## llm-clients

\`\`\`ts
// planejador
await c.messages.create(params, {
  timeout: getLlmTimeoutMs("planejador"),    // 30000
  maxRetries: getLlmMaxRetries("planejador"), // 3
});

// motor-drota
await c.chat.completions.create(params, {
  timeout: getLlmTimeoutMs("drota"),    // 90000
  maxRetries: getLlmMaxRetries("drota"), // 2
});
\`\`\`

SDKs Anthropic + OpenAI já fazem retry automático em 408/409/429/5xx — apenas explicitamos os values.

## Tests (43 novos)

| File | Tests | Cobre |
|---|---|---|
| \`shared/tests/llm-config.test.ts\` | 15 | timeout/retry/env override/classifier por classe de erro |
| \`planejador/tests/llm-client.test.ts\` | 12 | LlmCallResult shape (motor#19), max_tokens 2048, thinking ON/OFF, reasoning capture, timeout/retries forward |
| \`motor-drota/tests/llm-client.test.ts\` | 9 | shape, reasoning field (Kimi/DeepSeek-R1), max_tokens heuristic 2048/4096, content null fallback, timeout/retries |

Mocks de @anthropic-ai/sdk + openai via \`vi.mock\` — não bate API real.

**Total motor: 443 verde** (era 400). Build clean.

## Companion

**sts#11** cobre lado STS:
- persona-simulator timeout 30s + maxRetries 3 + tests
- scenario-runner per-event timeout wrapper (ASC_EVENT_TIMEOUT_SECONDS, default 180s)

## Test plan

- [x] motor build clean
- [x] motor 443 tests verde (43 novos)
- [x] timeout default 30s/90s/15s configurado em cada client
- [x] env override funcional
- [x] classifyLlmError cobre cada categoria
- [ ] sts#11 mergeado
- [ ] smoke-3d com Kimi K2.5 não trava (max 90s drota timeout corta)
- [ ] nagareyama-30d roda até o fim (event-timeout do sts#11 pula travado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)