### PR TITLE
feat(motor#21): LLM router multi-provider — defaults TUDO Kimi via Infomaniak

### DIFF
--- a/motor-drota/package.json
+++ b/motor-drota/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "@ascendimacy/shared": "*",
     "@modelcontextprotocol/sdk": "^1.10.2",
     "openai": "^4.77.0",

--- a/motor-drota/src/llm-client.ts
+++ b/motor-drota/src/llm-client.ts
@@ -1,40 +1,101 @@
+/**
+ * Motor-drota LLM client — motor#21 dual-provider (Anthropic + Infomaniak).
+ *
+ * Default: Infomaniak / Kimi K2.5. Override via env DROTA_PROVIDER + DROTA_MODEL.
+ *
+ * Spec: docs/specs/2026-04-24-debug-mode.md.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
-import { getLlmTimeoutMs, getLlmMaxRetries } from "@ascendimacy/shared";
+import {
+  isDebugModeEnabled,
+  getLlmTimeoutMs,
+  getLlmMaxRetries,
+  getProviderForStep,
+  getModelForStep,
+  getMaxTokensForStep,
+  shouldEnableThinking,
+  getThinkingBudgetTokens,
+  type LlmProvider,
+} from "@ascendimacy/shared";
 
-let client: OpenAI | null = null;
+let anthropicClient: Anthropic | null = null;
+let openaiClient: OpenAI | null = null;
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI({
+function getAnthropic(): Anthropic {
+  if (!anthropicClient) {
+    anthropicClient = new Anthropic({ apiKey: process.env["ANTHROPIC_API_KEY"] });
+  }
+  return anthropicClient;
+}
+
+function getOpenAI(): OpenAI {
+  if (!openaiClient) {
+    openaiClient = new OpenAI({
       apiKey: process.env["INFOMANIAK_API_KEY"] ?? "mock",
       baseURL: process.env["INFOMANIAK_BASE_URL"] ?? "https://api.infomaniak.com/1/ai",
     });
   }
-  return client;
+  return openaiClient;
 }
 
 export interface LlmCallResult {
   content: string;
   reasoning?: string;
   tokens: { in: number; out: number; reasoning: number };
+  provider: LlmProvider;
+  model: string;
 }
 
 /**
- * motor#19: bump max_tokens 512→2048 (4096 quando reasoning model detectado).
- * Captura campo `reasoning` expostos por modelos OpenAI-compat reasoning
- * (Kimi K2.5, DeepSeek-R1 via Infomaniak).
+ * motor#21 dispatcher. Default: Infomaniak / Kimi K2.5. Anthropic via DROTA_PROVIDER=anthropic.
  */
 export async function callLlm(systemPrompt: string, userMessage: string): Promise<LlmCallResult> {
-  const c = getClient();
-  const model = process.env["MOTOR_DROTA_MODEL"] ?? "mistral24b";
-  // Heurística simples: modelos reasoning drenam tokens em CoT. Se nome sugere
-  // reasoning, dobra o budget pra deixar espaço pro content visível.
-  const isReasoningModel = /kimi|deepseek-r|o1|o3|reason/i.test(model);
-  const maxTokens = isReasoningModel ? 4096 : 2048;
-
-  // motor#20: timeout + retries explícitos.
-  // OpenAI SDK retries 408/409/429/5xx automaticamente.
-  const response = await c.chat.completions.create(
+  const provider = getProviderForStep("drota");
+  if (provider === "anthropic") {
+    const c = getAnthropic();
+    const model = getModelForStep("drota", "anthropic");
+    const maxTokens = getMaxTokensForStep("drota", model);
+    const thinking = shouldEnableThinking("drota", "anthropic", isDebugModeEnabled());
+    const params: Anthropic.MessageCreateParams = {
+      model,
+      max_tokens: maxTokens,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+    };
+    if (thinking) {
+      (params as Anthropic.MessageCreateParams & { thinking?: unknown }).thinking = {
+        type: "enabled",
+        budget_tokens: getThinkingBudgetTokens(),
+      };
+    }
+    const r = await c.messages.create(params, {
+      timeout: getLlmTimeoutMs("drota"),
+      maxRetries: getLlmMaxRetries("drota"),
+    });
+    let content = "";
+    let reasoning: string | undefined;
+    for (const block of r.content) {
+      if (block.type === "text") content += block.text;
+      else if ((block as { type: string }).type === "thinking") {
+        reasoning = (block as { thinking?: string }).thinking;
+      }
+    }
+    const usage = r.usage as { input_tokens: number; output_tokens: number };
+    return {
+      content: content || "{}",
+      reasoning,
+      tokens: { in: usage.input_tokens, out: usage.output_tokens, reasoning: 0 },
+      provider: "anthropic",
+      model,
+    };
+  }
+  // Infomaniak (default)
+  const c = getOpenAI();
+  const model = getModelForStep("drota", "infomaniak");
+  const maxTokens = getMaxTokensForStep("drota", model);
+  const r = await c.chat.completions.create(
     {
       model,
       messages: [
@@ -48,21 +109,20 @@ export async function callLlm(systemPrompt: string, userMessage: string): Promis
       maxRetries: getLlmMaxRetries("drota"),
     },
   );
-
-  const msg = response.choices[0]?.message;
+  const msg = r.choices[0]?.message;
   const content = msg?.content ?? "";
-  // `reasoning` é campo não-standard expostos por Infomaniak em modelos reasoning.
   const reasoning = (msg as { reasoning?: string } | undefined)?.reasoning;
-
-  const usage = response.usage;
+  const usage = r.usage;
   return {
     content: content || "{}",
     reasoning,
     tokens: {
       in: usage?.prompt_tokens ?? 0,
       out: usage?.completion_tokens ?? 0,
-      reasoning: 0, // Infomaniak não separa reasoning_tokens; fica embutido no completion
+      reasoning: 0,
     },
+    provider: "infomaniak",
+    model,
   };
 }
 
@@ -74,5 +134,7 @@ export async function callLlmMock(_systemPrompt: string, _userMessage: string): 
         "Olá! Que bom ter você aqui. Posso te apresentar algo que pode facilitar muito o seu dia?",
     }),
     tokens: { in: 0, out: 0, reasoning: 0 },
+    provider: "infomaniak",
+    model: "mock",
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "name": "@ascendimacy/motor-drota",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
         "@ascendimacy/shared": "*",
         "@modelcontextprotocol/sdk": "^1.10.2",
         "openai": "^4.77.0",
@@ -4556,6 +4557,7 @@
         "@ascendimacy/shared": "*",
         "@modelcontextprotocol/sdk": "^1.10.2",
         "js-yaml": "^4.1.0",
+        "openai": "^4.77.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {

--- a/planejador/package.json
+++ b/planejador/package.json
@@ -15,6 +15,7 @@
     "@ascendimacy/shared": "*",
     "@modelcontextprotocol/sdk": "^1.10.2",
     "js-yaml": "^4.1.0",
+    "openai": "^4.77.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/planejador/src/llm-client.ts
+++ b/planejador/src/llm-client.ts
@@ -1,125 +1,180 @@
+/**
+ * Planejador LLM client — motor#21 dual-provider (Anthropic + Infomaniak).
+ *
+ * Provider escolhido per-callsite via env:
+ *   PLANEJADOR_PROVIDER=anthropic|infomaniak (default: infomaniak)
+ *   PLANEJADOR_MODEL=...                     (default: moonshotai/Kimi-K2.5)
+ *   HAIKU_TRIAGE_PROVIDER=...
+ *   HAIKU_TRIAGE_MODEL=...                   (default: mistral3)
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-24-debug-mode.md (router extension).
+ */
+
 import Anthropic from "@anthropic-ai/sdk";
-import { isDebugModeEnabled, getLlmTimeoutMs, getLlmMaxRetries } from "@ascendimacy/shared";
+import OpenAI from "openai";
+import {
+  isDebugModeEnabled,
+  getLlmTimeoutMs,
+  getLlmMaxRetries,
+  getProviderForStep,
+  getModelForStep,
+  getMaxTokensForStep,
+  shouldEnableThinking,
+  getThinkingBudgetTokens,
+  type LlmProvider,
+} from "@ascendimacy/shared";
 
-let client: Anthropic | null = null;
+let anthropicClient: Anthropic | null = null;
+let openaiClient: OpenAI | null = null;
 
-function getClient(): Anthropic {
-  if (!client) {
-    client = new Anthropic({ apiKey: process.env["ANTHROPIC_API_KEY"] });
+function getAnthropic(): Anthropic {
+  if (!anthropicClient) {
+    anthropicClient = new Anthropic({ apiKey: process.env["ANTHROPIC_API_KEY"] });
   }
-  return client;
+  return anthropicClient;
+}
+
+function getOpenAI(): OpenAI {
+  if (!openaiClient) {
+    openaiClient = new OpenAI({
+      apiKey: process.env["INFOMANIAK_API_KEY"] ?? "mock",
+      baseURL: process.env["INFOMANIAK_BASE_URL"] ?? "https://api.infomaniak.com/1/ai",
+    });
+  }
+  return openaiClient;
 }
 
 export interface LlmCallResult {
   content: string;
   reasoning?: string;
   tokens: { in: number; out: number; reasoning: number };
+  /** Provider efetivamente usado (útil pra debug log). */
+  provider: LlmProvider;
+  /** Model efetivamente usado. */
+  model: string;
 }
 
-/**
- * callLlm — planejador (Sonnet 4.6).
- *
- * motor#19: bump max_tokens 200→2048 (pré-reasoning-model era apertado).
- * Extended thinking habilitado em debug mode (budget 1024).
- */
-export async function callLlm(
+async function callAnthropic(
+  step: string,
   systemPrompt: string,
   userMessage: string,
 ): Promise<LlmCallResult> {
-  const c = getClient();
-  const model = process.env["PLANEJADOR_MODEL"] ?? "claude-sonnet-4-6";
-  const debug = isDebugModeEnabled();
+  const c = getAnthropic();
+  const model = getModelForStep(step, "anthropic");
+  const maxTokens = getMaxTokensForStep(step, model);
+  const thinking = shouldEnableThinking(step, "anthropic", isDebugModeEnabled());
 
   const params: Anthropic.MessageCreateParams = {
     model,
-    max_tokens: 2048,
+    max_tokens: maxTokens,
     system: systemPrompt,
     messages: [{ role: "user", content: userMessage }],
   };
-
-  if (debug) {
+  if (thinking) {
     (params as Anthropic.MessageCreateParams & { thinking?: unknown }).thinking = {
       type: "enabled",
-      budget_tokens: 1024,
+      budget_tokens: getThinkingBudgetTokens(),
     };
   }
 
-  // motor#20: timeout + retries explícitos pra evitar hang (Kimi-like 54min travamento).
-  // SDK Anthropic retries 408/409/429/5xx + network errors automaticamente.
   const response = await c.messages.create(params, {
-    timeout: getLlmTimeoutMs("planejador"),
-    maxRetries: getLlmMaxRetries("planejador"),
+    timeout: getLlmTimeoutMs(step),
+    maxRetries: getLlmMaxRetries(step),
   });
 
   let content = "";
   let reasoning: string | undefined;
   for (const block of response.content) {
-    if (block.type === "text") {
-      content += block.text;
-    } else if ((block as { type: string }).type === "thinking") {
+    if (block.type === "text") content += block.text;
+    else if ((block as { type: string }).type === "thinking") {
       reasoning = (block as { thinking?: string }).thinking;
     }
   }
   if (!content) {
-    throw new Error("Unexpected response: no text block from LLM");
+    throw new Error("Unexpected response: no text block from Anthropic");
   }
-  const usage = response.usage as {
-    input_tokens: number;
-    output_tokens: number;
-    cache_creation_input_tokens?: number;
-    cache_read_input_tokens?: number;
-  };
+  const usage = response.usage as { input_tokens: number; output_tokens: number };
   return {
     content,
     reasoning,
-    tokens: {
-      in: usage.input_tokens,
-      out: usage.output_tokens,
-      reasoning: 0, // thinking_tokens não separado no SDK atual; fica embutido em output
+    tokens: { in: usage.input_tokens, out: usage.output_tokens, reasoning: 0 },
+    provider: "anthropic",
+    model,
+  };
+}
+
+async function callInfomaniak(
+  step: string,
+  systemPrompt: string,
+  userMessage: string,
+): Promise<LlmCallResult> {
+  const c = getOpenAI();
+  const model = getModelForStep(step, "infomaniak");
+  const maxTokens = getMaxTokensForStep(step, model);
+
+  const response = await c.chat.completions.create(
+    {
+      model,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userMessage },
+      ],
+      max_tokens: maxTokens,
     },
+    {
+      timeout: getLlmTimeoutMs(step),
+      maxRetries: getLlmMaxRetries(step),
+    },
+  );
+
+  const msg = response.choices[0]?.message;
+  const content = msg?.content ?? "";
+  const reasoning = (msg as { reasoning?: string } | undefined)?.reasoning;
+  const usage = response.usage;
+  return {
+    content: content || "{}",
+    reasoning,
+    tokens: {
+      in: usage?.prompt_tokens ?? 0,
+      out: usage?.completion_tokens ?? 0,
+      reasoning: 0,
+    },
+    provider: "infomaniak",
+    model,
   };
 }
 
 /**
- * Haiku chamado pra triagem parental (Bloco 4 #17). Reuso do client global.
- * Modelo default `claude-haiku-4-5-20251001`. Curto (512 tokens) — rerank only.
+ * callLlm — motor#21 dispatcher pelo provider escolhido pra `planejador`.
+ */
+export async function callLlm(
+  systemPrompt: string,
+  userMessage: string,
+): Promise<LlmCallResult> {
+  const provider = getProviderForStep("planejador");
+  if (provider === "anthropic") {
+    return callAnthropic("planejador", systemPrompt, userMessage);
+  }
+  return callInfomaniak("planejador", systemPrompt, userMessage);
+}
+
+/**
+ * callHaiku — triage rerank Haiku (Bloco 4 #17).
  *
- * motor#19: bump 150→512; thinking OFF (safety-critical, determinístico-ish).
+ * Default agora é Infomaniak/mistral3 (small fast). Opt-in pra Anthropic Haiku
+ * via HAIKU_TRIAGE_PROVIDER=anthropic.
  */
 export async function callHaiku(
   systemPrompt: string,
   userMessage: string,
 ): Promise<LlmCallResult> {
-  const c = getClient();
-  const model = process.env["HAIKU_MODEL"] ?? "claude-haiku-4-5-20251001";
-  const response = await c.messages.create(
-    {
-      model,
-      max_tokens: 512,
-      system: systemPrompt,
-      messages: [{ role: "user", content: userMessage }],
-    },
-    {
-      timeout: getLlmTimeoutMs("haiku-triage"),
-      maxRetries: getLlmMaxRetries("haiku-triage"),
-    },
-  );
-  let content = "";
-  for (const block of response.content) {
-    if (block.type === "text") content += block.text;
+  const provider = getProviderForStep("haiku-triage");
+  if (provider === "anthropic") {
+    return callAnthropic("haiku-triage", systemPrompt, userMessage);
   }
-  if (!content) throw new Error("Unexpected response: no text block from Haiku");
-  const usage = response.usage as { input_tokens: number; output_tokens: number };
-  return {
-    content,
-    tokens: { in: usage.input_tokens, out: usage.output_tokens, reasoning: 0 },
-  };
+  return callInfomaniak("haiku-triage", systemPrompt, userMessage);
 }
 
-/**
- * Mock: planejador Bloco 2a devolve só rationale + hints.
- * Scoring de conteúdo é determinístico, fora do LLM.
- */
 export async function callLlmMock(
   _systemPrompt: string,
   _userMessage: string,
@@ -130,5 +185,7 @@ export async function callLlmMock(
       contextHints: { language: "pt-br", mood: "receptive", urgency: "low" },
     }),
     tokens: { in: 0, out: 0, reasoning: 0 },
+    provider: "infomaniak",
+    model: "mock",
   };
 }

--- a/planejador/tests/llm-client.test.ts
+++ b/planejador/tests/llm-client.test.ts
@@ -1,33 +1,40 @@
 /**
- * Tests do planejador llm-client (motor#19 + motor#20).
+ * Tests planejador llm-client (motor#19 + motor#20 + motor#21).
  *
- * Cobre:
- *   - LlmCallResult shape (content, reasoning, tokens) — motor#19
- *   - max_tokens=2048 — motor#19 (era 200 pré-#19)
- *   - Extended thinking ON em debug mode — motor#19
- *   - Timeout/maxRetries forwarded pra SDK — motor#20
- *   - Múltiplos blocks (text + thinking) tratados corretamente
- *   - Auth error com mensagem clara
- *
- * Mocka @anthropic-ai/sdk via vi.mock pra não bater na API real.
+ * motor#21: dual-provider (Anthropic + Infomaniak via OpenAI SDK).
+ * Default: Infomaniak / Kimi K2.5. Override via PLANEJADOR_PROVIDER.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Captura de params passados pra messages.create — preenchido pelos tests
-const captured: { params?: unknown; options?: unknown } = {};
-let mockResponse: unknown = null;
-let mockThrow: unknown = null;
+const captured: { aParams?: unknown; aOptions?: unknown; oParams?: unknown; oOptions?: unknown } = {};
+let mockAnthropicResponse: unknown = null;
+let mockOpenAIResponse: unknown = null;
 
 vi.mock("@anthropic-ai/sdk", () => {
   return {
     default: class MockAnthropic {
       messages = {
         create: async (params: unknown, options?: unknown) => {
-          captured.params = params;
-          captured.options = options;
-          if (mockThrow) throw mockThrow;
-          return mockResponse;
+          captured.aParams = params;
+          captured.aOptions = options;
+          return mockAnthropicResponse;
+        },
+      };
+    },
+  };
+});
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      chat = {
+        completions: {
+          create: async (params: unknown, options?: unknown) => {
+            captured.oParams = params;
+            captured.oOptions = options;
+            return mockOpenAIResponse;
+          },
         },
       };
     },
@@ -37,14 +44,19 @@ vi.mock("@anthropic-ai/sdk", () => {
 const ORIG_ENV = { ...process.env };
 
 beforeEach(() => {
-  captured.params = undefined;
-  captured.options = undefined;
-  mockResponse = null;
-  mockThrow = null;
+  captured.aParams = undefined;
+  captured.aOptions = undefined;
+  captured.oParams = undefined;
+  captured.oOptions = undefined;
+  mockAnthropicResponse = null;
+  mockOpenAIResponse = null;
   delete process.env["ASC_DEBUG_MODE"];
   delete process.env["ASC_LLM_TIMEOUT_PLANEJADOR"];
-  delete process.env["ASC_LLM_MAX_RETRIES_PLANEJADOR"];
+  delete process.env["PLANEJADOR_PROVIDER"];
+  delete process.env["PLANEJADOR_MODEL"];
+  delete process.env["LLM_PROVIDER"];
   process.env["ANTHROPIC_API_KEY"] = "test-key";
+  process.env["INFOMANIAK_API_KEY"] = "test-info-key";
 });
 
 afterEach(() => {
@@ -53,134 +65,168 @@ afterEach(() => {
   }
 });
 
-describe("planejador.callLlm — motor#19 + motor#20", () => {
-  it("retorna LlmCallResult shape com content + tokens", async () => {
-    mockResponse = {
-      content: [{ type: "text", text: "Hello world" }],
-      usage: { input_tokens: 100, output_tokens: 50 },
+describe("planejador.callLlm — provider DEFAULT (Infomaniak / Kimi K2.5)", () => {
+  it("usa OpenAI SDK (Infomaniak) por default", async () => {
+    mockOpenAIResponse = {
+      choices: [{ message: { content: "Hello" } }],
+      usage: { prompt_tokens: 100, completion_tokens: 50 },
     };
     const { callLlm } = await import("../src/llm-client.js");
     const r = await callLlm("system", "user");
-    expect(r.content).toBe("Hello world");
-    expect(r.tokens.in).toBe(100);
-    expect(r.tokens.out).toBe(50);
-    expect(r.tokens.reasoning).toBe(0);
-    expect(r.reasoning).toBeUndefined();
+    expect(r.content).toBe("Hello");
+    expect(r.provider).toBe("infomaniak");
+    expect(r.model).toBe("moonshotai/Kimi-K2.5"); // default
+    expect(captured.oParams).toBeDefined();
+    expect(captured.aParams).toBeUndefined(); // Anthropic não foi chamado
   });
 
-  it("max_tokens=2048 (motor#19 bump)", async () => {
-    mockResponse = {
+  it("captura reasoning field de Kimi/DeepSeek-R1", async () => {
+    mockOpenAIResponse = {
+      choices: [{ message: { content: "Final answer", reasoning: "Chain of thought..." } }],
+      usage: { prompt_tokens: 100, completion_tokens: 50 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.reasoning).toBe("Chain of thought...");
+  });
+
+  it("max_tokens=4096 pra Kimi (reasoning model heuristic)", async () => {
+    mockOpenAIResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.oParams as { max_tokens: number }).max_tokens).toBe(4096);
+  });
+
+  it("PLANEJADOR_MODEL override aplicado", async () => {
+    process.env["PLANEJADOR_MODEL"] = "mistral3";
+    mockOpenAIResponse = {
+      choices: [{ message: { content: "{}" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.model).toBe("mistral3");
+    expect((captured.oParams as { max_tokens: number }).max_tokens).toBe(2048); // non-reasoning
+  });
+});
+
+describe("planejador.callLlm — provider OVERRIDE (Anthropic)", () => {
+  beforeEach(() => {
+    process.env["PLANEJADOR_PROVIDER"] = "anthropic";
+  });
+
+  it("usa Anthropic SDK quando PLANEJADOR_PROVIDER=anthropic", async () => {
+    mockAnthropicResponse = {
+      content: [{ type: "text", text: "Hello" }],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.provider).toBe("anthropic");
+    expect(r.model).toBe("claude-sonnet-4-6"); // Anthropic fallback default
+    expect(captured.aParams).toBeDefined();
+    expect(captured.oParams).toBeUndefined();
+  });
+
+  it("max_tokens=2048 pra Sonnet (não reasoning na heurística)", async () => {
+    mockAnthropicResponse = {
       content: [{ type: "text", text: "ok" }],
       usage: { input_tokens: 1, output_tokens: 1 },
     };
     const { callLlm } = await import("../src/llm-client.js");
     await callLlm("s", "u");
-    expect((captured.params as { max_tokens: number }).max_tokens).toBe(2048);
-  });
-
-  it("thinking OFF por default (debug mode off)", async () => {
-    mockResponse = {
-      content: [{ type: "text", text: "ok" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.params as { thinking?: unknown }).thinking).toBeUndefined();
+    expect((captured.aParams as { max_tokens: number }).max_tokens).toBe(2048);
   });
 
   it("thinking ON com budget 1024 em debug mode", async () => {
     process.env["ASC_DEBUG_MODE"] = "true";
-    mockResponse = {
+    mockAnthropicResponse = {
       content: [{ type: "text", text: "ok" }],
       usage: { input_tokens: 1, output_tokens: 1 },
     };
     const { callLlm } = await import("../src/llm-client.js");
     await callLlm("s", "u");
-    const thinking = (captured.params as { thinking?: { type: string; budget_tokens: number } }).thinking;
-    expect(thinking).toEqual({ type: "enabled", budget_tokens: 1024 });
+    expect((captured.aParams as { thinking?: { budget_tokens: number } }).thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 1024,
+    });
+  });
+
+  it("thinking OFF default (debug off)", async () => {
+    mockAnthropicResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.aParams as { thinking?: unknown }).thinking).toBeUndefined();
   });
 
   it("captura reasoning de blocks type=thinking", async () => {
-    mockResponse = {
+    process.env["ASC_DEBUG_MODE"] = "true";
+    mockAnthropicResponse = {
       content: [
-        { type: "thinking", thinking: "I should help the user..." },
-        { type: "text", text: "Response text" },
+        { type: "thinking", thinking: "I should..." },
+        { type: "text", text: "Answer" },
       ],
       usage: { input_tokens: 100, output_tokens: 50 },
     };
     const { callLlm } = await import("../src/llm-client.js");
     const r = await callLlm("s", "u");
-    expect(r.content).toBe("Response text");
-    expect(r.reasoning).toBe("I should help the user...");
-  });
-
-  it("timeout default 30s passado pra SDK options (motor#20)", async () => {
-    mockResponse = {
-      content: [{ type: "text", text: "ok" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.options as { timeout: number }).timeout).toBe(30_000);
-  });
-
-  it("ASC_LLM_TIMEOUT_PLANEJADOR override aplicado (motor#20)", async () => {
-    process.env["ASC_LLM_TIMEOUT_PLANEJADOR"] = "120";
-    mockResponse = {
-      content: [{ type: "text", text: "ok" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.options as { timeout: number }).timeout).toBe(120_000);
-  });
-
-  it("maxRetries=3 default (motor#20)", async () => {
-    mockResponse = {
-      content: [{ type: "text", text: "ok" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.options as { maxRetries: number }).maxRetries).toBe(3);
+    expect(r.content).toBe("Answer");
+    expect(r.reasoning).toBe("I should...");
   });
 
   it("throw quando response sem text block", async () => {
-    mockResponse = { content: [], usage: { input_tokens: 1, output_tokens: 1 } };
+    mockAnthropicResponse = { content: [], usage: { input_tokens: 1, output_tokens: 1 } };
     const { callLlm } = await import("../src/llm-client.js");
     await expect(callLlm("s", "u")).rejects.toThrow(/no text block/);
   });
+
+  it("timeout 30s + maxRetries 3 forwarded pra SDK options", async () => {
+    mockAnthropicResponse = {
+      content: [{ type: "text", text: "ok" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    await callLlm("s", "u");
+    expect((captured.aOptions as { timeout: number; maxRetries: number }).timeout).toBe(30_000);
+    expect((captured.aOptions as { timeout: number; maxRetries: number }).maxRetries).toBe(3);
+  });
 });
 
-describe("planejador.callHaiku — motor#19 + motor#20", () => {
-  it("max_tokens=512 (motor#19 bump 150→512)", async () => {
-    mockResponse = {
-      content: [{ type: "text", text: "ok" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
+describe("planejador.callHaiku — triage", () => {
+  it("default Infomaniak / mistral3", async () => {
+    mockOpenAIResponse = {
+      choices: [{ message: { content: '{"ranking":["a"]}' } }],
+      usage: { prompt_tokens: 50, completion_tokens: 10 },
     };
     const { callHaiku } = await import("../src/llm-client.js");
-    await callHaiku("s", "u");
-    expect((captured.params as { max_tokens: number }).max_tokens).toBe(512);
+    const r = await callHaiku("s", "u");
+    expect(r.provider).toBe("infomaniak");
+    expect(r.model).toBe("mistral3");
+    expect((captured.oParams as { max_tokens: number }).max_tokens).toBe(512);
   });
 
-  it("timeout 15s (haiku-triage default)", async () => {
-    mockResponse = {
-      content: [{ type: "text", text: "ok" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
+  it("HAIKU_TRIAGE_PROVIDER=anthropic → Claude Haiku", async () => {
+    process.env["HAIKU_TRIAGE_PROVIDER"] = "anthropic";
+    mockAnthropicResponse = {
+      content: [{ type: "text", text: '{"ranking":["a"]}' }],
+      usage: { input_tokens: 50, output_tokens: 10 },
     };
     const { callHaiku } = await import("../src/llm-client.js");
-    await callHaiku("s", "u");
-    expect((captured.options as { timeout: number }).timeout).toBe(15_000);
-  });
-
-  it("thinking OFF mesmo em debug mode (Haiku é safety-critical determinístico)", async () => {
+    const r = await callHaiku("s", "u");
+    expect(r.provider).toBe("anthropic");
+    expect(r.model).toBe("claude-haiku-4-5-20251001");
+    expect((captured.aParams as { max_tokens: number }).max_tokens).toBe(512);
+    expect((captured.aOptions as { timeout: number }).timeout).toBe(15_000);
+    // Thinking sempre OFF em haiku-triage (mesmo com debug ON)
     process.env["ASC_DEBUG_MODE"] = "true";
-    mockResponse = {
-      content: [{ type: "text", text: "ok" }],
-      usage: { input_tokens: 1, output_tokens: 1 },
-    };
-    const { callHaiku } = await import("../src/llm-client.js");
+    captured.aParams = undefined;
     await callHaiku("s", "u");
-    expect((captured.params as { thinking?: unknown }).thinking).toBeUndefined();
+    expect((captured.aParams as { thinking?: unknown } | undefined)?.thinking).toBeUndefined();
   });
 });

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -16,3 +16,4 @@ export * from "./card-image-provider.js";
 export * from "./bullying-check.js";
 export * from "./debug-logger.js";
 export * from "./llm-config.js";
+export * from "./llm-router.js";

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -1,0 +1,177 @@
+/**
+ * LLM router — config helpers pra escolher provider + model por callsite (motor#21).
+ *
+ * Spec: docs/specs/2026-04-24-debug-mode.md (extension).
+ *
+ * Não chama LLM aqui — apenas decide CONFIG. Cada workspace implementa
+ * sua própria chamada com Anthropic SDK ou OpenAI SDK + Infomaniak baseURL,
+ * baseado no que getProviderForStep retorna.
+ *
+ * Defaults: TUDO Kimi K2.5 via Infomaniak (zero dependência de Anthropic credit).
+ * Override per-callsite via env <STEP>_PROVIDER + <STEP>_MODEL.
+ *
+ * Ex:
+ *   PLANEJADOR_PROVIDER=anthropic
+ *   PLANEJADOR_MODEL=claude-sonnet-4-6
+ *   PERSONA_SIM_PROVIDER=infomaniak
+ *   PERSONA_SIM_MODEL=mistral3
+ */
+
+export type LlmProvider = "anthropic" | "infomaniak";
+
+/** Steps válidos com config defaults. */
+export const LLM_STEPS = [
+  "planejador",
+  "drota",
+  "persona-sim",
+  "haiku-triage",
+  "haiku-bullying",
+] as const;
+export type LlmStep = (typeof LLM_STEPS)[number];
+
+/**
+ * Default provider por step.
+ * motor#21: TUDO Infomaniak por default — zero Anthropic dependency.
+ */
+export const DEFAULT_PROVIDERS: Record<LlmStep, LlmProvider> = {
+  planejador: "infomaniak",
+  drota: "infomaniak",
+  "persona-sim": "infomaniak",
+  "haiku-triage": "infomaniak",
+  "haiku-bullying": "infomaniak",
+};
+
+/**
+ * Default model por step.
+ * Reasoning models (Kimi K2.5) pra steps onde reasoning ajuda.
+ * mistral3 (Mistral-Small-3.2-24B) pra triage/bullying — small, fast, deterministic.
+ */
+export const DEFAULT_MODELS: Record<LlmStep, string> = {
+  planejador: "moonshotai/Kimi-K2.5",
+  drota: "moonshotai/Kimi-K2.5",
+  "persona-sim": "moonshotai/Kimi-K2.5",
+  "haiku-triage": "mistral3",
+  "haiku-bullying": "mistral3",
+};
+
+/**
+ * Anthropic-specific defaults (usado só se provider=anthropic).
+ * Mapeamento: step → modelo Claude equivalente.
+ */
+export const ANTHROPIC_FALLBACK_MODELS: Record<LlmStep, string> = {
+  planejador: "claude-sonnet-4-6",
+  drota: "claude-sonnet-4-6",
+  "persona-sim": "claude-sonnet-4-6",
+  "haiku-triage": "claude-haiku-4-5-20251001",
+  "haiku-bullying": "claude-haiku-4-5-20251001",
+};
+
+function envKey(step: string, suffix: string): string {
+  return `${step.toUpperCase().replace(/-/g, "_")}_${suffix}`;
+}
+
+/**
+ * Resolve provider pra um step.
+ *
+ * Ordem:
+ * 1. Env <STEP>_PROVIDER (ex: PLANEJADOR_PROVIDER)
+ * 2. Env LLM_PROVIDER (global override)
+ * 3. DEFAULT_PROVIDERS[step]
+ * 4. "infomaniak" (Kimi-first fallback)
+ */
+export function getProviderForStep(step: string): LlmProvider {
+  const perStep = process.env[envKey(step, "PROVIDER")];
+  if (perStep === "anthropic" || perStep === "infomaniak") return perStep;
+  const global = process.env["LLM_PROVIDER"];
+  if (global === "anthropic" || global === "infomaniak") return global;
+  return DEFAULT_PROVIDERS[step as LlmStep] ?? "infomaniak";
+}
+
+/**
+ * Resolve model pra um step. Provider-aware:
+ * - Se provider=anthropic e env <STEP>_MODEL é Anthropic-style ou ausente → Claude default
+ * - Se provider=infomaniak → Infomaniak model name
+ *
+ * Ordem:
+ * 1. Env <STEP>_MODEL (ex: PLANEJADOR_MODEL=moonshotai/Kimi-K2.5)
+ * 2. Default por step + provider
+ */
+export function getModelForStep(step: string, provider?: LlmProvider): string {
+  const explicit = process.env[envKey(step, "MODEL")];
+  if (explicit && explicit.length > 0) return explicit;
+  // Legacy compat: aceita nomes antigos (PLANEJADOR_MODEL, MOTOR_DROTA_MODEL)
+  // que existiam antes da padronização do router.
+  const legacyKeys: Record<string, string> = {
+    drota: "MOTOR_DROTA_MODEL",
+    planejador: "PLANEJADOR_MODEL",
+  };
+  const legacy = legacyKeys[step];
+  if (legacy && process.env[legacy]) return process.env[legacy]!;
+  // Fallback aware do provider escolhido
+  const p = provider ?? getProviderForStep(step);
+  if (p === "anthropic") {
+    return ANTHROPIC_FALLBACK_MODELS[step as LlmStep] ?? "claude-sonnet-4-6";
+  }
+  return DEFAULT_MODELS[step as LlmStep] ?? "moonshotai/Kimi-K2.5";
+}
+
+/**
+ * Heurística: modelo é reasoning-capable?
+ * Reasoning models drenam tokens em CoT antes de emitir content,
+ * então max_tokens precisa ser maior.
+ */
+export function isReasoningModel(model: string): boolean {
+  return /kimi|deepseek-r|o1|o3|reason|qwq|thinking/i.test(model);
+}
+
+/**
+ * max_tokens default por step + reasoning awareness.
+ * Override via env <STEP>_MAX_TOKENS.
+ */
+export function getMaxTokensForStep(step: string, model: string): number {
+  const explicit = process.env[envKey(step, "MAX_TOKENS")];
+  if (explicit) {
+    const n = Number.parseInt(explicit, 10);
+    if (!Number.isNaN(n) && n > 0) return n;
+  }
+  const reasoning = isReasoningModel(model);
+  switch (step) {
+    case "planejador":
+      return reasoning ? 4096 : 2048;
+    case "drota":
+      return reasoning ? 4096 : 2048;
+    case "persona-sim":
+      return reasoning ? 4096 : 2048;
+    case "haiku-triage":
+      return reasoning ? 2048 : 512;
+    case "haiku-bullying":
+      return reasoning ? 2048 : 512;
+    default:
+      return reasoning ? 4096 : 2048;
+  }
+}
+
+/**
+ * Anthropic extended thinking habilitado pra esse step?
+ *
+ * Só relevante se provider=anthropic. Para Infomaniak, reasoning vem
+ * automático em modelos reasoning (Kimi, DeepSeek-R1).
+ *
+ * Default: ON em planejador + persona-sim (debug útil), OFF em
+ * haiku-* (rerank simples, thinking custa latência).
+ */
+export function shouldEnableThinking(step: string, provider: LlmProvider, debugMode: boolean): boolean {
+  if (provider !== "anthropic") return false;
+  if (!debugMode) return false;
+  const noThinkSteps = new Set(["haiku-triage", "haiku-bullying"]);
+  return !noThinkSteps.has(step);
+}
+
+export function getThinkingBudgetTokens(): number {
+  const v = process.env["LLM_THINKING_BUDGET_TOKENS"];
+  if (v) {
+    const n = Number.parseInt(v, 10);
+    if (!Number.isNaN(n) && n > 0) return n;
+  }
+  return 1024;
+}

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests llm-router (motor#21) — provider selection + model routing + max_tokens.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getProviderForStep,
+  getModelForStep,
+  getMaxTokensForStep,
+  shouldEnableThinking,
+  isReasoningModel,
+  DEFAULT_PROVIDERS,
+  DEFAULT_MODELS,
+  ANTHROPIC_FALLBACK_MODELS,
+} from "../src/llm-router.js";
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (k.endsWith("_PROVIDER") || k.endsWith("_MODEL") || k.endsWith("_MAX_TOKENS") || k === "LLM_PROVIDER" || k === "LLM_THINKING_BUDGET_TOKENS") {
+      delete process.env[k];
+    }
+  }
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(ORIG_ENV)) {
+    if (k.endsWith("_PROVIDER") || k.endsWith("_MODEL") || k === "LLM_PROVIDER") process.env[k] = v;
+  }
+});
+
+describe("getProviderForStep", () => {
+  it("default infomaniak pra todos os steps", () => {
+    expect(getProviderForStep("planejador")).toBe("infomaniak");
+    expect(getProviderForStep("drota")).toBe("infomaniak");
+    expect(getProviderForStep("persona-sim")).toBe("infomaniak");
+    expect(getProviderForStep("haiku-triage")).toBe("infomaniak");
+    expect(getProviderForStep("haiku-bullying")).toBe("infomaniak");
+  });
+
+  it("PLANEJADOR_PROVIDER override per-step", () => {
+    process.env["PLANEJADOR_PROVIDER"] = "anthropic";
+    expect(getProviderForStep("planejador")).toBe("anthropic");
+    expect(getProviderForStep("drota")).toBe("infomaniak"); // não afeta outros
+  });
+
+  it("hyphen no step name vira underscore no env (haiku-triage → HAIKU_TRIAGE_PROVIDER)", () => {
+    process.env["HAIKU_TRIAGE_PROVIDER"] = "anthropic";
+    expect(getProviderForStep("haiku-triage")).toBe("anthropic");
+  });
+
+  it("LLM_PROVIDER global override quando step-specific ausente", () => {
+    process.env["LLM_PROVIDER"] = "anthropic";
+    expect(getProviderForStep("planejador")).toBe("anthropic");
+    expect(getProviderForStep("drota")).toBe("anthropic");
+  });
+
+  it("step-specific beats global", () => {
+    process.env["LLM_PROVIDER"] = "anthropic";
+    process.env["DROTA_PROVIDER"] = "infomaniak";
+    expect(getProviderForStep("drota")).toBe("infomaniak");
+    expect(getProviderForStep("planejador")).toBe("anthropic"); // global ainda
+  });
+
+  it("valor inválido em env → fallback default", () => {
+    process.env["PLANEJADOR_PROVIDER"] = "openai"; // não é "anthropic" nem "infomaniak"
+    expect(getProviderForStep("planejador")).toBe("infomaniak"); // default
+  });
+
+  it("step desconhecido → infomaniak fallback", () => {
+    expect(getProviderForStep("unknown-step")).toBe("infomaniak");
+  });
+});
+
+describe("getModelForStep", () => {
+  it("default Kimi K2.5 pra planejador/drota/persona-sim (Infomaniak)", () => {
+    expect(getModelForStep("planejador")).toBe("moonshotai/Kimi-K2.5");
+    expect(getModelForStep("drota")).toBe("moonshotai/Kimi-K2.5");
+    expect(getModelForStep("persona-sim")).toBe("moonshotai/Kimi-K2.5");
+  });
+
+  it("default mistral3 pra haiku-triage/haiku-bullying (rerank, sem reasoning)", () => {
+    expect(getModelForStep("haiku-triage")).toBe("mistral3");
+    expect(getModelForStep("haiku-bullying")).toBe("mistral3");
+  });
+
+  it("provider=anthropic → Claude fallback", () => {
+    expect(getModelForStep("planejador", "anthropic")).toBe("claude-sonnet-4-6");
+    expect(getModelForStep("haiku-triage", "anthropic")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("explicit env beats default", () => {
+    process.env["PLANEJADOR_MODEL"] = "deepseek-r1";
+    expect(getModelForStep("planejador")).toBe("deepseek-r1");
+  });
+
+  it("legacy MOTOR_DROTA_MODEL ainda funciona", () => {
+    process.env["MOTOR_DROTA_MODEL"] = "mistral3";
+    expect(getModelForStep("drota")).toBe("mistral3");
+  });
+
+  it("DROTA_MODEL beats MOTOR_DROTA_MODEL (new naming preferido)", () => {
+    process.env["DROTA_MODEL"] = "qwen3";
+    process.env["MOTOR_DROTA_MODEL"] = "mistral3";
+    expect(getModelForStep("drota")).toBe("qwen3");
+  });
+});
+
+describe("isReasoningModel", () => {
+  it("Kimi K2.5 é reasoning", () => {
+    expect(isReasoningModel("moonshotai/Kimi-K2.5")).toBe(true);
+  });
+  it("DeepSeek-R1 é reasoning", () => {
+    expect(isReasoningModel("deepseek-r1")).toBe(true);
+  });
+  it("o1/o3 são reasoning (OpenAI)", () => {
+    expect(isReasoningModel("o1-preview")).toBe(true);
+    expect(isReasoningModel("o3-mini")).toBe(true);
+  });
+  it("Mistral3 NÃO é reasoning", () => {
+    expect(isReasoningModel("mistral3")).toBe(false);
+  });
+  it("Sonnet NÃO é reasoning (mesmo com extended thinking opt-in)", () => {
+    expect(isReasoningModel("claude-sonnet-4-6")).toBe(false);
+  });
+});
+
+describe("getMaxTokensForStep", () => {
+  it("4096 pra planejador/drota/persona-sim com Kimi", () => {
+    expect(getMaxTokensForStep("planejador", "moonshotai/Kimi-K2.5")).toBe(4096);
+    expect(getMaxTokensForStep("drota", "moonshotai/Kimi-K2.5")).toBe(4096);
+    expect(getMaxTokensForStep("persona-sim", "moonshotai/Kimi-K2.5")).toBe(4096);
+  });
+  it("2048 pra mesmos steps com Sonnet", () => {
+    expect(getMaxTokensForStep("planejador", "claude-sonnet-4-6")).toBe(2048);
+    expect(getMaxTokensForStep("drota", "mistral3")).toBe(2048);
+  });
+  it("512 pra haiku-triage com mistral3", () => {
+    expect(getMaxTokensForStep("haiku-triage", "mistral3")).toBe(512);
+  });
+  it("2048 pra haiku-triage com Kimi (reasoning bumps mesmo Haiku)", () => {
+    expect(getMaxTokensForStep("haiku-triage", "moonshotai/Kimi-K2.5")).toBe(2048);
+  });
+  it("env override aplica", () => {
+    process.env["PLANEJADOR_MAX_TOKENS"] = "8192";
+    expect(getMaxTokensForStep("planejador", "moonshotai/Kimi-K2.5")).toBe(8192);
+  });
+});
+
+describe("shouldEnableThinking", () => {
+  it("OFF se provider=infomaniak (mesmo em debug)", () => {
+    expect(shouldEnableThinking("planejador", "infomaniak", true)).toBe(false);
+    expect(shouldEnableThinking("drota", "infomaniak", true)).toBe(false);
+  });
+
+  it("OFF se debug off (mesmo Anthropic)", () => {
+    expect(shouldEnableThinking("planejador", "anthropic", false)).toBe(false);
+  });
+
+  it("ON em planejador/drota/persona-sim com Anthropic + debug ON", () => {
+    expect(shouldEnableThinking("planejador", "anthropic", true)).toBe(true);
+    expect(shouldEnableThinking("drota", "anthropic", true)).toBe(true);
+    expect(shouldEnableThinking("persona-sim", "anthropic", true)).toBe(true);
+  });
+
+  it("OFF em haiku-triage/haiku-bullying mesmo com Anthropic + debug ON", () => {
+    expect(shouldEnableThinking("haiku-triage", "anthropic", true)).toBe(false);
+    expect(shouldEnableThinking("haiku-bullying", "anthropic", true)).toBe(false);
+  });
+});
+
+describe("constants exposure", () => {
+  it("DEFAULT_PROVIDERS é Infomaniak everywhere", () => {
+    for (const v of Object.values(DEFAULT_PROVIDERS)) expect(v).toBe("infomaniak");
+  });
+  it("DEFAULT_MODELS preenchido pra todos os steps", () => {
+    expect(DEFAULT_MODELS["planejador"]).toBeTruthy();
+    expect(DEFAULT_MODELS["drota"]).toBeTruthy();
+    expect(DEFAULT_MODELS["persona-sim"]).toBeTruthy();
+    expect(DEFAULT_MODELS["haiku-triage"]).toBeTruthy();
+    expect(DEFAULT_MODELS["haiku-bullying"]).toBeTruthy();
+  });
+  it("ANTHROPIC_FALLBACK_MODELS usa Claude", () => {
+    expect(ANTHROPIC_FALLBACK_MODELS["planejador"]).toContain("claude");
+    expect(ANTHROPIC_FALLBACK_MODELS["haiku-triage"]).toContain("haiku");
+  });
+});


### PR DESCRIPTION
**Resolve a falha do smoke-3d** (\"credit balance too low\" da Anthropic). Adiciona dual-provider em planejador + motor-drota com defaults zero-Anthropic.

## shared/src/llm-router.ts

Config helpers (sem SDK deps no shared):

\`\`\`ts
getProviderForStep(step) → "anthropic" | "infomaniak"
getModelForStep(step, provider?) → model name
getMaxTokensForStep(step, model) → reasoning-aware (4096 vs 2048 vs 512)
shouldEnableThinking(step, provider, debug) → Anthropic extended thinking only
isReasoningModel(model) → heurística (kimi/deepseek-r/o1/o3)
\`\`\`

## Defaults TUDO Kimi K2.5 via Infomaniak

| Step | Provider | Model |
|---|---|---|
| **planejador** | infomaniak | moonshotai/Kimi-K2.5 |
| **drota** | infomaniak | moonshotai/Kimi-K2.5 |
| **persona-sim** | infomaniak | moonshotai/Kimi-K2.5 |
| **haiku-triage** | infomaniak | mistral3 (rerank fast) |
| **haiku-bullying** | infomaniak | mistral3 |

**Zero dependência de Anthropic credit** por default. Smoke-3d roda sem ANTHROPIC_API_KEY (só precisa de INFOMANIAK_API_KEY).

## Override via env (per-callsite)

\`\`\`bash
# Voltar planejador pra Sonnet:
PLANEJADOR_PROVIDER=anthropic
PLANEJADOR_MODEL=claude-sonnet-4-6

# Drota com modelo diferente:
DROTA_PROVIDER=infomaniak
DROTA_MODEL=qwen3

# Persona-sim com Mistral:
PERSONA_SIM_PROVIDER=infomaniak
PERSONA_SIM_MODEL=mistral3

# Haiku triage via Claude:
HAIKU_TRIAGE_PROVIDER=anthropic

# Global override (todos):
LLM_PROVIDER=anthropic

# Legacy (backward compat):
MOTOR_DROTA_MODEL=mistral3   # ainda funciona, equiv a DROTA_MODEL
\`\`\`

## Refactor llm-clients

planejador + motor-drota agora dual-provider:
- \`callLlm()\` dispatch baseado em \`getProviderForStep()\`
- \`callAnthropic()\` quando provider=anthropic (with extended thinking opt-in em debug)
- \`callInfomaniak()\` quando provider=infomaniak (captura \`reasoning\` field)
- LlmCallResult ganha \`provider\` + \`model\` (útil pra debug log)

\`planejador/package.json\` + \`motor-drota/package.json\` agora têm ambas SDKs (\`@anthropic-ai/sdk\` + \`openai\`).

## Tests (30 novos)

| File | Tests | Cobre |
|---|---|---|
| \`shared/tests/llm-router.test.ts\` | 24 | provider routing, model defaults, max_tokens reasoning-aware, thinking ON/OFF logic, legacy env compat |
| \`planejador/tests/llm-client.test.ts\` (rewrite) | 12 | DEFAULT Infomaniak path + OVERRIDE Anthropic path + callHaiku dual provider |
| motor-drota/tests/llm-client.test.ts (existing) | 9 | passa com legacy MOTOR_DROTA_MODEL preservado |

**Total motor: 474 verde** (era 444). Build clean.

## Companion sts#12

\`persona-simulator\` ganha mesma capacidade dual-provider, defaults Kimi-first.

## Test plan

- [x] motor build clean
- [x] motor 474 tests verde (30 novos)
- [x] zero Anthropic dependency em defaults
- [x] override per-callsite funciona
- [x] legacy MOTOR_DROTA_MODEL preservado
- [ ] sts#12 mergeado
- [ ] smoke-3d com SOMENTE INFOMANIAK_API_KEY → emite cards sem hit em Anthropic

🤖 Generated with [Claude Code](https://claude.com/claude-code)