### PR TITLE
hotfix(motor#22): provider-aware mock detection — corrige planejador em mock pós-#21

### DIFF
--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -10,7 +10,7 @@ import type {
 import { rankPool } from "./evaluate.js";
 import { selectFromPool, sanitizeMaterialization } from "./select.js";
 import { callLlm, callLlmMock } from "./llm-client.js";
-import { logDebugEvent } from "@ascendimacy/shared";
+import { logDebugEvent, getProviderForStep } from "@ascendimacy/shared";
 
 const server = new McpServer({
   name: "motor-drota",
@@ -229,9 +229,13 @@ server.registerTool(
     }
 
     const selected = selectFromPool(ranked);
+    // motor#22: provider-aware mock detection.
+    const drotaProvider = getProviderForStep("drota");
+    const drotaKeyMissing = drotaProvider === "anthropic"
+      ? !process.env["ANTHROPIC_API_KEY"]
+      : !process.env["INFOMANIAK_API_KEY"];
     const useMock =
-      process.env["USE_MOCK_LLM"] === "true" ||
-      !process.env["INFOMANIAK_API_KEY"];
+      process.env["USE_MOCK_LLM"] === "true" || drotaKeyMissing;
     const systemPrompt = buildDrotaPrompt(input, selected);
     const userMessage = `Materialize o content selecionado em JSON.`;
 

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -33,6 +33,7 @@ import {
   isParentalProfileMinimal,
   triageForParents,
   logDebugEvent,
+  getProviderForStep,
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku } from "./llm-client.js";
 import { loadSeedPool, buildPool } from "./pool-builder.js";
@@ -187,9 +188,15 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   // 2. Triagem parental (Bloco 4 #17, paper §6 camada 2).
   //    Se persona.profile.parental_profile existir E estiver mínimo,
   //    passa topK pelo triageForParents (rule-based ou Haiku).
+  // motor#22: provider-aware mock detection — antes era hardcoded
+  // !ANTHROPIC_API_KEY (legacy pré-router motor#21). Agora checa a key
+  // do provider efetivamente configurado pra este step.
+  const planejadorProvider = getProviderForStep("planejador");
+  const planejadorKeyMissing = planejadorProvider === "anthropic"
+    ? !process.env["ANTHROPIC_API_KEY"]
+    : !process.env["INFOMANIAK_API_KEY"];
   const useMockLlm =
-    process.env["USE_MOCK_LLM"] === "true" ||
-    !process.env["ANTHROPIC_API_KEY"];
+    process.env["USE_MOCK_LLM"] === "true" || planejadorKeyMissing;
   const parentalProfile = extractParentalProfile(input.persona);
   let triageMode: "rule_based" | "haiku" | "skipped" = "skipped";
   let triageRejectedIds: string[] = [];


### PR DESCRIPTION
Bug encontrado no smoke-3d real-llm pós-merge motor#21:

\`planejador/src/plan.ts:191\` e \`motor-drota/src/server.ts:233\` usavam check legacy:

\`\`\`ts
const useMockLlm = process.env["USE_MOCK_LLM"] === "true" || !process.env["ANTHROPIC_API_KEY"];
\`\`\`

Pré-router motor#21 fazia sentido (planejador era Anthropic-only). Pós-router, isso ignora qual provider foi configurado.

## Sintoma observado

Smoke-3d rodado com \`unset ANTHROPIC_API_KEY\` (provando zero-Anthropic-dependency do motor#21):
- Drota: real path → Kimi K2.5 reasoning capturado, tokens 2885+1924
- Persona-sim: real path → Sonnet/Kimi capturado, tokens 1438+3087
- **Planejador: mock path** → tokens 0+0, lat 0ms em todos 6 events

## Fix

Ambos checks agora provider-aware:

\`\`\`ts
const provider = getProviderForStep("planejador");
const keyMissing = provider === "anthropic"
  ? !process.env["ANTHROPIC_API_KEY"]
  : !process.env["INFOMANIAK_API_KEY"];
const useMockLlm = process.env["USE_MOCK_LLM"] === "true" || keyMissing;
\`\`\`

Com defaults motor#21 (provider=infomaniak), basta \`INFOMANIAK_API_KEY\` setada → real path.

## Test plan

- [x] 474 motor tests verde inalterados
- [ ] re-rodar smoke-3d com \`unset ANTHROPIC_API_KEY\` → confirmar planejador events com tokens reais (não 0+0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)