### PR TITLE
feat(motor#23): drota prompt clarity + pool used_in_session penalty (corrige reuso massivo)

### DIFF
--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -128,8 +128,8 @@ ${instructionAdditionBody}
 3. Respeite <context_hints>. Se contém 'avoid', 'evitar' ou 'alertas', esses padrões são PROIBIDOS na saída.
 4. 'status_gates' em contextHints lista dimensões bloqueadas. Se dimensão bloqueada aparece como casel_focus, adapte tom (reparador, não desafiador).
 5. NUNCA vaze identificadores técnicos (id do content, dot-notation, 'content_pool', 'playbook') na fala.
-6. Língua: "${language}". Gere na MESMA língua.
-7. ${isLimitedProficiency ? `PROFICIÊNCIA LIMITADA: vocabulário simples, frases curtas, zero jargon, erros típicos de não-nativo.` : `Gere em ${language} fluente, natural, adequado à idade e contexto.`}
+6. Língua: "${language}". Gere na MESMA língua que o sujeito.
+7. ${isLimitedProficiency ? `**'pt-br limitado'** descreve o **DESTINATÁRIO** (${persona.name}), NÃO o seu output. SEU output deve ser **pt-br limpo, gramaticalmente correto e simples**: frases curtas, vocabulário básico, zero jargon. **NÃO simule erros de não-nativo no seu output** — o destinatário precisa entender uma fala correta + simples.` : `Gere em ${language} fluente, natural, adequado à idade e contexto.`}
 8. Se <instruction_addition> não está vazio, incorpore-o naturalmente. Exemplos: "day 2 of 5 of chain X" → continuar arco multi-dia; "technique_hint: tribunal" → framear como debate.${
     isJoint
       ? `

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -179,9 +179,20 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   const statusMatrix = input.state.statusMatrix ?? defaultMatrix();
   const focusDim = pickFocusDimension(statusMatrix);
   const caselTargets = focusDim ? caselTargetsFor(focusDim) : [];
+  // motor#23: extrai items já consumidos nesta sessão do event_log pra
+  // penalizar reuso e forçar rotação (descoberta no smoke-3d-bumped onde
+  // 12 calls drota selecionaram o mesmo item).
+  const usedInSession: string[] = (input.state.eventLog ?? [])
+    .filter((e) => e.type === "playbook_executed")
+    .map((e) => {
+      const data = e.data as { selectedContentId?: string | null } | undefined;
+      return data?.selectedContentId;
+    })
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
   const scored = scorePool(eligible, child, {
     now: new Date().toISOString(),
     casel_focus: caselTargets[0] as ScoredContentItem["item"]["casel_target"][number] | undefined,
+    used_in_session: usedInSession,
   });
   let topK = scored.slice(0, TOP_K_POOL);
 

--- a/shared/src/scorer.ts
+++ b/shared/src/scorer.ts
@@ -38,6 +38,14 @@ export const TREE_TOP_DOMAIN_BONUS = 5;
 /** Bônus por match do CASEL em foco com o target do item. */
 export const CASEL_FOCUS_BONUS = 3;
 
+/**
+ * motor#23: penalidade forte pra items já consumidos na sessão atual.
+ * Maior que qualquer bônus normal (base_score+surprise+casel ≈ 12-15) — efetivamente
+ * exclui o item enquanto outros disponíveis. Não 1000 (parent_pinned) pois ainda
+ * queremos permitir reuso se for última opção.
+ */
+export const USED_IN_SESSION_PENALTY = 100;
+
 export interface DomainRankEntry {
   score: number;
 }
@@ -73,6 +81,12 @@ export interface ScoringContext {
   casel_focus?: CaselDimension;
   /** Instante do turn (ISO). Injeção explícita → testes determinísticos. */
   now: string;
+  /**
+   * motor#23: items já selecionados nesta sessão (extraídos do event_log).
+   * Penalidade pesada (-100) pra evitar repetir mesma fala — descoberta no
+   * smoke-3d onde 12 chamadas drota selecionaram bio_dolphin_names todas.
+   */
+  used_in_session?: string[];
 }
 
 function daysBetween(laterIso: string, earlierIso: string): number {
@@ -172,6 +186,16 @@ export function scoreItem(
     const engagementBonus = engagement * 0.5;
     score += engagementBonus;
     reasons.push(`engagement_by_type=+${engagementBonus.toFixed(2)}`);
+  }
+
+  // motor#23: penalidade forte para items já usados nesta sessão.
+  // Antes desta fix, drota selecionava o mesmo item turn após turn (smoke-3d:
+  // 12 calls × bio_dolphin_names) porque scorer não considerava reuso intra-session.
+  // Penalidade de 100 pontos efetivamente exclui o item enquanto houver outros
+  // disponíveis (base_scores típicos = 5-10).
+  if (context.used_in_session?.includes(item.id)) {
+    score -= USED_IN_SESSION_PENALTY;
+    reasons.push(`used_in_session_penalty=-${USED_IN_SESSION_PENALTY}`);
   }
 
   return { item, score, reasons };

--- a/shared/tests/scorer.test.ts
+++ b/shared/tests/scorer.test.ts
@@ -6,6 +6,7 @@ import {
   CASEL_FOCUS_BONUS,
   TREE_TOP_DOMAIN_BONUS,
   RECENT_DOMAIN_PENALTY,
+  USED_IN_SESSION_PENALTY,
   DECAY_BY_TYPE,
 } from "../src/scorer.js";
 import type { ChildScoringProfile, ScoringContext } from "../src/scorer.js";
@@ -243,5 +244,57 @@ describe("scorePool", () => {
     expect(scored[0].item.id).toBe("fits");
     expect(scored[scored.length - 1].item.id).toBe("too_old");
     expect(scored[scored.length - 1].score).toBe(0);
+  });
+});
+
+// motor#23 — penalidade por reuso intra-session
+describe("scoreItem — used_in_session penalty (motor#23)", () => {
+  it("aplica -100 quando item.id em used_in_session", () => {
+    const item = hook({ id: "h1", surprise: 7, base_score: 7 });
+    const r = scoreItem(item, baseChild, { ...baseCtx, used_in_session: ["h1"] });
+    expect(r.reasons).toContain(`used_in_session_penalty=-${USED_IN_SESSION_PENALTY}`);
+    expect(r.score).toBeLessThan(0);
+  });
+
+  it("não aplica quando item.id NÃO está em used_in_session", () => {
+    const item = hook({ id: "h1", base_score: 7 });
+    const r = scoreItem(item, baseChild, { ...baseCtx, used_in_session: ["h_other"] });
+    expect(r.reasons.find((x) => x.includes("used_in_session"))).toBeUndefined();
+    expect(r.score).toBeGreaterThan(0);
+  });
+
+  it("não aplica quando used_in_session é undefined", () => {
+    const item = hook({ id: "h1" });
+    const r = scoreItem(item, baseChild, baseCtx);
+    expect(r.reasons.find((x) => x.includes("used_in_session"))).toBeUndefined();
+  });
+
+  it("scorePool: items usados rebatem para o fundo do ranking", () => {
+    const pool = [
+      hook({ id: "used", surprise: 10, base_score: 8 }), // teria score alto
+      hook({ id: "fresh1", surprise: 5, base_score: 5 }),
+      hook({ id: "fresh2", surprise: 4, base_score: 4 }),
+    ];
+    const scored = scorePool(pool, baseChild, {
+      ...baseCtx,
+      used_in_session: ["used"],
+    });
+    expect(scored[0].item.id).toBe("fresh1"); // fresh com score baixo > used penalizado
+    expect(scored[scored.length - 1].item.id).toBe("used");
+    expect(scored[scored.length - 1].score).toBeLessThan(0);
+  });
+
+  it("multiple items used: todos penalizados", () => {
+    const pool = [
+      hook({ id: "a", base_score: 10 }),
+      hook({ id: "b", base_score: 8 }),
+      hook({ id: "c", base_score: 5 }),
+    ];
+    const scored = scorePool(pool, baseChild, {
+      ...baseCtx,
+      used_in_session: ["a", "b"],
+    });
+    expect(scored[0].item.id).toBe("c"); // único não usado
+    expect(scored.filter((s) => s.score < 0).map((s) => s.item.id).sort()).toEqual(["a", "b"]);
   });
 });


### PR DESCRIPTION
Aplica 2 fixes da análise [smoke-3d prompts-analysis.md](../ascendimacy-sts/reports/smoke-3d/prompts-analysis.md):

## Fix 1 — Drota prompt: 'pt-br limitado' clareza

**Issue**: prompt drota tinha:

\`\`\`
6. Língua: \"\${language}\". Gere na MESMA língua.
7. PROFICIÊNCIA LIMITADA: vocabulário simples, frases curtas, zero jargon, erros típicos de não-nativo.
\`\`\`

Reasoning de Kimi (capturado em debug log) mostrava ~200-300 tokens de hesitação:

> Espera, isso se refere ao usuário/persona ou ao meu output? O contexto diz 'Língua: pt-br limitado. Gere na MESMA língua.' Isso provavelmente significa que devo falar como alguém com proficiência limitada em português, ou...

**Fix**: instruction 7 explicita que 'pt-br limitado' é atributo do **destinatário**, output deve ser pt-br limpo + simples:

> **'pt-br limitado'** descreve o **DESTINATÁRIO** (\${persona.name}), NÃO o seu output. SEU output deve ser **pt-br limpo, gramaticalmente correto e simples**: frases curtas, vocabulário básico, zero jargon. **NÃO simule erros de não-nativo no seu output** — o destinatário precisa entender uma fala correta + simples.

## Fix 2 — Pool builder: USED_IN_SESSION_PENALTY

**Issue**: smoke-3d-bumped run teve **TODAS 12 chamadas drota selecionando \`bio_dolphin_names\`**. Persona-sim Ryo turn 2 rejeitou: \"Ryo rejeita loop; exige 'golpe novo'\".

Causa: scorer só tinha decay temporal (half-life em DIAS) — irrelevante intra-session.

**Fix**: adiciona \`used_in_session?: string[]\` ao \`ScoringContext\`. Penalidade -100 quando \`item.id\` na lista. planejador extrai do \`event_log\` (events tipo playbook_executed → \`data.selectedContentId\`).

\`\`\`ts
const usedInSession = input.state.eventLog
  .filter((e) => e.type === \"playbook_executed\")
  .map((e) => e.data?.selectedContentId)
  .filter((id) => typeof id === \"string\");
\`\`\`

Penalidade -100 ≫ qualquer bônus normal (~12-15), < parent_pinned (1000). Item usado na sessão fica fundo do ranking automaticamente.

## Tests (5 novos)

\`shared/tests/scorer.test.ts\`:
- aplica -100 quando item.id em used_in_session
- NÃO aplica sem used_in_session ou item ausente
- scorePool: items usados rebatem pro fundo
- múltiplos items penalizados simultaneamente

**Total motor: 479 verde** (era 474, +5).

## Validação esperada (smoke-3d post-merge)

| Antes | Depois |
|---|---|
| 12 calls × bio_dolphin_names | rotação entre 10 items enriquecidos |
| Bot disse mesma coisa 3x ao Ryo | items diferentes turn after turn |
| Drota reasoning ~200 tokens hesitando | direto ao output |

🤖 Generated with [Claude Code](https://claude.com/claude-code)