### PR TITLE
docs(motor#28): spec LLM Gateway centralizado — decision-trail 006 v1

### DIFF
--- a/motorops/decision-trail/2026-04-26-006-llm-gateway.md
+++ b/motorops/decision-trail/2026-04-26-006-llm-gateway.md
@@ -1,0 +1,313 @@
+---
+date: 2026-04-26
+issue: motor#28 (proposed — não criado ainda)
+status: decided / ready for chunk 1
+predecessor: motor#25 (Pastor foundations) — introduziu 4ª chamada LLM por turn (signal-extractor)
+revisions:
+  - 2026-04-26 v0 — spec inicial
+  - 2026-04-26 v1 — refinos pré chunk 1 do Jun: was_fallback obrigatório no output + total_attempts_budget_ms cap (default 90s) + hard timeout 30s primary antes de fallback + run_id opcional no input + DoD test units adicionais
+---
+
+# motor#28 — LLM Gateway centralizado
+
+## Problema
+
+STS scenario `nagareyama-14d-v1` (2026-04-26 21:17 + 21:41 BRT) falhou em **14/22 events LLM-bound**, ambos os runs.
+
+Diagnóstico instrumentado (cause logging temporário em motor-drota + planejador + persona-sim):
+- 100% das falhas LLM têm `cause.code=ETIMEDOUT` (read timeout no socket TCP)
+- NÃO é DNS (ENOTFOUND), NÃO é cert (EPROTO), NÃO é refused (ECONNREFUSED), NÃO é RST (ECONNRESET)
+- Curl direto pro mesmo endpoint Infomaniak: HTTP 200 em 2.1s consistente
+- Padrão: undici (Node fetch interno do SDK OpenAI) timeout, mas curl externo funciona
+- motor#25 quadruplicou chamadas LLM por turn de conversa: planejador (Kimi) + drota evaluate (Kimi) + drota signal-extractor (Mistral3) + persona-sim STS (Kimi)
+- 4 children Node separados, cada um com seu próprio undici Agent — coordenação zero entre pools
+
+Combinações que produzem ETIMEDOUT compatíveis com sintomas:
+1. **Tarpit / soft rate-limit** — Infomaniak segura conexão silenciosamente quando bucket cheio (em vez de HTTP 429 limpo)
+2. **WSL2 + IPv6 stale** — undici prefere AAAA records que falham; curl força IPv4 e passa
+3. **undici keep-alive idle** — socket reusado depois de servidor matá-lo silenciosamente
+
+Em produção WhatsApp, mesmo cenário aparece com N usuários simultâneos (não com 4 children do STS). Resolver no STS = preparar pra prod.
+
+## Decisão
+
+Criar **`motor/llm-gateway/`** — novo package no monorepo motor, processo MCP único que centraliza TODAS chamadas LLM dos children (motor-drota, planejador, signal-extractor, persona-sim quando rodando via gateway).
+
+Children deixam de instanciar SDK OpenAI/Anthropic diretamente. Em vez disso: instanciam MCP client → conectam ao gateway → chamam tool `chat_completion`.
+
+## Arquitetura
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   motor/orchestrator                         │
+│                                                              │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  │
+│  │  planejador  │  │  motor-drota │  │ signal-extractor │  │
+│  │  (MCP child) │  │  (MCP child) │  │  (em motor-drota)│  │
+│  └──────┬───────┘  └──────┬───────┘  └────────┬─────────┘  │
+│         │                 │                    │             │
+│         │  callTool        callTool             │             │
+│         │   chat_completion                    │             │
+│         ▼                 ▼                    ▼             │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │               llm-gateway (MCP server)                 │  │
+│  │  ┌─────────────────────────────────────────────────┐  │  │
+│  │  │  Token bucket per provider (anthropic / infomaniak) │ │
+│  │  │  Retry com exponential backoff + jitter         │  │  │
+│  │  │  Provider fallback (infomaniak → anthropic)     │  │  │
+│  │  │  undici Agent global (HTTP/1.1, IPv4-first,     │  │  │
+│  │  │   keepAlive controlado)                          │  │  │
+│  │  │  Forward cache_control + reasoning blocks       │  │  │
+│  │  │  Logging próprio (logs/llm-gateway/)            │  │  │
+│  │  └─────────────────────────────────────────────────┘  │  │
+│  │       │                          │                     │  │
+│  │       ▼                          ▼                     │  │
+│  │  Anthropic SDK            OpenAI SDK (Infomaniak)     │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+
+(persona-sim no STS pode ou não usar gateway — STS roda fora do monorepo
+motor; opcional na v1, recomendado v2 quando gateway for stand-alone.)
+```
+
+## API contract — tool `chat_completion`
+
+Input:
+```ts
+{
+  step: "drota" | "planejador" | "signal-extractor" | "persona-sim" | string,
+  provider?: "anthropic" | "infomaniak",  // override do router default
+  model?: string,                          // override do router default
+  systemPrompt: string,
+  cacheableSystemPrefix?: string,          // motor#25 forward
+  userMessage: string,
+  maxTokens?: number,
+  enableThinking?: boolean,                // anthropic extended thinking
+  thinkingBudgetTokens?: number,
+  run_id?: string,                         // se omitido, gateway gera UUID local
+  // futuro: messages[] structured ao invés de system+user — defer
+}
+```
+
+Output:
+```ts
+{
+  content: string,
+  reasoning?: string,
+  tokens: {
+    in: number,
+    out: number,
+    reasoning: number,
+    cacheCreation?: number,    // anthropic-only
+    cacheRead?: number,         // ambos providers
+  },
+  provider: "anthropic" | "infomaniak",
+  model: string,
+  latency_ms: number,
+  attempt_count: number,         // 1 = sucesso primeiro try, >1 = retries usados
+  was_fallback: boolean,         // true se provider primário falhou e secundário foi usado
+  primary_provider_attempted?: "anthropic" | "infomaniak", // populated quando was_fallback=true
+}
+```
+
+Erros:
+- `BUDGET_EXHAUSTED` — token bucket esgotado, queue cheia → caller decide se espera ou aborta
+- `PROVIDER_DOWN` — todos providers configurados falharam após retries
+- `INVALID_REQUEST` — prompt malformado / params inválidos
+
+## Algoritmos
+
+### Token bucket (per provider)
+- Config inicial conservador: Infomaniak 5 req/s, Anthropic 50 req/s (configurável via env)
+- Capacidade do bucket: 10 (= 2 segundos de burst absorvido)
+- Quando vazio: caller espera FIFO (queue interno) com timeout de 60s; se queue cheia, lança `BUDGET_EXHAUSTED`
+- Bucket recupera 1 token a cada 1/rate segundos
+
+### Retry com backoff
+- Max 5 retries (vs default SDK 2), MAS com cap superior `total_attempts_budget_ms` (default: 90s)
+- Backoff: `min(60s, 1s * 2^attempt) * jitter(0.5, 1.5)`
+- Se backoff próximo + tempo decorrido excedem budget, abandona retry e cai imediatamente para provider fallback (ou erro `PROVIDER_DOWN` se já estiver no fallback)
+- Só retry em erros transitórios: ETIMEDOUT, ECONNRESET, ECONNREFUSED, EPIPE, 429, 502, 503, 504
+- NÃO retry: 4xx (exceto 429), validação, autenticação
+- Configurável: `LLM_GATEWAY_BUDGET_MS` (default 90000)
+
+### Provider fallback
+- Hard timeout total por provider antes de fallback: **30s** (não 3 retries consecutivos). Razão: 3 retries × 60s ceiling = 3min antes de tentar secundário — desperdício em prod. 30s detecta provider down rápido o suficiente.
+- Se primary acumulou 30s de tentativas sem sucesso → fallback imediato (mesmo que retry budget restante > 0)
+- Durante "degraded", marca primary por 60s; novas calls vão direto pro secundário (mesma família de modelo: Kimi K2.5 → Sonnet 4.6)
+- Após 60s, volta a tentar primary primeiro
+- Output sempre carrega `was_fallback` boolean. Orchestrator deve propagar esse flag para events.ndjson em campo destacado, NÃO escondido em metadata. Razão: calibração futura do EfficacyIndex (archetype X com Kimi vs Sonnet pode ter eficácia diferente; sem flag, inconsistência fica invisível).
+- Configurável: `LLM_GATEWAY_FALLBACK=enabled|disabled` (default: enabled)
+
+### undici Agent global
+- 1 Agent por provider, instanciado uma vez no gateway startup
+- `keepAliveTimeout: 4000`, `keepAliveMaxTimeout: 600000` (compatível com idle do servidor)
+- `connect: { family: 4 }` — força IPv4 (mitiga WSL2 IPv6 stale)
+- `headers: { "Accept-Encoding": "identity" }` — opt-out de gzip que deu problema em alguns provedores
+
+## Observabilidade
+
+Log próprio do gateway em NDJSON:
+```
+logs/llm-gateway/<run_id>.ndjson
+```
+
+Cada linha:
+```json
+{
+  "ts": "2026-04-26T...",
+  "request_id": "uuid",
+  "run_id": "<from input or generated>",
+  "step": "drota",
+  "provider": "infomaniak",
+  "model": "moonshotai/Kimi-K2.5",
+  "tokens": { "in": 2860, "out": 3233 },
+  "latency_ms": 31639,
+  "attempt_count": 1,
+  "outcome": "ok" | "error" | "fallback_used",
+  "error_class": null,
+  "was_fallback": false,
+  "primary_provider_attempted": "infomaniak",
+  "bucket_level_at_start": 7,
+  "bucket_level_at_end": 6
+}
+```
+
+NÃO duplica events.ndjson — esse fica no nível do orchestrator. Gateway log é específico de transporte LLM.
+
+## Multiuser + cache (resposta à pergunta do Jun)
+
+**Gateway MELHORA cache hit rate em produção multiuser**, não piora:
+
+1. **Anthropic prompt cache (motor#25)**: TTL 5min sliding. Hoje cada child tem seu SDK session — quando child reinicia, cache cold. Com gateway, 1 processo persistente: cache continuamente warm porque requests fluem regularmente.
+
+2. **Infomaniak auto-cache** (`cached_tokens` em `prompt_tokens_details`): provedor detecta prefixos idênticos por API key. Hoje 4 children abrem 4 perfis distintos no provedor. Com gateway, 1 cliente = dedup ótimo.
+
+3. **STABLE_DROTA_PREFIX é compartilhado entre todos users** (Ryo, Kei, Saki, futuras famílias). Cache hit é cross-user por design. O que muda por user vai DEPOIS do `cache_control` marker = não invalida prefix.
+
+Pegadinhas multiuser tratadas no MVP:
+- Forward transparente do `cache_control` — gateway NÃO modifica conteúdo cacheado
+- Token bucket é GLOBAL (não per-user) → fila FIFO em burst de N usuários simultâneos
+- API key única por provider → fallback automático para secundário absorve revogação/quota
+
+Pegadinhas que ficam para v2 pós-piloto:
+- Per-user fair queuing (anti-starvation)
+- Per-user rate limit (proteção anti-abuso)
+- Cache namespace separation se rodarmos múltiplos motor profiles em paralelo
+
+## Escopo MVP
+
+**Dentro:**
+- Package `motor/llm-gateway/` com MCP server expondo `chat_completion`
+- Provider router (anthropic + infomaniak) — herda lógica de `shared/src/llm-router.ts`
+- Token bucket per-provider (configurável)
+- Retry com exponential backoff + jitter (5 retries, 60s ceiling)
+- Provider fallback automático (transient failure → switch)
+- undici Agent global com IPv4-first + keepAlive controlado
+- Forward `cache_control` (Anthropic) + `prompt_tokens_details.cached_tokens` (Infomaniak)
+- Forward reasoning blocks (Kimi K2.5 reasoning, Anthropic thinking)
+- Logging próprio NDJSON
+- Refactor: motor-drota, planejador, signal-extractor passam a usar gateway via MCP
+- Testes: unit (token bucket, retry logic, provider router), integration (mock provider via stub server), smoke (1 call real Infomaniak)
+
+**Fora (deferred):**
+- Streaming
+- Caching DIY (confiamos em Anthropic prompt cache + Infomaniak auto-cache)
+- Distributed/Redis
+- Per-user fair queuing
+- Circuit breaker (defer — bucket + retry + fallback cobre 90%)
+- persona-sim (STS) integração — STS está fora do monorepo motor; v1 mantém SDK direto
+
+## Plano de implementação (em chunks de 1 PR cada)
+
+### Chunk 1 — gateway core (motor#28a, ~1 dia)
+- `motor/llm-gateway/package.json`, `tsconfig`, scaffolding
+- `src/server.ts` MCP server skeleton com tool `chat_completion`
+- `src/providers/anthropic.ts` + `src/providers/infomaniak.ts`
+- `src/token-bucket.ts` + tests
+- `src/retry.ts` (exponential backoff + jitter, com `total_attempts_budget_ms` cap) + tests
+- `src/router.ts` (provider selection, fallback logic, hard timeout 30s no primary) + tests
+- `src/agent.ts` (undici Agent config global) + smoke test
+- `src/logger.ts` (NDJSON logging com `run_id` + `was_fallback` + `primary_provider_attempted`)
+- Roda standalone — não integra com motor children ainda
+- DEFINITION OF DONE: stub provider integration test passa, smoke real Infomaniak passa, todos unit tests verde
+- DOD adicional (refinos pós-revisão):
+  - Test unit: token bucket FIFO atende dentro de `total_attempts_budget_ms`
+  - Test unit: fallback dispara após hard timeout 30s no primary (não espera 3 retries × 60s)
+  - Test unit: `was_fallback=true` no output quando secundário foi usado
+  - Test unit: `run_id` propaga do input para o log NDJSON; gera UUID quando omitido
+
+### Chunk 2 — motor-drota integration (motor#28b, ~0.5 dia)
+- Refactor `motor-drota/src/llm-client.ts` → MCP client do gateway
+- Refactor `motor-drota/src/signal-extractor.ts` → MCP client do gateway
+- Update tests motor-drota
+- Smoke teste isolado: motor-drota standalone com gateway
+- DEFINITION OF DONE: motor-drota tests verde, smoke isolado passa
+
+### Chunk 3 — planejador integration (motor#28c, ~0.5 dia)
+- Refactor `planejador/src/llm-client.ts` → MCP client do gateway
+- Update tests planejador
+- DEFINITION OF DONE: planejador tests verde
+
+### Chunk 4 — orchestrator wiring + smoke E2E (motor#28d, ~1 dia)
+- Update `motor/orchestrator/src/...` para spawnar llm-gateway child antes dos demais
+- Garantir env propagation (gateway recebe ANTHROPIC_API_KEY + INFOMANIAK_API_KEY; children NÃO precisam mais)
+- Update sts/orchestrator/src/motor-client.ts se necessário (mantém compat)
+- Smoke E2E: rodar smoke-3d STS via gateway
+- DEFINITION OF DONE: smoke-3d 100% verde, gateway log presente, latência por turn comparable a baseline
+
+### Chunk 5 — operacional + observability (motor#28e, ~0.5 dia)
+- Documentar config env: `LLM_GATEWAY_RATE_INFOMANIAK`, `LLM_GATEWAY_RATE_ANTHROPIC`, `LLM_GATEWAY_FALLBACK`, etc
+- Atualizar `.env.example` motor + sts
+- Update ARCHITECTURE.md §13 ou §15 nova seção sobre gateway
+- Run nagareyama-14d-v1 com gateway → confirmar zero ETIMEDOUT visíveis
+- DEFINITION OF DONE: nagareyama 14d completa com >90% success rate, decision-trail 007 com resultados
+
+**Total estimado: 3.5-4 dias** end-to-end com testes e validação real.
+
+## Riscos e mitigações
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|---|---|---|---|
+| Gateway crash bloqueia tudo | Baixa | Alto | Supervised restart no orchestrator (auto-respawn); health check periódico |
+| Latência extra (1 hop MCP) noticeable | Baixa | Médio | MCP stdio é ~1-2ms — irrelevante perto de 25s LLM call |
+| Refactor de 3 callsites quebra tests | Média | Médio | Cada chunk tem DOD com testes verde; NÃO mergeia chunk se quebrar |
+| Cache_control não passa transparente | Média | Alto | Test de integração verifica `cache_creation_input_tokens` > 0 em call cacheada |
+| Token bucket muito apertado → starva STS | Média | Baixo | Default 5 req/s gera 18000 req/h — STS 14d gera ~600 calls. 30x folga |
+| undici IPv4-first quebra em ambientes IPv6-only | Baixa | Médio | Config opt-in via env (default: ipv4-first em WSL2, dual-stack outros) |
+| User-perceived latência > 90s por call | Baixa | Alto | `total_attempts_budget_ms` hard cap; fallback eager após 30s no primary |
+
+## Não-decisão (escopo aceito mas adiado)
+
+- **Streaming**: nenhum callsite atual usa. Quando precisar (ex: response real-time WhatsApp), v2.
+- **DIY caching**: Anthropic prompt cache via header já cobre 90% do benefício. Infomaniak auto-cache idem. DIY semantic cache (LLM-based dedup) é overkill.
+- **Multi-region failover**: 1 região hoje. Quando expandir geograficamente, v2.
+- **Cost tracking**: tokens IN/OUT já capturados. Custo $$ agregado fica pra batch job no MotorOps pós-piloto.
+
+## Open questions (precisa decisão antes de chunk 1)
+
+1. **Nome do package**: `motor/llm-gateway/` ✓ proposto. Alternativas rejeitadas: `motor/llm-router/` (confunde com `shared/llm-router.ts`), `motor/ai-gateway/` (genérico demais).
+
+2. **MCP tool naming**: `chat_completion` ✓ proposto (alinha com OpenAI convention). Alternativa `complete` mais curta mas ambígua.
+
+3. **Where lives sts/persona-simulator**: STS está fora do monorepo motor. **MVP v1**: persona-sim mantém SDK direto (não vai pelo gateway). v2 pós-piloto: extrair gateway pra package separado `@ascendimacy/llm-gateway` e ambos repos consomem.
+
+4. **Logging dest**: `motor/logs/llm-gateway/<run>.ndjson` ✓ proposto. STS scenario ASC_DEBUG_RUN_ID propaga ou gateway tem run id próprio? **Decisão (refinada)**: gateway aceita `run_id` opcional no input do `chat_completion`. Caller propaga quando tem (orchestrator do motor sabe scenario run_id via `ASC_DEBUG_RUN_ID` env); gateway gera UUID local quando não vier. Logging NDJSON do gateway sempre inclui `run_id` (vindo ou gerado). Sem race em startup com calls concorrentes.
+
+## Critérios de aceitação (gate de close)
+
+- [ ] Gateway MCP server roda standalone, atende tool `chat_completion`, expõe logging NDJSON
+- [ ] Token bucket aplica throttle correto (testado com 100 req em 10s, todas atendidas via fila FIFO)
+- [ ] Retry funciona em ETIMEDOUT (testado com mock provider que falha N vezes)
+- [ ] Provider fallback funciona (testado com primary down → secundário)
+- [ ] Cache_control forward funciona (Anthropic `cache_creation_input_tokens` > 0)
+- [ ] motor-drota + planejador + signal-extractor todos consomem via gateway, tests verde
+- [ ] smoke-3d STS completa 100% verde via gateway
+- [ ] nagareyama-14d-v1 completa >90% success rate via gateway
+- [ ] Decision-trail 007 com resultados de produção
+
+---
+
+**Status decisório (2026-04-26 v1):**
+
+Spec aprovada com 3 refinos aplicados inline (ver `revisions` no front-matter). Próximo passo: chunk 1 (gateway core, ~1 dia).


### PR DESCRIPTION
## Summary
- Spec do LLM Gateway centralizado em [motorops/decision-trail/2026-04-26-006-llm-gateway.md](motorops/decision-trail/2026-04-26-006-llm-gateway.md)
- Resposta arquitetural ao ETIMEDOUT cascading detectado em STS nagareyama-14d-v1 (instrumentação confirmou 100% das falhas LLM = `cause.code=ETIMEDOUT`)
- v1 incorpora 3 refinos do Jun pré chunk 1: `was_fallback` obrigatório no output, `total_attempts_budget_ms` cap (90s), `run_id` opcional no input

## Plano em 5 chunks (~3.5-4 dias total)
- **28a** (1d) gateway core standalone — token bucket, retry, router, undici Agent, logger
- **28b** (0.5d) motor-drota + signal-extractor → MCP client do gateway
- **28c** (0.5d) planejador → MCP client do gateway
- **28d** (1d) orchestrator wiring + smoke-3d STS E2E
- **28e** (0.5d) operacional + nagareyama 14d validation (>90% success rate = critério de close)

## Test plan
- [ ] Esta PR: revisar spec, ajustar arquitetura/escopo se necessário
- [ ] Próximas PRs (28a → 28e): cada chunk com DoD próprio, testes verde
- [ ] Critério final de close: nagareyama-14d-v1 completa >90% success rate via gateway, decision-trail 007 com resultados de produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)