### PR TITLE
feat(motor#28b): motor-drota + signal-extractor via llm-gateway — chunk 2

### DIFF
--- a/motor-drota/scripts/smoke-via-gateway.mjs
+++ b/motor-drota/scripts/smoke-via-gateway.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Smoke isolado motor-drota → gateway (motor#28b chunk DoD).
+ *
+ * Verifica que motor-drota.callLlm() chama callGateway() → spawna gateway
+ * MCP via stdio → gateway chama Infomaniak/Anthropic → response volta.
+ *
+ * Run:
+ *   set -a && . ~/ascendimacy-sts/.env && set +a
+ *   node motor-drota/scripts/smoke-via-gateway.mjs
+ */
+
+import { callLlm } from "../dist/llm-client.js";
+import { closeGateway } from "@ascendimacy/shared";
+
+const t0 = Date.now();
+console.log(`[smoke-via-gateway] motor-drota.callLlm → gateway → Infomaniak/Kimi K2.5`);
+
+try {
+  const r = await callLlm(
+    "Você é gentil. Responde em pt-br curto.",
+    "diga apenas 'ok' em pt-br.",
+  );
+  const totalMs = Date.now() - t0;
+  console.log(`[smoke-via-gateway] ✓ provider=${r.provider} model=${r.model}`);
+  console.log(`[smoke-via-gateway] content="${r.content.slice(0, 80)}"`);
+  console.log(`[smoke-via-gateway] tokens: in=${r.tokens.in} out=${r.tokens.out} cacheRead=${r.tokens.cacheRead ?? 0}`);
+  console.log(`[smoke-via-gateway] total_ms=${totalMs}`);
+} catch (err) {
+  const e = err;
+  console.error(`[smoke-via-gateway] ✗ ${e.name ?? "Error"}: ${e.message ?? String(err)}`);
+  process.exitCode = 1;
+} finally {
+  await closeGateway();
+}

--- a/motor-drota/src/llm-client.ts
+++ b/motor-drota/src/llm-client.ts
@@ -1,17 +1,20 @@
 /**
- * Motor-drota LLM client — motor#21 dual-provider (Anthropic + Infomaniak).
+ * Motor-drota LLM client — motor#28b: routes via llm-gateway (MCP).
  *
- * Default: Infomaniak / Kimi K2.5. Override via env DROTA_PROVIDER + DROTA_MODEL.
+ * ANTES (motor#21+25): instanciava SDK Anthropic/OpenAI direto, com lógica
+ * própria de timeout/retry e cache_control wiring.
  *
- * Spec: docs/specs/2026-04-24-debug-mode.md.
+ * AGORA (motor#28b): chama `callGateway()` (do shared). Gateway centraliza
+ * retry, fallback, undici Agent IPv4-first, NDJSON logging. cache_control
+ * + reasoning forward são preservados via `cacheableSystemPrefix` no input
+ * do gateway.
+ *
+ * API pública (`callLlm`, `callLlmMock`) inalterada — drop-in pra evaluate.ts.
  */
 
-import Anthropic from "@anthropic-ai/sdk";
-import OpenAI from "openai";
 import {
+  callGateway,
   isDebugModeEnabled,
-  getLlmTimeoutMs,
-  getLlmMaxRetries,
   getProviderForStep,
   getModelForStep,
   getMaxTokensForStep,
@@ -20,26 +23,6 @@ import {
   type LlmProvider,
 } from "@ascendimacy/shared";
 
-let anthropicClient: Anthropic | null = null;
-let openaiClient: OpenAI | null = null;
-
-function getAnthropic(): Anthropic {
-  if (!anthropicClient) {
-    anthropicClient = new Anthropic({ apiKey: process.env["ANTHROPIC_API_KEY"] });
-  }
-  return anthropicClient;
-}
-
-function getOpenAI(): OpenAI {
-  if (!openaiClient) {
-    openaiClient = new OpenAI({
-      apiKey: process.env["INFOMANIAK_API_KEY"] ?? "mock",
-      baseURL: process.env["INFOMANIAK_BASE_URL"] ?? "https://api.infomaniak.com/1/ai",
-    });
-  }
-  return openaiClient;
-}
-
 export interface LlmCallResult {
   content: string;
   reasoning?: string;
@@ -47,9 +30,7 @@ export interface LlmCallResult {
     in: number;
     out: number;
     reasoning: number;
-    /** motor#25: cache write (prefix sendo cacheado pela 1ª vez). */
     cacheCreation?: number;
-    /** motor#25: cache read (prefix lido do cache, custo reduzido). */
     cacheRead?: number;
   };
   provider: LlmProvider;
@@ -57,12 +38,12 @@ export interface LlmCallResult {
 }
 
 /**
- * motor#21 dispatcher. Default: Infomaniak / Kimi K2.5. Anthropic via DROTA_PROVIDER=anthropic.
+ * motor#28b: motor-drota chama gateway via MCP. Gateway resolve provider,
+ * faz retry/fallback/bucket, chama SDK efetivo e retorna resposta unificada.
  *
- * motor#25 (handoff #24 Tarefa 2): aceita opcional cacheableSystemPrefix —
- * se passado e provider=anthropic, envia como system block array com
- * cache_control: ephemeral. callInfomaniak ignora (no-op — Infomaniak/OpenAI
- * fazem cache automático em prefixos consistentes).
+ * Aceita `cacheableSystemPrefix` (motor#25) — gateway forward transparente
+ * pro provider efetivo (Anthropic via cache_control bloco array, Infomaniak
+ * via concat string).
  */
 export async function callLlm(
   systemPrompt: string,
@@ -70,113 +51,36 @@ export async function callLlm(
   options: { cacheableSystemPrefix?: string } = {},
 ): Promise<LlmCallResult> {
   const provider = getProviderForStep("drota");
-  if (provider === "anthropic") {
-    const c = getAnthropic();
-    const model = getModelForStep("drota", "anthropic");
-    const maxTokens = getMaxTokensForStep("drota", model);
-    const thinking = shouldEnableThinking("drota", "anthropic", isDebugModeEnabled());
-    // motor#25: se cacheableSystemPrefix foi passado, usa block array com cache_control.
-    // Senão, system string direto (compat anterior).
-    const systemValue: Anthropic.MessageCreateParams["system"] = options.cacheableSystemPrefix
-      ? ([
-          {
-            type: "text",
-            text: options.cacheableSystemPrefix,
-            cache_control: { type: "ephemeral" },
-          },
-          { type: "text", text: systemPrompt },
-        ] as unknown as Anthropic.MessageCreateParams["system"])
-      : systemPrompt;
-    const params: Anthropic.MessageCreateParams = {
-      model,
-      max_tokens: maxTokens,
-      system: systemValue,
-      messages: [{ role: "user", content: userMessage }],
-    };
-    if (thinking) {
-      (params as Anthropic.MessageCreateParams & { thinking?: unknown }).thinking = {
-        type: "enabled",
-        budget_tokens: getThinkingBudgetTokens(),
-      };
-    }
-    const r = await c.messages.create(params, {
-      timeout: getLlmTimeoutMs("drota"),
-      maxRetries: getLlmMaxRetries("drota"),
-    });
-    let content = "";
-    let reasoning: string | undefined;
-    for (const block of r.content) {
-      if (block.type === "text") content += block.text;
-      else if ((block as { type: string }).type === "thinking") {
-        reasoning = (block as { thinking?: string }).thinking;
-      }
-    }
-    const usage = r.usage as {
-      input_tokens: number;
-      output_tokens: number;
-      cache_creation_input_tokens?: number;
-      cache_read_input_tokens?: number;
-    };
-    return {
-      content: content || "{}",
-      reasoning,
-      tokens: {
-        in: usage.input_tokens,
-        out: usage.output_tokens,
-        reasoning: 0,
-        cacheCreation: usage.cache_creation_input_tokens,
-        cacheRead: usage.cache_read_input_tokens,
-      },
-      provider: "anthropic",
-      model,
-    };
-  }
-  // Infomaniak (default)
-  // motor#25: pra Infomaniak, concatena prefix+dynamic em system string única.
-  // OpenAI-compat fazem prefix caching automático (>1024 tokens). Não tem
-  // parameter explícito tipo cache_control — confiamos na consistência do prefix.
-  const c = getOpenAI();
-  const model = getModelForStep("drota", "infomaniak");
+  const model = getModelForStep("drota", provider);
   const maxTokens = getMaxTokensForStep("drota", model);
-  const fullSystem = options.cacheableSystemPrefix
-    ? options.cacheableSystemPrefix + "\n\n" + systemPrompt
-    : systemPrompt;
-  const r = await c.chat.completions.create(
-    {
-      model,
-      messages: [
-        { role: "system", content: fullSystem },
-        { role: "user", content: userMessage },
-      ],
-      max_tokens: maxTokens,
-    },
-    {
-      timeout: getLlmTimeoutMs("drota"),
-      maxRetries: getLlmMaxRetries("drota"),
-    },
-  );
-  const msg = r.choices[0]?.message;
-  const content = msg?.content ?? "";
-  const reasoning = (msg as { reasoning?: string } | undefined)?.reasoning;
-  const usage = r.usage as
-    | {
-        prompt_tokens: number;
-        completion_tokens: number;
-        prompt_tokens_details?: { cached_tokens?: number };
-      }
-    | undefined;
-  return {
-    content: content || "{}",
-    reasoning,
-    tokens: {
-      in: usage?.prompt_tokens ?? 0,
-      out: usage?.completion_tokens ?? 0,
-      reasoning: 0,
-      // OpenAI-compat reporta cached_tokens em prompt_tokens_details quando aplicável
-      cacheRead: usage?.prompt_tokens_details?.cached_tokens,
-    },
-    provider: "infomaniak",
+  const enableThinking = shouldEnableThinking("drota", provider, isDebugModeEnabled());
+  const thinkingBudgetTokens = enableThinking ? getThinkingBudgetTokens() : undefined;
+
+  const out = await callGateway({
+    step: "drota",
+    provider,
     model,
+    systemPrompt,
+    cacheableSystemPrefix: options.cacheableSystemPrefix,
+    userMessage,
+    maxTokens,
+    enableThinking: enableThinking || undefined,
+    thinkingBudgetTokens,
+    run_id: process.env["ASC_DEBUG_RUN_ID"],
+  });
+
+  return {
+    content: out.content,
+    reasoning: out.reasoning,
+    tokens: {
+      in: out.tokens.in,
+      out: out.tokens.out,
+      reasoning: out.tokens.reasoning,
+      cacheCreation: out.tokens.cacheCreation,
+      cacheRead: out.tokens.cacheRead,
+    },
+    provider: out.provider,
+    model: out.model,
   };
 }
 

--- a/motor-drota/src/signal-extractor.ts
+++ b/motor-drota/src/signal-extractor.ts
@@ -12,39 +12,16 @@
  * tarefa é classificação de signals em texto curto, não exige reasoning chain.
  */
 
-import OpenAI from "openai";
-import Anthropic from "@anthropic-ai/sdk";
 import {
   SEMANTIC_SIGNALS,
   SIGNAL_DESCRIPTIONS,
   isSemanticSignal,
+  callGateway,
   getProviderForStep,
   getModelForStep,
-  getLlmTimeoutMs,
-  getLlmMaxRetries,
   type SemanticSignal,
   type SignalExtractionResult,
 } from "@ascendimacy/shared";
-
-let openaiClient: OpenAI | null = null;
-let anthropicClient: Anthropic | null = null;
-
-function getOpenAI(): OpenAI {
-  if (!openaiClient) {
-    openaiClient = new OpenAI({
-      apiKey: process.env["INFOMANIAK_API_KEY"] ?? "mock",
-      baseURL: process.env["INFOMANIAK_BASE_URL"] ?? "https://api.infomaniak.com/1/ai",
-    });
-  }
-  return openaiClient;
-}
-
-function getAnthropic(): Anthropic {
-  if (!anthropicClient) {
-    anthropicClient = new Anthropic({ apiKey: process.env["ANTHROPIC_API_KEY"] });
-  }
-  return anthropicClient;
-}
 
 /**
  * Constrói o prompt do Signal Extractor.
@@ -144,8 +121,6 @@ export async function extractSignals(args: {
 
   const provider = getProviderForStep("signal-extractor");
   const model = getModelForStep("signal-extractor", provider);
-  const timeout = getLlmTimeoutMs("signal-extractor");
-  const maxRetries = getLlmMaxRetries("signal-extractor");
   const prompt = buildSignalExtractorPrompt(args);
 
   // Gate A fix (b): max_tokens 512→2048 (cobre reasoning models + non-reasoning).
@@ -153,35 +128,21 @@ export async function extractSignals(args: {
   // Kimi K2.5: reasoning chain ~500-1500 + content ~150 = total ~1500-2000.
   const maxTokens = 2048;
 
+  // motor#28b: chama via gateway. systemPrompt vazio + userMessage = prompt
+  // (signal-extractor envia prompt único como user, sem system separado).
   let raw: string;
   let llmError: unknown = null;
   try {
-    if (provider === "anthropic") {
-      const c = getAnthropic();
-      const r = await c.messages.create(
-        {
-          model,
-          max_tokens: maxTokens,
-          messages: [{ role: "user", content: prompt }],
-        },
-        { timeout, maxRetries },
-      );
-      raw = "";
-      for (const b of r.content) {
-        if (b.type === "text") raw += b.text;
-      }
-    } else {
-      const c = getOpenAI();
-      const r = await c.chat.completions.create(
-        {
-          model,
-          messages: [{ role: "user", content: prompt }],
-          max_tokens: maxTokens,
-        },
-        { timeout, maxRetries },
-      );
-      raw = r.choices[0]?.message?.content ?? "";
-    }
+    const out = await callGateway({
+      step: "signal-extractor",
+      provider,
+      model,
+      systemPrompt: "",
+      userMessage: prompt,
+      maxTokens,
+      run_id: process.env["ASC_DEBUG_RUN_ID"],
+    });
+    raw = out.content;
   } catch (err) {
     llmError = err;
     raw = "";

--- a/motor-drota/tests/llm-client.test.ts
+++ b/motor-drota/tests/llm-client.test.ts
@@ -1,32 +1,31 @@
 /**
- * Tests do motor-drota llm-client (motor#19 + motor#20).
+ * Tests motor-drota llm-client (motor#28b — gateway integration).
  *
- * Cobre:
- *   - LlmCallResult shape — motor#19
- *   - max_tokens=2048 default + 4096 pra reasoning models — motor#19
- *   - Captura campo `reasoning` (Infomaniak Kimi/DeepSeek-R1) — motor#19
- *   - Timeout 90s default + maxRetries — motor#20
+ * ANTES (motor#19+25): mockava SDK OpenAI direto. Tests verificavam timeout,
+ * maxRetries, params.max_tokens — tudo concern de motor-drota.
  *
- * Mocka openai SDK.
+ * AGORA (motor#28b): motor-drota é proxy fino sobre `callGateway`. Tests
+ * mockam `callGateway` e verificam:
+ *   - input correto passado ao gateway (step, provider, model, maxTokens, cacheableSystemPrefix)
+ *   - output do gateway mapeado certo pra LlmCallResult
+ *   - reasoning + cacheRead/cacheCreation forwardados transparentes
+ *
+ * Timeout/maxRetries/retry/fallback ficam testados em llm-gateway/tests/.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { GatewayChatCompletionInput, GatewayChatCompletionOutput } from "@ascendimacy/shared";
 
-const captured: { params?: unknown; options?: unknown } = {};
-let mockResponse: unknown = null;
+const captured: { req?: GatewayChatCompletionInput } = {};
+let mockResponse: GatewayChatCompletionOutput;
 
-vi.mock("openai", () => {
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ascendimacy/shared")>();
   return {
-    default: class MockOpenAI {
-      chat = {
-        completions: {
-          create: async (params: unknown, options?: unknown) => {
-            captured.params = params;
-            captured.options = options;
-            return mockResponse;
-          },
-        },
-      };
+    ...actual,
+    callGateway: async (req: GatewayChatCompletionInput) => {
+      captured.req = req;
+      return mockResponse;
     },
   };
 });
@@ -34,11 +33,19 @@ vi.mock("openai", () => {
 const ORIG_ENV = { ...process.env };
 
 beforeEach(() => {
-  captured.params = undefined;
-  captured.options = undefined;
-  mockResponse = null;
+  captured.req = undefined;
+  mockResponse = {
+    content: "Hello",
+    tokens: { in: 100, out: 50, reasoning: 0 },
+    provider: "infomaniak",
+    model: "moonshotai/Kimi-K2.5",
+    latency_ms: 10,
+    attempt_count: 1,
+    was_fallback: false,
+  };
   delete process.env["MOTOR_DROTA_MODEL"];
-  delete process.env["ASC_LLM_TIMEOUT_DROTA"];
+  delete process.env["DROTA_PROVIDER"];
+  delete process.env["DROTA_MODEL"];
   process.env["INFOMANIAK_API_KEY"] = "test-key";
 });
 
@@ -48,11 +55,16 @@ afterEach(() => {
   }
 });
 
-describe("motor-drota.callLlm — motor#19 + motor#20", () => {
-  it("retorna LlmCallResult com content + tokens", async () => {
+describe("motor-drota.callLlm — motor#28b gateway integration", () => {
+  it("retorna LlmCallResult com content + tokens via gateway", async () => {
     mockResponse = {
-      choices: [{ message: { content: "Hello" } }],
-      usage: { prompt_tokens: 100, completion_tokens: 50 },
+      content: "Hello",
+      tokens: { in: 100, out: 50, reasoning: 0 },
+      provider: "infomaniak",
+      model: "moonshotai/Kimi-K2.5",
+      latency_ms: 10,
+      attempt_count: 1,
+      was_fallback: false,
     };
     const { callLlm } = await import("../src/llm-client.js");
     const r = await callLlm("s", "u");
@@ -60,141 +72,90 @@ describe("motor-drota.callLlm — motor#19 + motor#20", () => {
     expect(r.tokens.in).toBe(100);
     expect(r.tokens.out).toBe(50);
     expect(r.reasoning).toBeUndefined();
+    expect(r.provider).toBe("infomaniak");
   });
 
-  it("captura reasoning de message.reasoning (Kimi K2.5/DeepSeek-R1)", async () => {
+  it("forward reasoning do gateway pra LlmCallResult", async () => {
     mockResponse = {
-      choices: [{ message: { content: "Final answer", reasoning: "Let me think step by step..." } }],
-      usage: { prompt_tokens: 100, completion_tokens: 50 },
+      ...mockResponse,
+      reasoning: "Let me think step by step...",
     };
     const { callLlm } = await import("../src/llm-client.js");
     const r = await callLlm("s", "u");
-    expect(r.content).toBe("Final answer");
     expect(r.reasoning).toBe("Let me think step by step...");
   });
 
-  it("max_tokens=2048 pra modelo non-reasoning (mistral3)", async () => {
-    process.env["MOTOR_DROTA_MODEL"] = "mistral3";
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.params as { max_tokens: number }).max_tokens).toBe(2048);
-  });
-
-  it("max_tokens=4096 pra Kimi K2.5 (heurística reasoning)", async () => {
+  it("passa step=drota + provider/model/maxTokens corretos pro gateway", async () => {
     process.env["MOTOR_DROTA_MODEL"] = "moonshotai/Kimi-K2.5";
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    };
     const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.params as { max_tokens: number }).max_tokens).toBe(4096);
+    await callLlm("system", "user");
+    expect(captured.req).toBeDefined();
+    expect(captured.req!.step).toBe("drota");
+    expect(captured.req!.provider).toBe("infomaniak"); // default
+    expect(captured.req!.model).toBe("moonshotai/Kimi-K2.5");
+    expect(captured.req!.maxTokens).toBe(4096); // reasoning model heuristic
+    expect(captured.req!.systemPrompt).toBe("system");
+    expect(captured.req!.userMessage).toBe("user");
   });
 
-  it("max_tokens=4096 pra DeepSeek-R1", async () => {
-    process.env["MOTOR_DROTA_MODEL"] = "deepseek-r1";
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    };
+  it("max_tokens=2048 pra modelo non-reasoning (mistral3) passado pro gateway", async () => {
+    process.env["MOTOR_DROTA_MODEL"] = "mistral3";
     const { callLlm } = await import("../src/llm-client.js");
     await callLlm("s", "u");
-    expect((captured.params as { max_tokens: number }).max_tokens).toBe(4096);
+    expect(captured.req!.maxTokens).toBe(2048);
   });
 
-  it("content null → fallback '{}'", async () => {
-    mockResponse = {
-      choices: [{ message: { content: null } }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    const r = await callLlm("s", "u");
-    expect(r.content).toBe("{}");
-  });
-
-  it("timeout default 90s (drota)", async () => {
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    };
+  it("propaga ASC_DEBUG_RUN_ID como run_id no gateway input", async () => {
+    process.env["ASC_DEBUG_RUN_ID"] = "test-run-xyz";
     const { callLlm } = await import("../src/llm-client.js");
     await callLlm("s", "u");
-    expect((captured.options as { timeout: number }).timeout).toBe(90_000);
-  });
-
-  it("ASC_LLM_TIMEOUT_DROTA override (motor#20)", async () => {
-    process.env["ASC_LLM_TIMEOUT_DROTA"] = "30";
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.options as { timeout: number }).timeout).toBe(30_000);
-  });
-
-  it("maxRetries=2 default (drota — fail-fast em reasoning)", async () => {
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    };
-    const { callLlm } = await import("../src/llm-client.js");
-    await callLlm("s", "u");
-    expect((captured.options as { maxRetries: number }).maxRetries).toBe(2);
+    expect(captured.req!.run_id).toBe("test-run-xyz");
   });
 });
 
-// motor#25 (handoff #24 Tarefa 2) — prompt cache prefix
-describe("motor-drota.callLlm — cacheableSystemPrefix (motor#25)", () => {
-  it("Infomaniak: passa prefix concatenado ao system (default behavior, sem cache_control)", async () => {
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 100, completion_tokens: 50 },
-    };
+// motor#25 prompt cache forward — preservado em motor#28b
+describe("motor-drota.callLlm — cacheableSystemPrefix (motor#25 forward via gateway)", () => {
+  it("passa cacheableSystemPrefix pro gateway sem modificar", async () => {
     const { callLlm } = await import("../src/llm-client.js");
     await callLlm("DYNAMIC_BODY", "user msg", {
       cacheableSystemPrefix: "STABLE_PREFIX",
     });
-    const params = captured.params as { messages: Array<{ role: string; content: string }> };
-    // Sistema OpenAI-compat: prefix + body concatenados
-    expect(params.messages[0]!.role).toBe("system");
-    expect(params.messages[0]!.content).toContain("STABLE_PREFIX");
-    expect(params.messages[0]!.content).toContain("DYNAMIC_BODY");
+    expect(captured.req!.cacheableSystemPrefix).toBe("STABLE_PREFIX");
+    expect(captured.req!.systemPrompt).toBe("DYNAMIC_BODY");
   });
 
-  it("Infomaniak: sem cacheableSystemPrefix, system = systemPrompt direto", async () => {
-    mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 100, completion_tokens: 50 },
-    };
+  it("sem cacheableSystemPrefix, gateway recebe undefined", async () => {
     const { callLlm } = await import("../src/llm-client.js");
     await callLlm("just system", "user");
-    const params = captured.params as { messages: Array<{ content: string }> };
-    expect(params.messages[0]!.content).toBe("just system");
+    expect(captured.req!.cacheableSystemPrefix).toBeUndefined();
+    expect(captured.req!.systemPrompt).toBe("just system");
   });
 
-  it("captura cacheRead de prompt_tokens_details.cached_tokens (Infomaniak)", async () => {
+  it("forward cacheRead do gateway tokens", async () => {
     mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: {
-        prompt_tokens: 1000,
-        completion_tokens: 50,
-        prompt_tokens_details: { cached_tokens: 800 },
-      },
+      ...mockResponse,
+      tokens: { in: 1000, out: 50, reasoning: 0, cacheRead: 800 },
     };
     const { callLlm } = await import("../src/llm-client.js");
     const r = await callLlm("s", "u");
     expect(r.tokens.cacheRead).toBe(800);
   });
 
-  it("cacheRead undefined quando provider não reporta cached_tokens", async () => {
+  it("forward cacheCreation do gateway tokens (Anthropic-only)", async () => {
     mockResponse = {
-      choices: [{ message: { content: "{}" } }],
-      usage: { prompt_tokens: 100, completion_tokens: 50 },
+      ...mockResponse,
+      tokens: { in: 1000, out: 50, reasoning: 0, cacheCreation: 200, cacheRead: 0 },
+      provider: "anthropic",
+    };
+    const { callLlm } = await import("../src/llm-client.js");
+    const r = await callLlm("s", "u");
+    expect(r.tokens.cacheCreation).toBe(200);
+  });
+
+  it("cacheRead undefined quando gateway não reporta cached_tokens", async () => {
+    mockResponse = {
+      ...mockResponse,
+      tokens: { in: 100, out: 50, reasoning: 0 },
     };
     const { callLlm } = await import("../src/llm-client.js");
     const r = await callLlm("s", "u");

--- a/package-lock.json
+++ b/package-lock.json
@@ -4619,6 +4619,9 @@
     "shared": {
       "name": "@ascendimacy/shared",
       "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.10.2"
+      },
       "devDependencies": {
         "@types/node": "*",
         "typescript": "*",

--- a/shared/package.json
+++ b/shared/package.json
@@ -10,6 +10,9 @@
     "test": "vitest run",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.10.2"
+  },
   "devDependencies": {
     "typescript": "*",
     "vitest": "*",

--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -1,0 +1,186 @@
+/**
+ * Gateway client — singleton MCP client for the LLM Gateway (motor#28b).
+ *
+ * Children (motor-drota, planejador, signal-extractor) chamam `callGateway()`
+ * em vez de instanciar SDK Anthropic/OpenAI direto. Centraliza retry, fallback,
+ * undici Agent IPv4-first, NDJSON logging.
+ *
+ * Modelo de transport: stdio. Cada child que importa shared/gateway-client
+ * spawna seu próprio processo gateway via subprocess. **Trade-off**: token
+ * bucket coordination não é cross-process (cada child tem seu bucket).
+ * Mitigado em motor#28f (HTTP transport pre-prod) — pra STS pilot/Yuji,
+ * per-process bucket é suficiente.
+ *
+ * Tipos inlined aqui pra evitar cycle com `@ascendimacy/llm-gateway`
+ * (gateway depende de shared; shared não pode depender de gateway).
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { join, dirname } from "node:path";
+import { createRequire } from "node:module";
+import type { LlmProvider } from "./llm-router.js";
+
+// Tipos espelham llm-gateway/src/types.ts. Mantidos sincronizados manualmente.
+export interface GatewayChatCompletionInput {
+  step: string;
+  provider?: LlmProvider;
+  model?: string;
+  systemPrompt: string;
+  cacheableSystemPrefix?: string;
+  userMessage: string;
+  maxTokens?: number;
+  enableThinking?: boolean;
+  thinkingBudgetTokens?: number;
+  run_id?: string;
+}
+
+export interface GatewayTokenUsage {
+  in: number;
+  out: number;
+  reasoning: number;
+  cacheCreation?: number;
+  cacheRead?: number;
+}
+
+export interface GatewayChatCompletionOutput {
+  content: string;
+  reasoning?: string;
+  tokens: GatewayTokenUsage;
+  provider: LlmProvider;
+  model: string;
+  latency_ms: number;
+  attempt_count: number;
+  was_fallback: boolean;
+  primary_provider_attempted?: LlmProvider;
+}
+
+let _client: Client | null = null;
+let _connecting: Promise<Client> | null = null;
+
+const PROPAGATED_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "INFOMANIAK_API_KEY",
+  "INFOMANIAK_BASE_URL",
+  "LLM_PROVIDER",
+  "PLANEJADOR_PROVIDER",
+  "PLANEJADOR_MODEL",
+  "MOTOR_DROTA_MODEL",
+  "DROTA_PROVIDER",
+  "DROTA_MODEL",
+  "SIGNAL_EXTRACTOR_PROVIDER",
+  "SIGNAL_EXTRACTOR_MODEL",
+  "PERSONA_SIM_PROVIDER",
+  "PERSONA_SIM_MODEL",
+  "LLM_GATEWAY_RATE_INFOMANIAK",
+  "LLM_GATEWAY_RATE_ANTHROPIC",
+  "LLM_GATEWAY_PRIMARY_TIMEOUT_MS",
+  "LLM_GATEWAY_BUDGET_MS",
+  "LLM_GATEWAY_FALLBACK",
+  "LLM_GATEWAY_IPV4_FIRST",
+  "LLM_GATEWAY_LOG",
+  "LLM_THINKING_BUDGET_TOKENS",
+  "ASC_DEBUG_MODE",
+  "ASC_DEBUG_RUN_ID",
+  "ASC_DEBUG_DIR",
+  "ASC_LLM_TIMEOUT_SECONDS",
+  "ASC_LLM_MAX_RETRIES",
+];
+
+function buildGatewayEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const k of PROPAGATED_ENV_KEYS) {
+    const v = process.env[k];
+    if (v !== undefined) env[k] = v;
+  }
+  return env;
+}
+
+function resolveGatewayServerPath(): string {
+  // Caminho 1: MOTOR_LLM_GATEWAY_PATH explícito (override pra STS / desenvolvimento)
+  const explicit = process.env["MOTOR_LLM_GATEWAY_PATH"];
+  if (explicit) return explicit;
+
+  // Caminho 2: resolve via npm workspace
+  try {
+    const require = createRequire(import.meta.url);
+    const pkgPath = require.resolve("@ascendimacy/llm-gateway/package.json");
+    return join(dirname(pkgPath), "dist/server.js");
+  } catch {
+    // Caminho 3: relativo ao motor root via env
+    const motorPath = process.env["MOTOR_PATH"];
+    if (motorPath) return join(motorPath, "llm-gateway/dist/server.js");
+  }
+  throw new Error(
+    "gateway-client: cannot resolve llm-gateway path. Set MOTOR_LLM_GATEWAY_PATH or ensure @ascendimacy/llm-gateway is installed.",
+  );
+}
+
+async function getClient(): Promise<Client> {
+  if (_client) return _client;
+  if (_connecting) return _connecting;
+  _connecting = (async () => {
+    const client = new Client({ name: "llm-gateway-client", version: "0.1.0" });
+    const serverPath = resolveGatewayServerPath();
+    await client.connect(
+      new StdioClientTransport({
+        command: process.execPath,
+        args: [serverPath],
+        env: buildGatewayEnv(),
+      }),
+    );
+    _client = client;
+    return client;
+  })();
+  try {
+    return await _connecting;
+  } finally {
+    _connecting = null;
+  }
+}
+
+/**
+ * Chama o gateway. Lazy-spawn no primeiro call; reusa o mesmo processo
+ * gateway pro resto da vida do processo caller.
+ */
+export async function callGateway(
+  req: GatewayChatCompletionInput,
+): Promise<GatewayChatCompletionOutput> {
+  const client = await getClient();
+  const result = await client.callTool({
+    name: "chat_completion",
+    arguments: req as unknown as Record<string, unknown>,
+  });
+  const r = result as { content: Array<{ type: string; text: string }>; isError?: boolean };
+  const text = r.content?.find((c) => c.type === "text")?.text ?? "";
+  if (r.isError) {
+    let parsed: { error?: { message?: string; code?: string } };
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = {};
+    }
+    throw new Error(
+      `gateway error: ${parsed.error?.code ?? "UNKNOWN"} — ${parsed.error?.message ?? text.slice(0, 200)}`,
+    );
+  }
+  return JSON.parse(text) as GatewayChatCompletionOutput;
+}
+
+/** Para fechar o gateway (útil em testes ou shutdown). */
+export async function closeGateway(): Promise<void> {
+  if (_client) {
+    try {
+      await _client.close();
+    } catch {
+      /* swallow — best effort */
+    }
+    _client = null;
+  }
+}
+
+/** Para tests — injeta um Client mock. */
+export function _setClientForTests(client: Client | null): void {
+  _client = client;
+  _connecting = null;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -19,3 +19,4 @@ export * from "./llm-config.js";
 export * from "./llm-router.js";
 export * from "./semantic-signals.js";
 export * from "./transitions-schema.js";
+export * from "./gateway-client.js";


### PR DESCRIPTION
## Summary
- Refactor motor-drota llm-client + signal-extractor pra chamar llm-gateway via MCP (substituindo SDK Anthropic/OpenAI direto)
- Novo `shared/src/gateway-client.ts` — singleton MCP Client com lazy spawn do gateway via stdio
- Mantém API pública `callLlm()` drop-in compatível (motor#19+25 forward de cacheableSystemPrefix preservado)
- Smoke real Infomaniak via gateway: motor-drota → gateway → Infomaniak ✓ 2.5s

## Trade-off arquitetural (decisão pragmática)
Modelo A: cada child do motor spawna seu próprio gateway subprocess via stdio. Bucket coordination NÃO é cross-process. Mitigado em motor#28f (HTTP transport pre-prod). Para STS pilot/Yuji, per-process bucket é suficiente — undici Agent IPv4-first + retry/fallback resolvem o ETIMEDOUT cascading que motivou o gateway.

Modelo B (HTTP transport, processo único realmente compartilhado) fica pra chunk 28f post-pilot.

## Test plan
- [x] `npm run build` — verde nos 7 workspaces
- [x] `npm test` motor-drota — 55/55 verde (rewrite de llm-client.test.ts mockando callGateway)
- [x] Smoke isolado: `node motor-drota/scripts/smoke-via-gateway.mjs` ✓ 2.5s real Infomaniak
- [x] Total motor: 575 tests verde (motor-drota 58→55: -3 tests deletados que viraram concern do gateway, 0 regressões)
- [ ] Mergeio quando review ok
- [ ] Próximo chunk 28c: planejador idem

## Notas
- `motor-drota/package.json` ainda lista `@anthropic-ai/sdk` + `openai` como dependências — usadas pelo llm-gateway (transitivo) mas não mais por motor-drota direto. Limpeza opcional pode entrar no 28c ou 28e
- DROTA_PROVIDER + DROTA_MODEL env override continuam funcionando (router resolve no caller, gateway respeita explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)