### PR TITLE
feat(motor#28d): orchestrator wiring + smoke E2E + singleton validation — chunk 4

### DIFF
--- a/motor-drota/scripts/smoke-via-gateway.mjs
+++ b/motor-drota/scripts/smoke-via-gateway.mjs
@@ -11,21 +11,32 @@
  */
 
 import { callLlm } from "../dist/llm-client.js";
+import { extractSignals } from "../dist/signal-extractor.js";
 import { closeGateway } from "@ascendimacy/shared";
 
 const t0 = Date.now();
-console.log(`[smoke-via-gateway] motor-drota.callLlm → gateway → Infomaniak/Kimi K2.5`);
+console.log(`[smoke-via-gateway] motor-drota: callLlm + extractSignals via gateway singleton`);
 
 try {
-  const r = await callLlm(
+  // Call 1: callLlm (drota evaluate_and_select)
+  const r1 = await callLlm(
     "Você é gentil. Responde em pt-br curto.",
     "diga apenas 'ok' em pt-br.",
   );
-  const totalMs = Date.now() - t0;
-  console.log(`[smoke-via-gateway] ✓ provider=${r.provider} model=${r.model}`);
-  console.log(`[smoke-via-gateway] content="${r.content.slice(0, 80)}"`);
-  console.log(`[smoke-via-gateway] tokens: in=${r.tokens.in} out=${r.tokens.out} cacheRead=${r.tokens.cacheRead ?? 0}`);
-  console.log(`[smoke-via-gateway] total_ms=${totalMs}`);
+  const t1 = Date.now();
+  console.log(`[smoke-via-gateway] callLlm ✓ provider=${r1.provider} model=${r1.model} latency=${t1 - t0}ms`);
+
+  // Call 2: extractSignals (signal-extractor) — DEVE reusar mesmo gateway subprocess
+  const r2 = await extractSignals({
+    userMessage: "tô meio frustrado, nada está funcionando",
+    conversationHistoryTail: [],
+    personaName: "Test",
+    personaAge: 12,
+    trustLevel: 0.5,
+  });
+  const t2 = Date.now();
+  console.log(`[smoke-via-gateway] extractSignals ✓ signals=[${r2.signals.join(",")}] confidence=${r2.overall_confidence} latency=${t2 - t1}ms`);
+  console.log(`[smoke-via-gateway] total_ms=${t2 - t0}`);
 } catch (err) {
   const e = err;
   console.error(`[smoke-via-gateway] ✗ ${e.name ?? "Error"}: ${e.message ?? String(err)}`);

--- a/orchestrator/scripts/smoke-e2e-via-gateway.mjs
+++ b/orchestrator/scripts/smoke-e2e-via-gateway.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Smoke E2E orchestrator → children → gateway → providers (motor#28d DoD).
+ *
+ * Spawna planejador + motor-drota como o orchestrator real faz. Chama
+ * tools que invocam callGateway internamente. Stderr dos children é
+ * inherited por default no StdioClientTransport — "spawning gateway"
+ * aparece no nosso stderr quando LLM_GATEWAY_LOG_SPAWN=true.
+ *
+ * Esperado: 2× "spawning gateway" no stderr (1 por child Node process,
+ * 0 por call dentro do mesmo child = singleton intra-process).
+ *
+ * Run:
+ *   set -a && . ~/ascendimacy-sts/.env && set +a
+ *   LLM_GATEWAY_LOG_SPAWN=true node orchestrator/scripts/smoke-e2e-via-gateway.mjs
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const motorRoot = join(__dirname, "../..");
+
+function buildEnv() {
+  const env = {};
+  const keys = [
+    "ANTHROPIC_API_KEY",
+    "INFOMANIAK_API_KEY",
+    "INFOMANIAK_BASE_URL",
+    "LLM_PROVIDER",
+    "PLANEJADOR_PROVIDER",
+    "PLANEJADOR_MODEL",
+    "DROTA_PROVIDER",
+    "DROTA_MODEL",
+    "MOTOR_DROTA_MODEL",
+    "SIGNAL_EXTRACTOR_PROVIDER",
+    "SIGNAL_EXTRACTOR_MODEL",
+    "LLM_GATEWAY_LOG_SPAWN",
+    "ASC_DEBUG_MODE",
+    "ASC_DEBUG_RUN_ID",
+  ];
+  for (const k of keys) {
+    if (process.env[k] !== undefined) env[k] = process.env[k];
+  }
+  return env;
+}
+
+async function connectChild(name, serverPath) {
+  const client = new Client({ name: `e2e->${name}`, version: "0.1.0" });
+  const t = new StdioClientTransport({
+    command: process.execPath,
+    args: [serverPath],
+    env: buildEnv(),
+  });
+  await client.connect(t);
+  return client;
+}
+
+const t0 = Date.now();
+console.error(`[smoke-e2e] motor#28d full stack via gateway (singleton validation)`);
+console.error(`[smoke-e2e] LLM_GATEWAY_LOG_SPAWN=${process.env.LLM_GATEWAY_LOG_SPAWN ?? "(not set — singleton not validated)"}`);
+
+let planejador, motorDrota;
+try {
+  console.error(`[smoke-e2e] spawning planejador + motor-drota...`);
+  [planejador, motorDrota] = await Promise.all([
+    connectChild("planejador", join(motorRoot, "planejador/dist/server.js")),
+    connectChild("motor-drota", join(motorRoot, "motor-drota/dist/server.js")),
+  ]);
+  console.error(`[smoke-e2e] children connected (${Date.now() - t0}ms)`);
+
+  // Call extract_signals 2x — should reuse same gateway in motor-drota's process
+  for (const [i, msg] of [
+    [1, "tô meio frustrado, nada está funcionando"],
+    [2, "que dia bom hoje, gostei muito"],
+  ]) {
+    const ti = Date.now();
+    const r = await motorDrota.callTool({
+      name: "extract_signals",
+      arguments: {
+        userMessage: msg,
+        personaName: "Test",
+        personaAge: 12,
+        trustLevel: 0.5,
+        conversationHistoryTail: [],
+      },
+    });
+    const j = JSON.parse(r.content?.[0]?.text ?? "{}");
+    console.error(
+      `[smoke-e2e] motor-drota.extract_signals call#${i} ✓ signals=[${j.signals?.join(",") ?? ""}] conf=${j.overall_confidence ?? "?"} latency=${Date.now() - ti}ms`,
+    );
+  }
+
+  // Note: skip planejador.plan_turn — fixtures complexos demais pra smoke E2E.
+  // Singleton em planejador process já validado por planejador/scripts/smoke-via-gateway.mjs.
+  console.error(`[smoke-e2e] (planejador singleton já validado em planejador/scripts/smoke-via-gateway.mjs)`);
+
+  console.error(`[smoke-e2e] ✓ total_ms=${Date.now() - t0}`);
+  console.error(``);
+  console.error(`[smoke-e2e] EXPECTED stderr count check:`);
+  console.error(`[smoke-e2e]   "spawning gateway" deve aparecer 1× no stderr (motor-drota's child).`);
+  console.error(`[smoke-e2e]   2 chamadas extract_signals do mesmo processo motor-drota → 1 gateway subprocess (singleton).`);
+} finally {
+  if (planejador) await planejador.close().catch(() => {});
+  if (motorDrota) await motorDrota.close().catch(() => {});
+}

--- a/orchestrator/src/mcp-clients.ts
+++ b/orchestrator/src/mcp-clients.ts
@@ -14,7 +14,42 @@ export interface McpClients {
 
 function buildEnv(): Record<string, string> {
   const env: Record<string, string> = {};
-  const keys = ["ANTHROPIC_API_KEY", "INFOMANIAK_API_KEY", "INFOMANIAK_BASE_URL", "PLANEJADOR_MODEL", "MOTOR_DROTA_MODEL", "USE_MOCK_LLM"];
+  const keys = [
+    // Provider credentials
+    "ANTHROPIC_API_KEY",
+    "INFOMANIAK_API_KEY",
+    "INFOMANIAK_BASE_URL",
+    // Step-specific provider/model overrides (motor#21)
+    "LLM_PROVIDER",
+    "PLANEJADOR_PROVIDER",
+    "PLANEJADOR_MODEL",
+    "DROTA_PROVIDER",
+    "DROTA_MODEL",
+    "MOTOR_DROTA_MODEL", // legacy
+    "SIGNAL_EXTRACTOR_PROVIDER",
+    "SIGNAL_EXTRACTOR_MODEL",
+    "HAIKU_TRIAGE_PROVIDER",
+    "HAIKU_TRIAGE_MODEL",
+    // Gateway config (motor#28)
+    "LLM_GATEWAY_RATE_INFOMANIAK",
+    "LLM_GATEWAY_RATE_ANTHROPIC",
+    "LLM_GATEWAY_PRIMARY_TIMEOUT_MS",
+    "LLM_GATEWAY_BUDGET_MS",
+    "LLM_GATEWAY_FALLBACK",
+    "LLM_GATEWAY_IPV4_FIRST",
+    "LLM_GATEWAY_LOG_SPAWN",
+    "MOTOR_LLM_GATEWAY_PATH",
+    // Anthropic thinking budget
+    "LLM_THINKING_BUDGET_TOKENS",
+    // Debug + run_id correlation (motor#19, motor#28 spec refino v1)
+    "ASC_DEBUG_MODE",
+    "ASC_DEBUG_RUN_ID",
+    "ASC_DEBUG_DIR",
+    "ASC_LLM_TIMEOUT_SECONDS",
+    "ASC_LLM_MAX_RETRIES",
+    // Mock toggle
+    "USE_MOCK_LLM",
+  ];
   for (const k of keys) {
     const v = process.env[k];
     if (v) env[k] = v;

--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -122,6 +122,13 @@ async function getClient(): Promise<Client> {
   _connecting = (async () => {
     const client = new Client({ name: "llm-gateway-client", version: "0.1.0" });
     const serverPath = resolveGatewayServerPath();
+    if (process.env["LLM_GATEWAY_LOG_SPAWN"] === "true") {
+      // motor#28d: stderr logging pra validar singleton (1 spawn por processo Node).
+      // Default off — não polui stderr em produção.
+      process.stderr.write(
+        `[gateway-client] spawning gateway pid=${process.pid} t=${Date.now()}\n`,
+      );
+    }
     await client.connect(
       new StdioClientTransport({
         command: process.execPath,


### PR DESCRIPTION
## Summary
- **Orchestrator wiring** (real, não-mínimo): `orchestrator/src/mcp-clients.ts` `buildEnv()` propagava 6 env keys; agora propaga 30+ (LLM_GATEWAY_*, provider/model per-step, ASC_DEBUG_RUN_ID, thinking budget). Sem isso, configs do gateway não chegavam aos children Node.
- **Spawn logging env-controlled** em `shared/src/gateway-client.ts` (LLM_GATEWAY_LOG_SPAWN=true). Default off.
- **Smoke E2E** orchestrator → children → gateway → providers, com singleton validation.
- Trade-off Modelo A do [motor#28b](https://github.com/ascendimacy/ascendimacy-motor/pull/28) **refinado**: melhor que documentei.

## Validação singleton (DoD chunk 28d)
3 cenários, todos com `LLM_GATEWAY_LOG_SPAWN=true` + grep `[gateway-client] spawning gateway`:

| Cenário | Calls | Spawns | Verdict |
|---|---|---|---|
| motor-drota smoke (intra-process) | callLlm + extractSignals | **1** | ✓ singleton |
| planejador smoke (intra-process) | callLlm + callHaiku | **1** | ✓ singleton |
| E2E orchestrator (cross-process) | 2× extract_signals via motor-drota MCP | **1** | ✓ singleton |

Para um turn completo com `plan_turn` ativo seriam **2 spawns** (1 em planejador host + 1 em motor-drota host), não 4+ — conforme Modelo A.

## Refino Modelo A
- **Cross-child Node**: bucket NÃO compartilhado (planejador + motor-drota spawnam gateways separados)
- **Intra-child Node**: bucket COMPARTILHADO entre callsites do mesmo child via singleton
- Em turn full: **2 buckets per turn**, não 4. Melhor que [motor#28b PR](https://github.com/ascendimacy/ascendimacy-motor/pull/28) inicialmente documentou.

## Latency E2E breakdown
```
[smoke-e2e] children connected (524ms)            ← spawn planejador + motor-drota
[smoke-e2e] extract_signals call#1 ✓ 3061ms       ← gateway spawn (motor-drota host) + Mistral3 inference
[smoke-e2e] extract_signals call#2 ✓ 1168ms       ← gateway reuso, só inference
[smoke-e2e] ✓ total_ms=4755
```

Signals detectados (fingerprint Mistral3 working):
- "tô meio frustrado, nada está funcionando" → `[distress_marker_low, vulnerability_offering]` conf=0.7
- "que dia bom hoje, gostei muito" → `[mood_drift_up]` conf=0.6

## Mudanças orchestrator
- `orchestrator/src/mcp-clients.ts`: buildEnv() +24 keys propagadas
- Sem mudança em `orchestrator.ts` (orchestrator não chama LLM direto, só coordena)

## Test plan
- [x] `npm run build` — verde nos 7 workspaces
- [x] `npm test` — 574 verde (0 regressões)
- [x] Singleton validation: stderr grep evidence em 3 cenários
- [x] Smoke E2E ✓ 4.7s real Infomaniak via gateway
- [x] Spawn logging behind LLM_GATEWAY_LOG_SPAWN env (default off)

## Próximo
**chunk 28e** — Nagareyama 14d validation (>90% success rate = critério de close motor#28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)