### PR TITLE
feat(motor#28e): infra de medição Nagareyama 14d — chunk 5

### DIFF
--- a/llm-gateway/scripts/aggregate-gateway-logs.mjs
+++ b/llm-gateway/scripts/aggregate-gateway-logs.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * aggregate-gateway-logs CLI — motor#28e validation infra.
+ *
+ * Lê NDJSON gerado pelo llm-gateway e produz markdown report.
+ *
+ * Usage:
+ *   node llm-gateway/scripts/aggregate-gateway-logs.mjs [options]
+ *
+ * Options:
+ *   --dir <path>           Diretório com .ndjson (default: motor/logs/llm-gateway)
+ *   --prefix <str>         Filtra run_ids por prefix (ex: "nagareyama-14d")
+ *   --sla-ms <number>      Threshold E2E SLA proxy em ms (default: 15000)
+ *   --output <path>        Caminho do markdown output (default: stdout)
+ */
+
+import { join, dirname } from "node:path";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { loadEventsFromDir, computeReport, formatReportMarkdown } from "../dist/aggregate.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const motorRoot = join(__dirname, "../..");
+
+function parseArgs(argv) {
+  const args = { dir: join(motorRoot, "logs/llm-gateway"), prefix: undefined, slaMs: 15000, output: undefined };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dir") args.dir = argv[++i];
+    else if (a === "--prefix") args.prefix = argv[++i];
+    else if (a === "--sla-ms") args.slaMs = Number.parseInt(argv[++i] ?? "15000", 10);
+    else if (a === "--output") args.output = argv[++i];
+    else if (a === "--help" || a === "-h") {
+      console.log(`Usage: aggregate-gateway-logs.mjs [--dir <path>] [--prefix <str>] [--sla-ms <n>] [--output <path>]`);
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+console.error(`[aggregate] reading from ${args.dir}${args.prefix ? ` (prefix=${args.prefix})` : ""}`);
+const events = loadEventsFromDir(args.dir, args.prefix);
+console.error(`[aggregate] ${events.length} events loaded`);
+
+const report = computeReport(events, { e2eSlaMs: args.slaMs, runIdPrefix: args.prefix });
+const md = formatReportMarkdown(report);
+
+if (args.output) {
+  writeFileSync(args.output, md);
+  console.error(`[aggregate] report written to ${args.output}`);
+} else {
+  process.stdout.write(md);
+}

--- a/llm-gateway/src/aggregate.ts
+++ b/llm-gateway/src/aggregate.ts
@@ -1,0 +1,287 @@
+/**
+ * aggregate-gateway-logs — métricas de validação Nagareyama 14d (motor#28e).
+ *
+ * Lê N arquivos NDJSON gerados pelo llm-gateway logger e calcula métricas
+ * de success rate. Crítério close motor#28: ≥90% em ambas métricas.
+ *
+ * Métrica B (turn-level success):
+ *   Agrupa events por run_id (= 1 turn STS). Turn é "full" se tem ≥3
+ *   eventos cobrindo planejador + drota + signal-extractor. Turn é
+ *   "success" se NENHUM desses 3 events tem was_fallback=true E
+ *   nenhum tem outcome="error".
+ *
+ * Métrica C (E2E SLA proxy):
+ *   Soma latency_ms dos events do mesmo run_id. Proxy razoável pra SLA
+ *   WhatsApp (LLM é componente dominante; orchestrator + rede WhatsApp
+ *   adicionam <1s). Threshold default: 15000ms (configurável).
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { LlmProvider } from "@ascendimacy/shared";
+
+export interface GatewayLogEntry {
+  ts: string;
+  request_id: string;
+  run_id: string;
+  step: string;
+  provider: LlmProvider;
+  model: string;
+  tokens: { in: number; out: number; reasoning?: number };
+  latency_ms: number;
+  attempt_count: number;
+  outcome: "ok" | "error" | "fallback_used";
+  error_class: string | null;
+  was_fallback: boolean;
+  primary_provider_attempted: LlmProvider | null;
+  bucket_level_at_start?: number;
+  bucket_level_at_end?: number;
+}
+
+export interface TurnAgg {
+  run_id: string;
+  events: GatewayLogEntry[];
+  steps: Set<string>;
+  total_latency_ms: number;
+  any_fallback: boolean;
+  any_error: boolean;
+  is_full: boolean; // tem ≥3 dos 3 steps obrigatórios
+}
+
+const REQUIRED_STEPS_FOR_FULL_TURN = ["planejador", "drota", "signal-extractor"] as const;
+
+export interface AggregateOptions {
+  /** Latency threshold ms pra Métrica C. Default 15000. */
+  e2eSlaMs?: number;
+  /** Filtra apenas run_ids matching prefix (ex: "nagareyama-14d"). */
+  runIdPrefix?: string;
+}
+
+export interface AggregateReport {
+  range: { from: string | null; to: string | null };
+  total_events: number;
+  total_turns_observed: number;
+  total_turns_full: number;
+  metric_b_turn_level: { passed: number; total: number; rate: number };
+  metric_c_e2e_sla: { passed: number; total: number; rate: number; threshold_ms: number };
+  latency: {
+    by_step: Record<string, { p50: number; p95: number; p99: number; n: number }>;
+  };
+  provider_mix: Record<string, number>;
+  fallback_events: { count: number; by_step: Record<string, number> };
+  error_events: { count: number; by_class: Record<string, number> };
+}
+
+function parseNdjsonFile(path: string): GatewayLogEntry[] {
+  const content = readFileSync(path, "utf-8");
+  const out: GatewayLogEntry[] = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      out.push(JSON.parse(line) as GatewayLogEntry);
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}
+
+/**
+ * Lê todos *.ndjson sob `dir` (não recursivo) e retorna events concatenados.
+ * Filtra por runIdPrefix se passado.
+ */
+export function loadEventsFromDir(dir: string, runIdPrefix?: string): GatewayLogEntry[] {
+  if (!statSync(dir).isDirectory()) {
+    throw new Error(`not a directory: ${dir}`);
+  }
+  const out: GatewayLogEntry[] = [];
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".ndjson")) continue;
+    const events = parseNdjsonFile(join(dir, f));
+    for (const e of events) {
+      if (runIdPrefix && !e.run_id.startsWith(runIdPrefix)) continue;
+      out.push(e);
+    }
+  }
+  return out;
+}
+
+export function groupByRunId(events: GatewayLogEntry[]): Map<string, TurnAgg> {
+  const turns = new Map<string, TurnAgg>();
+  for (const e of events) {
+    let t = turns.get(e.run_id);
+    if (!t) {
+      t = {
+        run_id: e.run_id,
+        events: [],
+        steps: new Set(),
+        total_latency_ms: 0,
+        any_fallback: false,
+        any_error: false,
+        is_full: false,
+      };
+      turns.set(e.run_id, t);
+    }
+    t.events.push(e);
+    t.steps.add(e.step);
+    t.total_latency_ms += e.latency_ms;
+    if (e.was_fallback) t.any_fallback = true;
+    if (e.outcome === "error") t.any_error = true;
+  }
+  for (const t of turns.values()) {
+    t.is_full = REQUIRED_STEPS_FOR_FULL_TURN.every((s) => t.steps.has(s));
+  }
+  return turns;
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx]!;
+}
+
+export function computeReport(
+  events: GatewayLogEntry[],
+  opts: AggregateOptions = {},
+): AggregateReport {
+  const e2eSlaMs = opts.e2eSlaMs ?? 15_000;
+
+  const turns = groupByRunId(events);
+  const fullTurns = [...turns.values()].filter((t) => t.is_full);
+
+  // Métrica B
+  const bPassed = fullTurns.filter((t) => !t.any_fallback && !t.any_error).length;
+
+  // Métrica C
+  const cPassed = fullTurns.filter((t) => t.total_latency_ms < e2eSlaMs).length;
+
+  // Latency p50/p95/p99 by step
+  const byStep: Record<string, number[]> = {};
+  for (const e of events) {
+    if (!byStep[e.step]) byStep[e.step] = [];
+    byStep[e.step]!.push(e.latency_ms);
+  }
+  const latencyByStep: Record<string, { p50: number; p95: number; p99: number; n: number }> = {};
+  for (const [step, lats] of Object.entries(byStep)) {
+    latencyByStep[step] = {
+      p50: percentile(lats, 50),
+      p95: percentile(lats, 95),
+      p99: percentile(lats, 99),
+      n: lats.length,
+    };
+  }
+
+  // Provider mix
+  const providerMix: Record<string, number> = {};
+  for (const e of events) {
+    providerMix[e.provider] = (providerMix[e.provider] ?? 0) + 1;
+  }
+
+  // Fallback events
+  let fallbackCount = 0;
+  const fallbackByStep: Record<string, number> = {};
+  for (const e of events) {
+    if (e.was_fallback) {
+      fallbackCount += 1;
+      fallbackByStep[e.step] = (fallbackByStep[e.step] ?? 0) + 1;
+    }
+  }
+
+  // Error events
+  let errorCount = 0;
+  const errorByClass: Record<string, number> = {};
+  for (const e of events) {
+    if (e.outcome === "error") {
+      errorCount += 1;
+      const key = e.error_class ?? "unknown";
+      errorByClass[key] = (errorByClass[key] ?? 0) + 1;
+    }
+  }
+
+  // Range
+  const tss = events.map((e) => e.ts).sort();
+  const from = tss[0] ?? null;
+  const to = tss[tss.length - 1] ?? null;
+
+  return {
+    range: { from, to },
+    total_events: events.length,
+    total_turns_observed: turns.size,
+    total_turns_full: fullTurns.length,
+    metric_b_turn_level: {
+      passed: bPassed,
+      total: fullTurns.length,
+      rate: fullTurns.length > 0 ? bPassed / fullTurns.length : 0,
+    },
+    metric_c_e2e_sla: {
+      passed: cPassed,
+      total: fullTurns.length,
+      rate: fullTurns.length > 0 ? cPassed / fullTurns.length : 0,
+      threshold_ms: e2eSlaMs,
+    },
+    latency: { by_step: latencyByStep },
+    provider_mix: providerMix,
+    fallback_events: { count: fallbackCount, by_step: fallbackByStep },
+    error_events: { count: errorCount, by_class: errorByClass },
+  };
+}
+
+function pct(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+function pass(rate: number, threshold = 0.9): string {
+  return rate >= threshold ? "✓ PASS" : "✗ FAIL";
+}
+
+export function formatReportMarkdown(report: AggregateReport): string {
+  const lines: string[] = [];
+  lines.push(`# llm-gateway aggregate report`);
+  lines.push(``);
+  lines.push(`**Range**: ${report.range.from ?? "n/a"} → ${report.range.to ?? "n/a"}`);
+  lines.push(``);
+  lines.push(`## Volume`);
+  lines.push(`- Total events: ${report.total_events}`);
+  lines.push(`- Turns observed: ${report.total_turns_observed}`);
+  lines.push(`- Turns full (≥3 required steps): ${report.total_turns_full}`);
+  lines.push(``);
+  lines.push(`## Métrica B — turn-level success (≥90% = pass)`);
+  const b = report.metric_b_turn_level;
+  lines.push(`- ${b.passed}/${b.total} turns sem fallback E sem error → **${pct(b.rate)}** ${pass(b.rate)}`);
+  lines.push(``);
+  lines.push(`## Métrica C — E2E SLA proxy (≥90% = pass)`);
+  const c = report.metric_c_e2e_sla;
+  lines.push(`- ${c.passed}/${c.total} turns com latency total < ${c.threshold_ms}ms → **${pct(c.rate)}** ${pass(c.rate)}`);
+  lines.push(``);
+  lines.push(`## Latency p50/p95/p99 por step`);
+  lines.push(`| step | n | p50 (ms) | p95 (ms) | p99 (ms) |`);
+  lines.push(`|---|---|---|---|---|`);
+  for (const [step, l] of Object.entries(report.latency.by_step).sort()) {
+    lines.push(`| ${step} | ${l.n} | ${l.p50} | ${l.p95} | ${l.p99} |`);
+  }
+  lines.push(``);
+  lines.push(`## Provider mix`);
+  for (const [p, n] of Object.entries(report.provider_mix).sort((a, b) => b[1] - a[1])) {
+    const total = report.total_events;
+    lines.push(`- ${p}: ${n} (${pct(n / total)})`);
+  }
+  lines.push(``);
+  lines.push(`## Fallback events`);
+  lines.push(`- Total: ${report.fallback_events.count}`);
+  if (report.fallback_events.count > 0) {
+    for (const [step, n] of Object.entries(report.fallback_events.by_step).sort((a, b) => b[1] - a[1])) {
+      lines.push(`  - ${step}: ${n}`);
+    }
+  }
+  lines.push(``);
+  lines.push(`## Error events`);
+  lines.push(`- Total: ${report.error_events.count}`);
+  if (report.error_events.count > 0) {
+    for (const [klass, n] of Object.entries(report.error_events.by_class).sort((a, b) => b[1] - a[1])) {
+      lines.push(`  - ${klass}: ${n}`);
+    }
+  }
+  lines.push(``);
+  return lines.join("\n");
+}

--- a/llm-gateway/src/index.ts
+++ b/llm-gateway/src/index.ts
@@ -22,3 +22,13 @@ export {
   type GatewayErrorCode,
 } from "./types.js";
 export { createGatewayServer } from "./server.js";
+export {
+  loadEventsFromDir,
+  groupByRunId,
+  computeReport,
+  formatReportMarkdown,
+  type GatewayLogEntry as GatewayLogEntryAggregate,
+  type AggregateReport,
+  type AggregateOptions,
+  type TurnAgg,
+} from "./aggregate.js";

--- a/llm-gateway/tests/aggregate.test.ts
+++ b/llm-gateway/tests/aggregate.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests do aggregate-gateway-logs (motor#28e DoD).
+ *
+ * Fixtures synthetic cobrindo:
+ *   T1 — turn full success (3 steps, no fallback, latency<15s)
+ *   T2 — turn full com fallback em 1 step (B-fail; C-pass se latency<15s)
+ *   T3 — turn full com error em 1 step (B-fail; geralmente C-fail)
+ *   T4 — partial turn (só 2 steps) — NÃO conta como "full", excluído
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeReport, groupByRunId } from "../src/aggregate.js";
+import type { GatewayLogEntry } from "../src/aggregate.js";
+
+const baseEvent: Omit<GatewayLogEntry, "step" | "run_id" | "request_id" | "ts"> = {
+  provider: "infomaniak",
+  model: "moonshotai/Kimi-K2.5",
+  tokens: { in: 100, out: 50 },
+  latency_ms: 2000,
+  attempt_count: 1,
+  outcome: "ok",
+  error_class: null,
+  was_fallback: false,
+  primary_provider_attempted: null,
+};
+
+function ev(over: Partial<GatewayLogEntry>): GatewayLogEntry {
+  return {
+    ts: "2026-04-27T03:00:00.000Z",
+    request_id: `req-${Math.random()}`,
+    run_id: "default-run",
+    step: "drota",
+    ...baseEvent,
+    ...over,
+  };
+}
+
+const fixture: GatewayLogEntry[] = [
+  // T1 — full success (3 steps, no fallback, latency total = 6000ms < 15000)
+  ev({ run_id: "T1", step: "planejador", latency_ms: 2000 }),
+  ev({ run_id: "T1", step: "drota", latency_ms: 2500 }),
+  ev({ run_id: "T1", step: "signal-extractor", latency_ms: 1500 }),
+
+  // T2 — full + fallback em drota (B-fail; C-pass: 2000+3000+1500=6500<15000)
+  ev({ run_id: "T2", step: "planejador", latency_ms: 2000 }),
+  ev({
+    run_id: "T2",
+    step: "drota",
+    latency_ms: 3000,
+    was_fallback: true,
+    primary_provider_attempted: "infomaniak",
+    outcome: "fallback_used",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+  }),
+  ev({ run_id: "T2", step: "signal-extractor", latency_ms: 1500 }),
+
+  // T3 — full com error em planejador (B-fail; C-fail provavelmente)
+  ev({
+    run_id: "T3",
+    step: "planejador",
+    latency_ms: 5000,
+    outcome: "error",
+    error_class: "GatewayError",
+  }),
+  ev({ run_id: "T3", step: "drota", latency_ms: 8000 }),
+  ev({ run_id: "T3", step: "signal-extractor", latency_ms: 4000 }),
+  // total T3 = 17000 > 15000 → C-fail também
+
+  // T4 — partial (só 2 steps) — excluído de "full"
+  ev({ run_id: "T4", step: "planejador", latency_ms: 2000 }),
+  ev({ run_id: "T4", step: "drota", latency_ms: 2000 }),
+];
+
+describe("groupByRunId", () => {
+  it("agrupa events por run_id e identifica is_full corretamente", () => {
+    const turns = groupByRunId(fixture);
+    expect(turns.size).toBe(4);
+    expect(turns.get("T1")!.is_full).toBe(true);
+    expect(turns.get("T2")!.is_full).toBe(true);
+    expect(turns.get("T3")!.is_full).toBe(true);
+    expect(turns.get("T4")!.is_full).toBe(false); // 2 steps apenas
+  });
+
+  it("calcula total_latency_ms e flags any_*", () => {
+    const turns = groupByRunId(fixture);
+    expect(turns.get("T1")!.total_latency_ms).toBe(6000);
+    expect(turns.get("T1")!.any_fallback).toBe(false);
+    expect(turns.get("T1")!.any_error).toBe(false);
+
+    expect(turns.get("T2")!.any_fallback).toBe(true);
+    expect(turns.get("T2")!.any_error).toBe(false);
+
+    expect(turns.get("T3")!.total_latency_ms).toBe(17000);
+    expect(turns.get("T3")!.any_error).toBe(true);
+  });
+});
+
+describe("computeReport — Métrica B (turn-level)", () => {
+  it("conta apenas turns FULL, success = sem fallback E sem error", () => {
+    const r = computeReport(fixture);
+    expect(r.total_turns_observed).toBe(4);
+    expect(r.total_turns_full).toBe(3); // T1+T2+T3
+    expect(r.metric_b_turn_level.passed).toBe(1); // só T1
+    expect(r.metric_b_turn_level.total).toBe(3);
+    expect(r.metric_b_turn_level.rate).toBeCloseTo(1 / 3, 3);
+  });
+});
+
+describe("computeReport — Métrica C (E2E SLA proxy)", () => {
+  it("threshold default 15s: T1+T2 pass (6s+6.5s), T3 fail (17s)", () => {
+    const r = computeReport(fixture);
+    expect(r.metric_c_e2e_sla.threshold_ms).toBe(15_000);
+    expect(r.metric_c_e2e_sla.passed).toBe(2); // T1+T2
+    expect(r.metric_c_e2e_sla.total).toBe(3);
+    expect(r.metric_c_e2e_sla.rate).toBeCloseTo(2 / 3, 3);
+  });
+
+  it("threshold customizado 5000ms: nenhum passa", () => {
+    const r = computeReport(fixture, { e2eSlaMs: 5000 });
+    expect(r.metric_c_e2e_sla.passed).toBe(0);
+    expect(r.metric_c_e2e_sla.threshold_ms).toBe(5000);
+  });
+});
+
+describe("computeReport — fallback + error breakdown", () => {
+  it("counta fallbacks corretamente", () => {
+    const r = computeReport(fixture);
+    expect(r.fallback_events.count).toBe(1);
+    expect(r.fallback_events.by_step).toEqual({ drota: 1 });
+  });
+
+  it("counta errors por class", () => {
+    const r = computeReport(fixture);
+    expect(r.error_events.count).toBe(1);
+    expect(r.error_events.by_class).toEqual({ GatewayError: 1 });
+  });
+});
+
+describe("computeReport — provider mix + latency", () => {
+  it("provider mix conta events corretamente", () => {
+    const r = computeReport(fixture);
+    // 11 events total; 1 anthropic (T2 drota fallback), resto infomaniak
+    expect(r.provider_mix.infomaniak).toBe(10);
+    expect(r.provider_mix.anthropic).toBe(1);
+  });
+
+  it("latency p50 por step", () => {
+    const r = computeReport(fixture);
+    // planejador: T1=2000, T2=2000, T3=5000, T4=2000 → sorted [2000,2000,2000,5000]; p50 idx=2 → 2000
+    expect(r.latency.by_step.planejador!.n).toBe(4); // T1+T2+T3+T4 todos têm planejador
+    expect(r.latency.by_step.planejador!.p50).toBe(2000);
+    // drota: T1=2500, T2=3000, T3=8000, T4=2000 → sorted [2000,2500,3000,8000]; p50 idx=2 → 3000
+    expect(r.latency.by_step.drota!.n).toBe(4); // T1+T2+T3+T4 todos têm drota
+    expect(r.latency.by_step.drota!.p50).toBe(3000);
+  });
+});
+
+describe("computeReport — empty input edge case", () => {
+  it("rates = 0 quando sem turns", () => {
+    const r = computeReport([]);
+    expect(r.total_turns_observed).toBe(0);
+    expect(r.metric_b_turn_level.rate).toBe(0);
+    expect(r.metric_c_e2e_sla.rate).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **Infra de medição** pra critério close motor#28: agregador de NDJSON do gateway calculando 2 métricas de success rate
- **Não é a validação 14d em si** — esse é gate MANUAL após este merge
- Critério close motor#28: ambas métricas ≥90% após ≥14d de uso real

## Status wiring eBrota → motor
**NOT integrated** (reportado pré-execução). eBrota tem stack LLM própria em `src/ai.js` (openai + anthropic SDKs direto, circuit breaker próprio, modelos Qwen3-235B + Sonnet 4.6). Não consome `@ascendimacy/llm-gateway` nem qualquer pacote do `ascendimacy-motor`.

**Reinterpretação aceita**: "Nagareyama 14d validation" = scenario STS [`nagareyama-14d-v1`](https://github.com/ascendimacy/ascendimacy-sts/blob/main/scenarios/nagareyama-14d-v1.yaml) (criado em sts#18), que SIM exercita o motor full stack via gateway. Wiring eBrota fica pra motor#29+ ou v2 pós-piloto.

## Schema NDJSON
```ts
{
  ts: string;                                  // ISO timestamp
  request_id: string;                          // UUID per call
  run_id: string;                              // ASC_DEBUG_RUN_ID ou UUID
  step: "drota" | "planejador" | "signal-extractor" | ...;
  provider: "anthropic" | "infomaniak";
  model: string;
  tokens: { in, out, reasoning };
  latency_ms, attempt_count;
  outcome: "ok" | "error" | "fallback_used";
  error_class: string | null;
  was_fallback: boolean;
  primary_provider_attempted: LlmProvider | null;
  bucket_level_at_start, bucket_level_at_end;
}
```

## Métricas calculadas
**B — turn-level success** (≥90% pass): % de turns FULL sem fallback E sem error. Turn é "full" se cobre 3 steps obrigatórios (planejador + drota + signal-extractor).

**C — E2E SLA proxy** (≥90% pass): % de turns com `sum(latency_ms)` < 15000ms. Proxy razoável pra SLA WhatsApp (LLM domina; orchestrator + rede WhatsApp <1s extra).

## Sample report (gerado de smoke E2E real)
```
# llm-gateway aggregate report

**Range**: 2026-04-27T03:37:06.985Z → 2026-04-27T03:37:21.901Z

## Volume
- Total events: 6
- Turns observed: 3
- Turns full (≥3 required steps): 0

## Métrica B — turn-level success (≥90% = pass)
- 0/0 turns sem fallback E sem error → **0.0%** ✗ FAIL

## Métrica C — E2E SLA proxy (≥90% = pass)
- 0/0 turns com latency total < 15000ms → **0.0%** ✗ FAIL

## Latency p50/p95/p99 por step
| step | n | p50 (ms) | p95 (ms) | p99 (ms) |
|---|---|---|---|---|
| signal-extractor | 6 | 2142 | 2273 | 2273 |

## Provider mix
- infomaniak: 6 (100.0%)

## Fallback events
- Total: 0

## Error events
- Total: 0
```

(0/0 full turns é correto: smoke E2E [motor#28d] só exercita extract_signals — 1 step, não 3. Scenario STS Nagareyama vai produzir full turns reais.)

## Test plan
- [x] `npm run build` — verde nos 7 workspaces
- [x] llm-gateway: 28 → **38 verde** (+10 aggregate tests)
- [x] Total motor: 574 → **584 verde** (+10, zero regressões)
- [x] Smoke do aggregate em NDJSON real produz markdown plausível

## Validation Gate (MANUAL, pós-merge)
Close motor#28 (épico) **só acontece** quando:
1. STS scenario `nagareyama-14d-v1` rodou ≥14d de uso real (ou agregação de execuções equivalentes)
2. `aggregate-gateway-logs --prefix nagareyama-14d` mostra:
   - **Métrica B** (turn-level): ≥90%
   - **Métrica C** (E2E SLA): ≥90%
3. Decision-trail 007 documentando os números finais

Esse gate **NÃO está nas DoDs deste PR** — apenas a infra que torna a medição possível.

🤖 Generated with [Claude Code](https://claude.com/claude-code)