### PR TITLE
fix(motor#28f): aggregate requiredSteps configurável (STS = 2-step pipeline)

### DIFF
--- a/llm-gateway/scripts/aggregate-gateway-logs.mjs
+++ b/llm-gateway/scripts/aggregate-gateway-logs.mjs
@@ -8,10 +8,13 @@
  *   node llm-gateway/scripts/aggregate-gateway-logs.mjs [options]
  *
  * Options:
- *   --dir <path>           Diretório com .ndjson (default: motor/logs/llm-gateway)
- *   --prefix <str>         Filtra run_ids por prefix (ex: "nagareyama-14d")
- *   --sla-ms <number>      Threshold E2E SLA proxy em ms (default: 15000)
- *   --output <path>        Caminho do markdown output (default: stdout)
+ *   --dir <path>             Diretório com .ndjson (default: motor/logs/llm-gateway)
+ *   --prefix <str>           Filtra run_ids por prefix (ex: "nagareyama-14d")
+ *   --sla-ms <number>        Threshold E2E SLA proxy em ms (default: 15000)
+ *   --required-steps <list>  Steps comma-separated obrigatórios pra "full turn"
+ *                            (default: planejador,drota,signal-extractor — motor full pipeline)
+ *                            STS context: planejador,drota
+ *   --output <path>          Caminho do markdown output (default: stdout)
  */
 
 import { join, dirname } from "node:path";
@@ -23,15 +26,26 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const motorRoot = join(__dirname, "../..");
 
 function parseArgs(argv) {
-  const args = { dir: join(motorRoot, "logs/llm-gateway"), prefix: undefined, slaMs: 15000, output: undefined };
+  const args = {
+    dir: join(motorRoot, "logs/llm-gateway"),
+    prefix: undefined,
+    slaMs: 15000,
+    requiredSteps: undefined, // undefined = use default in computeReport
+    output: undefined,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--dir") args.dir = argv[++i];
     else if (a === "--prefix") args.prefix = argv[++i];
     else if (a === "--sla-ms") args.slaMs = Number.parseInt(argv[++i] ?? "15000", 10);
-    else if (a === "--output") args.output = argv[++i];
+    else if (a === "--required-steps") {
+      const v = argv[++i] ?? "";
+      args.requiredSteps = v.split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (a === "--output") args.output = argv[++i];
     else if (a === "--help" || a === "-h") {
-      console.log(`Usage: aggregate-gateway-logs.mjs [--dir <path>] [--prefix <str>] [--sla-ms <n>] [--output <path>]`);
+      console.log(
+        `Usage: aggregate-gateway-logs.mjs [--dir <path>] [--prefix <str>] [--sla-ms <n>] [--required-steps <list>] [--output <path>]`,
+      );
       process.exit(0);
     }
   }
@@ -44,7 +58,9 @@ console.error(`[aggregate] reading from ${args.dir}${args.prefix ? ` (prefix=${a
 const events = loadEventsFromDir(args.dir, args.prefix);
 console.error(`[aggregate] ${events.length} events loaded`);
 
-const report = computeReport(events, { e2eSlaMs: args.slaMs, runIdPrefix: args.prefix });
+const reportOpts = { e2eSlaMs: args.slaMs, runIdPrefix: args.prefix };
+if (args.requiredSteps) reportOpts.requiredSteps = args.requiredSteps;
+const report = computeReport(events, reportOpts);
 const md = formatReportMarkdown(report);
 
 if (args.output) {

--- a/llm-gateway/src/aggregate.ts
+++ b/llm-gateway/src/aggregate.ts
@@ -48,17 +48,30 @@ export interface TurnAgg {
   is_full: boolean; // tem ≥3 dos 3 steps obrigatórios
 }
 
-const REQUIRED_STEPS_FOR_FULL_TURN = ["planejador", "drota", "signal-extractor"] as const;
+/**
+ * Default = pipeline completo do motor's próprio orchestrator (motor#25).
+ * STS orchestrator pula signal-extractor → use ["planejador", "drota"] via
+ * AggregateOptions.requiredSteps quando rodando contra NDJSON do STS.
+ */
+const REQUIRED_STEPS_FOR_FULL_TURN_DEFAULT = ["planejador", "drota", "signal-extractor"] as const;
 
 export interface AggregateOptions {
   /** Latency threshold ms pra Métrica C. Default 15000. */
   e2eSlaMs?: number;
   /** Filtra apenas run_ids matching prefix (ex: "nagareyama-14d"). */
   runIdPrefix?: string;
+  /**
+   * Steps obrigatórios pra um turn ser "full" (motor#28f).
+   * Default = motor's own orchestrator pipeline (3 steps).
+   * STS context: passar ["planejador", "drota"] (sem signal-extractor).
+   */
+  requiredSteps?: string[];
 }
 
 export interface AggregateReport {
   range: { from: string | null; to: string | null };
+  /** Steps obrigatórios pra "full turn" (motor#28f). */
+  required_steps: string[];
   total_events: number;
   total_turns_observed: number;
   total_turns_full: number;
@@ -106,7 +119,10 @@ export function loadEventsFromDir(dir: string, runIdPrefix?: string): GatewayLog
   return out;
 }
 
-export function groupByRunId(events: GatewayLogEntry[]): Map<string, TurnAgg> {
+export function groupByRunId(
+  events: GatewayLogEntry[],
+  requiredSteps: readonly string[] = REQUIRED_STEPS_FOR_FULL_TURN_DEFAULT,
+): Map<string, TurnAgg> {
   const turns = new Map<string, TurnAgg>();
   for (const e of events) {
     let t = turns.get(e.run_id);
@@ -129,7 +145,7 @@ export function groupByRunId(events: GatewayLogEntry[]): Map<string, TurnAgg> {
     if (e.outcome === "error") t.any_error = true;
   }
   for (const t of turns.values()) {
-    t.is_full = REQUIRED_STEPS_FOR_FULL_TURN.every((s) => t.steps.has(s));
+    t.is_full = requiredSteps.every((s) => t.steps.has(s));
   }
   return turns;
 }
@@ -146,8 +162,9 @@ export function computeReport(
   opts: AggregateOptions = {},
 ): AggregateReport {
   const e2eSlaMs = opts.e2eSlaMs ?? 15_000;
+  const requiredSteps = opts.requiredSteps ?? [...REQUIRED_STEPS_FOR_FULL_TURN_DEFAULT];
 
-  const turns = groupByRunId(events);
+  const turns = groupByRunId(events, requiredSteps);
   const fullTurns = [...turns.values()].filter((t) => t.is_full);
 
   // Métrica B
@@ -206,6 +223,7 @@ export function computeReport(
 
   return {
     range: { from, to },
+    required_steps: [...requiredSteps],
     total_events: events.length,
     total_turns_observed: turns.size,
     total_turns_full: fullTurns.length,
@@ -240,11 +258,12 @@ export function formatReportMarkdown(report: AggregateReport): string {
   lines.push(`# llm-gateway aggregate report`);
   lines.push(``);
   lines.push(`**Range**: ${report.range.from ?? "n/a"} → ${report.range.to ?? "n/a"}`);
+  lines.push(`**Required steps for full turn**: ${report.required_steps.join(", ")}`);
   lines.push(``);
   lines.push(`## Volume`);
   lines.push(`- Total events: ${report.total_events}`);
   lines.push(`- Turns observed: ${report.total_turns_observed}`);
-  lines.push(`- Turns full (≥3 required steps): ${report.total_turns_full}`);
+  lines.push(`- Turns full (≥${report.required_steps.length} required steps): ${report.total_turns_full}`);
   lines.push(``);
   lines.push(`## Métrica B — turn-level success (≥90% = pass)`);
   const b = report.metric_b_turn_level;

--- a/llm-gateway/tests/aggregate.test.ts
+++ b/llm-gateway/tests/aggregate.test.ts
@@ -164,3 +164,51 @@ describe("computeReport — empty input edge case", () => {
     expect(r.metric_c_e2e_sla.rate).toBe(0);
   });
 });
+
+describe("computeReport — requiredSteps configurável (motor#28f)", () => {
+  // Fixture STS-style: turns têm planejador + drota apenas (sem signal-extractor)
+  const stsFixture: GatewayLogEntry[] = [
+    // S1 — sucesso pleno (2 steps STS, sem fallback, latency 35s)
+    ev({ run_id: "S1", step: "planejador", latency_ms: 15000 }),
+    ev({ run_id: "S1", step: "drota", latency_ms: 20000 }),
+    // S2 — sucesso pleno (2 steps STS, sem fallback, latency 12s — passa SLA)
+    ev({ run_id: "S2", step: "planejador", latency_ms: 5000 }),
+    ev({ run_id: "S2", step: "drota", latency_ms: 7000 }),
+  ];
+
+  it("STS context: requiredSteps=['planejador','drota'] → 2 turns FULL", () => {
+    const r = computeReport(stsFixture, { requiredSteps: ["planejador", "drota"] });
+    expect(r.required_steps).toEqual(["planejador", "drota"]);
+    expect(r.total_turns_full).toBe(2); // S1 + S2 full
+    expect(r.metric_b_turn_level.passed).toBe(2);
+    expect(r.metric_b_turn_level.rate).toBe(1.0);
+  });
+
+  it("STS context: Métrica C respeita threshold (S1 35s > 15s fail; S2 12s pass)", () => {
+    const r = computeReport(stsFixture, { requiredSteps: ["planejador", "drota"] });
+    expect(r.metric_c_e2e_sla.passed).toBe(1); // só S2
+    expect(r.metric_c_e2e_sla.rate).toBe(0.5);
+  });
+
+  it("default (sem opt) preserva comportamento — turn 2-step não conta como FULL", () => {
+    // Regression check: motor's own pipeline expects 3 steps
+    const r = computeReport(stsFixture);
+    expect(r.required_steps).toEqual([
+      "planejador",
+      "drota",
+      "signal-extractor",
+    ]);
+    expect(r.total_turns_full).toBe(0); // nenhum turn tem signal-extractor
+    expect(r.metric_b_turn_level.total).toBe(0);
+  });
+
+  it("requiredSteps customizado funciona com lista qualquer", () => {
+    const events: GatewayLogEntry[] = [
+      ev({ run_id: "X", step: "haiku-triage", latency_ms: 500 }),
+      ev({ run_id: "X", step: "drota", latency_ms: 2000 }),
+    ];
+    const r = computeReport(events, { requiredSteps: ["haiku-triage", "drota"] });
+    expect(r.total_turns_full).toBe(1);
+    expect(r.metric_b_turn_level.rate).toBe(1.0);
+  });
+});


### PR DESCRIPTION
## Summary
- Dry-run do scenario `nagareyama-14d-v1` (sts#18) revelou que STS pipeline = **planejador + drota** (2 steps), não os 3 do motor's próprio orchestrator (que inclui signal-extractor via motor#25).
- Aggregate hardcoded em 3 steps reportava `0/0 full turns` contra NDJSON do STS — ambas métricas FAIL com denominador zero.
- Fix: `requiredSteps` configurável em `AggregateOptions`, default preserva comportamento.

## Compat
Default sem opt = comportamento anterior (3 steps motor full pipeline). Regression test confirma.

## Sample run contra NDJSON dry-run STS
```
$ aggregate-gateway-logs --dir /home/alexa/ascendimacy-sts/logs/llm-gateway \
                         --prefix nagareyama-14d-dryrun-1 \
                         --required-steps planejador,drota

Range: 2026-04-27T04:08:35.894Z → 2026-04-27T04:09:00.278Z
Required steps for full turn: planejador, drota

Volume:
- Total events: 2
- Turns observed: 1
- Turns full (≥2 required steps): 1

Métrica B: 1/1 → 100.0% ✓ PASS
Métrica C: 0/1 → 0.0% ✗ FAIL  (latency 38966ms > 15000ms threshold)

Latency:
- planejador  n=1  p50=15017ms
- drota       n=1  p50=23949ms

Provider mix: infomaniak 100%
Fallbacks: 0
Errors: 0
```

## Observação sobre latency real (não bug)
Latency total 38.9s no single-turn dry-run reflete custo de Kimi K2.5 reasoning sem prompt cache warm-up. Em 14d real:
- Anthropic prompt cache (motor#25 via cache_control) amortiza prefix STABLE_DROTA_PREFIX
- Infomaniak auto-cache via prompt_tokens_details.cached_tokens igual
- TTL 5min sliding mantém cache warm em uso contínuo

C=FAIL no single-turn dry-run **não é diagnóstico definitivo** do 14d real. Validação 14d vai mostrar se cache write→read amortiza pra <15s.

## Test plan
- [x] `npm run build` — verde nos 7 workspaces
- [x] `npm test` motor full: **584 → 588 verde** (+4 novos, 0 regressões)
- [x] 4 novos tests:
  - STS context: turns 2-step contam como FULL com `requiredSteps=["planejador","drota"]`
  - Métrica C respeita threshold real (50% pass quando 1 turn passa, 1 não)
  - Regression default: turn 2-step NÃO conta como FULL sem opt
  - Custom list arbitrária funciona
- [x] CLI `--required-steps planejador,drota` funcional contra NDJSON real

## Pré-requisito pra rodar 14d Nagareyama
Este PR + skeleton ops/docs/governance/motor28-close-gate-2026-04-27.md (ou similar) atualizado pra usar `--required-steps planejador,drota` no comando de validação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)