### PR TITLE
feat(shared): F1-mood PART A — types + window + repo (motor#35)

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,6 +6,8 @@ export * from "./scorer.js";
 export * from "./tree-node.js";
 export * from "./status-matrix.js";
 export * from "./status-matrix-repo-memory.js";
+export * from "./mood.js";
+export * from "./mood-repo-memory.js";
 export * from "./mixins/with-gardner-program.js";
 export * from "./parental-profile.js";
 export * from "./parental-authorization.js";

--- a/shared/src/mood-repo-memory.ts
+++ b/shared/src/mood-repo-memory.ts
@@ -1,0 +1,42 @@
+/**
+ * In-memory adapter pro `MoodRepo` (port em mood.ts).
+ *
+ * Uso: tests + STS smoke runs. Postgres concrete adapter fica pra
+ * F1-bootstrap-db (ascendimacy-motor#40).
+ *
+ * Não é thread-safe — assume single-process. Array linear; load
+ * filtra+sorta sob demanda. Aceitável pra volumes de teste/sim.
+ */
+
+import type { MoodReadingRow, MoodRepo } from "./mood.js";
+
+/**
+ * Cria adapter in-memory opcionalmente seedado com leituras iniciais.
+ *
+ * Cada chamada cria store independente — útil em tests pra isolamento.
+ */
+export function inMemoryMoodRepo(
+  seed: MoodReadingRow[] = [],
+): MoodRepo {
+  const store: MoodReadingRow[] = [...seed];
+
+  return {
+    async loadHistory(userId, options = {}) {
+      let rows = store.filter((r) => r.userId === userId);
+      if (options.since) {
+        const sinceMs = new Date(options.since).getTime();
+        rows = rows.filter((r) => new Date(r.at).getTime() >= sinceMs);
+      }
+      rows.sort(
+        (a, b) => new Date(b.at).getTime() - new Date(a.at).getTime(),
+      );
+      if (options.limit !== undefined) {
+        rows = rows.slice(0, options.limit);
+      }
+      return rows;
+    },
+    async append(reading) {
+      store.push(reading);
+    },
+  };
+}

--- a/shared/src/mood.ts
+++ b/shared/src/mood.ts
@@ -1,0 +1,177 @@
+/**
+ * Mood — estado emocional absoluto da criança por turn/sessão.
+ *
+ * Escala (DT-MOOD-01, Jun 2026-04-27): integer 1-10. LLM-friendly
+ * ("humor 5/10" lê bem em prompt). Comfort gate dispara em mood ≤ 3.
+ *
+ * Persistência: tabela `conversations.mood INT` via `MoodRepo` port
+ * (concrete postgres adapter fica pra F1-bootstrap-db, ascendimacy-motor#40).
+ *
+ * Integration:
+ *   - Producer (LLM extractor + fallback rule-based): motor-drota/src/mood-extractor.ts
+ *     (DT-MOOD-02 = LLM v0 + fallback) — pendente de PR PART B.
+ *   - Comfort gate (DT-MOOD-03): mood ≤ 3 ativa "mode aquecimento" (POC SessionMode);
+ *     congela helix advance (alinhado com CLAUDE_6 §5.3 buffer day).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-27-statevector-primitives-inventory-f1.md §2
+ * Sub-issue: ascendimacy-motor#35
+ */
+
+/** Escala canônica: integer 1 (péssimo) → 10 (excelente). */
+export const MOOD_MIN = 1;
+export const MOOD_MAX = 10;
+/** Default neutral usado quando producer não rodou ainda (turn 1) ou falhou. */
+export const MOOD_DEFAULT = 5;
+/** Threshold do comfort gate. Mood ≤ COMFORT_GATE → mode aquecimento. */
+export const COMFORT_GATE = 3;
+
+/** Score de mood — integer 1-10. Type-aliased pra clareza em assinaturas. */
+export type MoodScore = number;
+
+/** Origem da leitura — útil pra trace/audit. */
+export type MoodSource = "llm" | "rule_based" | "manual";
+
+/** Uma leitura de mood — par (score, timestamp) + origem. */
+export interface MoodReading {
+  score: MoodScore;
+  /** ISO 8601 UTC. */
+  at: string;
+  source: MoodSource;
+}
+
+/**
+ * Janela móvel de mood — agregações pra usar em prompt context e
+ * comfort gate. Ambos podem ser null se sem leituras na janela.
+ */
+export interface MoodWindow {
+  /** Média das últimas 3 leituras (turns mais recentes). */
+  recent3turns: number | null;
+  /** Média das leituras dentro de 7 dias do `now` injetado. */
+  recent7days: number | null;
+  /** Leitura mais recente (latest), ou null se histórico vazio. */
+  latest: MoodReading | null;
+  /** Quantas leituras caíram na janela 7d (debug/trace). */
+  countIn7Days: number;
+}
+
+/**
+ * Type guard pra MoodScore. Aceita só integer no range [1,10].
+ * Decimais e fora-do-range retornam false (defensivo contra LLM
+ * que ocasionalmente devolve 7.5 ou 11).
+ */
+export function isMoodScore(v: unknown): v is MoodScore {
+  return (
+    typeof v === "number" &&
+    Number.isInteger(v) &&
+    v >= MOOD_MIN &&
+    v <= MOOD_MAX
+  );
+}
+
+/**
+ * Clampa um número arbitrário pro range [MOOD_MIN, MOOD_MAX].
+ * Decimais são arredondados pro inteiro mais próximo. Útil quando
+ * LLM devolve algo fora do schema esperado e queremos coerção
+ * resiliente em vez de falha hard.
+ */
+export function clampMoodScore(v: number): MoodScore {
+  if (!Number.isFinite(v)) return MOOD_DEFAULT;
+  const rounded = Math.round(v);
+  if (rounded < MOOD_MIN) return MOOD_MIN;
+  if (rounded > MOOD_MAX) return MOOD_MAX;
+  return rounded;
+}
+
+/** True se mood ativa o comfort gate (≤ COMFORT_GATE). */
+export function triggersComfortGate(mood: MoodScore): boolean {
+  return mood <= COMFORT_GATE;
+}
+
+/**
+ * Computa MoodWindow a partir de histórico de leituras.
+ *
+ * - `recent3turns`: média das 3 leituras mais recentes (por timestamp desc).
+ *   Se < 3 leituras existem, média do que tem. Null se vazio.
+ * - `recent7days`: média de todas leituras com `at >= now - 7 days`.
+ *   Null se nenhuma leitura cair na janela.
+ * - `latest`: leitura mais recente.
+ * - `countIn7Days`: count das leituras na janela 7d.
+ *
+ * `now` injetado pra determinismo em tests.
+ */
+export function computeMoodWindow(
+  history: MoodReading[],
+  now: string,
+): MoodWindow {
+  if (history.length === 0) {
+    return {
+      recent3turns: null,
+      recent7days: null,
+      latest: null,
+      countIn7Days: 0,
+    };
+  }
+
+  const sorted = [...history].sort(
+    (a, b) => new Date(b.at).getTime() - new Date(a.at).getTime(),
+  );
+
+  const last3 = sorted.slice(0, 3);
+  const recent3turns = average(last3.map((r) => r.score));
+
+  const sevenDaysAgoMs =
+    new Date(now).getTime() - 7 * 24 * 60 * 60 * 1000;
+  const within7days = sorted.filter(
+    (r) => new Date(r.at).getTime() >= sevenDaysAgoMs,
+  );
+  const recent7days =
+    within7days.length > 0
+      ? average(within7days.map((r) => r.score))
+      : null;
+
+  return {
+    recent3turns,
+    recent7days,
+    latest: sorted[0]!,
+    countIn7Days: within7days.length,
+  };
+}
+
+function average(scores: number[]): number | null {
+  if (scores.length === 0) return null;
+  const sum = scores.reduce((a, b) => a + b, 0);
+  return sum / scores.length;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Persistência — port (interface) + helpers
+//
+// Concrete adapter postgres em F1-bootstrap-db (ascendimacy-motor#40).
+// In-memory adapter pra tests/STS em mood-repo-memory.ts.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Linha persistida da tabela `conversations` filtrada pras colunas de mood. */
+export interface MoodReadingRow extends MoodReading {
+  userId: string;
+  /** Opcional — id da conversation/turn pra cross-reference no trace. */
+  conversationId?: string;
+}
+
+/**
+ * Port de persistência. Implementações concretas:
+ *   - InMemory (testes + STS): mood-repo-memory.ts
+ *   - Postgres (produção): F1-bootstrap-db
+ */
+export interface MoodRepo {
+  /**
+   * Carrega histórico ordenado por `at` desc.
+   * - `limit`: pega só as N mais recentes.
+   * - `since`: filtra leituras com `at >= since`.
+   */
+  loadHistory(
+    userId: string,
+    options?: { limit?: number; since?: string },
+  ): Promise<MoodReadingRow[]>;
+  /** Append nova leitura. */
+  append(reading: MoodReadingRow): Promise<void>;
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,5 +1,6 @@
 import type { StatusMatrix } from "./status-matrix.js";
 import type { GardnerProgramState } from "./mixins/with-gardner-program.js";
+import type { MoodScore, MoodWindow } from "./mood.js";
 
 export interface PersonaDef {
   id: string;
@@ -35,6 +36,20 @@ export interface SessionState {
   statusMatrix?: StatusMatrix;
   /** Estado do programa Gardner 5 semanas (Bloco 2b). */
   gardnerProgram?: GardnerProgramState;
+
+  // ─── F1 mood (motor#35) ──────────────────────────────────────────────
+
+  /**
+   * Mood absoluto da criança neste turn (1-10 integer). Producer:
+   * mood-extractor (LLM v0 + fallback rule-based, PR PART B).
+   * Default MOOD_DEFAULT (5) quando producer não rodou.
+   */
+  currentMood?: MoodScore;
+  /**
+   * Janela móvel pra comfort gate + prompt context. Computada via
+   * `computeMoodWindow(history, now)` no início do turn.
+   */
+  moodWindow?: MoodWindow;
 
   // ─── Bloco 6 — Dinâmicas em grupo (dyad) ─────────────────────────────
 

--- a/shared/tests/mood.test.ts
+++ b/shared/tests/mood.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  MOOD_MIN,
+  MOOD_MAX,
+  MOOD_DEFAULT,
+  COMFORT_GATE,
+  isMoodScore,
+  clampMoodScore,
+  triggersComfortGate,
+  computeMoodWindow,
+} from "../src/mood.js";
+import type { MoodReading, MoodReadingRow } from "../src/mood.js";
+import { inMemoryMoodRepo } from "../src/mood-repo-memory.js";
+
+describe("MoodScore guards + clamping", () => {
+  it("isMoodScore aceita integers 1-10", () => {
+    expect(isMoodScore(1)).toBe(true);
+    expect(isMoodScore(5)).toBe(true);
+    expect(isMoodScore(10)).toBe(true);
+  });
+
+  it("isMoodScore rejeita 0, 11, decimais, não-números", () => {
+    expect(isMoodScore(0)).toBe(false);
+    expect(isMoodScore(11)).toBe(false);
+    expect(isMoodScore(7.5)).toBe(false);
+    expect(isMoodScore("5")).toBe(false);
+    expect(isMoodScore(null)).toBe(false);
+    expect(isMoodScore(undefined)).toBe(false);
+    expect(isMoodScore(NaN)).toBe(false);
+  });
+
+  it("clampMoodScore arredonda + clampa pro range", () => {
+    expect(clampMoodScore(0)).toBe(MOOD_MIN);
+    expect(clampMoodScore(11)).toBe(MOOD_MAX);
+    expect(clampMoodScore(7.5)).toBe(8);
+    expect(clampMoodScore(7.4)).toBe(7);
+    expect(clampMoodScore(-3)).toBe(MOOD_MIN);
+    expect(clampMoodScore(100)).toBe(MOOD_MAX);
+  });
+
+  it("clampMoodScore retorna MOOD_DEFAULT pra valores inválidos", () => {
+    expect(clampMoodScore(NaN)).toBe(MOOD_DEFAULT);
+    expect(clampMoodScore(Infinity)).toBe(MOOD_DEFAULT);
+    expect(clampMoodScore(-Infinity)).toBe(MOOD_DEFAULT);
+  });
+});
+
+describe("triggersComfortGate", () => {
+  it("ativa em mood ≤ COMFORT_GATE (3)", () => {
+    expect(triggersComfortGate(1)).toBe(true);
+    expect(triggersComfortGate(2)).toBe(true);
+    expect(triggersComfortGate(3)).toBe(true);
+  });
+
+  it("não ativa em mood > COMFORT_GATE", () => {
+    expect(triggersComfortGate(4)).toBe(false);
+    expect(triggersComfortGate(7)).toBe(false);
+    expect(triggersComfortGate(10)).toBe(false);
+  });
+});
+
+describe("computeMoodWindow", () => {
+  const now = "2026-04-27T12:00:00Z";
+
+  const reading = (
+    score: number,
+    at: string,
+    source: "llm" | "rule_based" | "manual" = "llm",
+  ): MoodReading => ({ score, at, source });
+
+  it("histórico vazio retorna null/zeros", () => {
+    const w = computeMoodWindow([], now);
+    expect(w.recent3turns).toBeNull();
+    expect(w.recent7days).toBeNull();
+    expect(w.latest).toBeNull();
+    expect(w.countIn7Days).toBe(0);
+  });
+
+  it("1 leitura: recent3turns == score, latest == leitura", () => {
+    const r = reading(7, "2026-04-27T11:00:00Z");
+    const w = computeMoodWindow([r], now);
+    expect(w.recent3turns).toBe(7);
+    expect(w.recent7days).toBe(7);
+    expect(w.latest).toEqual(r);
+    expect(w.countIn7Days).toBe(1);
+  });
+
+  it("recent3turns = média das 3 leituras mais recentes", () => {
+    const history: MoodReading[] = [
+      reading(2, "2026-04-26T10:00:00Z"),
+      reading(4, "2026-04-27T08:00:00Z"),
+      reading(8, "2026-04-27T10:00:00Z"),
+      reading(6, "2026-04-27T11:00:00Z"),
+      reading(5, "2026-04-27T11:30:00Z"),
+    ];
+    const w = computeMoodWindow(history, now);
+    // 3 mais recentes: 5, 6, 8 (timestamps 11:30, 11:00, 10:00)
+    expect(w.recent3turns).toBeCloseTo((5 + 6 + 8) / 3);
+    expect(w.latest?.score).toBe(5);
+  });
+
+  it("recent7days filtra leituras antigas (>7d) corretamente", () => {
+    const history: MoodReading[] = [
+      reading(3, "2026-04-15T10:00:00Z"), // > 7 days ago — fora
+      reading(7, "2026-04-21T10:00:00Z"), // ~6 days ago — dentro
+      reading(8, "2026-04-26T10:00:00Z"), // 1 day ago — dentro
+    ];
+    const w = computeMoodWindow(history, now);
+    expect(w.countIn7Days).toBe(2);
+    expect(w.recent7days).toBeCloseTo((7 + 8) / 2);
+  });
+
+  it("recent7days null se nenhuma leitura na janela 7d", () => {
+    const history: MoodReading[] = [
+      reading(5, "2026-04-15T10:00:00Z"), // > 7 days ago
+    ];
+    const w = computeMoodWindow(history, now);
+    expect(w.recent7days).toBeNull();
+    expect(w.countIn7Days).toBe(0);
+    // recent3turns ainda é computado (sobre todo histórico, não janela 7d)
+    expect(w.recent3turns).toBe(5);
+  });
+
+  it("ordena desc independente da ordem de input", () => {
+    const history: MoodReading[] = [
+      reading(8, "2026-04-27T10:00:00Z"),
+      reading(5, "2026-04-27T11:30:00Z"),
+      reading(6, "2026-04-27T11:00:00Z"),
+    ];
+    const w = computeMoodWindow(history, now);
+    expect(w.latest?.score).toBe(5); // timestamp 11:30 é mais recente
+  });
+});
+
+describe("inMemoryMoodRepo — port adapter", () => {
+  it("retorna histórico vazio quando user sem leituras", async () => {
+    const repo = inMemoryMoodRepo();
+    const rows = await repo.loadHistory("user-1");
+    expect(rows).toEqual([]);
+  });
+
+  it("isola users — não vaza leituras entre user-1 e user-2", async () => {
+    const seed: MoodReadingRow[] = [
+      { userId: "user-1", score: 5, at: "2026-04-27T10:00:00Z", source: "llm" },
+      { userId: "user-2", score: 8, at: "2026-04-27T10:00:00Z", source: "llm" },
+    ];
+    const repo = inMemoryMoodRepo(seed);
+    const rows1 = await repo.loadHistory("user-1");
+    expect(rows1).toHaveLength(1);
+    expect(rows1[0]?.score).toBe(5);
+  });
+
+  it("append + loadHistory roundtrip", async () => {
+    const repo = inMemoryMoodRepo();
+    await repo.append({
+      userId: "user-1",
+      score: 7,
+      at: "2026-04-27T10:00:00Z",
+      source: "llm",
+    });
+    await repo.append({
+      userId: "user-1",
+      score: 6,
+      at: "2026-04-27T11:00:00Z",
+      source: "rule_based",
+    });
+    const rows = await repo.loadHistory("user-1");
+    expect(rows).toHaveLength(2);
+    // ordenado desc por at
+    expect(rows[0]?.score).toBe(6);
+    expect(rows[1]?.score).toBe(7);
+  });
+
+  it("opção limit pega só as N mais recentes", async () => {
+    const seed: MoodReadingRow[] = [
+      { userId: "user-1", score: 3, at: "2026-04-25T10:00:00Z", source: "llm" },
+      { userId: "user-1", score: 5, at: "2026-04-26T10:00:00Z", source: "llm" },
+      { userId: "user-1", score: 7, at: "2026-04-27T10:00:00Z", source: "llm" },
+    ];
+    const repo = inMemoryMoodRepo(seed);
+    const rows = await repo.loadHistory("user-1", { limit: 2 });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.score).toBe(7); // mais recente
+    expect(rows[1]?.score).toBe(5);
+  });
+
+  it("opção since filtra por timestamp", async () => {
+    const seed: MoodReadingRow[] = [
+      { userId: "user-1", score: 3, at: "2026-04-20T10:00:00Z", source: "llm" },
+      { userId: "user-1", score: 7, at: "2026-04-27T10:00:00Z", source: "llm" },
+    ];
+    const repo = inMemoryMoodRepo(seed);
+    const rows = await repo.loadHistory("user-1", {
+      since: "2026-04-25T00:00:00Z",
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.score).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

Implementa **PART A** de motor#35 (F1-mood): primitivas puras + repo port + in-memory adapter.

PART B (LLM extractor + fallback rule-based) fica pra PR follow-up — escopo separado pra manter PRs pequenos per cadência.

## DT-* honradas

- ✅ DT-MOOD-01: integer 1-10 (LLM-friendly)
- ✅ DT-MOOD-03: COMFORT_GATE = 3 alinhado com mode aquecimento POC + buffer day CLAUDE_6 §5.3
- ⏳ DT-MOOD-02 (LLM extractor + fallback rule-based): PART B

## Mudanças

**`shared/src/mood.ts`** (commit 1, novo)
- Constantes: `MOOD_MIN=1`, `MOOD_MAX=10`, `MOOD_DEFAULT=5`, `COMFORT_GATE=3`
- Tipos: `MoodScore`, `MoodSource`, `MoodReading`, `MoodWindow`, `MoodReadingRow`, `MoodRepo`
- Funções puras: `isMoodScore`, `clampMoodScore`, `triggersComfortGate`, `computeMoodWindow(history, now)`
- Notes: `clampMoodScore` é resiliente a LLM devolvendo 7.5 ou 11 (arredonda + clampa); NaN/Infinity → MOOD_DEFAULT

**`shared/src/mood-repo-memory.ts`** (commit 2, novo)
- `inMemoryMoodRepo(seed)` com Map<userId|...>
- Suporta opções `{ limit, since }` em loadHistory
- Sort desc por `at`

**`shared/src/types.ts`** (commit 3)
- `SessionState.currentMood?: MoodScore`
- `SessionState.moodWindow?: MoodWindow`
- Ambos opcionais (compat com código existente)

**`shared/src/index.ts`** (commit 2)
- Re-export de mood + mood-repo-memory

**`shared/tests/mood.test.ts`** (commit 4, novo)
- 17 tests: 4 guards/clamp + 2 comfort gate + 6 computeMoodWindow + 5 repo adapter

## Validação

- ✅ `npm test --workspace shared` — **284/284 verde** (foi 267, +17 novos)
- ✅ `npm run build --workspace shared` — TypeScript clean

## Diff stats

```
shared/src/mood.ts                | 177 +++++++++++++++++++++  (new)
shared/src/mood-repo-memory.ts    |  43 ++++++  (new)
shared/src/types.ts               |  15 ++++++++
shared/src/index.ts               |   2 ++
shared/tests/mood.test.ts         | 199 ++++++++++++++++++++++++++  (new)
```

Total: ~436 linhas. Bem dentro do limite cadência <500.

## Pattern replicação

Segue mesmo pattern hexagonal estabelecido em motor#38 (mergeado em #39):
- Port (interface) em arquivo principal
- In-memory adapter em arquivo `*-repo-memory.ts`
- Concrete postgres pra F1-bootstrap-db (motor#40)
- Tests usam in-memory adapter pra isolamento

## Próximas ações

1. **PART B (motor#35 follow-up)**: `motor-drota/src/mood-extractor.ts` (LLM v0 + fallback rule-based) — DT-MOOD-02. Estimativa adicional: ~2-3 dias CC.
2. Em paralelo: motor#34 (trust) + motor#36 (budget) podem rodar (sem dependências mútuas).
3. motor#37 (helix) por último — consome mood + status como inputs.

## Refs

- Sub-issue: [ascendimacy-motor#35](https://github.com/ascendimacy/ascendimacy-motor/issues/35)
- Umbrella: [ascendimacy-ops#384](https://github.com/ascendimacy/ascendimacy-ops/issues/384)
- F1-bootstrap-db (postgres concrete adapter): [ascendimacy-motor#40](https://github.com/ascendimacy/ascendimacy-motor/issues/40)
- Inventário: [statevector-primitives-inventory-f1 §2](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-27-statevector-primitives-inventory-f1.md)
- Pattern origem: [motor#39 mergeado](https://github.com/ascendimacy/ascendimacy-motor/pull/39)

## Test plan
- [x] `npm test --workspace shared` 284/284 verde
- [x] `npm run build --workspace shared` clean
- [ ] Jun aprova split A/B
- [ ] Após merge: tocar motor#35 PART B (LLM extractor) ou paralelo motor#34 (trust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)