### PR TITLE
feat(shared): F1-trust — calculator + label + adapter + repo (closes motor#34)

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -8,6 +8,8 @@ export * from "./status-matrix.js";
 export * from "./status-matrix-repo-memory.js";
 export * from "./mood.js";
 export * from "./mood-repo-memory.js";
+export * from "./trust.js";
+export * from "./trust-repo-memory.js";
 export * from "./mixins/with-gardner-program.js";
 export * from "./parental-profile.js";
 export * from "./parental-authorization.js";

--- a/shared/src/trust-repo-memory.ts
+++ b/shared/src/trust-repo-memory.ts
@@ -1,0 +1,28 @@
+/**
+ * In-memory adapter pro `TrustRepo` (port em trust.ts).
+ *
+ * Uso: tests + STS smoke runs. Postgres concrete adapter fica pra
+ * F1-bootstrap-db (ascendimacy-motor#40).
+ *
+ * Map<userId, TrustCacheEntry>; cada chamada cria store independente.
+ */
+
+import type { TrustCacheEntry, TrustRepo } from "./trust.js";
+
+export function inMemoryTrustRepo(
+  seed: TrustCacheEntry[] = [],
+): TrustRepo {
+  const store = new Map<string, TrustCacheEntry>();
+  for (const entry of seed) {
+    store.set(entry.userId, entry);
+  }
+
+  return {
+    async loadCachedLevel(userId) {
+      return store.get(userId) ?? null;
+    },
+    async saveCachedLevel(entry) {
+      store.set(entry.userId, entry);
+    },
+  };
+}

--- a/shared/src/trust.ts
+++ b/shared/src/trust.ts
@@ -1,0 +1,139 @@
+/**
+ * Trust — nível de confiança calibrado por sessões + mood + engagement.
+ *
+ * Formula (port direto de ebrota/src/kids/trust.js):
+ *   score = (sessions × 2) + avgMood + avgEngagement
+ *   score ≥ 30 → trusted (0.0...1.0 = 1.0)
+ *   score ≥ 20 → warm    (≈ 0.67)
+ *   score ≥ 10 → warming (≈ 0.33)
+ *   score < 10 → cold    (0.0)
+ *
+ * SessionState.trustLevel (em types.ts) é o adapter 0-1; este módulo
+ * expõe ambas representações (numeric pra motor + label pra consumers
+ * que precisam vocabulário ebrota).
+ *
+ * Persistência: cache em `users.trust_level NUMERIC(3,2)` via `TrustRepo`
+ * port (concrete postgres em F1-bootstrap-db, ascendimacy-motor#40).
+ * Recalcular ocorre no fim da sessão (orchestrator), persiste o resultado.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-27-statevector-primitives-inventory-f1.md §1
+ * Sub-issue: ascendimacy-motor#34
+ * DT-TRUST-01: producer mora aqui (puro, reusável).
+ */
+
+/** Labels canônicas (port ebrota). */
+export const TRUST_LEVELS = ["cold", "warming", "warm", "trusted"] as const;
+export type TrustLabel = (typeof TRUST_LEVELS)[number];
+
+/** Thresholds da formula (score >= threshold → label). */
+export const TRUST_THRESHOLD_TRUSTED = 30;
+export const TRUST_THRESHOLD_WARM = 20;
+export const TRUST_THRESHOLD_WARMING = 10;
+
+/**
+ * Defaults pra inputs ausentes — matches ebrota behavior.
+ * Novo user (sessions=0, sem mood/engagement) → score 10 → warming (0.33).
+ * Decisão deliberada: assume média neutra quando sem dados, em vez de cold absoluto.
+ */
+export const DEFAULT_AVG_MOOD = 5;
+export const DEFAULT_AVG_ENGAGEMENT = 5;
+
+/** Profundidade conversacional adaptada ao trust label. */
+export const DEPTH_LEVELS = ["light", "medium", "deep"] as const;
+export type Depth = (typeof DEPTH_LEVELS)[number];
+
+/**
+ * Inputs pra calcular trust. Todos opcionais salvo `sessions` —
+ * defaults ebrota aplicados em ausentes.
+ */
+export interface TrustInputs {
+  /** Total de sessões completadas (session_end IS NOT NULL no kids_sessions equivalente). */
+  sessions: number;
+  /** Média mood recente — escala 1-10. Default DEFAULT_AVG_MOOD se ausente. */
+  avgMood?: number;
+  /** Média engagement (turn_count médio ou métrica derivada). Default DEFAULT_AVG_ENGAGEMENT. */
+  avgEngagement?: number;
+}
+
+/**
+ * Score bruto da formula ebrota: (sessions × 2) + avgMood + avgEngagement.
+ * Retorna número ≥ 0.
+ */
+export function calculateTrustScore(inputs: TrustInputs): number {
+  const sessions = inputs.sessions ?? 0;
+  const avgMood = inputs.avgMood ?? DEFAULT_AVG_MOOD;
+  const avgEngagement = inputs.avgEngagement ?? DEFAULT_AVG_ENGAGEMENT;
+  return sessions * 2 + avgMood + avgEngagement;
+}
+
+/**
+ * Mapeia score numérico pra label categórica.
+ * Buckets: cold (< 10), warming (10-19), warm (20-29), trusted (≥ 30).
+ */
+export function trustLabelFromScore(score: number): TrustLabel {
+  if (score >= TRUST_THRESHOLD_TRUSTED) return "trusted";
+  if (score >= TRUST_THRESHOLD_WARM) return "warm";
+  if (score >= TRUST_THRESHOLD_WARMING) return "warming";
+  return "cold";
+}
+
+/**
+ * Adapter pra escala numérica 0.0-1.0 que motor canonical
+ * `SessionState.trustLevel` espera.
+ *
+ * Conversão: `score / TRUST_THRESHOLD_TRUSTED`, clampado em [0, 1].
+ *
+ * Mapping aproximado vs labels:
+ *   cold     → 0.0 - 0.32
+ *   warming  → 0.33 - 0.66
+ *   warm     → 0.67 - 0.99
+ *   trusted  → 1.0
+ */
+export function calculateTrustLevel(inputs: TrustInputs): number {
+  const score = calculateTrustScore(inputs);
+  const ratio = score / TRUST_THRESHOLD_TRUSTED;
+  if (ratio <= 0) return 0;
+  if (ratio >= 1) return 1;
+  return ratio;
+}
+
+/**
+ * Adapta profundidade conversacional ao trust label (port ebrota).
+ *
+ * - cold/warming → light (perguntas curtas, baixa demanda)
+ * - warm → medium (perguntas com follow-up)
+ * - trusted → deep (provocações, scaffolding pedagógico)
+ */
+export function adaptDepth(label: TrustLabel): Depth {
+  if (label === "cold" || label === "warming") return "light";
+  if (label === "warm") return "medium";
+  return "deep";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Persistência — port (interface)
+//
+// Concrete adapter postgres fica em F1-bootstrap-db (motor#40).
+// In-memory adapter pra tests/STS em trust-repo-memory.ts.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Linha persistida do cache de trust por user. */
+export interface TrustCacheEntry {
+  userId: string;
+  level: number;
+  /** ISO 8601 — quando o cálculo rodou (pra invalidação eventual). */
+  calculatedAt: string;
+}
+
+/**
+ * Port de persistência do cache de trust.
+ * Implementações:
+ *   - InMemory (testes + STS): trust-repo-memory.ts
+ *   - Postgres (produção): F1-bootstrap-db
+ */
+export interface TrustRepo {
+  /** Lê cache de trust do user. Retorna null se nunca calculado. */
+  loadCachedLevel(userId: string): Promise<TrustCacheEntry | null>;
+  /** Persiste cache. Idempotente (upsert). */
+  saveCachedLevel(entry: TrustCacheEntry): Promise<void>;
+}

--- a/shared/tests/trust.test.ts
+++ b/shared/tests/trust.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  TRUST_LEVELS,
+  TRUST_THRESHOLD_TRUSTED,
+  TRUST_THRESHOLD_WARM,
+  TRUST_THRESHOLD_WARMING,
+  DEFAULT_AVG_MOOD,
+  DEFAULT_AVG_ENGAGEMENT,
+  calculateTrustScore,
+  trustLabelFromScore,
+  calculateTrustLevel,
+  adaptDepth,
+} from "../src/trust.js";
+import type { TrustCacheEntry } from "../src/trust.js";
+import { inMemoryTrustRepo } from "../src/trust-repo-memory.js";
+
+describe("calculateTrustScore", () => {
+  it("aplica defaults ebrota (avgMood=5, avgEngagement=5)", () => {
+    expect(calculateTrustScore({ sessions: 0 })).toBe(
+      0 + DEFAULT_AVG_MOOD + DEFAULT_AVG_ENGAGEMENT,
+    );
+  });
+
+  it("formula (sessions × 2) + avgMood + avgEngagement", () => {
+    expect(
+      calculateTrustScore({ sessions: 5, avgMood: 7, avgEngagement: 6 }),
+    ).toBe(5 * 2 + 7 + 6);
+  });
+
+  it("respeita avgMood/avgEngagement passados (não usa defaults)", () => {
+    expect(
+      calculateTrustScore({ sessions: 0, avgMood: 1, avgEngagement: 1 }),
+    ).toBe(2);
+  });
+
+  it("score sobe com sessions altos", () => {
+    expect(calculateTrustScore({ sessions: 20 })).toBeGreaterThanOrEqual(
+      TRUST_THRESHOLD_TRUSTED,
+    );
+  });
+});
+
+describe("trustLabelFromScore — buckets", () => {
+  it("score < 10 → cold", () => {
+    expect(trustLabelFromScore(0)).toBe("cold");
+    expect(trustLabelFromScore(9.99)).toBe("cold");
+  });
+
+  it("score em [10, 20) → warming", () => {
+    expect(trustLabelFromScore(10)).toBe("warming");
+    expect(trustLabelFromScore(19.99)).toBe("warming");
+  });
+
+  it("score em [20, 30) → warm", () => {
+    expect(trustLabelFromScore(20)).toBe("warm");
+    expect(trustLabelFromScore(29.99)).toBe("warm");
+  });
+
+  it("score >= 30 → trusted", () => {
+    expect(trustLabelFromScore(30)).toBe("trusted");
+    expect(trustLabelFromScore(100)).toBe("trusted");
+  });
+
+  it("TRUST_LEVELS contém todos os labels esperados", () => {
+    expect(TRUST_LEVELS).toEqual(["cold", "warming", "warm", "trusted"]);
+  });
+});
+
+describe("calculateTrustLevel — adapter 0-1", () => {
+  it("score 0 → 0.0 (clamp inferior)", () => {
+    expect(
+      calculateTrustLevel({ sessions: 0, avgMood: 0, avgEngagement: 0 }),
+    ).toBe(0);
+  });
+
+  it("score >= 30 → 1.0 (clamp superior)", () => {
+    expect(calculateTrustLevel({ sessions: 30 })).toBe(1);
+  });
+
+  it("score 15 → ~0.5 (linear)", () => {
+    expect(
+      calculateTrustLevel({ sessions: 0, avgMood: 7.5, avgEngagement: 7.5 }),
+    ).toBeCloseTo(0.5);
+  });
+
+  it("default new user (sessions=0, sem mood/engagement) → 0.33 (warming bucket)", () => {
+    const level = calculateTrustLevel({ sessions: 0 });
+    expect(level).toBeCloseTo(10 / 30);
+    // Confirma que cai no bucket warming via label
+    expect(trustLabelFromScore(calculateTrustScore({ sessions: 0 }))).toBe(
+      "warming",
+    );
+  });
+});
+
+describe("adaptDepth — label → conversational depth", () => {
+  it("cold → light", () => {
+    expect(adaptDepth("cold")).toBe("light");
+  });
+  it("warming → light", () => {
+    expect(adaptDepth("warming")).toBe("light");
+  });
+  it("warm → medium", () => {
+    expect(adaptDepth("warm")).toBe("medium");
+  });
+  it("trusted → deep", () => {
+    expect(adaptDepth("trusted")).toBe("deep");
+  });
+});
+
+describe("inMemoryTrustRepo — port adapter", () => {
+  it("loadCachedLevel retorna null quando user sem cache", async () => {
+    const repo = inMemoryTrustRepo();
+    expect(await repo.loadCachedLevel("user-1")).toBeNull();
+  });
+
+  it("save + load roundtrip", async () => {
+    const repo = inMemoryTrustRepo();
+    const entry: TrustCacheEntry = {
+      userId: "user-1",
+      level: 0.67,
+      calculatedAt: "2026-04-27T10:00:00Z",
+    };
+    await repo.saveCachedLevel(entry);
+    expect(await repo.loadCachedLevel("user-1")).toEqual(entry);
+  });
+
+  it("isolamento entre users — não vaza cache de user-2 pra user-1", async () => {
+    const repo = inMemoryTrustRepo([
+      {
+        userId: "user-2",
+        level: 0.9,
+        calculatedAt: "2026-04-27T10:00:00Z",
+      },
+    ]);
+    expect(await repo.loadCachedLevel("user-1")).toBeNull();
+    expect(await repo.loadCachedLevel("user-2")).not.toBeNull();
+  });
+
+  it("upsert idempotente — segunda save sobrescreve", async () => {
+    const repo = inMemoryTrustRepo();
+    await repo.saveCachedLevel({
+      userId: "user-1",
+      level: 0.33,
+      calculatedAt: "2026-04-27T10:00:00Z",
+    });
+    await repo.saveCachedLevel({
+      userId: "user-1",
+      level: 0.67,
+      calculatedAt: "2026-04-27T11:00:00Z",
+    });
+    const cached = await repo.loadCachedLevel("user-1");
+    expect(cached?.level).toBe(0.67);
+    expect(cached?.calculatedAt).toBe("2026-04-27T11:00:00Z");
+  });
+});


### PR DESCRIPTION
## Summary

Implementa motor#34 (F1-trust). Port direto de `ebrota/src/kids/trust.js` pra TS no motor canônico, seguindo pattern hexagonal estabelecido em motor#39 (status) e motor#41 (mood PART A).

## DT-* honradas

- ✅ DT-TRUST-01: producer mora em `shared/src/trust.ts` (puro, reusável)

## Mudanças

**`shared/src/trust.ts`** (commit 1, novo)
- Constantes: `TRUST_LEVELS`, `TRUST_THRESHOLD_*`, `DEFAULT_AVG_MOOD=5`, `DEFAULT_AVG_ENGAGEMENT=5`, `DEPTH_LEVELS`
- Tipos: `TrustLabel` ('cold'|'warming'|'warm'|'trusted'), `Depth` ('light'|'medium'|'deep'), `TrustInputs`, `TrustCacheEntry`, `TrustRepo`
- Funções puras:
  - `calculateTrustScore({sessions, avgMood?, avgEngagement?})` — formula `(sessions×2) + avgMood + avgEngagement`
  - `trustLabelFromScore(score)` — buckets: <10 cold, 10-19 warming, 20-29 warm, ≥30 trusted
  - `calculateTrustLevel(inputs)` — adapter 0-1 (`score / 30`, clampado)
  - `adaptDepth(label)` — cold/warming → light, warm → medium, trusted → deep

**`shared/src/trust-repo-memory.ts`** (commit 2, novo)
- `inMemoryTrustRepo(seed)` com `Map<userId, TrustCacheEntry>`

**`shared/src/index.ts`** (commit 2)
- Re-export trust + adapter

**`shared/tests/trust.test.ts`** (commit 3, novo)
- 21 tests: 4 score + 5 label + 4 adapter + 4 depth + 4 repo

## Decisões de design

- **Defaults ebrota preservados** (avgMood=5, avgEngagement=5) — novo user (sessions=0) cai em warming (0.33), não cold absoluto. Decisão deliberada do design original mantida (P5 da migration spec: "equivalente em qualidade").
- **adaptDepth port'd** — UX helper do ebrota mantido pra consumers que precisam mapear trust → depth conversacional.
- **Cache em users.trust_level** (não tabela própria) — `TrustRepo.loadCachedLevel/saveCachedLevel` operam sobre cache; recálculo ocorre no fim da sessão (orchestrator), persiste resultado.

## Validação

- ✅ `npm test --workspace shared` — **305/305 verde** (foi 284, +21 trust)
- ✅ `npm run build --workspace shared` — TypeScript clean

## Diff stats

```
shared/src/trust.ts                | 139 ++++++++++++++++++  (new)
shared/src/trust-repo-memory.ts    |  30 ++++++  (new)
shared/src/index.ts                |   2 ++
shared/tests/trust.test.ts         | 156 +++++++++++++++++++++++++++++++  (new)
```

Total: ~327 linhas. Bem dentro do limite cadência <500.

## Pattern hexagonal — confirma escala

3º sub-issue F1 seguindo mesmo pattern (status #38 → mood PART A #35 → trust #34). Pattern escala bem; próximas sub-issues (budget #36, mood PART B, helix #37) podem replicar com confiança.

## Próximas ações

1. **Track 1**: motor#34 mergeado → motor#35 PART B (mood LLM extractor)
2. **Track 2**: motor#40 (F1-bootstrap-db) ainda em greenlight paralelo

## Refs

- Sub-issue: [ascendimacy-motor#34](https://github.com/ascendimacy/ascendimacy-motor/issues/34)
- Umbrella: [ascendimacy-ops#384](https://github.com/ascendimacy/ascendimacy-ops/issues/384)
- F1-bootstrap-db: [motor#40](https://github.com/ascendimacy/ascendimacy-motor/issues/40)
- Inventário: [statevector-primitives-inventory-f1 §1](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-27-statevector-primitives-inventory-f1.md)
- Pattern origem: motor#39 (status), motor#41 (mood A)
- Source de port: [ebrota/src/kids/trust.js](https://github.com/ascendimacy/ebrota/blob/main/src/kids/trust.js) (referência arqueológica)

## Test plan
- [x] `npm test --workspace shared` 305/305 verde
- [x] `npm run build --workspace shared` clean
- [ ] Jun aprova merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)