### PR TITLE
feat(motor-drota): F1-mood PART B — LLM extractor + rule-based fallback (closes motor#35)

### DIFF
--- a/motor-drota/src/mood-extractor.ts
+++ b/motor-drota/src/mood-extractor.ts
@@ -1,0 +1,215 @@
+/**
+ * Mood Extractor — produtor de MoodReading absoluto via LLM v0
+ * com fallback rule-based em distress markers.
+ *
+ * Estratégia (DT-MOOD-02, Jun 2026-04-27):
+ * 1. Tenta LLM (callGateway com step "mood-extractor", Mistral3 default).
+ *    Prompt curto pede JSON {score: 1-10, rationale}. Parse + clamp.
+ * 2. Se LLM lança erro OU JSON inválido OU score fora do range:
+ *    fallback rule-based (regex distress PT/JA + monossilábicos seguidos).
+ *
+ * Defesa em camadas: clampMoodScore() do shared/mood sanitiza qualquer
+ * número arbitrário (NaN, decimal, fora-do-range) pro range válido.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-27-statevector-primitives-inventory-f1.md §2
+ * Sub-issue: ascendimacy-motor#35 PART B
+ */
+
+import {
+  callGateway,
+  clampMoodScore,
+  MOOD_DEFAULT,
+} from "@ascendimacy/shared";
+import type { MoodReading } from "@ascendimacy/shared";
+
+export interface MoodExtractInput {
+  /** Texto do usuário a analisar (último turn da criança). */
+  userText: string;
+  /**
+   * Histórico recente opcional pra context (1-3 turns prévios).
+   * role 'user' = criança; 'assistant' = bot.
+   */
+  recentHistory?: Array<{ role: "user" | "assistant"; content: string }>;
+  /** Run id pra trace propagation no gateway logger. */
+  run_id?: string;
+}
+
+export interface MoodExtractResult extends MoodReading {
+  /** Justificativa LLM ou marker rule-based que disparou. */
+  rationale: string;
+  /** True se LLM falhou e fallback rule-based foi usado. */
+  fallback_used: boolean;
+}
+
+const SYSTEM_PROMPT = `Você é um avaliador silencioso de humor infantil em conversas educacionais.
+
+Tarefa: ler a fala da criança e estimar o humor numa escala de 1 a 10:
+- 1-2: muito mal (irritado, triste, querendo sair)
+- 3: cansado/desinteressado (gate de comfort track — bot deve recuar)
+- 4-6: neutro/ok
+- 7-8: bem, engajado
+- 9-10: ótimo, animado
+
+Responda APENAS em JSON estrito, sem markdown, sem texto fora do JSON:
+{"score": <integer 1-10>, "rationale": "<frase curta de até 80 caracteres>"}`;
+
+/**
+ * Distress markers — PT-BR e JA. Match em qualquer = mood 2 (low).
+ *
+ * PT: irritado/triste, querer sair, tédio explícito.
+ * JA: 疲 (cansaço), 嫌 (recusa), もういい (chega), さよなら/owari (despedida), つまらん (sem graça).
+ *
+ * Heurística é tosca por design — refino vira sub-issue F+1 quando
+ * piloto Yuji gerar dados reais.
+ */
+const DISTRESS_PATTERNS: RegExp[] = [
+  /\b(t[ôo]\s+mal|t[ôo]\s+triste|estou\s+mal|n[ãa]o\s+quero|chato|t[ée]dio|cansad[oa]|preciso\s+ir|tchau|n[ãa]o\s+t[ôo]\s+afim)\b/i,
+  /(疲|つかれ|嫌|やだ|もういい|つまらん|さよなら|sayonara|owari)/i,
+];
+
+/** Limiar pra detectar resposta "fechada" (várias palavras curtas em texto curto). */
+const SHORT_WORD_THRESHOLD = 2;
+const MAX_WORDS_FOR_LOW_ENGAGEMENT = 6;
+
+/**
+ * Extrai mood absoluto. Sempre retorna MoodExtractResult válido —
+ * nunca lança (LLM error → fallback; fallback sempre produz score).
+ */
+export async function extractMood(
+  input: MoodExtractInput,
+  options: { now?: () => string } = {},
+): Promise<MoodExtractResult> {
+  const now = options.now ?? (() => new Date().toISOString());
+  const at = now();
+
+  try {
+    const llm = await extractMoodViaLLM(input);
+    if (llm) {
+      return {
+        score: llm.score,
+        at,
+        source: "llm",
+        rationale: llm.rationale,
+        fallback_used: false,
+      };
+    }
+    // LLM retornou null (parse falhou) → fallback
+  } catch {
+    // LLM lançou (timeout, network, etc.) → fallback
+  }
+
+  const rule = scoreByRules(input.userText);
+  return {
+    score: rule.score,
+    at,
+    source: "rule_based",
+    rationale: rule.rationale,
+    fallback_used: true,
+  };
+}
+
+async function extractMoodViaLLM(
+  input: MoodExtractInput,
+): Promise<{ score: number; rationale: string } | null> {
+  const historyText =
+    input.recentHistory && input.recentHistory.length > 0
+      ? input.recentHistory
+          .map(
+            (t) => `${t.role === "user" ? "Criança" : "Bot"}: ${t.content}`,
+          )
+          .join("\n")
+      : "";
+
+  const userMessage = historyText
+    ? `Última fala da criança:\n"${input.userText}"\n\nContext (turns recentes):\n${historyText}\n\nResponda em JSON.`
+    : `Última fala da criança:\n"${input.userText}"\n\nResponda em JSON.`;
+
+  const result = await callGateway({
+    step: "mood-extractor",
+    systemPrompt: SYSTEM_PROMPT,
+    userMessage,
+    maxTokens: 256,
+    run_id: input.run_id,
+  });
+
+  return parseJsonResponse(result.content);
+}
+
+function parseJsonResponse(
+  text: string,
+): { score: number; rationale: string } | null {
+  try {
+    const cleaned = text
+      .replace(/```(?:json)?\n?/g, "")
+      .replace(/```/g, "")
+      .trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const obj = JSON.parse(match[0]);
+    if (typeof obj.score !== "number") return null;
+    const score = clampMoodScore(obj.score);
+    const rationale =
+      typeof obj.rationale === "string" ? obj.rationale.slice(0, 200) : "";
+    return { score, rationale };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fallback rule-based. Retorna score determinístico baseado em sinais
+ * superficiais do texto.
+ *
+ * Ordem (primeira regra que casa, vence):
+ * 1. Distress marker (PT ou JA) → 2 (low)
+ * 2. Texto vazio/whitespace → MOOD_DEFAULT
+ * 3. 1 palavra muito curta ("ok", "sim", "n") → 4 (slightly low)
+ * 4. Várias palavras curtas seguidas em texto curto → 4
+ * 5. Default → MOOD_DEFAULT (5, neutro)
+ *
+ * Escolhi não tentar inferir "alto" via heurística porque sinais positivos
+ * são ambíguos sem context (LLM faz isso melhor). Rule-based só protege
+ * contra LLM ausente em casos onde detecção de baixo importa (comfort gate).
+ */
+export function scoreByRules(text: string): {
+  score: number;
+  rationale: string;
+} {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return { score: MOOD_DEFAULT, rationale: "fallback: texto vazio" };
+  }
+
+  for (const pattern of DISTRESS_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return {
+        score: 2,
+        rationale: "fallback: distress marker detectado",
+      };
+    }
+  }
+
+  const words = trimmed.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length === 1 && words[0]!.length <= 3) {
+    return {
+      score: 4,
+      rationale: "fallback: resposta monossilábica curta",
+    };
+  }
+
+  const shortCount = words.filter((w) => w.length <= 2).length;
+  if (
+    shortCount >= SHORT_WORD_THRESHOLD &&
+    words.length < MAX_WORDS_FOR_LOW_ENGAGEMENT
+  ) {
+    return {
+      score: 4,
+      rationale: "fallback: várias palavras curtas em texto curto",
+    };
+  }
+
+  return {
+    score: MOOD_DEFAULT,
+    rationale: "fallback: sem signal claro, default neutro",
+  };
+}

--- a/motor-drota/tests/mood-extractor.test.ts
+++ b/motor-drota/tests/mood-extractor.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests pra mood-extractor (motor#35 PART B).
+ *
+ * Mock pattern (espelha motor-drota/tests/llm-client.test.ts): vi.mock
+ * de "@ascendimacy/shared" sobrescrevendo callGateway com versão sob
+ * controle do test. Captura `req` em closure pra assertions sobre o
+ * payload enviado ao gateway.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+} from "@ascendimacy/shared";
+
+// Estado do mock — closures referenciadas pelo vi.mock factory.
+const captured: { req?: GatewayChatCompletionInput } = {};
+let mockResponse: GatewayChatCompletionOutput | null = null;
+let mockError: Error | null = null;
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: async (req: GatewayChatCompletionInput) => {
+      captured.req = req;
+      if (mockError) throw mockError;
+      if (!mockResponse) {
+        throw new Error("test setup error: mockResponse not set");
+      }
+      return mockResponse;
+    },
+  };
+});
+
+import { extractMood, scoreByRules } from "../src/mood-extractor.js";
+
+const FIXED_NOW = "2026-04-27T12:00:00Z";
+
+function buildLlmResponse(content: string): GatewayChatCompletionOutput {
+  return {
+    content,
+    tokens: { in: 100, out: 50, reasoning: 0 },
+    provider: "infomaniak",
+    model: "mistral3",
+    latency_ms: 150,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
+beforeEach(() => {
+  captured.req = undefined;
+  mockResponse = null;
+  mockError = null;
+});
+
+describe("extractMood — happy path LLM", () => {
+  it("parsea JSON válido + retorna source='llm', fallback_used=false", async () => {
+    mockResponse = buildLlmResponse(
+      `{"score": 7, "rationale": "Tom animado, fala sobre Dragon Ball"}`,
+    );
+    const result = await extractMood(
+      { userText: "ah, hoje vi o Goku indo SSJ4!" },
+      { now: () => FIXED_NOW },
+    );
+    expect(result.score).toBe(7);
+    expect(result.source).toBe("llm");
+    expect(result.fallback_used).toBe(false);
+    expect(result.at).toBe(FIXED_NOW);
+    expect(result.rationale).toContain("Dragon Ball");
+  });
+
+  it("envia step='mood-extractor' + maxTokens=256 ao gateway", async () => {
+    mockResponse = buildLlmResponse(`{"score": 5, "rationale": "neutro"}`);
+    await extractMood({ userText: "sei lá" });
+    expect(captured.req?.step).toBe("mood-extractor");
+    expect(captured.req?.maxTokens).toBe(256);
+  });
+
+  it("inclui recentHistory no userMessage quando passado", async () => {
+    mockResponse = buildLlmResponse(`{"score": 6, "rationale": "ok"}`);
+    await extractMood({
+      userText: "talvez",
+      recentHistory: [
+        { role: "assistant", content: "quer continuar?" },
+        { role: "user", content: "hm" },
+      ],
+    });
+    expect(captured.req?.userMessage).toContain("Context");
+    expect(captured.req?.userMessage).toContain("quer continuar?");
+  });
+
+  it("clampa score >10 ou decimais via clampMoodScore", async () => {
+    mockResponse = buildLlmResponse(
+      `{"score": 12, "rationale": "fora do range"}`,
+    );
+    const result = await extractMood({ userText: "muito legal!" });
+    expect(result.score).toBe(10); // clamp superior
+    expect(result.source).toBe("llm");
+  });
+
+  it("aceita JSON com markdown fences (strip antes de parse)", async () => {
+    mockResponse = buildLlmResponse(
+      "```json\n{\"score\": 8, \"rationale\": \"animado\"}\n```",
+    );
+    const result = await extractMood({ userText: "uhul!" });
+    expect(result.score).toBe(8);
+    expect(result.source).toBe("llm");
+  });
+});
+
+describe("extractMood — fallback rule-based", () => {
+  it("LLM lança erro → fallback rule-based", async () => {
+    mockError = new Error("gateway timeout");
+    const result = await extractMood({ userText: "tô mal" });
+    expect(result.source).toBe("rule_based");
+    expect(result.fallback_used).toBe(true);
+    expect(result.score).toBe(2); // distress marker PT
+  });
+
+  it("LLM retorna JSON inválido → fallback rule-based", async () => {
+    mockResponse = buildLlmResponse("não consegui responder em JSON");
+    const result = await extractMood({ userText: "tchau" });
+    expect(result.source).toBe("rule_based");
+    expect(result.score).toBe(2); // distress marker PT
+  });
+
+  it("LLM retorna JSON sem campo score → fallback", async () => {
+    mockResponse = buildLlmResponse(`{"rationale": "esqueci o score"}`);
+    const result = await extractMood({ userText: "tudo bem" });
+    expect(result.source).toBe("rule_based");
+  });
+
+  it("LLM retorna score como string → fallback", async () => {
+    mockResponse = buildLlmResponse(
+      `{"score": "sete", "rationale": "string"}`,
+    );
+    const result = await extractMood({ userText: "valeu" });
+    expect(result.source).toBe("rule_based");
+  });
+});
+
+describe("scoreByRules — distress markers PT", () => {
+  it.each([
+    "tô mal",
+    "estou mal",
+    "não quero mais",
+    "preciso ir",
+    "tchau",
+    "que tédio",
+    "tô cansado",
+  ])("'%s' → score 2 (distress marker)", (text) => {
+    expect(scoreByRules(text).score).toBe(2);
+  });
+});
+
+describe("scoreByRules — distress markers JA", () => {
+  it.each([
+    "疲れた",
+    "つかれた",
+    "嫌だ",
+    "やだ",
+    "もういい",
+    "つまらん",
+    "さよなら",
+    "owari",
+  ])("'%s' → score 2 (distress marker JA)", (text) => {
+    expect(scoreByRules(text).score).toBe(2);
+  });
+});
+
+describe("scoreByRules — engagement signals", () => {
+  it("texto vazio → MOOD_DEFAULT", () => {
+    expect(scoreByRules("").score).toBe(5);
+    expect(scoreByRules("   ").score).toBe(5);
+  });
+
+  it("1 palavra curta ('ok') → 4 (low engagement)", () => {
+    expect(scoreByRules("ok").score).toBe(4);
+    expect(scoreByRules("sim").score).toBe(4);
+  });
+
+  it("várias palavras curtas em texto curto → 4", () => {
+    expect(scoreByRules("eu n sei").score).toBe(4);
+  });
+
+  it("texto longo neutro → MOOD_DEFAULT", () => {
+    expect(
+      scoreByRules(
+        "estou pensando em qual personagem do Dragon Ball é mais forte",
+      ).score,
+    ).toBe(5);
+  });
+
+  it("rationale contém marker descritivo", () => {
+    expect(scoreByRules("tô mal").rationale).toMatch(/distress/);
+    expect(scoreByRules("ok").rationale).toMatch(/monoss/);
+    expect(scoreByRules("texto longo aqui").rationale).toMatch(/neutro/);
+  });
+});

--- a/shared/src/llm-config.ts
+++ b/shared/src/llm-config.ts
@@ -21,6 +21,8 @@ export const LLM_TIMEOUT_DEFAULTS: Record<string, number> = {
   "persona-sim": 30_000,
   // motor#25 — Signal Extractor (Mistral3 default, classification curta)
   "signal-extractor": 15_000,
+  // motor#35 PART B — Mood Extractor (Mistral3 default, classification curta)
+  "mood-extractor": 15_000,
 };
 
 /** MaxRetries default por step. */
@@ -31,6 +33,7 @@ export const LLM_MAX_RETRIES_DEFAULTS: Record<string, number> = {
   drota: 2, // reasoning model retry é caro, fail-fast é melhor
   "persona-sim": 3,
   "signal-extractor": 2, // motor#25 — fail-fast, fallback rule-based existe
+  "mood-extractor": 2, // motor#35 PART B — fail-fast, fallback rule-based existe
 };
 
 /**

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -27,6 +27,7 @@ export const LLM_STEPS = [
   "haiku-triage",
   "haiku-bullying",
   "signal-extractor", // motor#25 — captura signals semânticos antes de Environment Assessor
+  "mood-extractor", // motor#35 — extração de mood absoluto da criança (F1-mood PART B)
 ] as const;
 export type LlmStep = (typeof LLM_STEPS)[number];
 
@@ -41,6 +42,7 @@ export const DEFAULT_PROVIDERS: Record<LlmStep, LlmProvider> = {
   "haiku-triage": "infomaniak",
   "haiku-bullying": "infomaniak",
   "signal-extractor": "infomaniak",
+  "mood-extractor": "infomaniak",
 };
 
 /**
@@ -57,6 +59,9 @@ export const DEFAULT_MODELS: Record<LlmStep, string> = {
   // Signal Extractor: Mistral3 default — não-reasoning, ~5s/call.
   // Tarefa é classificação de signals em texto curto, não exige reasoning.
   "signal-extractor": "mistral3",
+  // Mood Extractor (motor#35 PART B): Mistral3 default — classificação curta
+  // ("humor 1-10 + rationale"), não-reasoning. Mesmo perfil do signal-extractor.
+  "mood-extractor": "mistral3",
 };
 
 /**
@@ -70,6 +75,7 @@ export const ANTHROPIC_FALLBACK_MODELS: Record<LlmStep, string> = {
   "haiku-triage": "claude-haiku-4-5-20251001",
   "haiku-bullying": "claude-haiku-4-5-20251001",
   "signal-extractor": "claude-haiku-4-5-20251001",
+  "mood-extractor": "claude-haiku-4-5-20251001",
 };
 
 function envKey(step: string, suffix: string): string {


### PR DESCRIPTION
## Summary

Implementa **PART B** de motor#35 (F1-mood). Producer de `MoodReading` absoluto via LLM (callGateway step="mood-extractor", Mistral3 default) com fallback rule-based em distress markers PT/JA.

PART A (mood module: types + window + repo + in-memory) já mergeada em #41.

## DT-* honradas

- ✅ DT-MOOD-02: LLM extractor v0 + fallback rule-based
- ✅ DT-MOOD-04 (descoberta no recon): novo step "mood-extractor" registrado em llm-router + llm-config

## Mudanças

**`shared/src/llm-router.ts`** + **`shared/src/llm-config.ts`** (commit 1)
- Novo step "mood-extractor" registrado: `LLM_STEPS`, `DEFAULT_PROVIDERS` (infomaniak), `DEFAULT_MODELS` (mistral3, perfil identico ao signal-extractor), `ANTHROPIC_FALLBACK_MODELS` (haiku-4-5), `LLM_TIMEOUT_DEFAULTS` (15s), `LLM_MAX_RETRIES_DEFAULTS` (2)

**`motor-drota/src/mood-extractor.ts`** (commit 2, novo)
- `extractMood({userText, recentHistory?, run_id?}, {now?})` — sempre retorna resultado válido, nunca lança
- LLM path: prompt curto pedindo JSON `{score: 1-10, rationale}`; parse strip markdown + clampMoodScore
- Fallback rule-based: distress regex PT/JA + heurística de palavras curtas + default neutro
- `scoreByRules` exportado pra reuso

**`motor-drota/tests/mood-extractor.test.ts`** (commit 3, novo)
- 29 tests: 5 happy path LLM + 4 fallback paths + 15 distress markers (7 PT + 8 JA) + 5 engagement signals
- Mock pattern espelha llm-client.test.ts: `vi.mock("@ascendimacy/shared")` sobrescrevendo `callGateway`

## Recon LLM infra (registrado antes da implementação)

[Comment em motor#35](https://github.com/ascendimacy/ascendimacy-motor/issues/35#issuecomment-4330422623) documenta:
- `callGateway` API + singleton stdio MCP transport
- Pattern `vi.mock` pra mock em tests (substitui callGateway via importOriginal)
- Defaults recomendados (infomaniak/mistral3, 15s, 2 retries — perfil signal-extractor)
- DT-MOOD-04 (registro de step novo, não fricção)

## Validação

- ✅ `npm test --workspace shared` — 305/305 verde (router/config sem regressão)
- ✅ `npm test --workspace motor-drota` — **84/84 verde** (29 novos)
- ✅ `npm run build --workspace shared` + `--workspace motor-drota` — TypeScript clean

## Diff stats

```
shared/src/llm-router.ts             |  4 ++++
shared/src/llm-config.ts             |  4 ++++
motor-drota/src/mood-extractor.ts    | 215 +++++++++++++++++++++++++  (new)
motor-drota/tests/mood-extractor.test.ts | 202 +++++++++++++++++++++  (new)
```

Total: ~425 linhas. Dentro do limite cadência <500.

## Decisões de design

- **Heurística rule-based deliberadamente conservadora**: só detecta sinais BAIXOS. Sinais altos vêm do LLM (ambiguidade sem context). Protege comfort gate quando LLM falha; não tenta inferir engajamento alto sem contexto.
- **Defesa em camadas**: `clampMoodScore` do shared/mood sanitiza qualquer número arbitrário do LLM (NaN, decimal, fora-do-range) — extractor não precisa duplicar validação.
- **`extractMood` nunca lança**: LLM error → fallback. Garante producer determinístico no orchestrator.
- **`scoreByRules` exportado**: reutilizável fora do extractor (ex: STS smoke pode validar fallback isolado).

## Pattern hexagonal — 4º consecutivo

motor#39 (status) → motor#41 (mood A) → motor#42 (trust) → **motor#43 (mood B)**. Pattern escala bem: shared expõe ports puros + tipos; motor-drota implementa producers que consomem callGateway; tests mockam gateway via vi.mock.

## Próximas ações

motor#35 fica completo (PART A + PART B mergeadas). Próximas opções:
- **motor#36 (budget)** — pattern + estimativa similar a trust (~2 dias)
- **motor#37 (helix)** — DT-HELIX-01=A, escopo maior (~4-5 dias)
- **motor#40 (bootstrap-db)** — Track 2, paralelo (~2-3 dias)

## Refs

- Sub-issue: [ascendimacy-motor#35](https://github.com/ascendimacy/ascendimacy-motor/issues/35)
- Recon LLM: [comment em motor#35](https://github.com/ascendimacy/ascendimacy-motor/issues/35#issuecomment-4330422623)
- Umbrella: [ascendimacy-ops#384](https://github.com/ascendimacy/ascendimacy-ops/issues/384)
- PART A merged: motor#41
- Inventário: [statevector-primitives-inventory-f1 §2](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-27-statevector-primitives-inventory-f1.md)

## Test plan
- [x] `npm test --workspace motor-drota` 84/84 verde
- [x] `npm test --workspace shared` 305/305 verde
- [x] Builds TS clean em ambos workspaces
- [ ] Jun aprova merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)