### PR TITLE
feat: kids.transitions.yaml v0.2 + 11 tests (A-01 GAP-02)

### DIFF
--- a/content/profiles/kids.transitions.yaml
+++ b/content/profiles/kids.transitions.yaml
@@ -1,53 +1,100 @@
 # transitions.yaml — Função de transição declarativa para perfil Kids (motor#25)
 #
-# Spec: docs/handoffs/2026-04-26-cc-motor-pre-piloto-strategic-gaps.md §motor#25.
-# ARCHITECTURE.md §14 (adicionado neste PR).
-#
-# Filosofia (DA-PRE-PILOTO-02): declarativo bloqueante. Função computacional
-# vira tech debt explícito SE função estática mostrar-se insuficiente após
-# 30d de piloto. Inverter essa ordem = caixa-preta dobrada.
-#
+# Versão: v0.2 — 2026-04-28 — A-01 GAP-02 do implementation plan pré-piloto.
+# Spec: ascendimacy-ops/docs/handoffs/2026-04-28-implementation-plan-gaps-pre-piloto.md §A-01
 # Schema validado por shared/src/transitions-schema.ts (Zod).
 #
 # Status atual da statusMatrix Kids: brejo → baia → pasto.
-# Cada transição lista signals que devem aparecer (required), signals que
-# confirmam (confirmatory), e signals que regridem (regression_to).
+# 4 transições: 2 ascendentes (brejo→baia, baia→pasto) +
+# 2 regressões explícitas (baia→brejo, pasto→baia).
+#
+# ─── Notas operacionais ────────────────────────────────────────────────
+# - Trigger Evaluator no Planejador roda após cada turn (loadTransitionsConfig)
+# - Lê signals do event_log (signals_extracted events) das últimas N turns
+# - Avalia required → if match emite transition_evaluated event
+# - v0 read-only: NÃO move statusMatrix automaticamente. Auto-mov vira v1
+#   pós-piloto, depois de validar precision com piloto Yuji.
+#
+# ─── Mapping spec → schema (DT-A01-01) ────────────────────────────────
+# Spec original (handoff §A-01) usa nomes diferentes do schema atual:
+#   spec.required_signals_any  → schema.required_signals (match_mode default OR)
+#   spec.required_signals_all  → schema.required_signals (match_mode "AND")
+#   spec.forbidden_signals_any → schema.regression_to_<estado>_if
+#   spec.min_window_turns      → schema.minimum_window_turns
+#   spec.from_status/to_status → encoded no NOME da transição
+#   spec.consecutive_turns_required → NÃO SUPORTADO no schema; comentado abaixo.
+#
+# DT-A01-01: extender schema pra suportar consecutive_turns_required + from/to
+# explícitos vira tarefa F+1 se piloto mostrar precisão insuficiente.
 
 profile_id: kids
-schema_version: v0
-last_updated: 2026-04-26
+schema_version: v0.2
+last_updated: "2026-04-28"
 
 transitions:
-  # Subida brejo → baia: signal de auto-aceitação OU engajamento sustentado
+
+  # ── Subida brejo → baia ───────────────────────────────────────────────
+  # Critério: qualquer signal de auto-aceitação OU engajamento ascendente.
+  # Janela: mínimo 2 turns desde brejo registrado (evita oscilação rápida).
+  # Regressão: distress alto OU resistência manifesta volta pra brejo.
   brejo_to_baia:
     required_signals:
       - philosophical_self_acceptance
-      - voluntary_topic_deepening  # OR via: 3 turns de mood_drift_up
-    minimum_window_turns: 2  # mínimo 2 turns desde último brejo registrado
-    confirmatory_signals:
       - voluntary_topic_deepening
       - mood_drift_up
+    match_mode: OR
+    minimum_window_turns: 2
+    confirmatory_signals: []
     regression_to_brejo_if:
-      - distress_marker_high  # gatilho forte → volta pra brejo
-      - 2_consecutive_deflexions  # 2 deflection_thematic ou _silence em sequência
+      - distress_marker_high
+      - gatekeeper_resistance
 
-  # Subida baia → pasto: meta-cognição OU síntese de framework próprio
+  # ── Subida baia → pasto ───────────────────────────────────────────────
+  # Critério: frame_synthesis (síntese de framework próprio) é obrigatório.
+  # meta_cognitive_observation + voluntary_topic_deepening elevam confidence.
+  # Janela: mínimo 5 turns em baia antes de virar pasto.
+  #
+  # DT-A01-02: spec original pedia required_signals_all:[frame_synthesis] +
+  # required_signals_any:[meta_cog, voluntary_topic]. Schema atual não
+  # combina 2 grupos — frame_synthesis vira required (AND com 1 elemento),
+  # os outros 2 viram confirmatory (não bloqueiam, mas documentam).
+  # Semantic loss: signals "any" não são strictly required no v0.
   baia_to_pasto:
     required_signals:
-      - meta_cognitive_observation
-      - frame_synthesis  # OR via: aplicação voluntária a novo contexto
-    minimum_window_turns: 5  # mínimo 5 turns em baia antes de virar pasto
+      - frame_synthesis
+    match_mode: AND
+    minimum_window_turns: 5
     confirmatory_signals:
-      - voluntary_application_to_new_context  # signal especial: detectado por bot via tópico shift consciente
-      - peer_reference  # menciona aprendizado pra irmão/amigo
+      - meta_cognitive_observation
+      - voluntary_topic_deepening
     regression_to_baia_if:
       - distress_marker_high
-      - explicit_request_for_simpler_framing  # "isso tá complicado demais"
+      - gatekeeper_resistance
 
-# Notas operacionais:
-# - Trigger Evaluator no Planejador roda APÓS cada turn
-# - Lê signals do event_log (extracted_signals events) das últimas N turns
-# - Avalia required → if match emite transition_evaluated event com decisão
-# - **NÃO move statusMatrix automaticamente em v0** — só EMITE evento.
-#   Movimentação real continua via inject_status (manual) ou mecanismo externo.
-#   Auto-movimentação fica pra v1 pós-piloto, depois de validar precision.
+  # ── Regressão baia → brejo (explícita) ────────────────────────────────
+  # Critério: distress alto OU 2 deflexões consecutivas.
+  # Janela: 0 (regressão imediata, sem buffer).
+  #
+  # DT-A01-03: spec pedia consecutive_turns_required: 2 — schema não
+  # suporta consecutive matching. v0 dispara em ocorrência única.
+  # Conservative: 1 distress_marker_high É suficiente; 1 deflection
+  # também (mais permissivo que spec). Refinar v1 se false positive alto.
+  regression_baia_to_brejo:
+    required_signals:
+      - distress_marker_high
+      - deflection_silence
+      - deflection_thematic
+    match_mode: OR
+    minimum_window_turns: 0
+    confirmatory_signals: []
+
+  # ── Regressão pasto → baia (explícita) ────────────────────────────────
+  # Critério: distress alto OU resistência manifesta.
+  # Janela: 0 (regressão imediata).
+  regression_pasto_to_baia:
+    required_signals:
+      - distress_marker_high
+      - gatekeeper_resistance
+    match_mode: OR
+    minimum_window_turns: 0
+    confirmatory_signals: []

--- a/planejador/tests/trigger-evaluator.test.ts
+++ b/planejador/tests/trigger-evaluator.test.ts
@@ -154,3 +154,148 @@ describe("collectRecentSignals", () => {
     expect(collectRecentSignals(log, 5)).toEqual(["valid"]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// A-01 (GAP-02): Verifica que kids.transitions.yaml real existe + carrega
+// + tem as 4 transições esperadas + dispara conforme spec.
+// ─────────────────────────────────────────────────────────────────────
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadTransitionsConfig } from "../src/trigger-evaluator.js";
+
+describe("kids.transitions.yaml — A-01 acceptance criteria", () => {
+  const REAL_CONTENT_DIR = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../content/profiles",
+  );
+
+  beforeEach(() => {
+    process.env["CONTENT_PROFILES_DIR"] = REAL_CONTENT_DIR;
+    resetTransitionsConfigCache();
+  });
+
+  it("loadTransitionsConfig('kids') retorna config sem erro", () => {
+    const config = loadTransitionsConfig("kids");
+    expect(config).not.toBeNull();
+    expect(config!.profile_id).toBe("kids");
+  });
+
+  it("contém as 4 transições da spec A-01", () => {
+    const config = loadTransitionsConfig("kids");
+    const names = Object.keys(config!.transitions);
+    expect(names).toContain("brejo_to_baia");
+    expect(names).toContain("baia_to_pasto");
+    expect(names).toContain("regression_baia_to_brejo");
+    expect(names).toContain("regression_pasto_to_baia");
+  });
+
+  it("brejo_to_baia dispara com philosophical_self_acceptance + janela ≥ 2", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["philosophical_self_acceptance"],
+      3,
+    );
+    const brejoToBaia = results.find(
+      (r) => r.transition_name === "brejo_to_baia",
+    );
+    expect(brejoToBaia?.fired).toBe(true);
+  });
+
+  it("brejo_to_baia bloqueado por janela insuficiente (< 2 turns)", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["philosophical_self_acceptance"],
+      1,
+    );
+    const brejoToBaia = results.find(
+      (r) => r.transition_name === "brejo_to_baia",
+    );
+    expect(brejoToBaia?.fired).toBe(false);
+    expect(brejoToBaia?.reason).toMatch(/window/);
+  });
+
+  it("brejo_to_baia bloqueado por regression signal (distress_marker_high)", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["philosophical_self_acceptance", "distress_marker_high"],
+      5,
+    );
+    const brejoToBaia = results.find(
+      (r) => r.transition_name === "brejo_to_baia",
+    );
+    expect(brejoToBaia?.fired).toBe(false);
+    expect(brejoToBaia?.regression_signals_present).toContain(
+      "distress_marker_high",
+    );
+  });
+
+  it("baia_to_pasto requer frame_synthesis (AND mode, 1 elemento)", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["frame_synthesis", "meta_cognitive_observation"],
+      6,
+    );
+    const baiaToPasto = results.find(
+      (r) => r.transition_name === "baia_to_pasto",
+    );
+    expect(baiaToPasto?.fired).toBe(true);
+    expect(baiaToPasto?.confirmatory_matched).toContain(
+      "meta_cognitive_observation",
+    );
+  });
+
+  it("baia_to_pasto bloqueado sem frame_synthesis", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["meta_cognitive_observation", "voluntary_topic_deepening"],
+      10,
+    );
+    const baiaToPasto = results.find(
+      (r) => r.transition_name === "baia_to_pasto",
+    );
+    expect(baiaToPasto?.fired).toBe(false);
+  });
+
+  it("regression_baia_to_brejo dispara com distress_marker_high (window=0)", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["distress_marker_high"],
+      0,
+    );
+    const regr = results.find(
+      (r) => r.transition_name === "regression_baia_to_brejo",
+    );
+    expect(regr?.fired).toBe(true);
+  });
+
+  it("regression_baia_to_brejo dispara com deflection_silence", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["deflection_silence"],
+      0,
+    );
+    const regr = results.find(
+      (r) => r.transition_name === "regression_baia_to_brejo",
+    );
+    expect(regr?.fired).toBe(true);
+  });
+
+  it("regression_pasto_to_baia dispara com gatekeeper_resistance (window=0)", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["gatekeeper_resistance"],
+      0,
+    );
+    const regr = results.find(
+      (r) => r.transition_name === "regression_pasto_to_baia",
+    );
+    expect(regr?.fired).toBe(true);
+  });
+
+  it("texto neutro (signals vazios) → nenhuma transição dispara", () => {
+    const results = evaluateAllTransitions("kids", [], 10);
+    const fired = results.filter((r) => r.fired);
+    expect(fired).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

A-01 do implementation plan pré-piloto Nagareyama. GAP-02 fechado: `content/profiles/kids.transitions.yaml` reescrito com 4 transições válidas + 11 unit tests cobrindo carregamento e disparo.

**Label intent**: `lane:review actor:jun scope:ascendimacy-motor` — Jun aplica via UI se preferir.

## Status pré-PR

`content/profiles/kids.transitions.yaml` **existia** mas tinha apenas 2 transições + signals inválidos (`2_consecutive_deflexions`, `voluntary_application_to_new_context`, `peer_reference`, `explicit_request_for_simpler_framing` — nenhum desses está em `shared/src/semantic-signals.ts`). Trigger Evaluator rodaria silenciosamente sem matchear.

## Mudanças

**`content/profiles/kids.transitions.yaml`** (reescrita v0.1 → v0.2)
- 4 transições com signals exclusivamente válidos:
  - `brejo_to_baia` (philosophical_self_acceptance OR voluntary_topic_deepening OR mood_drift_up; window≥2; regression: distress_marker_high|gatekeeper_resistance)
  - `baia_to_pasto` (frame_synthesis AND; confirmatory: meta_cog + voluntary_topic; window≥5)
  - `regression_baia_to_brejo` (distress|deflection_silence|deflection_thematic; window=0)
  - `regression_pasto_to_baia` (distress|gatekeeper_resistance; window=0)

**`planejador/tests/trigger-evaluator.test.ts`** (+11 tests)
- Verificam carregamento real do YAML, todas 4 transições presentes, disparos esperados, bloqueio por window/regression, texto neutro → 0 disparos.

## DTs descobertos durante implementação

**DT-A01-01**: spec original (`docs/handoffs/2026-04-28-...md` §A-01) usa nomes de campos que NÃO existem no `TransitionRuleSchema` (`shared/src/transitions-schema.ts`):

| Spec | Schema real |
|---|---|
| `required_signals_any` | `required_signals` + `match_mode: "OR"` (default) |
| `required_signals_all` | `required_signals` + `match_mode: "AND"` |
| `forbidden_signals_any` | `regression_to_<estado>_if` |
| `min_window_turns` | `minimum_window_turns` |
| `from_status` / `to_status` | encoded no NOME da transição |
| `consecutive_turns_required` | **NÃO suportado** |

Mapping documentado inline no header do YAML. Decisão CC (autonomia): respeitar schema existente, não estender. DT futura pode adicionar `consecutive_turns_required` + `from_status`/`to_status` explícitos se piloto mostrar precisão insuficiente.

**DT-A01-02**: `baia_to_pasto` spec combinava `required_signals_all: [frame_synthesis]` + `required_signals_any: [meta_cog, voluntary_topic]`. Schema só tem 1 grupo `required_signals` — frame_synthesis vira required (AND, 1 elemento), os outros 2 viram `confirmatory_signals`. Semantic loss: signals "any" não são strictly required no v0.

**DT-A01-03**: `regression_baia_to_brejo` perdeu semântica de `consecutive_turns_required: 2`; v0 dispara em ocorrência única. Mais permissivo que spec; refinar v1 se false positive alto.

## Validação

- ✅ `npm test --workspace planejador` — **97/97 verde** (foi 86, +11 A-01)
- ✅ `npm test` (monorepo): shared 360, motor-drota 85, motor-execucao 86, llm-gateway 42, orchestrator 2 — todos verde
- ✅ `npm run build --workspace planejador` — TS clean

## Acceptance criteria

- ✅ `loadTransitionsConfig("kids")` retorna config sem erro
- ✅ Arquivo commitado em `content/profiles/kids.transitions.yaml`
- ⏳ Trigger Evaluator no smoke-3d emite ≥1 `transition_evaluated` event — verificável post-merge via `npx sts run-scenario scenarios/smoke-3d.yaml --real-llm`. Tests unitários já confirmam que disparos ocorrem com signals esperados.

## Sequência

A-04 ([sts#19](https://github.com/ascendimacy/ascendimacy-sts/pull/19)) ✅ → **A-01** (este PR) → A-03 → A-05 → A-02

## Refs

- Spec: ascendimacy-ops/docs/handoffs/2026-04-28-implementation-plan-gaps-pre-piloto.md §A-01
- Test plan: ascendimacy-ops/docs/tests/pilot-test-plan-nagareyama-v1.md PL02-01..05
- Schema fonte: `shared/src/transitions-schema.ts`
- Signals fonte: `shared/src/semantic-signals.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)