### PR TITLE
feat(motor-drota): apresentação inaugural turn 0 — templates JP/BR/recorrente (A-02)

### DIFF
--- a/motor-drota/src/inaugural.ts
+++ b/motor-drota/src/inaugural.ts
@@ -1,0 +1,89 @@
+export interface InauguralContext {
+  personaName: string;
+  personaAge: number;
+  profileId: string;
+  culturalDefaults?: object;
+  sessionNumber: number;
+  isJoint: boolean;
+  jointPartnerName?: string;
+}
+
+export interface InauguralOutput {
+  text: string;
+  template_used: string;
+  non_evaluation_clause_present: boolean;
+  exit_right_present: boolean;
+}
+
+function isJpProfile(profileId: string): boolean {
+  return profileId.includes("-jp") || profileId.includes("_jp") || profileId.includes("nagareyama");
+}
+
+function buildSoloJp(ctx: InauguralContext): InauguralOutput {
+  const addressee = ctx.isJoint && ctx.jointPartnerName
+    ? `${ctx.personaName} e ${ctx.jointPartnerName}`
+    : ctx.personaName;
+
+  const text = [
+    `${addressee}, bom te ver por aqui.`,
+    ``,
+    `Não estou aqui pra te avaliar — sem provas, sem notas, sem julgamentos. O que você compartilhar aqui fica entre nós.`,
+    ``,
+    `Se em algum momento quiser parar, é só falar — sem explicação necessária.`,
+    ``,
+    `${ctx.personaName}, tem algo que move você bastante ultimamente? Pode ser um interesse, algo que você pratica, ou uma ideia que fica voltando mesmo quando você não quer.`,
+  ].join("\n");
+
+  return {
+    text,
+    template_used: "inaugural_solo_jp",
+    non_evaluation_clause_present: true,
+    exit_right_present: true,
+  };
+}
+
+function buildSoloBr(ctx: InauguralContext): InauguralOutput {
+  const addressee = ctx.isJoint && ctx.jointPartnerName
+    ? `${ctx.personaName} e ${ctx.jointPartnerName}`
+    : ctx.personaName;
+
+  const text = [
+    `${addressee}, bom te conhecer.`,
+    ``,
+    `Quero deixar claro logo de cara: não estou aqui pra te avaliar. Sem provas, sem julgamentos — o que você trouxer aqui, fica aqui.`,
+    ``,
+    `Se quiser parar em qualquer momento, é só me falar. Sem problema nenhum.`,
+    ``,
+    `Tem alguma coisa que te interesse muito ultimamente, ${ctx.personaName}? Pode ser qualquer coisa — algo que você faz, aprende, ou que fica na sua cabeça mesmo sem querer.`,
+  ].join("\n");
+
+  return {
+    text,
+    template_used: "inaugural_solo_br",
+    non_evaluation_clause_present: true,
+    exit_right_present: true,
+  };
+}
+
+function buildRecorrente(ctx: InauguralContext): InauguralOutput {
+  const text = ctx.isJoint && ctx.jointPartnerName
+    ? `${ctx.personaName}, ${ctx.jointPartnerName} — bom ter vocês dois de volta. Da última vez vocês trouxeram coisas que ficaram martelando. Alguma delas ainda está na cabeça de vocês?`
+    : `${ctx.personaName}, bom ter você de volta. Da última vez você trouxe coisas interessantes — alguma delas ficou martelando na sua cabeça desde então?`;
+
+  return {
+    text,
+    template_used: "inaugural_recorrente",
+    non_evaluation_clause_present: false,
+    exit_right_present: false,
+  };
+}
+
+export async function buildInaugural(ctx: InauguralContext): Promise<InauguralOutput> {
+  if (ctx.sessionNumber > 1) {
+    return buildRecorrente(ctx);
+  }
+  if (isJpProfile(ctx.profileId)) {
+    return buildSoloJp(ctx);
+  }
+  return buildSoloBr(ctx);
+}

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -12,6 +12,7 @@ import { selectFromPool, sanitizeMaterialization } from "./select.js";
 import { callLlm, callLlmMock } from "./llm-client.js";
 import { parseDrotaOutput } from "./parse-output.js";
 import { extractSignals } from "./signal-extractor.js";
+import { buildInaugural } from "./inaugural.js";
 import { logDebugEvent, getProviderForStep } from "@ascendimacy/shared";
 
 const server = new McpServer({
@@ -224,6 +225,47 @@ server.registerTool(
     } as any,
   },
   async (input: EvaluateAndSelectInput) => {
+    // A-02: inaugural turn — returned directly, bypasses scorePool
+    const isFirstTurn = input.state.turn === 0;
+    const isFirstSession = !(input.state.eventLog ?? []).some(
+      (e) => (e as { type?: string }).type === "playbook_executed",
+    );
+    if (isFirstTurn) {
+      const inauguralOutput = await buildInaugural({
+        personaName: input.persona.name,
+        personaAge: input.persona.age,
+        profileId: String(input.contextHints?.["profile_id"] ?? input.persona.id ?? ""),
+        sessionNumber: isFirstSession ? 1 : 2,
+        isJoint: input.state.sessionMode === "joint",
+        jointPartnerName: input.state.jointPartnerName,
+      });
+      const inauguralResult: EvaluateAndSelectOutput = {
+        selectedContent: {
+          item: {
+            id: "__inaugural__",
+            type: "curiosity_hook",
+            domain: "social_emotional",
+            casel_target: ["relationship_skills"],
+            age_range: [10, 18],
+            surprise: 5,
+            verified: true,
+            base_score: 10,
+            fact: "",
+            bridge: "",
+            quest: "",
+            sacrifice_type: "reflect",
+          } as unknown as ContentItem,
+          score: 10,
+          reasons: [`inaugural:${inauguralOutput.template_used}`],
+        },
+        selectionRationale: `inaugural:${inauguralOutput.template_used}`,
+        linguisticMaterialization: inauguralOutput.text,
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(inauguralResult) }],
+      };
+    }
+
     const ranked = rankPool(input.contentPool);
     if (ranked.length === 0) {
       // Pool vazio: fallback conversacional (v2 §4.2 do plano).

--- a/motor-drota/tests/inaugural.test.ts
+++ b/motor-drota/tests/inaugural.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { buildInaugural } from "../src/inaugural.js";
+import type { InauguralContext } from "../src/inaugural.js";
+
+const baseCtxJp: InauguralContext = {
+  personaName: "Ryo",
+  personaAge: 13,
+  profileId: "kids-jp",
+  sessionNumber: 1,
+  isJoint: false,
+};
+
+const baseCtxBr: InauguralContext = {
+  personaName: "Paula",
+  personaAge: 13,
+  profileId: "kids-br",
+  sessionNumber: 1,
+  isJoint: false,
+};
+
+describe("buildInaugural — primeira sessão (turn 0 + isFirstSession)", () => {
+  it("JP profile: non_evaluation_clause present", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.non_evaluation_clause_present).toBe(true);
+    expect(result.text).toMatch(/não.*avaliar|sem.*julgamento/i);
+  });
+
+  it("JP profile: exit_right present", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.exit_right_present).toBe(true);
+    expect(result.text).toMatch(/parar|sair/i);
+  });
+
+  it("JP profile: uses inaugural_solo_jp template", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.template_used).toBe("inaugural_solo_jp");
+  });
+
+  it("BR profile: uses inaugural_solo_br template", async () => {
+    const result = await buildInaugural(baseCtxBr);
+    expect(result.template_used).toBe("inaugural_solo_br");
+    expect(result.non_evaluation_clause_present).toBe(true);
+    expect(result.exit_right_present).toBe(true);
+  });
+
+  it("nagareyama profileId routes to JP template", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, profileId: "nagareyama-ryo-001" });
+    expect(result.template_used).toBe("inaugural_solo_jp");
+  });
+
+  it("addresses persona by name", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.text).toContain("Ryo");
+  });
+
+  it("NUNCA 'Como posso te ajudar'", async () => {
+    const jp = await buildInaugural(baseCtxJp);
+    const br = await buildInaugural(baseCtxBr);
+    expect(jp.text).not.toMatch(/como posso te?\s+ajudar/i);
+    expect(br.text).not.toMatch(/como posso te?\s+ajudar/i);
+  });
+
+  it("NUNCA identificadores técnicos (dot-notation, UUIDs)", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.text).not.toMatch(/kids-jp|nagareyama-ryo|[a-f0-9-]{36}/i);
+    expect(result.text).not.toMatch(/profileId|personaAge|sessionNumber/i);
+  });
+
+  it("NUNCA 'Como IA' ou tom de assistente genérico", async () => {
+    const jp = await buildInaugural(baseCtxJp);
+    const br = await buildInaugural(baseCtxBr);
+    expect(jp.text).not.toMatch(/como ia/i);
+    expect(br.text).not.toMatch(/como ia/i);
+    expect(jp.text).not.toMatch(/estou aqui para te ajudar/i);
+    expect(br.text).not.toMatch(/estou aqui para te ajudar/i);
+  });
+});
+
+describe("buildInaugural — segunda sessão (turn 0 + !isFirstSession)", () => {
+  it("uses inaugural_recorrente template", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, sessionNumber: 2 });
+    expect(result.template_used).toBe("inaugural_recorrente");
+  });
+
+  it("recorrente does NOT require non_evaluation_clause (já estabelecido)", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, sessionNumber: 2 });
+    expect(result.non_evaluation_clause_present).toBe(false);
+  });
+
+  it("recorrente references previous session", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, sessionNumber: 2 });
+    expect(result.text).toMatch(/últim|de volta|voltou/i);
+  });
+});
+
+describe("buildInaugural — modo joint", () => {
+  it("addresses both names in joint JP session", async () => {
+    const result = await buildInaugural({
+      ...baseCtxJp,
+      isJoint: true,
+      jointPartnerName: "Kei",
+    });
+    expect(result.text).toMatch(/Ryo/);
+    expect(result.text).toMatch(/Kei/);
+    expect(result.non_evaluation_clause_present).toBe(true);
+  });
+
+  it("joint recorrente also addresses both", async () => {
+    const result = await buildInaugural({
+      ...baseCtxJp,
+      sessionNumber: 2,
+      isJoint: true,
+      jointPartnerName: "Kei",
+    });
+    expect(result.text).toMatch(/Ryo/);
+    expect(result.text).toMatch(/Kei/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements GAP-05: turn 0 is now differentiated — instead of passing through the regular scorePool/LLM pipeline, it returns a purpose-built inaugural message. Yuji/Yuko need to see a proper first-contact message before the pilot.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `motor-drota/src/inaugural.ts` | New file: `InauguralContext`, `InauguralOutput`, `buildInaugural` |
| `motor-drota/src/server.ts` | Before `rankPool`: check `isFirstTurn`, call `buildInaugural`, return directly |
| `motor-drota/tests/inaugural.test.ts` | 14 new tests |

## Templates v0

**`inaugural_solo_jp`** (profileId contains `jp` or `nagareyama`):
> Ryo, bom te ver por aqui.
>
> Não estou aqui pra te avaliar — sem provas, sem notas, sem julgamentos. O que você compartilhar aqui fica entre nós.
>
> Se em algum momento quiser parar, é só falar — sem explicação necessária.
>
> Ryo, tem algo que move você bastante ultimamente? Pode ser um interesse, algo que você pratica, ou uma ideia que fica voltando mesmo quando você não quer.

**`inaugural_solo_br`** (PT-BR, same structural requirements):
> Paula, bom te conhecer.
>
> Quero deixar claro logo de cara: não estou aqui pra te avaliar. Sem provas, sem julgamentos — o que você trouxer aqui, fica aqui.
>
> Se quiser parar em qualquer momento, é só me falar. Sem problema nenhum.
>
> Tem alguma coisa que te interesse muito ultimamente, Paula? Pode ser qualquer coisa — algo que você faz, aprende, ou que fica na sua cabeça mesmo sem querer.

**`inaugural_recorrente`** (sessionNumber > 1, turn 0 de sessão subsequente):
> Ryo, bom ter você de volta. Da última vez você trouxe coisas interessantes — alguma delas ficou martelando na sua cabeça desde então?

## Regras cumpridas

- [x] NUNCA "Como posso te ajudar" (testado explicitamente)
- [x] NUNCA identificadores técnicos (IDs, dot-notation, UUIDs)
- [x] NUNCA tom de assistente genérico
- [x] Adequado para teen 13yo, contexto JP respeitoso
- [x] `non_evaluation_clause` obrigatória na primeira sessão
- [x] `exit_right` obrigatório na primeira sessão
- [x] Joint mode endereça ambos por nome

## Integração em server.ts

```typescript
const isFirstTurn = input.state.turn === 0;
const isFirstSession = !(input.state.eventLog ?? []).some(
  (e) => e.type === "playbook_executed",
);
if (isFirstTurn) {
  const inauguralOutput = await buildInaugural({
    personaName: input.persona.name,
    personaAge: input.persona.age,
    profileId: String(input.contextHints?.["profile_id"] ?? input.persona.id ?? ""),
    sessionNumber: isFirstSession ? 1 : 2,
    isJoint: input.state.sessionMode === "joint",
    jointPartnerName: input.state.jointPartnerName,
  });
  // return inauguralResult directly
}
```

## DTs descobertos

**DT-A02-01**: `sessionNumber` is currently limited to `1` vs `2+`. If the spec later needs turn-0 customization for session 3+ (e.g., referencing specific milestones), `buildInaugural` would need the full event log or a richer context. For v0, `sessionNumber > 1 → inaugural_recorrente` is sufficient.

**DT-A02-02**: Template selection uses `contextHints.profile_id` (preferred) with fallback to `persona.id`. The orchestrator must pass `profile_id` in contextHints for correct routing (Ryo → `kids-jp`, Paula → `kids-br`). If not present, falls back to `persona.id` which includes "ryo-ochiai" → no JP match → routes to BR. This is documented as a "proceed, Jun confirms" gap.

**DT-A02-03**: `inaugural_recorrente` has `non_evaluation_clause_present=false` and `exit_right_present=false` (session context already established). This is intentional for v0 — Jun may want to add a soft reminder in a future iteration.

## Validação

```
npm run build  ✓
npm test (motor-drota): 99 tests passed (14 new)
Full workspace:  744 tests passed, 7 skipped — no failures
```

## Acceptance criteria

- [x] Turn 0 + primeira sessão → `non_evaluation_clause` e `exit_right` presentes
- [x] Turn 0 + segunda sessão → template `inaugural_recorrente`
- [x] Turn > 0 → código inaugural não invocado (scorePool caminho normal)
- [x] Testes unitários com USE_MOCK_LLM=true equivalente (buildInaugural é template-only, sem LLM)

## Refs

- Handoff: `docs/handoffs/2026-04-28-implementation-plan-gaps-pre-piloto.md` §A-02
- GAP-05 / INT-08 (test plan `inaugural-ryo-turn0`)

lane:review actor:jun scope:ascendimacy-motor

---
_Generated by [Claude Code](https://claude.ai/code/session_014QxtX1DRZygMWSLhf7tuAZ)_