### PR TITLE
feat: motor-simplificacao Steps 1-5 (feature flag side-by-side)

### DIFF
--- a/llm-gateway/src/router.ts
+++ b/llm-gateway/src/router.ts
@@ -46,9 +46,15 @@ interface DegradedState {
   marks: Map<LlmProvider, number>;
 }
 
+// Note: este Router (legacy) só implementa fallback entre anthropic ⇄ infomaniak.
+// Providers "local" e "mock" foram adicionados ao type union (motor-simplificacao-v1)
+// mas não usam este router — chamam direto via callGateway/callLocalVllm/callLlmMock.
+// Os entries são placeholders para satisfazer o type checker; nunca são usados.
 const FALLBACK_MAP: Record<LlmProvider, LlmProvider> = {
   anthropic: "infomaniak",
   infomaniak: "anthropic",
+  local: "anthropic",
+  mock: "anthropic",
 };
 
 export class Router {
@@ -63,13 +69,24 @@ export class Router {
   private readonly degraded: DegradedState = { marks: new Map() };
 
   constructor(opts: RouterOptions = {}) {
+    // local + mock: providers placeholder pra satisfazer Record<LlmProvider, ...>.
+    // Não são chamados por este Router; veja comentário em FALLBACK_MAP.
+    const noopProvider: ProviderClient = {
+      call: async () => {
+        throw new GatewayError("INVALID_REQUEST", "noop placeholder provider — not callable");
+      },
+    };
     this.providers = {
       anthropic: opts.providers?.anthropic ?? anthropicProvider,
       infomaniak: opts.providers?.infomaniak ?? infomaniakProvider,
+      local: opts.providers?.local ?? noopProvider,
+      mock: opts.providers?.mock ?? noopProvider,
     };
     this.buckets = {
       anthropic: opts.buckets?.anthropic ?? new TokenBucket({ rate: parseRate("LLM_GATEWAY_RATE_ANTHROPIC", 50) }),
       infomaniak: opts.buckets?.infomaniak ?? new TokenBucket({ rate: parseRate("LLM_GATEWAY_RATE_INFOMANIAK", 5) }),
+      local: opts.buckets?.local ?? new TokenBucket({ rate: 50 }),
+      mock: opts.buckets?.mock ?? new TokenBucket({ rate: 50 }),
     };
     this.logger = opts.logger ?? { log: () => {} };
     this.primaryHardTimeoutMs = opts.primaryHardTimeoutMs ?? parseMs("LLM_GATEWAY_PRIMARY_TIMEOUT_MS", 30_000);

--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -1,0 +1,204 @@
+/**
+ * Constrained Materializer — substitui Linguistic Materializer + Post-Processor
+ * F1-F5 (motor-drota-v1 §2.4 + §2.5) com constraints embutidas no system prompt.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5
+ *
+ * Filosofia (DS-03, DS-05):
+ *   - Constraints de segurança ficam no system prompt (não em filtros separados)
+ *   - Modelo retorna FALLBACK: <texto seguro> quando seria forçado a violar
+ *   - SEM loop de re-tentativa — fallback é o output (não falha)
+ *   - sanitizeMaterialization mantida como camada final defensiva
+ *
+ * DT-SIM-05 (Jun, 28-abr): voice_profile.materializer.model proposto na spec
+ * (default "qwen") usa string que não está no LlmStep enum atual. Solução v0:
+ * usar step "drota" existente (que já roteia para Kimi via Infomaniak por
+ * default e respeita override per-callsite via DROTA_PROVIDER/DROTA_MODEL env).
+ * Quando voice profile ganhar tipo formal (DT-SIM-02), refatorar pra ler
+ * model dali.
+ */
+
+import { callGateway } from "@ascendimacy/shared";
+import type { ScoredContentItem, EngagementLevel } from "@ascendimacy/shared";
+import { sanitizeMaterialization } from "./select.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface MaterializerContext {
+  /** Item selecionado pelo Pragmatic Selector. */
+  action: ScoredContentItem;
+  /** Nome do sujeito (forma adequada — sem honorífico por padrão JP). */
+  subjectNameForm: string;
+  /** Mood atual 1-10. */
+  mood: number;
+  /** Engajamento. */
+  engagement: EngagementLevel;
+  /** Turno atual da sessão. */
+  turnCount: number;
+  /** Budget remaining após deduct (do SelectionResult). */
+  budgetRemaining: number;
+  /** Jurisdição ativa pra constraints. */
+  jurisdictionActive: "br" | "jp" | "ch";
+  /** Run id pra trace. */
+  run_id?: string;
+  /** Override do step LLM (default "drota"). DT-SIM-05. */
+  llmStep?: string;
+  /** Max tokens (default 300 — Kids respostas curtas). */
+  maxTokens?: number;
+}
+
+export interface MaterializationResult {
+  /** Texto final pronto pra Bridge (já sanitizado). */
+  text: string;
+  /** Modelo usado (provedor:nome). */
+  model_used: string;
+  /** True se LLM retornou FALLBACK: prefix (constraint violado em prompt). */
+  fallback_triggered: boolean;
+  /** Latência da chamada LLM em ms. */
+  latency_ms: number;
+  /** Token count estimado (out tokens). */
+  token_count: number;
+  /** True se sanitizeMaterialization removeu palavras (defensiva final). */
+  sanitization_applied: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// System prompt (Kids — perfil neutro-respeitoso JP/BR)
+// ─────────────────────────────────────────────────────────────────────────
+
+const FALLBACK_PREFIX = "FALLBACK:";
+
+function buildSystemPrompt(ctx: MaterializerContext): string {
+  const moodLowGuidance =
+    ctx.mood <= 3
+      ? "\n- IMPORTANTE: mood ≤ 3 → SEM perguntas abertas. Apenas reconhecimento factual curto."
+      : "";
+
+  const disengagingGuidance =
+    ctx.engagement === "disengaging"
+      ? "\n- IMPORTANTE: engagement=disengaging → 1 frase, tom leve, sem pressão."
+      : "";
+
+  const lengthGuidance =
+    ctx.turnCount <= 3
+      ? "Comprimento: 1-2 frases (turn inicial)."
+      : "Comprimento: pode expandir conforme engajamento, mas sem prolixidade.";
+
+  return `Você é um acompanhante pedagógico de crianças. Seu nome não importa — você é uma voz, não um personagem.
+
+CONTEXTO DO SUJEITO:
+- Nome: ${ctx.subjectNameForm} (use sem honorífico salvo orientação contrária)
+- Mood atual: ${ctx.mood}/10
+- Engajamento: ${ctx.engagement}
+- Turn #${ctx.turnCount} desta sessão
+- Budget de sacrifício restante: ${ctx.budgetRemaining}
+
+AÇÃO A MATERIALIZAR:
+- ID: ${ctx.action.item.id}
+- Tipo: ${ctx.action.item.type}
+- Domínio: ${ctx.action.item.domain}
+- Fact (referência): ${(ctx.action.item as { fact?: string }).fact ?? "(sem fact)"}
+- Bridge: ${(ctx.action.item as { bridge?: string }).bridge ?? "(sem bridge)"}
+- Quest: ${(ctx.action.item as { quest?: string }).quest ?? "(sem quest)"}
+
+CONTRATO DE VOZ (obrigatório):
+- Tom: neutro-respeitoso. Zero infantilização.
+- Zero diminutivos não-solicitados.
+- Zero elogios automáticos ("que legal!", "incrível!", "muito bem!", "que bonitinho!").
+- Zero jargão pedagógico ("dimensão", "CASEL", "Dreyfus", "score", "playbook").
+- Zero falsa simetria ("eu também adoro X").
+- Zero terapia-esqueléstica ("como você está se sentindo com isso?").
+- Zero "Como posso te ajudar?" — você não é assistente genérico.${moodLowGuidance}${disengagingGuidance}
+- ${lengthGuidance}
+
+CONSTRAINTS DE SEGURANÇA (violação = retornar FALLBACK):
+- NUNCA induza o sujeito a compartilhar dados sensíveis (localização, escola, informações de terceiros).
+- NUNCA mencione dados de outros sujeitos por nome (ex: não mencione Kei em sessão de Ryo).
+- NUNCA contradiga restrições de jurisdição ativas (${ctx.jurisdictionActive}).
+- Se a ação especificada exige violar qualquer constraint acima:
+  retorne EXATAMENTE: ${FALLBACK_PREFIX} <reconhecimento neutro de 1 frase sem conteúdo da ação>
+
+INSTRUÇÕES FINAIS:
+Retorne apenas o texto a ser enviado ao sujeito. Sem explicação, sem metadados, sem markdown.
+Se retornar FALLBACK, use exatamente o formato acima.`;
+}
+
+function buildUserMessage(ctx: MaterializerContext): string {
+  return `Materialize a ação especificada acima como mensagem ao sujeito ${ctx.subjectNameForm}. Respeite o contrato de voz.`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Materializa o texto final. Sempre retorna MaterializationResult válido,
+ * nunca lança.
+ *
+ * Pipeline:
+ *   1. Build system prompt com slots dinâmicos
+ *   2. callGateway(step="drota") com constraints embutidas
+ *   3. Parse output: se começar com FALLBACK:, extrai texto seguro
+ *   4. sanitizeMaterialization defensiva final (FORBIDDEN_WORDS)
+ *
+ * Em caso de erro do LLM: retorna texto fallback hardcoded conservador.
+ */
+export async function materialize(
+  ctx: MaterializerContext,
+): Promise<MaterializationResult> {
+  const t0 = Date.now();
+  const systemPrompt = buildSystemPrompt(ctx);
+  const userMessage = buildUserMessage(ctx);
+
+  let rawText: string;
+  let modelUsed = "unknown";
+  let outTokens = 0;
+
+  try {
+    const out = await callGateway({
+      step: ctx.llmStep ?? "drota",
+      systemPrompt,
+      userMessage,
+      maxTokens: ctx.maxTokens ?? 300,
+      run_id: ctx.run_id,
+    });
+    rawText = out.content;
+    modelUsed = `${out.provider}:${out.model}`;
+    outTokens = out.tokens.out;
+  } catch {
+    // LLM error → texto neutro fallback hardcoded
+    return {
+      text: "Tô por aqui. Quando quiser me contar mais, conta.",
+      model_used: "fallback_hardcoded",
+      fallback_triggered: true,
+      latency_ms: Date.now() - t0,
+      token_count: 0,
+      sanitization_applied: false,
+    };
+  }
+
+  // Detect FALLBACK: prefix
+  const fallbackTriggered = rawText.trimStart().startsWith(FALLBACK_PREFIX);
+  let textBeforeSanitize: string;
+  if (fallbackTriggered) {
+    const idx = rawText.indexOf(FALLBACK_PREFIX);
+    textBeforeSanitize = rawText.slice(idx + FALLBACK_PREFIX.length).trim();
+  } else {
+    textBeforeSanitize = rawText.trim();
+  }
+
+  // Sanitização defensiva final
+  const sanitized = sanitizeMaterialization(textBeforeSanitize);
+  const sanitizationApplied = sanitized !== textBeforeSanitize;
+
+  return {
+    text: sanitized,
+    model_used: modelUsed,
+    fallback_triggered: fallbackTriggered,
+    latency_ms: Date.now() - t0,
+    token_count: outTokens,
+    sanitization_applied: sanitizationApplied,
+  };
+}

--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -47,6 +47,8 @@ export interface MaterializerContext {
   llmStep?: string;
   /** Max tokens (default 300 — Kids respostas curtas). */
   maxTokens?: number;
+  /** Última mensagem do sujeito — necessária pra "prioridade contextual". */
+  incomingMessage?: string;
 }
 
 export interface MaterializationResult {
@@ -79,7 +81,8 @@ const FALLBACK_PREFIX = "FALLBACK:";
  * Inclui contrato de voz + regras condicionais (texto fixo) + constraints
  * de segurança. Nada que muda turn-a-turn.
  */
-export const STABLE_MATERIALIZER_PREFIX = `Você é um acompanhante pedagógico de crianças. Seu nome não importa — você é uma voz, não um personagem.
+export const STABLE_MATERIALIZER_PREFIX = `/no_think
+Você é um acompanhante pedagógico de crianças. Seu nome não importa — você é uma voz, não um personagem.
 
 CONTRATO DE VOZ (obrigatório):
 - Tom: neutro-respeitoso. Zero infantilização.
@@ -90,10 +93,16 @@ CONTRATO DE VOZ (obrigatório):
 - Zero terapia-esqueléstica ("como você está se sentindo com isso?").
 - Zero "Como posso te ajudar?" — você não é assistente genérico.
 
+PRIORIDADE CONTEXTUAL (regra geral, vale antes das outras):
+- A ação abaixo é uma POSSIBILIDADE LATENTE, não obrigação. Use-a SÓ se houver ponte natural com o que o sujeito acabou de dizer.
+- O sujeito trouxe um tema concreto na mensagem (objeto, lugar, sentimento, fato dele)? Reconheça PRIMEIRO o tema dele em 1 frase. SE o Domínio/Fact da ação conectar de forma honesta com o tema dele → traga Fact e/ou Bridge/Quest reformulados DENTRO desse tema. SE NÃO conectar → ignore Fact/Bridge/Quest e faça 1 pergunta aberta sobre o tema dele.
+- O sujeito NÃO trouxe tema concreto (turn inaugural, "oi", "tudo bem?", silêncio, mensagem vaga)? → NÃO materialize Fact/Bridge/Quest. Abra com 1 frase curta + 1 pergunta aberta sobre como ele está hoje. Deixa ele puxar o tema.
+- Quest e Bridge entram SEMPRE dentro do contexto que o sujeito puxou — nunca como pergunta solta.
+
 REGRAS CONDICIONAIS (texto fixo; aplicar conforme situação dinâmica abaixo):
 - Se mood ≤ 3 → SEM perguntas abertas. Apenas reconhecimento factual curto.
 - Se engagement = disengaging → 1 frase, tom leve, sem pressão.
-- Se turn ≤ 3 → 1-2 frases (turn inicial).
+- Se turn ≤ 3 → 1-2 frases (turn inicial). Prioridade contextual acima vale duplo.
 - Se turn > 3 → pode expandir conforme engajamento, mas sem prolixidade.
 
 CONSTRAINTS DE SEGURANÇA (violação = retornar FALLBACK):
@@ -116,12 +125,19 @@ function buildUserMessage(ctx: MaterializerContext): string {
   const bridge = (ctx.action.item as { bridge?: string }).bridge ?? "(sem bridge)";
   const quest = (ctx.action.item as { quest?: string }).quest ?? "(sem quest)";
 
+  const incoming = ctx.incomingMessage?.trim() ?? "";
+  const subjectBlock = incoming.length > 0
+    ? `MENSAGEM DO SUJEITO (use como tema, se houver):\n"${incoming}"`
+    : `MENSAGEM DO SUJEITO: (vazia / vaga — não há tema concreto pra puxar)`;
+
   return `SUJEITO: ${ctx.subjectNameForm}
 MOOD: ${ctx.mood}/10 | ENGAJAMENTO: ${ctx.engagement} | TURN: ${ctx.turnCount}
 BUDGET: ${ctx.budgetRemaining}
 JURISDIÇÃO: ${ctx.jurisdictionActive}
 
-AÇÃO A MATERIALIZAR:
+${subjectBlock}
+
+AÇÃO LATENTE (use só se houver ponte natural com a mensagem do sujeito acima):
 - ID: ${ctx.action.item.id}
 - Tipo: ${ctx.action.item.type}
 - Domínio: ${ctx.action.item.domain}
@@ -129,7 +145,7 @@ AÇÃO A MATERIALIZAR:
 - Bridge: ${bridge}
 - Quest: ${quest}
 
-Materialize a ação acima como mensagem ao sujeito. Respeite o contrato de voz e as regras condicionais aplicáveis ao mood/engajamento/turn atual.`;
+Aplique a PRIORIDADE CONTEXTUAL do contrato. Se houver ponte → traga Fact/Bridge/Quest dentro do tema do sujeito. Se não houver tema/ponte → reconheça e abra com 1 pergunta sobre o que ele trouxe (ou como ele está, se mensagem vazia). Respeite contrato de voz + regras condicionais.`;
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -65,43 +65,21 @@ export interface MaterializationResult {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// System prompt (Kids — perfil neutro-respeitoso JP/BR)
+// Prompts (Kids — perfil neutro-respeitoso JP/BR)
+//
+// Step 8 do handoff vLLM: separação STABLE_MATERIALIZER_PREFIX (cacheável)
+// vs userMessage (dinâmico) pra prefix caching funcionar.
+// vLLM faz hash do system message; campos volatéis lá quebram cache hit.
 // ─────────────────────────────────────────────────────────────────────────
 
 const FALLBACK_PREFIX = "FALLBACK:";
 
-function buildSystemPrompt(ctx: MaterializerContext): string {
-  const moodLowGuidance =
-    ctx.mood <= 3
-      ? "\n- IMPORTANTE: mood ≤ 3 → SEM perguntas abertas. Apenas reconhecimento factual curto."
-      : "";
-
-  const disengagingGuidance =
-    ctx.engagement === "disengaging"
-      ? "\n- IMPORTANTE: engagement=disengaging → 1 frase, tom leve, sem pressão."
-      : "";
-
-  const lengthGuidance =
-    ctx.turnCount <= 3
-      ? "Comprimento: 1-2 frases (turn inicial)."
-      : "Comprimento: pode expandir conforme engajamento, mas sem prolixidade.";
-
-  return `Você é um acompanhante pedagógico de crianças. Seu nome não importa — você é uma voz, não um personagem.
-
-CONTEXTO DO SUJEITO:
-- Nome: ${ctx.subjectNameForm} (use sem honorífico salvo orientação contrária)
-- Mood atual: ${ctx.mood}/10
-- Engajamento: ${ctx.engagement}
-- Turn #${ctx.turnCount} desta sessão
-- Budget de sacrifício restante: ${ctx.budgetRemaining}
-
-AÇÃO A MATERIALIZAR:
-- ID: ${ctx.action.item.id}
-- Tipo: ${ctx.action.item.type}
-- Domínio: ${ctx.action.item.domain}
-- Fact (referência): ${(ctx.action.item as { fact?: string }).fact ?? "(sem fact)"}
-- Bridge: ${(ctx.action.item as { bridge?: string }).bridge ?? "(sem bridge)"}
-- Quest: ${(ctx.action.item as { quest?: string }).quest ?? "(sem quest)"}
+/**
+ * Prefixo IMUTÁVEL na sessão — vai pra cacheableSystemPrefix.
+ * Inclui contrato de voz + regras condicionais (texto fixo) + constraints
+ * de segurança. Nada que muda turn-a-turn.
+ */
+export const STABLE_MATERIALIZER_PREFIX = `Você é um acompanhante pedagógico de crianças. Seu nome não importa — você é uma voz, não um personagem.
 
 CONTRATO DE VOZ (obrigatório):
 - Tom: neutro-respeitoso. Zero infantilização.
@@ -110,23 +88,48 @@ CONTRATO DE VOZ (obrigatório):
 - Zero jargão pedagógico ("dimensão", "CASEL", "Dreyfus", "score", "playbook").
 - Zero falsa simetria ("eu também adoro X").
 - Zero terapia-esqueléstica ("como você está se sentindo com isso?").
-- Zero "Como posso te ajudar?" — você não é assistente genérico.${moodLowGuidance}${disengagingGuidance}
-- ${lengthGuidance}
+- Zero "Como posso te ajudar?" — você não é assistente genérico.
+
+REGRAS CONDICIONAIS (texto fixo; aplicar conforme situação dinâmica abaixo):
+- Se mood ≤ 3 → SEM perguntas abertas. Apenas reconhecimento factual curto.
+- Se engagement = disengaging → 1 frase, tom leve, sem pressão.
+- Se turn ≤ 3 → 1-2 frases (turn inicial).
+- Se turn > 3 → pode expandir conforme engajamento, mas sem prolixidade.
 
 CONSTRAINTS DE SEGURANÇA (violação = retornar FALLBACK):
 - NUNCA induza o sujeito a compartilhar dados sensíveis (localização, escola, informações de terceiros).
-- NUNCA mencione dados de outros sujeitos por nome (ex: não mencione Kei em sessão de Ryo).
-- NUNCA contradiga restrições de jurisdição ativas (${ctx.jurisdictionActive}).
+- NUNCA mencione dados de outros sujeitos por nome.
+- NUNCA contradiga restrições de jurisdição ativa.
 - Se a ação especificada exige violar qualquer constraint acima:
   retorne EXATAMENTE: ${FALLBACK_PREFIX} <reconhecimento neutro de 1 frase sem conteúdo da ação>
 
 INSTRUÇÕES FINAIS:
 Retorne apenas o texto a ser enviado ao sujeito. Sem explicação, sem metadados, sem markdown.
 Se retornar FALLBACK, use exatamente o formato acima.`;
-}
 
+/**
+ * userMessage — DINÂMICO turn-a-turn. Inclui SUJEITO/MOOD/ENGAJAMENTO/TURN/
+ * BUDGET/AÇÃO. NÃO vai pro cacheableSystemPrefix — varia a cada turn.
+ */
 function buildUserMessage(ctx: MaterializerContext): string {
-  return `Materialize a ação especificada acima como mensagem ao sujeito ${ctx.subjectNameForm}. Respeite o contrato de voz.`;
+  const fact = (ctx.action.item as { fact?: string }).fact ?? "(sem fact)";
+  const bridge = (ctx.action.item as { bridge?: string }).bridge ?? "(sem bridge)";
+  const quest = (ctx.action.item as { quest?: string }).quest ?? "(sem quest)";
+
+  return `SUJEITO: ${ctx.subjectNameForm}
+MOOD: ${ctx.mood}/10 | ENGAJAMENTO: ${ctx.engagement} | TURN: ${ctx.turnCount}
+BUDGET: ${ctx.budgetRemaining}
+JURISDIÇÃO: ${ctx.jurisdictionActive}
+
+AÇÃO A MATERIALIZAR:
+- ID: ${ctx.action.item.id}
+- Tipo: ${ctx.action.item.type}
+- Domínio: ${ctx.action.item.domain}
+- Fact: ${fact}
+- Bridge: ${bridge}
+- Quest: ${quest}
+
+Materialize a ação acima como mensagem ao sujeito. Respeite o contrato de voz e as regras condicionais aplicáveis ao mood/engajamento/turn atual.`;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -138,8 +141,8 @@ function buildUserMessage(ctx: MaterializerContext): string {
  * nunca lança.
  *
  * Pipeline:
- *   1. Build system prompt com slots dinâmicos
- *   2. callGateway(step="drota") com constraints embutidas
+ *   1. STABLE_MATERIALIZER_PREFIX (cacheável) + userMessage (dinâmico)
+ *   2. callGateway(step="drota") — vLLM prefix caching opera sobre prefix
  *   3. Parse output: se começar com FALLBACK:, extrai texto seguro
  *   4. sanitizeMaterialization defensiva final (FORBIDDEN_WORDS)
  *
@@ -149,7 +152,6 @@ export async function materialize(
   ctx: MaterializerContext,
 ): Promise<MaterializationResult> {
   const t0 = Date.now();
-  const systemPrompt = buildSystemPrompt(ctx);
   const userMessage = buildUserMessage(ctx);
 
   let rawText: string;
@@ -159,7 +161,10 @@ export async function materialize(
   try {
     const out = await callGateway({
       step: ctx.llmStep ?? "drota",
-      systemPrompt,
+      // systemPrompt vazio: tudo fixo está em cacheableSystemPrefix.
+      // Preserva prefix caching no vLLM (Step 8 do handoff).
+      systemPrompt: "",
+      cacheableSystemPrefix: STABLE_MATERIALIZER_PREFIX,
       userMessage,
       maxTokens: ctx.maxTokens ?? 300,
       run_id: ctx.run_id,

--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -84,14 +84,18 @@ const FALLBACK_PREFIX = "FALLBACK:";
 export const STABLE_MATERIALIZER_PREFIX = `/no_think
 Você é um acompanhante pedagógico de crianças. Seu nome não importa — você é uma voz, não um personagem.
 
-CONTRATO DE VOZ (obrigatório):
+CONTRATO DE VOZ (obrigatório, sem exceção):
 - Tom: neutro-respeitoso. Zero infantilização.
 - Zero diminutivos não-solicitados.
-- Zero elogios automáticos ("que legal!", "incrível!", "muito bem!", "que bonitinho!").
+- Zero elogios automáticos. PROIBIDO usar (mesmo prefixados em meio à frase): "que legal!", "legal!", "incrível!", "muito bem!", "ótimo!", "isso é ótimo", "parece legal", "parece divertido", "que bonitinho!", "Que bom!", "isso é bom para…".
 - Zero jargão pedagógico ("dimensão", "CASEL", "Dreyfus", "score", "playbook").
-- Zero falsa simetria ("eu também adoro X").
+- Zero falsa simetria. PROIBIDO dizer "eu também", "tô X também", "também adoro/curto/treino/jogo X". Você não tem hobbies, gostos, treino próprio — você acompanha o sujeito.
 - Zero terapia-esqueléstica ("como você está se sentindo com isso?").
 - Zero "Como posso te ajudar?" — você não é assistente genérico.
+
+ANTI-LOOP (importante, sob risco de soar artificial):
+- Se o sujeito repete a mesma resposta entre turns (ex: "tô treinando tênis" 3x seguidas), NÃO insista no mesmo enquadramento. Reconheça brevemente (1 cláusula) e MUDE o ângulo: pergunte sobre algo adjacente, ou recue ("ok, tô por aqui quando quiser").
+- Não escale com elogios cumulativos ("legal!" → "muito legal!" → "que demais!") — isso soa falso e o contrato proíbe.
 
 PRIORIDADE CONTEXTUAL (regra geral, vale antes das outras):
 - A ação abaixo é uma POSSIBILIDADE LATENTE, não obrigação. Use-a SÓ se houver ponte natural com o que o sujeito acabou de dizer.

--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -49,6 +49,12 @@ export interface MaterializerContext {
   maxTokens?: number;
   /** Última mensagem do sujeito — necessária pra "prioridade contextual". */
   incomingMessage?: string;
+  /** motor#69 H4: Helix phase ("solo" / "retrieval" / "boss"). */
+  helixPhase?: "solo" | "retrieval" | "boss";
+  /** motor#69 H4: dim CASEL ativa do meta-ciclo Helix. */
+  caselFocusDim?: string;
+  /** motor#69 H4: dim CASEL anterior (retrieval) — só se phase != solo. */
+  caselRetrievalDim?: string;
 }
 
 export interface MaterializationResult {
@@ -108,6 +114,8 @@ REGRAS CONDICIONAIS (texto fixo; aplicar conforme situação dinâmica abaixo):
 - Se engagement = disengaging → 1 frase, tom leve, sem pressão.
 - Se turn ≤ 3 → 1-2 frases (turn inicial). Prioridade contextual acima vale duplo.
 - Se turn > 3 → pode expandir conforme engajamento, mas sem prolixidade.
+- Se HELIX_PHASE = boss (Double Helix integrador) → quest/desafio integra os DOIS domínios CASEL (CASEL_FOCUS_DIM + CASEL_RETRIEVAL_DIM) numa única atividade concreta, não em quests separadas. Ex: SOC ativo + SA retrieval → "como sua autoconsciência muda quando está com outras pessoas?" (não duas perguntas).
+- Se HELIX_PHASE = retrieval → mencionar CASEL_RETRIEVAL_DIM sutilmente como ponte (re-visita), sem forçar.
 
 CONSTRAINTS DE SEGURANÇA (violação = retornar FALLBACK):
 - NUNCA induza o sujeito a compartilhar dados sensíveis (localização, escola, informações de terceiros).
@@ -134,11 +142,16 @@ function buildUserMessage(ctx: MaterializerContext): string {
     ? `MENSAGEM DO SUJEITO (use como tema, se houver):\n"${incoming}"`
     : `MENSAGEM DO SUJEITO: (vazia / vaga — não há tema concreto pra puxar)`;
 
+  // motor#69 H4: helix block (omit quando phase=undefined / fora do helix path).
+  const helixBlock = ctx.helixPhase
+    ? `\nHELIX_PHASE: ${ctx.helixPhase}${ctx.caselFocusDim ? ` | CASEL_FOCUS_DIM: ${ctx.caselFocusDim}` : ""}${ctx.caselRetrievalDim ? ` | CASEL_RETRIEVAL_DIM: ${ctx.caselRetrievalDim}` : ""}\n`
+    : "";
+
   return `SUJEITO: ${ctx.subjectNameForm}
 MOOD: ${ctx.mood}/10 | ENGAJAMENTO: ${ctx.engagement} | TURN: ${ctx.turnCount}
 BUDGET: ${ctx.budgetRemaining}
 JURISDIÇÃO: ${ctx.jurisdictionActive}
-
+${helixBlock}
 ${subjectBlock}
 
 AÇÃO LATENTE (use só se houver ponte natural com a mensagem do sujeito acima):

--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -55,6 +55,14 @@ export interface MaterializerContext {
   caselFocusDim?: string;
   /** motor#69 H4: dim CASEL anterior (retrieval) — só se phase != solo. */
   caselRetrievalDim?: string;
+  /**
+   * 2026-05-05 (sts-realista): janela curta de history (últimos 3 pares
+   * user/assistant). Motor é semi-stateless: estratégia (helix, status,
+   * gardner) vem de state; awareness conversacional vem daqui pra evitar
+   * loops + permitir continuidade temática. NÃO vai pro PREFIX cacheável —
+   * é dinâmico turn-a-turn, fica em userMessage.
+   */
+  recentTurns?: Array<{ role: "user" | "assistant"; content: string }>;
 }
 
 export interface MaterializationResult {
@@ -102,18 +110,33 @@ CONTRATO DE VOZ (obrigatório, sem exceção):
 ANTI-LOOP (importante, sob risco de soar artificial):
 - Se o sujeito repete a mesma resposta entre turns (ex: "tô treinando tênis" 3x seguidas), NÃO insista no mesmo enquadramento. Reconheça brevemente (1 cláusula) e MUDE o ângulo: pergunte sobre algo adjacente, ou recue ("ok, tô por aqui quando quiser").
 - Não escale com elogios cumulativos ("legal!" → "muito legal!" → "que demais!") — isso soa falso e o contrato proíbe.
+- Se o sujeito desviou de um tema (mudou de assunto explicitamente), NÃO retorne a esse tema na mesma resposta. O contextHints.avoid indica o tema a evitar — respeite-o literalmente.
 
-PRIORIDADE CONTEXTUAL (regra geral, vale antes das outras):
-- A ação abaixo é uma POSSIBILIDADE LATENTE, não obrigação. Use-a SÓ se houver ponte natural com o que o sujeito acabou de dizer.
-- O sujeito trouxe um tema concreto na mensagem (objeto, lugar, sentimento, fato dele)? Reconheça PRIMEIRO o tema dele em 1 frase. SE o Domínio/Fact da ação conectar de forma honesta com o tema dele → traga Fact e/ou Bridge/Quest reformulados DENTRO desse tema. SE NÃO conectar → ignore Fact/Bridge/Quest e faça 1 pergunta aberta sobre o tema dele.
-- O sujeito NÃO trouxe tema concreto (turn inaugural, "oi", "tudo bem?", silêncio, mensagem vaga)? → NÃO materialize Fact/Bridge/Quest. Abra com 1 frase curta + 1 pergunta aberta sobre como ele está hoje. Deixa ele puxar o tema.
-- Quest e Bridge entram SEMPRE dentro do contexto que o sujeito puxou — nunca como pergunta solta.
+CONTEÚDO PEDAGÓGICO (regra obrigatória):
+O Fact abaixo FOI SELECIONADO para este sujeito neste momento. Você DEVE
+usá-lo — a questão é COMO, não SE.
+
+Regra de ancoragem:
+1. Reconheça o tema do sujeito em 1 frase curta (sem elogio, sem eco excessivo).
+2. Introduza o Fact com uma ponte NATURAL ao que ele disse.
+   - Se o tema do sujeito conecta diretamente ao Domínio → traga o Fact diretamente.
+   - Se o tema do sujeito não conecta diretamente → use o Fact como ângulo lateral.
+     Exemplo: sujeito falou de tênis, Fact é sobre golfinhos com nome → bridge:
+     "Golfinhos chamam uns aos outros pelo nome. Quando você tá em jogo, como
+     chama a atenção do parceiro?"
+3. Bridge e Quest entram DEPOIS do Fact, reformulados dentro do contexto do sujeito.
+4. Exceção única: se o sujeito enviou sinal EXPLÍCITO de saída ("tchau", "preciso ir",
+   "para") OU se o Fact exigiria violar CONSTRAINTS DE SEGURANÇA → ignore o Fact e
+   reconheça brevemente a saída ou retorne FALLBACK.
+
+NUNCA gere resposta genérica ignorando o Fact. Se não encontrar ângulo, crie um.
 
 REGRAS CONDICIONAIS (texto fixo; aplicar conforme situação dinâmica abaixo):
 - Se mood ≤ 3 → SEM perguntas abertas. Apenas reconhecimento factual curto.
 - Se engagement = disengaging → 1 frase, tom leve, sem pressão.
 - Se turn ≤ 3 → 1-2 frases (turn inicial). Prioridade contextual acima vale duplo.
 - Se turn > 3 → pode expandir conforme engajamento, mas sem prolixidade.
+- Se MENSAGEM DO SUJEITO está marcada como vazia/vaga (turn inaugural, "oi", mensagem ≤ 3 palavras sem tema) → NÃO use Fact/Bridge/Quest. Abra com apresentação curta do que vão fazer juntos + 1 pergunta sobre o sujeito.
 - Se HELIX_PHASE = boss (Double Helix integrador) → quest/desafio integra os DOIS domínios CASEL (CASEL_FOCUS_DIM + CASEL_RETRIEVAL_DIM) numa única atividade concreta, não em quests separadas. Ex: SOC ativo + SA retrieval → "como sua autoconsciência muda quando está com outras pessoas?" (não duas perguntas).
 - Se HELIX_PHASE = retrieval → mencionar CASEL_RETRIEVAL_DIM sutilmente como ponte (re-visita), sem forçar.
 
@@ -147,12 +170,32 @@ function buildUserMessage(ctx: MaterializerContext): string {
     ? `\nHELIX_PHASE: ${ctx.helixPhase}${ctx.caselFocusDim ? ` | CASEL_FOCUS_DIM: ${ctx.caselFocusDim}` : ""}${ctx.caselRetrievalDim ? ` | CASEL_RETRIEVAL_DIM: ${ctx.caselRetrievalDim}` : ""}\n`
     : "";
 
+  // 2026-05-05 (sts-realista): janela curta de history pra anti-loop awareness.
+  // Excluímos o turn atual do sujeito (já está em subjectBlock).
+  const turns = ctx.recentTurns ?? [];
+  const tail = turns.slice(-6); // último ~3 pares
+  const botRecent = tail.filter((t) => t.role === "assistant").slice(-3);
+  const userRecent = tail.filter((t) => t.role === "user").slice(-3);
+  const formatLines = (arr: typeof botRecent): string =>
+    arr.length === 0
+      ? "(nenhum)"
+      : arr.map((t, i) => `[${i + 1}] "${t.content.slice(0, 240).replace(/\n/g, " ")}"`).join("\n");
+  const historyBlock = tail.length > 0
+    ? `
+
+VOCÊ JÁ DISSE (não repita verbatim — varie ângulo, vocabulário, abertura):
+${formatLines(botRecent)}
+
+SUJEITO JÁ DISSE (continue o que está em aberto, não recomece zero):
+${formatLines(userRecent)}`
+    : "";
+
   return `SUJEITO: ${ctx.subjectNameForm}
 MOOD: ${ctx.mood}/10 | ENGAJAMENTO: ${ctx.engagement} | TURN: ${ctx.turnCount}
 BUDGET: ${ctx.budgetRemaining}
 JURISDIÇÃO: ${ctx.jurisdictionActive}
 ${helixBlock}
-${subjectBlock}
+${subjectBlock}${historyBlock}
 
 AÇÃO LATENTE (use só se houver ponte natural com a mensagem do sujeito acima):
 - ID: ${ctx.action.item.id}
@@ -162,7 +205,7 @@ AÇÃO LATENTE (use só se houver ponte natural com a mensagem do sujeito acima)
 - Bridge: ${bridge}
 - Quest: ${quest}
 
-Aplique a PRIORIDADE CONTEXTUAL do contrato. Se houver ponte → traga Fact/Bridge/Quest dentro do tema do sujeito. Se não houver tema/ponte → reconheça e abra com 1 pergunta sobre o que ele trouxe (ou como ele está, se mensagem vazia). Respeite contrato de voz + regras condicionais.`;
+Aplique a PRIORIDADE CONTEXTUAL do contrato. Se houver ponte → traga Fact/Bridge/Quest dentro do tema do sujeito. Se não houver tema/ponte → reconheça e abra com 1 pergunta sobre o que ele trouxe (ou como ele está, se mensagem vazia). Respeite contrato de voz + regras condicionais. ANTI-LOOP: se algo da sua lista "VOCÊ JÁ DISSE" está sendo replicado mentalmente, MUDE de ângulo agora.`;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -186,6 +229,12 @@ export async function materialize(
 ): Promise<MaterializationResult> {
   const t0 = Date.now();
   const userMessage = buildUserMessage(ctx);
+  if (process.env["ASC_DEBUG_MATERIALIZER"] === "true") {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[materialize] turn=${ctx.turnCount} recentTurns=${(ctx.recentTurns ?? []).length} userMsgLen=${userMessage.length}\n--- USER MSG START ---\n${userMessage}\n--- USER MSG END ---`,
+    );
+  }
 
   let rawText: string;
   let modelUsed = "unknown";
@@ -199,7 +248,10 @@ export async function materialize(
       systemPrompt: "",
       cacheableSystemPrefix: STABLE_MATERIALIZER_PREFIX,
       userMessage,
-      maxTokens: ctx.maxTokens ?? 300,
+      // 2026-05-05 (sts-realista): turn 1-3 mantém 300 (rapport curto).
+      // turn 4+ permite 600 — abre espaço pra profundidade quando há contexto
+      // estabelecido. Override explícito via ctx.maxTokens vence a heurística.
+      maxTokens: ctx.maxTokens ?? (ctx.turnCount >= 4 ? 600 : 300),
       run_id: ctx.run_id,
     });
     rawText = out.content;

--- a/motor-drota/src/inaugural-template.ts
+++ b/motor-drota/src/inaugural-template.ts
@@ -1,0 +1,259 @@
+/**
+ * Inaugural Template Resolver — apresentação do bot na primeira sessão.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5.5
+ *
+ * Cascade fallback:
+ *   1. ClientVoiceProfile (override por família) → mais específico
+ *   2. CulturalDefaultProfile (ja.yaml, br-pt.yaml, _neutral.yaml)
+ *   3. UniversalTemplate (built-in fallback hardcoded)
+ *
+ * Slots resolvidos:
+ *   - greeting (texto da saudação)
+ *   - subject_name_form (nome do sujeito + honorífico)
+ *   - purpose (1-2 frases sobre o que vão fazer)
+ *   - non_evaluation_clause (obrigatória — "não é teste")
+ *   - exit_right (sempre presente — como sair)
+ *   - confirmation_invite (ancorado em interesse se disponível)
+ *
+ * DT-SIM-06: voice_profile + cultural_default ainda são YAMLs sem loader
+ * canônico em runtime. Esta função aceita os dois como `Record<string, unknown>`
+ * (ja parsed via js-yaml externamente). Refatora quando profile-loader real
+ * entrar.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface InauguralChild {
+  /** Nome do sujeito como deve aparecer (sem honorífico por padrão JP). */
+  name: string;
+  /** Honorific override (se família configurou diferente do default). */
+  honorific?: string;
+  /** Idade — usada pra calibração de tom (não exposta no template). */
+  age?: number;
+  /** Interesse principal pra ancorar confirmation_invite. */
+  topInterest?: string;
+}
+
+export interface InauguralResolveInput {
+  /** Voice profile parseado (ClientVoiceProfile). Pode ser null. */
+  voiceProfile?: Record<string, unknown> | null;
+  /** Cultural default parseado (ja.yaml, _neutral.yaml). Pode ser null. */
+  culturalDefault?: Record<string, unknown> | null;
+  /** Dados da criança/sujeito. */
+  child: InauguralChild;
+  /** Número da sessão (1=inaugural, 2+=recorrente). */
+  sessionNumber: number;
+  /** Modo joint? (templates de dyad ficam pra v1). */
+  isJoint?: boolean;
+  /** Nome do parceiro (se joint). */
+  jointPartnerName?: string;
+}
+
+export interface InauguralResolveOutput {
+  /** Texto completo pronto pra Bridge. */
+  text: string;
+  /** Template resolvido (cascade source). */
+  template_used:
+    | "inaugural_solo_jp"
+    | "inaugural_solo_br"
+    | "inaugural_recorrente"
+    | "inaugural_universal_fallback";
+  /** Cláusula de não-avaliação presente? (acceptance criterion). */
+  non_evaluation_clause_present: boolean;
+  /** Direito de saída presente? (acceptance criterion). */
+  exit_right_present: boolean;
+  /** Source da cascade ("client_override" | "cultural_default" | "universal"). */
+  cascade_source: "client_override" | "cultural_default" | "universal";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Universal fallback (built-in PT-BR — funciona sem nenhum YAML)
+// ─────────────────────────────────────────────────────────────────────────
+
+const UNIVERSAL_FALLBACK = {
+  greeting: "Oi",
+  purpose:
+    "Estou aqui pra pensar coisas com você. Não dou respostas — falo junto.",
+  non_evaluation_clause: "Isso não é prova nem avaliação.",
+  exit_right: "Se quiser parar, é só falar.",
+  confirmation_invite_default: "O que tá rolando aí?",
+  confirmation_invite_template: "Hoje quer falar sobre {interest}?",
+};
+
+const UNIVERSAL_RECORRENTE = {
+  template: "Olá de novo, {name}. Pegando de onde paramos?",
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function getNested(
+  obj: Record<string, unknown> | null | undefined,
+  path: string[],
+): unknown {
+  if (!obj) return undefined;
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (cur && typeof cur === "object" && key in cur) {
+      cur = (cur as Record<string, unknown>)[key];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function buildSubjectNameForm(child: InauguralChild): string {
+  const honorific = child.honorific && child.honorific !== "bare_name"
+    ? `-${child.honorific}`
+    : "";
+  return `${child.name}${honorific}`;
+}
+
+function fillTemplate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  let out = template;
+  for (const [k, v] of Object.entries(vars)) {
+    out = out.replace(new RegExp(`\\{${k}\\}`, "g"), v);
+  }
+  return out;
+}
+
+/** Resolve campo via cascade: client → cultural → universal fallback. */
+function resolveField(
+  path: string[],
+  client: Record<string, unknown> | null | undefined,
+  cultural: Record<string, unknown> | null | undefined,
+  fallback: string,
+): { value: string; source: "client_override" | "cultural_default" | "universal" } {
+  const fromClient = asString(getNested(client, path));
+  if (fromClient) return { value: fromClient, source: "client_override" };
+  const fromCultural = asString(getNested(cultural, path));
+  if (fromCultural) return { value: fromCultural, source: "cultural_default" };
+  return { value: fallback, source: "universal" };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve template inaugural via cascade. Sempre retorna texto válido.
+ *
+ * sessionNumber > 1 → template recorrente (curto, referencia sessão anterior).
+ * sessionNumber = 1 → template completo com greeting + purpose + non_eval +
+ * exit_right + confirmation_invite.
+ */
+export function resolveInauguralTemplate(
+  input: InauguralResolveInput,
+): InauguralResolveOutput {
+  // Sessão recorrente — template curto
+  if (input.sessionNumber > 1) {
+    const recorrenteOverride = asString(
+      getNested(input.voiceProfile, ["client_overrides", "recorrente_template"]),
+    );
+    const template = recorrenteOverride ?? UNIVERSAL_RECORRENTE.template;
+    return {
+      text: fillTemplate(template, {
+        name: buildSubjectNameForm(input.child),
+      }),
+      template_used: "inaugural_recorrente",
+      non_evaluation_clause_present: false, // recorrente não precisa
+      exit_right_present: false,
+      cascade_source: recorrenteOverride ? "client_override" : "universal",
+    };
+  }
+
+  // Sessão 1 — template completo
+  const subjectNameForm = buildSubjectNameForm(input.child);
+
+  const greetingPath = ["inaugural", "greeting"];
+  const purposePath = ["inaugural", "purpose"];
+  const nonEvalPath = ["inaugural", "non_evaluation_clause"];
+  const exitRightPath = ["inaugural", "exit_right"];
+  const inviteDefaultPath = ["inaugural", "confirmation_invite_default"];
+  const inviteTemplatePath = ["inaugural", "confirmation_invite_template"];
+
+  const greeting = resolveField(
+    greetingPath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.greeting,
+  );
+  const purpose = resolveField(
+    purposePath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.purpose,
+  );
+  const nonEval = resolveField(
+    nonEvalPath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.non_evaluation_clause,
+  );
+  const exitRight = resolveField(
+    exitRightPath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.exit_right,
+  );
+
+  // Confirmation invite: usa template se interesse disponível, default se não
+  let invite: string;
+  if (input.child.topInterest) {
+    const tmpl = resolveField(
+      inviteTemplatePath,
+      input.voiceProfile,
+      input.culturalDefault,
+      UNIVERSAL_FALLBACK.confirmation_invite_template,
+    );
+    invite = fillTemplate(tmpl.value, { interest: input.child.topInterest });
+  } else {
+    const def = resolveField(
+      inviteDefaultPath,
+      input.voiceProfile,
+      input.culturalDefault,
+      UNIVERSAL_FALLBACK.confirmation_invite_default,
+    );
+    invite = def.value;
+  }
+
+  // Compose final text
+  const greetingLine = `${greeting.value}, ${subjectNameForm}.`;
+  const text = [greetingLine, purpose.value, nonEval.value, exitRight.value, invite]
+    .filter((s) => s && s.trim().length > 0)
+    .join(" ");
+
+  // Cascade source: pega o mais específico que contribuiu
+  const sources = [greeting.source, purpose.source, nonEval.source, exitRight.source];
+  let cascadeSource: "client_override" | "cultural_default" | "universal" = "universal";
+  if (sources.includes("client_override")) cascadeSource = "client_override";
+  else if (sources.includes("cultural_default")) cascadeSource = "cultural_default";
+
+  // Decide template label baseado no language do cultural default
+  let templateUsed: InauguralResolveOutput["template_used"] = "inaugural_universal_fallback";
+  if (cascadeSource !== "universal") {
+    const lang = asString(getNested(input.culturalDefault, ["language"]));
+    if (lang === "ja") templateUsed = "inaugural_solo_jp";
+    else if (lang === "pt") templateUsed = "inaugural_solo_br";
+  }
+
+  return {
+    text: text.trim(),
+    template_used: templateUsed,
+    non_evaluation_clause_present: nonEval.value.length > 0,
+    exit_right_present: exitRight.value.length > 0,
+    cascade_source: cascadeSource,
+  };
+}

--- a/motor-drota/src/llm-client.ts
+++ b/motor-drota/src/llm-client.ts
@@ -96,7 +96,8 @@ export async function callLlmMock(
         "Olá! Que bom ter você aqui. Posso te apresentar algo que pode facilitar muito o seu dia?",
     }),
     tokens: { in: 0, out: 0, reasoning: 0 },
-    provider: "infomaniak",
+    // 2026-05-05: provider/model = "mock" pra distinguir de real call em traces
+    provider: "mock",
     model: "mock",
   };
 }

--- a/motor-drota/src/pragmatic-selector.ts
+++ b/motor-drota/src/pragmatic-selector.ts
@@ -1,0 +1,321 @@
+/**
+ * Pragmatic Selector — substitui Action Evaluator + Action Selector composite
+ * (motor-drota-v1 §2.2 + §2.3) com lógica DETERMINÍSTICA, zero LLM.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §4
+ *
+ * Filosofia: filtro de viabilidade por mood + budget → menor custo entre
+ * viáveis. Tie-break por tactical weight (score do planejador). Pulso hook
+ * opcional para empates dentro de threshold.
+ *
+ * DT-SIM-04 (Jun, 28-abr): spec original usa ActionCandidate com campos
+ * criticality (rotineira|importante|seguranca), estimated_cost, tactical_weight.
+ * Realidade do código: motor-drota recebe ScoredContentItem[] do planejador
+ * com score (~tactical_weight) + item.sacrifice_amount (~estimated_cost). Sem
+ * criticality. Mapping inline; criticality gate fica como stub testável (sempre
+ * 'rotineira' por default) até criticality entrar no schema do ContentItem.
+ */
+
+import { deductBudget } from "@ascendimacy/shared";
+import type {
+  ScoredContentItem,
+  SessionState,
+  EngagementLevel,
+} from "@ascendimacy/shared";
+import type { AssessmentResult } from "./unified-assessor.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Criticality stub — DT-SIM-04 — até campo entrar no ContentItem real. */
+export type Criticality = "rotineira" | "importante" | "seguranca";
+
+export type EscalationReason =
+  | "no_viable_action"
+  | "budget_exhausted"
+  | "criticality_seguranca"; // se vier do meta de input
+
+export interface SelectorInput {
+  /** Pool já scorado pelo planejador. */
+  candidates: ScoredContentItem[];
+  /** Resultado do Unified Assessor — mood + signals + engagement. */
+  assessment: AssessmentResult;
+  /** SessionState atual (volátil — budget_remaining usado). */
+  state: SessionState;
+  /** Override opcional de criticality por candidate (se motor#X adicionar). */
+  criticalityByItemId?: Record<string, Criticality>;
+}
+
+export interface SelectionResult {
+  /** Item escolhido — null se nenhuma viável. */
+  selected: ScoredContentItem | null;
+  /** Estado após deduct (ou intacto se selected null). */
+  newState: SessionState;
+  /** Justificativa em linguagem humana — auditável MotorOps. */
+  decision_path: string;
+  /** Quantas candidatas no pool original. */
+  candidates_count: number;
+  /** Quantas passaram no filtro de viabilidade. */
+  viable_count: number;
+  /** Custo da selecionada (sacrifice_amount ?? 0). */
+  selected_cost: number;
+  /** Budget antes do deduct. */
+  budget_before: number;
+  /** Budget após deduct (= newState.budgetRemaining). */
+  budget_after: number;
+  /** Pulso disparou? */
+  pulso_emitted: boolean;
+  /** Escalação se selected null. */
+  escalate_to: "bridge" | "planner" | null;
+  /** Reason de escalação (se aplicável). */
+  escalate_reason?: EscalationReason;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Constantes (limiares spec §4.2)
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Mood threshold abaixo do qual só ações "leves" são viáveis. */
+const MOOD_LOW_THRESHOLD = 3;
+/** Cost cap quando mood ≤ 3 → só ações ≤ 3. */
+const MOOD_LOW_COST_CAP = 3;
+
+/** Budget threshold abaixo do qual modo conservador. */
+const BUDGET_LOW_THRESHOLD = 10;
+/** Cost cap quando budget < 10 → só ações ≤ 5. */
+const BUDGET_LOW_COST_CAP = 5;
+
+/** Cost cap quando engajamento = disengaging → só ações ≤ 4. */
+const DISENGAGING_COST_CAP = 4;
+
+/** Cost cap em modo mínimo (budget ≤ 0). */
+const MINIMAL_COST_CAP = 2;
+
+/** Tie threshold pra Pulso (delta de score ou cost). */
+const TIE_COST_DELTA = 1;
+const TIE_SCORE_DELTA = 0.05;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function getCost(item: ScoredContentItem): number {
+  return item.item.sacrifice_amount ?? 0;
+}
+
+function getCriticality(
+  item: ScoredContentItem,
+  overrides?: Record<string, Criticality>,
+): Criticality {
+  // DT-SIM-04: sem campo criticality em ContentItem ainda.
+  // Override permite tests + futura integração.
+  return overrides?.[item.item.id] ?? "rotineira";
+}
+
+function applyCostCap(
+  candidates: ScoredContentItem[],
+  cap: number,
+): ScoredContentItem[] {
+  return candidates.filter((c) => getCost(c) <= cap);
+}
+
+/** Texto humano resumindo viabilidade. */
+function describeViabilityFilter(
+  mood: number,
+  engagement: EngagementLevel,
+  budget: number,
+  initial: number,
+  filtered: number,
+): string {
+  const filters: string[] = [];
+  if (mood <= MOOD_LOW_THRESHOLD) {
+    filters.push(`mood=${mood} (≤${MOOD_LOW_THRESHOLD}) → cost≤${MOOD_LOW_COST_CAP}`);
+  } else if (engagement === "disengaging") {
+    filters.push(`engagement=disengaging → cost≤${DISENGAGING_COST_CAP}`);
+  } else if (budget < BUDGET_LOW_THRESHOLD) {
+    filters.push(`budget=${budget} (<${BUDGET_LOW_THRESHOLD}) → cost≤${BUDGET_LOW_COST_CAP}`);
+  }
+  if (filters.length === 0) return `${initial} candidatas viáveis (mood/budget ok)`;
+  return `${filters.join("; ")} → ${filtered}/${initial} viáveis`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Seleciona ação determinísticamente. Zero LLM.
+ *
+ * Pipeline (spec §4.2):
+ *   1. Gate criticality:seguranca → escalate Bridge sem materializar
+ *   2. Filtro viabilidade por mood/engagement/budget
+ *   3. Sem viáveis → escalate Planejador
+ *   4. Budget ≤ 0 → modo mínimo (cost ≤ 2)
+ *   5. Sort: menor custo + tie-break por score (tactical_weight)
+ *   6. Pulso hook para empates dentro de threshold (futuro)
+ *
+ * Sempre retorna SelectionResult válido, nunca lança.
+ */
+export function selectAction(input: SelectorInput): SelectionResult {
+  const { candidates, assessment, state, criticalityByItemId } = input;
+  const budgetBefore = state.budgetRemaining;
+
+  // Pool vazio → escala Planejador
+  if (candidates.length === 0) {
+    return {
+      selected: null,
+      newState: state,
+      decision_path: "pool vazio → escala Planejador",
+      candidates_count: 0,
+      viable_count: 0,
+      selected_cost: 0,
+      budget_before: budgetBefore,
+      budget_after: budgetBefore,
+      pulso_emitted: false,
+      escalate_to: "planner",
+      escalate_reason: "no_viable_action",
+    };
+  }
+
+  // Step 1 — Gate criticality:seguranca
+  const securityActions = candidates.filter(
+    (c) => getCriticality(c, criticalityByItemId) === "seguranca",
+  );
+  if (securityActions.length > 0) {
+    const selected = securityActions[0]!;
+    const cost = getCost(selected);
+    const newState = deductBudget(state, cost);
+    return {
+      selected,
+      newState,
+      decision_path: `criticality=seguranca → escala Bridge (sem Materializer); selecionada=${selected.item.id} cost=${cost}`,
+      candidates_count: candidates.length,
+      viable_count: securityActions.length,
+      selected_cost: cost,
+      budget_before: budgetBefore,
+      budget_after: newState.budgetRemaining,
+      pulso_emitted: false,
+      escalate_to: "bridge",
+      escalate_reason: "criticality_seguranca",
+    };
+  }
+
+  // Step 4 (early) — Budget ≤ 0 → modo mínimo
+  if (budgetBefore <= 0) {
+    const minimal = applyCostCap(candidates, MINIMAL_COST_CAP);
+    if (minimal.length === 0) {
+      return {
+        selected: null,
+        newState: state,
+        decision_path: `budget=${budgetBefore} ≤ 0; nenhuma ação cost≤${MINIMAL_COST_CAP} disponível → escala Planejador`,
+        candidates_count: candidates.length,
+        viable_count: 0,
+        selected_cost: 0,
+        budget_before: budgetBefore,
+        budget_after: budgetBefore,
+        pulso_emitted: false,
+        escalate_to: "planner",
+        escalate_reason: "budget_exhausted",
+      };
+    }
+    minimal.sort((a, b) => getCost(a) - getCost(b));
+    const selected = minimal[0]!;
+    const cost = getCost(selected);
+    const newState = deductBudget(state, cost);
+    return {
+      selected,
+      newState,
+      decision_path: `budget=${budgetBefore} ≤ 0 → modo mínimo; selecionada cost-mínima=${selected.item.id} cost=${cost}`,
+      candidates_count: candidates.length,
+      viable_count: minimal.length,
+      selected_cost: cost,
+      budget_before: budgetBefore,
+      budget_after: newState.budgetRemaining,
+      pulso_emitted: false,
+      escalate_to: null,
+    };
+  }
+
+  // Step 2 — Filtro viabilidade
+  const mood = assessment.mood;
+  const engagement = assessment.engagement;
+
+  let viable: ScoredContentItem[];
+  if (mood <= MOOD_LOW_THRESHOLD) {
+    viable = applyCostCap(candidates, MOOD_LOW_COST_CAP);
+  } else if (engagement === "disengaging") {
+    viable = applyCostCap(candidates, DISENGAGING_COST_CAP);
+  } else if (budgetBefore < BUDGET_LOW_THRESHOLD) {
+    viable = applyCostCap(candidates, BUDGET_LOW_COST_CAP);
+  } else {
+    viable = [...candidates];
+  }
+
+  // Step 3 — Sem viáveis → escala Planejador
+  if (viable.length === 0) {
+    return {
+      selected: null,
+      newState: state,
+      decision_path: `${describeViabilityFilter(mood, engagement, budgetBefore, candidates.length, 0)} → escala Planejador`,
+      candidates_count: candidates.length,
+      viable_count: 0,
+      selected_cost: 0,
+      budget_before: budgetBefore,
+      budget_after: budgetBefore,
+      pulso_emitted: false,
+      escalate_to: "planner",
+      escalate_reason: "no_viable_action",
+    };
+  }
+
+  // Step 5 — Sort: menor custo + tie-break por score (desc)
+  viable.sort((a, b) => {
+    const costDiff = getCost(a) - getCost(b);
+    if (costDiff !== 0) return costDiff;
+    return b.score - a.score; // maior score primeiro em empate
+  });
+
+  const top = viable[0]!;
+  const topCost = getCost(top);
+
+  // Step 6 — Pulso hook (futuro). Detecta empate dentro de threshold.
+  const tied = viable.filter(
+    (c) =>
+      Math.abs(getCost(c) - topCost) <= TIE_COST_DELTA &&
+      Math.abs(c.score - top.score) < TIE_SCORE_DELTA,
+  );
+
+  // Pulso ainda não plugado em motor canônico (motor#33). Quando plugar,
+  // chamada vira: if (tied.length > 1 && pulsoEnabled) { applyPulso(tied) }.
+  // Por enquanto: empate resolve por order primeiro (sort stable).
+
+  const selected = top;
+  const newState = deductBudget(state, topCost);
+
+  const filterDesc = describeViabilityFilter(
+    mood,
+    engagement,
+    budgetBefore,
+    candidates.length,
+    viable.length,
+  );
+
+  let path = `${filterDesc}; menor custo: ${selected.item.id} (cost=${topCost})`;
+  if (tied.length > 1) {
+    path += ` [empate ${tied.length}-way; Pulso hook ainda não plugado, ordem estável aplicada]`;
+  }
+
+  return {
+    selected,
+    newState,
+    decision_path: path,
+    candidates_count: candidates.length,
+    viable_count: viable.length,
+    selected_cost: topCost,
+    budget_before: budgetBefore,
+    budget_after: newState.budgetRemaining,
+    pulso_emitted: false,
+    escalate_to: null,
+  };
+}

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -13,6 +13,11 @@ import { callLlm, callLlmMock } from "./llm-client.js";
 import { parseDrotaOutput } from "./parse-output.js";
 import { extractSignals } from "./signal-extractor.js";
 import { logDebugEvent, getProviderForStep } from "@ascendimacy/shared";
+// motor-simplificacao Step 5 (feature flag side-by-side)
+import { assess } from "./unified-assessor.js";
+import { selectAction } from "./pragmatic-selector.js";
+import { materialize } from "./constrained-materializer.js";
+import { resolveInauguralTemplate } from "./inaugural-template.js";
 
 const server = new McpServer({
   name: "motor-drota",
@@ -190,6 +195,135 @@ function buildDrotaPrompt(
   return STABLE_DROTA_PREFIX + "\n\n" + buildDrotaDynamicBody(input, selected);
 }
 
+// ─── motor-simplificacao Step 5: handler simplificado side-by-side ──────────
+// USE_SIMPLIFIED_PIPELINE=true desvia internamente pro pipeline novo
+// (Unified Assessor + Pragmatic Selector + Constrained Materializer).
+// Fluxo antigo (selectFromPool + callLlm + parseDrotaOutput) permanece intacto;
+// rollback = remover env var.
+async function handleSimplifiedPipeline(
+  input: EvaluateAndSelectInput,
+  ranked: ScoredContentItem[],
+): Promise<EvaluateAndSelectOutput> {
+  // Mensagem do sujeito vem em contextHints.last_user_message; fallback
+  // pra instruction_addition se ausente; se ambos vazios, assess opera com
+  // string vazia (mood=5 conservador via rule-based).
+  const lastUserMessage =
+    (input.contextHints?.["last_user_message"] as string | undefined) ??
+    (input.instruction_addition ?? "");
+
+  const recentTurns =
+    (input.contextHints?.["recent_turns"] as
+      | Array<{ role: "user" | "assistant"; content: string }>
+      | undefined) ?? [];
+
+  // 1. Unified Assessor — extrai mood + signals + engagement em 1 chamada
+  //    Haiku (ou rule-based se confidence high pre-LLM).
+  const assessment = await assess({
+    message: lastUserMessage,
+    recentTurns,
+    personaName: input.persona.name,
+    personaAge: input.persona.age,
+    trustLevel: input.state.trustLevel,
+    run_id: input.sessionId,
+  });
+
+  // 2. Pragmatic Selector — determinístico, zero LLM.
+  const selectionResult = selectAction({
+    candidates: ranked,
+    assessment,
+    state: input.state,
+  });
+
+  // Escalação: pool sem viáveis ou budget exausto → fallback conversacional
+  if (!selectionResult.selected || selectionResult.escalate_to !== null) {
+    return {
+      selectedContent:
+        selectionResult.selected ??
+        ranked[0] ?? {
+          item: {
+            id: "__empty_pool__",
+            type: "curiosity_hook",
+            domain: "generic",
+            casel_target: [],
+            age_range: [0, 99],
+            surprise: 7,
+            verified: false,
+            base_score: 0,
+            fact: "",
+            bridge: "",
+            quest: "",
+            sacrifice_type: "reflect",
+          } as ContentItem,
+          score: 0,
+          reasons: ["simplified_pipeline_escalation"],
+        },
+      selectionRationale: selectionResult.decision_path,
+      linguisticMaterialization:
+        "Me conta o que está passando na sua cabeça.",
+      ...(selectionResult.escalate_reason
+        ? { skipReason: selectionResult.escalate_reason }
+        : {}),
+    };
+  }
+
+  // 3a. Apresentação inaugural — turn 0 + flag explícita em contextHints.
+  //     Cascade resolver não chama LLM; texto retorna direto pro Bridge.
+  const isInauguralTurn =
+    input.state.turn === 0 &&
+    input.contextHints?.["is_inaugural_turn"] === true;
+
+  if (isInauguralTurn) {
+    const inaugural = resolveInauguralTemplate({
+      voiceProfile:
+        (input.contextHints?.["voice_profile"] as Record<
+          string,
+          unknown
+        > | undefined) ?? null,
+      culturalDefault:
+        (input.contextHints?.["cultural_default"] as Record<
+          string,
+          unknown
+        > | undefined) ?? null,
+      child: {
+        name: input.persona.name,
+        age: input.persona.age,
+        topInterest: input.contextHints?.["top_interest"] as
+          | string
+          | undefined,
+      },
+      sessionNumber: 1,
+    });
+    return {
+      selectedContent: selectionResult.selected,
+      selectionRationale: `${selectionResult.decision_path} [inaugural ${inaugural.template_used}]`,
+      linguisticMaterialization: inaugural.text,
+    };
+  }
+
+  // 3b. Constrained Materializer — gera texto com constraints in-prompt.
+  const matResult = await materialize({
+    action: selectionResult.selected,
+    subjectNameForm: input.persona.name,
+    mood: assessment.mood,
+    engagement: assessment.engagement,
+    turnCount: input.state.turn,
+    budgetRemaining: selectionResult.budget_after,
+    jurisdictionActive:
+      ((input.contextHints?.["jurisdiction"] as string | undefined) as
+        | "br"
+        | "jp"
+        | "ch") ?? "br",
+    run_id: input.sessionId,
+  });
+
+  return {
+    selectedContent: selectionResult.selected,
+    selectionRationale: selectionResult.decision_path,
+    linguisticMaterialization: matResult.text,
+    ...(matResult.fallback_triggered ? { skipReason: "materializer_fallback" } : {}),
+  };
+}
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 server.registerTool(
   "evaluate_and_select",
@@ -225,6 +359,79 @@ server.registerTool(
   },
   async (input: EvaluateAndSelectInput) => {
     const ranked = rankPool(input.contentPool);
+
+    // ── motor-simplificacao Step 5: feature flag side-by-side ───────────────
+    // USE_SIMPLIFIED_PIPELINE=true desvia pro pipeline simplificado.
+    // Fluxo antigo (linhas abaixo) permanece intacto; rollback = remover env var.
+    if (process.env["USE_SIMPLIFIED_PIPELINE"] === "true") {
+      if (ranked.length === 0) {
+        // Pool vazio: mesmo comportamento do fluxo antigo (consistência).
+        const emptyOutput: EvaluateAndSelectOutput = {
+          selectedContent: {
+            item: {
+              id: "__empty_pool__",
+              type: "curiosity_hook",
+              domain: "generic",
+              casel_target: [],
+              age_range: [0, 99],
+              surprise: 7,
+              verified: false,
+              base_score: 0,
+              fact: "",
+              bridge: "",
+              quest: "",
+              sacrifice_type: "reflect",
+            } as ContentItem,
+            score: 0,
+            reasons: ["pool_empty_fallback"],
+          },
+          selectionRationale: "Pool vazio — fallback conversacional.",
+          linguisticMaterialization:
+            "Oi! Me conta o que está passando na sua cabeça.",
+        };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(emptyOutput) }],
+        };
+      }
+
+      const simplifiedOutput = await handleSimplifiedPipeline(input, ranked);
+
+      logDebugEvent({
+        side: "motor",
+        step: "drota",
+        user_id: input.persona.id,
+        session_id: input.sessionId,
+        turn_number: input.state.turn,
+        model: "simplified_pipeline",
+        provider: "internal",
+        tokens: { in: 0, out: 0 },
+        latency_ms: 0,
+        prompt: "[simplified_pipeline]",
+        response: simplifiedOutput.linguisticMaterialization,
+        reasoning: simplifiedOutput.selectionRationale,
+        snapshots_pre: {
+          drota: {
+            pipeline: "simplified",
+            pool_size: input.contentPool.length,
+          },
+        },
+        snapshots_post: {
+          drota: {
+            selected_item_id: simplifiedOutput.selectedContent.item.id,
+            materialization_length:
+              simplifiedOutput.linguisticMaterialization.length,
+          },
+        },
+        outcome: simplifiedOutput.skipReason ? "skip" : "ok",
+        error_class: simplifiedOutput.skipReason ?? null,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(simplifiedOutput) }],
+      };
+    }
+    // ── FIM motor-simplificacao Step 5 ──────────────────────────────────────
+
     if (ranked.length === 0) {
       // Pool vazio: fallback conversacional (v2 §4.2 do plano).
       const output: EvaluateAndSelectOutput = {

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -314,6 +314,7 @@ async function handleSimplifiedPipeline(
         | "jp"
         | "ch") ?? "br",
     run_id: input.sessionId,
+    incomingMessage: lastUserMessage,
   });
 
   return {

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -12,7 +12,7 @@ import { selectFromPool, sanitizeMaterialization } from "./select.js";
 import { callLlm, callLlmMock } from "./llm-client.js";
 import { parseDrotaOutput } from "./parse-output.js";
 import { extractSignals } from "./signal-extractor.js";
-import { logDebugEvent, getProviderForStep } from "@ascendimacy/shared";
+import { logDebugEvent, getProviderForStep, isApiKeyMissing } from "@ascendimacy/shared";
 // motor-simplificacao Step 5 (feature flag side-by-side)
 import { assess } from "./unified-assessor.js";
 import { selectAction } from "./pragmatic-selector.js";
@@ -471,12 +471,15 @@ server.registerTool(
     // EvaluateAndSelectOutput (compat — caller pega budget de outras camadas).
     const { selected } = selectFromPool(ranked, input.state);
     // motor#22: provider-aware mock detection.
+    // 2026-05-05: usa isApiKeyMissing pra cobrir provider="local" (bug fix).
     const drotaProvider = getProviderForStep("drota");
-    const drotaKeyMissing = drotaProvider === "anthropic"
-      ? !process.env["ANTHROPIC_API_KEY"]
-      : !process.env["INFOMANIAK_API_KEY"];
-    const useMock =
-      process.env["USE_MOCK_LLM"] === "true" || drotaKeyMissing;
+    const drotaKeyMissing = isApiKeyMissing(drotaProvider);
+    const drotaMockReason = process.env["USE_MOCK_LLM"] === "true"
+      ? "USE_MOCK_LLM=true"
+      : drotaKeyMissing
+        ? `${drotaProvider}_api_key_missing`
+        : null;
+    const useMock = drotaMockReason !== null;
     // motor#25 (handoff #24 Tarefa 2): split em stable prefix + dynamic body
     // pra prompt caching. STABLE_DROTA_PREFIX (BLOCO 1+4+5) é literalmente
     // idêntico entre calls — Anthropic cache_control: ephemeral funciona.
@@ -526,6 +529,7 @@ server.registerTool(
 
     // motor#19: debug log (no-op se ASC_DEBUG_MODE off)
     // motor#25: cache hit/miss info via llmResult.tokens.cacheCreation/cacheRead
+    // 2026-05-05: mock_reason refletido no event quando useMock=true.
     logDebugEvent({
       side: "motor",
       step: "drota",
@@ -536,6 +540,7 @@ server.registerTool(
       provider: llmResult.provider,
       tokens: llmResult.tokens,
       latency_ms: llmLatency,
+      mock_reason: drotaMockReason,
       prompt: systemPrompt + "\n\n[USER]\n" + userMessage,
       response: llmResult.content,
       reasoning: llmResult.reasoning,

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -234,6 +234,16 @@ async function handleSimplifiedPipeline(
     state: input.state,
   });
 
+  // 2026-05-05 (sts-realista): assessment exposto no output pra STS usar mood real.
+  const assessmentForOutput = {
+    mood: assessment.mood,
+    mood_confidence: assessment.mood_confidence,
+    mood_method: assessment.mood_method,
+    signals: assessment.signals,
+    engagement: assessment.engagement,
+    rationale: assessment.rationale,
+  };
+
   // Escalação: pool sem viáveis ou budget exausto → fallback conversacional
   if (!selectionResult.selected || selectionResult.escalate_to !== null) {
     return {
@@ -260,6 +270,7 @@ async function handleSimplifiedPipeline(
       selectionRationale: selectionResult.decision_path,
       linguisticMaterialization:
         "Me conta o que está passando na sua cabeça.",
+      assessment: assessmentForOutput,
       ...(selectionResult.escalate_reason
         ? { skipReason: selectionResult.escalate_reason }
         : {}),
@@ -297,6 +308,7 @@ async function handleSimplifiedPipeline(
       selectedContent: selectionResult.selected,
       selectionRationale: `${selectionResult.decision_path} [inaugural ${inaugural.template_used}]`,
       linguisticMaterialization: inaugural.text,
+      assessment: assessmentForOutput,
     };
   }
 
@@ -319,12 +331,15 @@ async function handleSimplifiedPipeline(
     helixPhase: input.contextHints?.["helix_phase"] as "solo" | "retrieval" | "boss" | undefined,
     caselFocusDim: input.contextHints?.["casel_focus_dim"] as string | undefined,
     caselRetrievalDim: input.contextHints?.["casel_retrieval_dim"] as string | undefined,
+    // 2026-05-05 (sts-realista): janela curta de history pra anti-loop.
+    recentTurns,
   });
 
   return {
     selectedContent: selectionResult.selected,
     selectionRationale: selectionResult.decision_path,
     linguisticMaterialization: matResult.text,
+    assessment: assessmentForOutput,
     ...(matResult.fallback_triggered ? { skipReason: "materializer_fallback" } : {}),
   };
 }

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -315,6 +315,10 @@ async function handleSimplifiedPipeline(
         | "ch") ?? "br",
     run_id: input.sessionId,
     incomingMessage: lastUserMessage,
+    // motor#69 H4: helix metadata pra LLM ler regras condicionais boss/retrieval no PREFIX.
+    helixPhase: input.contextHints?.["helix_phase"] as "solo" | "retrieval" | "boss" | undefined,
+    caselFocusDim: input.contextHints?.["casel_focus_dim"] as string | undefined,
+    caselRetrievalDim: input.contextHints?.["casel_retrieval_dim"] as string | undefined,
   });
 
   return {

--- a/motor-drota/src/unified-assessor.ts
+++ b/motor-drota/src/unified-assessor.ts
@@ -1,0 +1,404 @@
+/**
+ * Unified Assessor — substitui signal-extractor + mood-extractor + Environment
+ * Assessor (motor-drota-v1 §2.1) em UMA chamada Haiku.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §3
+ *
+ * Estratégia (DS-06, DS-07, DS-08):
+ *   1. Rule-based pre-pass sobre raw text (regex distress/exit/monosyllabic).
+ *      Cobre ~70% dos casos sem LLM. Confidence high → retorna direto.
+ *   2. Quando rule-based retorna null (ambíguo): chama Haiku via gateway com
+ *      JSON estruturado pedindo signals + mood + engagement em 1 shot.
+ *   3. Haiku falhar / JSON inválido → fallback degradado (mood=5 conservador,
+ *      signals=[], engagement=medium, mood_method='rule', method='fallback').
+ *
+ * DT-SIM-01 (Jun, 28-abr): vocabulário de signals da spec (12 itens) diverge
+ * do código (15 SEMANTIC_SIGNALS canônicos). Decisão CC: usar 15 canônicos
+ * (compat com Trigger Evaluator + transitions.yaml). Mapping spec→canon:
+ *   spec.explicit_distress  → canon.distress_marker_high
+ *   spec.crying_marker      → canon.distress_marker_high
+ *   spec.enthusiasm_high    → heurística text-based (sem signal canônico)
+ *   spec.monosyllabic       → heurística text-based
+ *   spec.exit_marker_*      → heurística text-based + canon.deflection_thematic
+ *   spec.engagement_*       → derivado dos canônicos
+ *   spec.trust_signal       → não mapeado (trust vem de trust-calculator)
+ *   spec.topic_initiated    → canon.voluntary_topic_deepening (próximo)
+ */
+
+import {
+  callGateway,
+  isSemanticSignal,
+} from "@ascendimacy/shared";
+import type { SemanticSignal, EngagementLevel } from "@ascendimacy/shared";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+export type MoodConfidence = "high" | "medium" | "low";
+export type MoodMethod = "rule" | "llm" | "fallback";
+export type AssessmentMethod = "unified_haiku" | "rule_only" | "fallback";
+
+export interface AssessorTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface AssessorInput {
+  /** Mensagem atual do sujeito. */
+  message: string;
+  /** Últimos 5 turns (mensagem + resposta). Vazio em turn 1. */
+  recentTurns: AssessorTurn[];
+  /** Nome do sujeito pra context (pode ser sem honorífico). */
+  personaName?: string;
+  /** Idade do sujeito pra calibração de tom. */
+  personaAge?: number;
+  /** Trust level atual (0-1) — input do trust-calculator. */
+  trustLevel?: number;
+  /** Run id pra trace propagation no gateway logger. */
+  run_id?: string;
+}
+
+export interface AssessmentResult {
+  /** Mood escala 1-10 integer. 1=crise, 5=neutro, 10=eufórico. */
+  mood: number;
+  /** Confidence do mood. */
+  mood_confidence: MoodConfidence;
+  /** Origem do mood pra auditabilidade. */
+  mood_method: MoodMethod;
+
+  /** Signals canônicos detectados (vocabulário 15 SEMANTIC_SIGNALS). */
+  signals: SemanticSignal[];
+
+  /** Engajamento derivado dos signals + mood. */
+  engagement: EngagementLevel;
+
+  /** Método global do assessment. */
+  assessment_method: AssessmentMethod;
+
+  /** Frase curta pra event_log (auditabilidade humana). */
+  rationale: string;
+
+  /** Latência da chamada LLM em ms (0 se rule-only). */
+  latency_ms: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Constantes
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Mood default conservador quando inferência falha. */
+export const MOOD_FALLBACK = 5;
+
+/**
+ * Distress markers PT/JA — mood baixo direto. Inspirados em
+ * mood-extractor.ts mas separados (esta camada roda PRE-LLM, não usa signals).
+ */
+const DISTRESS_PATTERNS: RegExp[] = [
+  // PT
+  /\b(t[ôo]\s+mal|t[ôo]\s+triste|estou\s+(mal|triste)|n[ãa]o\s+quero|chato|t[ée]dio|cansad[oa])\b/i,
+  // JA
+  /(疲|つかれ|嫌|やだ|もういい|つまらん)/i,
+];
+
+/** Exit markers — sujeito quer sair. PT/JA. */
+const EXIT_MARKER_PATTERNS: RegExp[] = [
+  /\b(tchau|preciso\s+ir|vou\s+sair|n[ãa]o\s+t[ôo]\s+afim)\b/i,
+  /(さよなら|sayonara|owari|またね)/i,
+];
+
+/** Enthusiasm — exclamação repetida + entusiasmo lexical. */
+const ENTHUSIASM_PATTERNS: RegExp[] = [
+  /!{2,}/,
+  /\b(adorei|amei|incr[íi]vel|demais|massa|legal\s+pra\s+caramba)\b/i,
+];
+
+const SHORT_TEXT_THRESHOLD = 15;
+const ENTHUSIASM_LENGTH_THRESHOLD = 50;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Rule-based pre-pass
+// ─────────────────────────────────────────────────────────────────────────
+
+interface RuleResult {
+  mood: number;
+  mood_confidence: MoodConfidence;
+  signals: SemanticSignal[];
+  engagement: EngagementLevel;
+  rationale: string;
+}
+
+/**
+ * Tenta inferir mood + signals + engagement por regras determinísticas
+ * sobre texto. Retorna null se ambíguo (LLM resolve depois).
+ *
+ * Cobertura esperada (~70% por spec): distress markers, exit markers,
+ * monosyllabic curto, entusiasmo lexical.
+ */
+export function assessByRules(input: AssessorInput): RuleResult | null {
+  const text = input.message.trim();
+
+  if (text.length === 0) {
+    return {
+      mood: MOOD_FALLBACK,
+      mood_confidence: "low",
+      signals: [],
+      engagement: "low",
+      rationale: "rule: mensagem vazia → mood neutro conservador",
+    };
+  }
+
+  // 1. Distress alto → mood 2
+  for (const pattern of DISTRESS_PATTERNS) {
+    if (pattern.test(text)) {
+      return {
+        mood: 2,
+        mood_confidence: "high",
+        signals: ["distress_marker_high"],
+        engagement: "disengaging",
+        rationale: "rule: distress marker detectado",
+      };
+    }
+  }
+
+  // 2. Exit marker → mood 3
+  for (const pattern of EXIT_MARKER_PATTERNS) {
+    if (pattern.test(text)) {
+      return {
+        mood: 3,
+        mood_confidence: "high",
+        signals: ["deflection_thematic"],
+        engagement: "disengaging",
+        rationale: "rule: exit marker detectado",
+      };
+    }
+  }
+
+  // 3. Entusiasmo + texto longo → mood 8
+  if (text.length > ENTHUSIASM_LENGTH_THRESHOLD) {
+    for (const pattern of ENTHUSIASM_PATTERNS) {
+      if (pattern.test(text)) {
+        return {
+          mood: 8,
+          mood_confidence: "high",
+          signals: ["voluntary_topic_deepening"],
+          engagement: "high",
+          rationale: "rule: entusiasmo lexical + texto longo",
+        };
+      }
+    }
+  }
+
+  // 4. Texto muito curto (sem signals positivos) → mood 4 (medium conf)
+  if (text.length < SHORT_TEXT_THRESHOLD) {
+    const words = text.split(/\s+/).filter((w) => w.length > 0);
+    const monosyllabic = words.length <= 2 && words.every((w) => w.length <= 4);
+    if (monosyllabic) {
+      return {
+        mood: 4,
+        mood_confidence: "medium",
+        signals: ["deflection_silence"],
+        engagement: "low",
+        rationale: "rule: resposta monossilábica/curta",
+      };
+    }
+  }
+
+  // Ambíguo — LLM resolve.
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM call (Haiku unified)
+// ─────────────────────────────────────────────────────────────────────────
+
+const SIGNALS_LIST = [
+  "philosophical_self_acceptance",
+  "frame_rejection",
+  "meta_cognitive_observation",
+  "frame_synthesis",
+  "voluntary_topic_deepening",
+  "vulnerability_offering",
+  "distress_marker_high",
+  "distress_marker_low",
+  "deflection_thematic",
+  "deflection_silence",
+  "mood_drift_up",
+  "mood_drift_down",
+  "peer_reference",
+  "authority_questioning",
+  "gatekeeper_resistance",
+] as const;
+
+const SYSTEM_PROMPT = `Você é um extrator de estado conversacional para acompanhamento pedagógico de crianças/adolescentes.
+Analise mensagem + histórico recente. Retorne APENAS JSON válido, sem markdown, sem explicação.
+
+Schema obrigatório:
+{
+  "mood": <integer 1-10>,
+  "mood_confidence": "<high|medium|low>",
+  "signals": [<lista de strings do vocabulário canônico>],
+  "engagement": "<high|medium|low|disengaging>",
+  "rationale": "<frase curta de até 80 caracteres>"
+}
+
+Vocabulário canônico (use APENAS estes 15 signals):
+${SIGNALS_LIST.join(", ")}
+
+Regras:
+- mood 1-3: sofrimento/resistência. mood 4-6: neutro. mood 7-10: receptivo/empolgado.
+- Mensagem muito curta (<10 chars) sem contexto → mood 5 (conservador).
+- signals = [] se nenhum signal claro. NUNCA invente fora do vocabulário.
+- engagement deriva: high se voluntary_topic_deepening|frame_synthesis; disengaging se distress|deflection.`;
+
+interface LlmJsonOutput {
+  mood: number;
+  mood_confidence: MoodConfidence;
+  signals: string[];
+  engagement: EngagementLevel;
+  rationale: string;
+}
+
+function clampMood(v: unknown): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return MOOD_FALLBACK;
+  const r = Math.round(v);
+  if (r < 1) return 1;
+  if (r > 10) return 10;
+  return r;
+}
+
+function parseJsonResponse(text: string): LlmJsonOutput | null {
+  try {
+    const cleaned = text
+      .replace(/```(?:json)?\n?/g, "")
+      .replace(/```/g, "")
+      .trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const obj = JSON.parse(match[0]) as Record<string, unknown>;
+    if (typeof obj.mood !== "number") return null;
+    return {
+      mood: clampMood(obj.mood),
+      mood_confidence: (obj.mood_confidence as MoodConfidence) ?? "medium",
+      signals: Array.isArray(obj.signals) ? (obj.signals as string[]) : [],
+      engagement: (obj.engagement as EngagementLevel) ?? "medium",
+      rationale:
+        typeof obj.rationale === "string" ? obj.rationale.slice(0, 200) : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildUserMessage(input: AssessorInput): string {
+  const historyText =
+    input.recentTurns.length > 0
+      ? input.recentTurns
+          .map(
+            (t) =>
+              `${t.role === "user" ? input.personaName ?? "Sujeito" : "Bot"}: ${t.content}`,
+          )
+          .join("\n")
+      : "(turn 1 — sem histórico)";
+
+  return `Histórico recente:
+${historyText}
+
+Mensagem atual:
+${input.message}
+
+Responda em JSON.`;
+}
+
+async function assessByLlm(
+  input: AssessorInput,
+): Promise<{ result: LlmJsonOutput; latency_ms: number } | null> {
+  const t0 = Date.now();
+  try {
+    const out = await callGateway({
+      step: "unified-assessor",
+      systemPrompt: SYSTEM_PROMPT,
+      userMessage: buildUserMessage(input),
+      maxTokens: 256,
+      run_id: input.run_id,
+    });
+    const parsed = parseJsonResponse(out.content);
+    if (!parsed) return null;
+    return { result: parsed, latency_ms: Date.now() - t0 };
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Assess unificado: sempre retorna AssessmentResult válido. Nunca lança.
+ *
+ * Pipeline:
+ *   1. Rule-based pre-pass — se confidence high, retorna direto.
+ *   2. LLM (Haiku) com JSON estruturado.
+ *   3. Fallback degradado se LLM falha (mood=5 neutro).
+ */
+export async function assess(
+  input: AssessorInput,
+): Promise<AssessmentResult> {
+  // Step 1 — rule-based
+  const rule = assessByRules(input);
+  if (rule && rule.mood_confidence === "high") {
+    return {
+      mood: rule.mood,
+      mood_confidence: rule.mood_confidence,
+      mood_method: "rule",
+      signals: rule.signals,
+      engagement: rule.engagement,
+      assessment_method: "rule_only",
+      rationale: rule.rationale,
+      latency_ms: 0,
+    };
+  }
+
+  // Step 2 — LLM (Haiku)
+  const llm = await assessByLlm(input);
+  if (llm) {
+    const validSignals = llm.result.signals.filter(isSemanticSignal);
+    return {
+      mood: llm.result.mood,
+      mood_confidence: llm.result.mood_confidence,
+      mood_method: "llm",
+      signals: validSignals,
+      engagement: llm.result.engagement,
+      assessment_method: "unified_haiku",
+      rationale: llm.result.rationale,
+      latency_ms: llm.latency_ms,
+    };
+  }
+
+  // Step 3 — fallback degradado.
+  // Se rule-based retornou medium-conf, prefere isso ao puro neutro.
+  if (rule) {
+    return {
+      mood: rule.mood,
+      mood_confidence: rule.mood_confidence,
+      mood_method: "rule",
+      signals: rule.signals,
+      engagement: rule.engagement,
+      assessment_method: "rule_only",
+      rationale: rule.rationale + " (LLM indisponível)",
+      latency_ms: 0,
+    };
+  }
+
+  return {
+    mood: MOOD_FALLBACK,
+    mood_confidence: "low",
+    mood_method: "fallback",
+    signals: [],
+    engagement: "medium",
+    assessment_method: "fallback",
+    rationale: "fallback: rule-based ambíguo + LLM indisponível",
+    latency_ms: 0,
+  };
+}

--- a/motor-drota/tests/constrained-materializer.test.ts
+++ b/motor-drota/tests/constrained-materializer.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+  ScoredContentItem,
+  ContentItem,
+} from "@ascendimacy/shared";
+
+const captured: { req?: GatewayChatCompletionInput } = {};
+let mockResponse: GatewayChatCompletionOutput | null = null;
+let mockError: Error | null = null;
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: async (req: GatewayChatCompletionInput) => {
+      captured.req = req;
+      if (mockError) throw mockError;
+      if (!mockResponse) {
+        throw new Error("test setup error: mockResponse not set");
+      }
+      return mockResponse;
+    },
+  };
+});
+
+import { materialize } from "../src/constrained-materializer.js";
+import type { MaterializerContext } from "../src/constrained-materializer.js";
+
+const buildLlmResponse = (content: string): GatewayChatCompletionOutput => ({
+  content,
+  tokens: { in: 100, out: 50, reasoning: 0 },
+  provider: "infomaniak",
+  model: "moonshotai/Kimi-K2.5",
+  latency_ms: 150,
+  attempt_count: 1,
+  was_fallback: false,
+});
+
+const stubItem = (id = "test-action"): ScoredContentItem => ({
+  item: {
+    id,
+    type: "curiosity_hook",
+    domain: "biology",
+    casel_target: ["SA"],
+    age_range: [7, 14],
+    surprise: 7,
+    verified: true,
+    base_score: 7,
+    fact: "Os golfinhos têm nomes próprios.",
+    bridge: "Que som você teria como nome?",
+    quest: "Pensa num apelido pra você.",
+    sacrifice_type: "reflect",
+    sacrifice_amount: 3,
+  } as ContentItem,
+  score: 8,
+  reasons: [],
+});
+
+const stubCtx = (overrides: Partial<MaterializerContext> = {}): MaterializerContext => ({
+  action: stubItem(),
+  subjectNameForm: "Ryo",
+  mood: 6,
+  engagement: "medium",
+  turnCount: 2,
+  budgetRemaining: 12,
+  jurisdictionActive: "jp",
+  ...overrides,
+});
+
+beforeEach(() => {
+  captured.req = undefined;
+  mockResponse = null;
+  mockError = null;
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Happy path
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — happy path", () => {
+  it("LLM válido → text limpo, fallback_triggered=false", async () => {
+    mockResponse = buildLlmResponse("Que som você teria como nome?");
+    const r = await materialize(stubCtx());
+    expect(r.text).toBe("Que som você teria como nome?");
+    expect(r.fallback_triggered).toBe(false);
+    expect(r.model_used).toContain("Kimi");
+  });
+
+  it("envia step='drota' por default", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx());
+    expect(captured.req?.step).toBe("drota");
+  });
+
+  it("override de step funciona", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ llmStep: "persona-sim" }));
+    expect(captured.req?.step).toBe("persona-sim");
+  });
+
+  it("system prompt inclui slots dinâmicos", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ subjectNameForm: "Kei", mood: 4 }));
+    const sys = captured.req?.systemPrompt ?? "";
+    expect(sys).toContain("Kei");
+    expect(sys).toContain("Mood atual: 4/10");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// FALLBACK: prefix handling
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — FALLBACK: prefix", () => {
+  it("LLM retorna 'FALLBACK: ...' → fallback_triggered=true e texto extraído", async () => {
+    mockResponse = buildLlmResponse(
+      "FALLBACK: Estou aqui. Conta quando quiser.",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(true);
+    expect(r.text).toBe("Estou aqui. Conta quando quiser.");
+  });
+
+  it("FALLBACK com whitespace inicial", async () => {
+    mockResponse = buildLlmResponse(
+      "  FALLBACK: Texto seguro.  ",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(true);
+    expect(r.text).toBe("Texto seguro.");
+  });
+
+  it("texto SEM prefix FALLBACK → fallback_triggered=false", async () => {
+    mockResponse = buildLlmResponse(
+      "Resposta normal sem fallback prefix.",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sanitização defensiva final (FORBIDDEN_WORDS)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — sanitização final", () => {
+  it("FORBIDDEN_WORDS no output → sanitization_applied=true e palavras removidas", async () => {
+    mockResponse = buildLlmResponse(
+      "Vou usar o playbook pra você.",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.sanitization_applied).toBe(true);
+    expect(r.text).not.toContain("playbook");
+  });
+
+  it("output limpo → sanitization_applied=false", async () => {
+    mockResponse = buildLlmResponse("Texto normal sem termo proibido.");
+    const r = await materialize(stubCtx());
+    expect(r.sanitization_applied).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mood baixo / engagement disengaging — guidance no prompt
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — mood/engagement guidance no prompt", () => {
+  it("mood ≤ 3 inclui guidance 'SEM perguntas abertas'", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ mood: 2 }));
+    expect(captured.req?.systemPrompt).toContain("SEM perguntas abertas");
+  });
+
+  it("engagement disengaging inclui guidance '1 frase, tom leve'", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ engagement: "disengaging" }));
+    expect(captured.req?.systemPrompt).toContain("1 frase, tom leve");
+  });
+
+  it("turn ≤ 3 → guidance comprimento curto", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ turnCount: 1 }));
+    expect(captured.req?.systemPrompt).toContain("turn inicial");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM error → fallback hardcoded
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — LLM error fallback", () => {
+  it("erro do gateway → texto fallback hardcoded + model_used='fallback_hardcoded'", async () => {
+    mockError = new Error("gateway timeout");
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(true);
+    expect(r.model_used).toBe("fallback_hardcoded");
+    expect(r.text.length).toBeGreaterThan(0);
+    expect(r.text).not.toContain("playbook"); // forbidden words check
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Latência + token count
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — metadata", () => {
+  it("latency_ms registrado", async () => {
+    mockResponse = buildLlmResponse("ok");
+    const r = await materialize(stubCtx());
+    expect(r.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("token_count vem do gateway tokens.out", async () => {
+    mockResponse = buildLlmResponse("ok");
+    const r = await materialize(stubCtx());
+    expect(r.token_count).toBe(50); // do mock
+  });
+});

--- a/motor-drota/tests/constrained-materializer.test.ts
+++ b/motor-drota/tests/constrained-materializer.test.ts
@@ -101,12 +101,30 @@ describe("materialize — happy path", () => {
     expect(captured.req?.step).toBe("persona-sim");
   });
 
-  it("system prompt inclui slots dinâmicos", async () => {
+  it("userMessage inclui slots dinâmicos (post-Step 8 refactor)", async () => {
     mockResponse = buildLlmResponse("ok");
     await materialize(stubCtx({ subjectNameForm: "Kei", mood: 4 }));
-    const sys = captured.req?.systemPrompt ?? "";
-    expect(sys).toContain("Kei");
-    expect(sys).toContain("Mood atual: 4/10");
+    // Step 8: campos dinâmicos vão pro userMessage (não systemPrompt) pra
+    // preservar prefix caching no vLLM.
+    const user = captured.req?.userMessage ?? "";
+    expect(user).toContain("Kei");
+    expect(user).toContain("MOOD: 4/10");
+  });
+
+  it("cacheableSystemPrefix é STABLE_MATERIALIZER_PREFIX (cache hit pro vLLM)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx());
+    const prefix = captured.req?.cacheableSystemPrefix ?? "";
+    expect(prefix.length).toBeGreaterThan(100);
+    expect(prefix).toContain("CONTRATO DE VOZ");
+    expect(prefix).toContain("CONSTRAINTS DE SEGURANÇA");
+    expect(prefix).toContain("REGRAS CONDICIONAIS");
+  });
+
+  it("systemPrompt vazio (tudo fixo está em cacheableSystemPrefix)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx());
+    expect(captured.req?.systemPrompt).toBe("");
   });
 });
 
@@ -167,23 +185,34 @@ describe("materialize — sanitização final", () => {
 // Mood baixo / engagement disengaging — guidance no prompt
 // ─────────────────────────────────────────────────────────────────────────
 
-describe("materialize — mood/engagement guidance no prompt", () => {
-  it("mood ≤ 3 inclui guidance 'SEM perguntas abertas'", async () => {
+describe("materialize — regras condicionais sempre no cacheableSystemPrefix", () => {
+  // Step 8: regras condicionais ficam SEMPRE no prefix como texto fixo
+  // ("Se mood ≤ 3 → ..."). Aplicação em runtime depende do mood/engajamento
+  // que LLM lê no userMessage. Cache hit preservado.
+  it("'SEM perguntas abertas' no prefix (regra mood ≤ 3 fixa)", async () => {
     mockResponse = buildLlmResponse("ok");
     await materialize(stubCtx({ mood: 2 }));
-    expect(captured.req?.systemPrompt).toContain("SEM perguntas abertas");
+    expect(captured.req?.cacheableSystemPrefix).toContain("SEM perguntas abertas");
   });
 
-  it("engagement disengaging inclui guidance '1 frase, tom leve'", async () => {
+  it("'1 frase, tom leve' no prefix (regra disengaging fixa)", async () => {
     mockResponse = buildLlmResponse("ok");
     await materialize(stubCtx({ engagement: "disengaging" }));
-    expect(captured.req?.systemPrompt).toContain("1 frase, tom leve");
+    expect(captured.req?.cacheableSystemPrefix).toContain("1 frase, tom leve");
   });
 
-  it("turn ≤ 3 → guidance comprimento curto", async () => {
+  it("'turn inicial' no prefix (regra turn ≤ 3 fixa)", async () => {
     mockResponse = buildLlmResponse("ok");
     await materialize(stubCtx({ turnCount: 1 }));
-    expect(captured.req?.systemPrompt).toContain("turn inicial");
+    expect(captured.req?.cacheableSystemPrefix).toContain("turn inicial");
+  });
+
+  it("MOOD value vai pro userMessage (LLM aplica regra fixa do prefix)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ mood: 2, engagement: "disengaging", turnCount: 1 }));
+    expect(captured.req?.userMessage).toContain("MOOD: 2");
+    expect(captured.req?.userMessage).toContain("ENGAJAMENTO: disengaging");
+    expect(captured.req?.userMessage).toContain("TURN: 1");
   });
 });
 

--- a/motor-drota/tests/constrained-materializer.test.ts
+++ b/motor-drota/tests/constrained-materializer.test.ts
@@ -248,3 +248,42 @@ describe("materialize — metadata", () => {
     expect(r.token_count).toBe(50); // do mock
   });
 });
+
+// ─── 2026-05-05 (bugfix-materializer-content-anchor) ────────────────────────
+describe("STABLE_MATERIALIZER_PREFIX — content anchor + deflection", () => {
+  it("contém 'CONTEÚDO PEDAGÓGICO' e ordena Fact como obrigatório", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("CONTEÚDO PEDAGÓGICO");
+    expect(STABLE_MATERIALIZER_PREFIX).toContain(
+      "FOI SELECIONADO para este sujeito",
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("a questão é COMO, não SE");
+  });
+
+  it("não contém mais 'POSSIBILIDADE LATENTE'", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).not.toContain("POSSIBILIDADE LATENTE");
+  });
+
+  it("ANTI-LOOP inclui constraint de não retornar a tema desviado", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("desviou de um tema");
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("contextHints.avoid");
+  });
+
+  it("REGRAS CONDICIONAIS incluem turn inaugural sem tema → não usar Fact", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("turn inaugural");
+    expect(STABLE_MATERIALIZER_PREFIX).toContain(
+      "NÃO use Fact/Bridge/Quest",
+    );
+  });
+});

--- a/motor-drota/tests/inaugural-template.test.ts
+++ b/motor-drota/tests/inaugural-template.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import { resolveInauguralTemplate } from "../src/inaugural-template.js";
+
+const JA_CULTURAL = {
+  language: "ja",
+  inaugural: {
+    greeting: "こんにちは",
+    purpose: "僕はあなたと一緒に何かを考える相手だよ。",
+    non_evaluation_clause: "これはテストじゃないよ。",
+    exit_right: "「もういい」って言えば、いつでも終われるよ。",
+    confirmation_invite_default: "今日は何が気になってる?",
+    confirmation_invite_template: "今日、{interest}について話したい?",
+  },
+};
+
+const PT_CULTURAL = {
+  language: "pt",
+  inaugural: {
+    greeting: "Oi",
+    purpose: "Estou aqui pra pensar coisas com você.",
+    non_evaluation_clause: "Isso não é prova nem avaliação.",
+    exit_right: "Se quiser parar, é só falar.",
+    confirmation_invite_default: "O que tá rolando aí?",
+    confirmation_invite_template: "Hoje quer falar sobre {interest}?",
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sessão 1 — template completo
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — sessão 1 cultural JP", () => {
+  it("retorna texto JP com todos os slots", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("こんにちは");
+    expect(r.text).toContain("Ryo");
+    expect(r.text).toContain("これはテストじゃないよ");
+    expect(r.text).toContain("もういい");
+    expect(r.template_used).toBe("inaugural_solo_jp");
+    expect(r.non_evaluation_clause_present).toBe(true);
+    expect(r.exit_right_present).toBe(true);
+    expect(r.cascade_source).toBe("cultural_default");
+  });
+
+  it("usa interest no confirmation_invite quando disponível", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo", topInterest: "Dragon Ball" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Dragon Ball");
+  });
+
+  it("usa default invite quando interest ausente", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("気になってる");
+  });
+
+  it("honorific bare_name → sem sufixo", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo", honorific: "bare_name" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Ryo.");
+    expect(r.text).not.toContain("Ryo-");
+  });
+
+  it("honorific kun → sufixo aplicado", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo", honorific: "kun" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Ryo-kun");
+  });
+});
+
+describe("resolveInauguralTemplate — sessão 1 cultural PT", () => {
+  it("retorna texto PT-BR com todos os slots", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: PT_CULTURAL,
+      child: { name: "Saki" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Oi");
+    expect(r.text).toContain("Saki");
+    expect(r.text).toContain("não é prova");
+    expect(r.template_used).toBe("inaugural_solo_br");
+    expect(r.non_evaluation_clause_present).toBe(true);
+    expect(r.exit_right_present).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Cascade override (ClientVoiceProfile)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — cascade ClientVoiceProfile sobrescreve", () => {
+  it("client_override.inaugural.purpose vence cultural", () => {
+    const client = {
+      inaugural: {
+        purpose: "Custom purpose desta família.",
+      },
+    };
+    const r = resolveInauguralTemplate({
+      voiceProfile: client,
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Custom purpose desta família");
+    expect(r.text).not.toContain("僕はあなた"); // cultural purpose NÃO usado
+    expect(r.cascade_source).toBe("client_override");
+  });
+
+  it("client parcial → fallback cultural pros campos não cobertos", () => {
+    const client = { inaugural: { greeting: "Olá!" } }; // só override greeting
+    const r = resolveInauguralTemplate({
+      voiceProfile: client,
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Olá!"); // do client
+    expect(r.text).toContain("もういい"); // do cultural (exit_right)
+    expect(r.cascade_source).toBe("client_override");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Universal fallback (sem voice profile nem cultural)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — universal fallback", () => {
+  it("sem profile nem cultural → texto built-in PT-BR funciona", () => {
+    const r = resolveInauguralTemplate({
+      child: { name: "Test" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Test");
+    expect(r.text.length).toBeGreaterThan(20);
+    expect(r.template_used).toBe("inaugural_universal_fallback");
+    expect(r.non_evaluation_clause_present).toBe(true);
+    expect(r.exit_right_present).toBe(true);
+    expect(r.cascade_source).toBe("universal");
+  });
+
+  it("cultural null + voice null → fallback hardcoded sempre disponível", () => {
+    const r = resolveInauguralTemplate({
+      voiceProfile: null,
+      culturalDefault: null,
+      child: { name: "X" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toBeTruthy();
+    expect(r.exit_right_present).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sessão recorrente (sessionNumber > 1)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — sessão recorrente", () => {
+  it("sessionNumber=2 → template recorrente curto", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 2,
+    });
+    expect(r.template_used).toBe("inaugural_recorrente");
+    expect(r.text).toContain("Ryo");
+    // Recorrente não precisa de non_eval/exit (já apresentados na sessão 1)
+    expect(r.non_evaluation_clause_present).toBe(false);
+    expect(r.exit_right_present).toBe(false);
+  });
+
+  it("sessionNumber=10 também usa recorrente", () => {
+    const r = resolveInauguralTemplate({
+      child: { name: "Kei" },
+      sessionNumber: 10,
+    });
+    expect(r.template_used).toBe("inaugural_recorrente");
+    expect(r.text).toContain("Kei");
+  });
+
+  it("client_override.recorrente_template vence universal", () => {
+    const client = {
+      client_overrides: { recorrente_template: "Custom: {name}, vamos lá!" },
+    };
+    const r = resolveInauguralTemplate({
+      voiceProfile: client,
+      child: { name: "Ryo" },
+      sessionNumber: 3,
+    });
+    expect(r.text).toBe("Custom: Ryo, vamos lá!");
+    expect(r.cascade_source).toBe("client_override");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Acceptance criteria do spec §11
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("acceptance criteria — non_eval + exit_right bilíngue", () => {
+  it("PT + JP ambos têm non_eval + exit_right (sessão 1)", () => {
+    const ja = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    const pt = resolveInauguralTemplate({
+      culturalDefault: PT_CULTURAL,
+      child: { name: "Saki" },
+      sessionNumber: 1,
+    });
+    expect(ja.non_evaluation_clause_present).toBe(true);
+    expect(ja.exit_right_present).toBe(true);
+    expect(pt.non_evaluation_clause_present).toBe(true);
+    expect(pt.exit_right_present).toBe(true);
+  });
+});

--- a/motor-drota/tests/llm-client.test.ts
+++ b/motor-drota/tests/llm-client.test.ts
@@ -86,12 +86,16 @@ describe("motor-drota.callLlm — motor#28b gateway integration", () => {
   });
 
   it("passa step=drota + provider/model/maxTokens corretos pro gateway", async () => {
+    // motor-simplificacao-v1: default mudou pra anthropic+Haiku. Override
+    // explícito pra Kimi via MOTOR_DROTA_MODEL + DROTA_PROVIDER pra preservar
+    // o cenário original do test (reasoning model heuristic com max_tokens=4096).
+    process.env["DROTA_PROVIDER"] = "infomaniak";
     process.env["MOTOR_DROTA_MODEL"] = "moonshotai/Kimi-K2.5";
     const { callLlm } = await import("../src/llm-client.js");
     await callLlm("system", "user");
     expect(captured.req).toBeDefined();
     expect(captured.req!.step).toBe("drota");
-    expect(captured.req!.provider).toBe("infomaniak"); // default
+    expect(captured.req!.provider).toBe("infomaniak"); // override explícito
     expect(captured.req!.model).toBe("moonshotai/Kimi-K2.5");
     expect(captured.req!.maxTokens).toBe(4096); // reasoning model heuristic
     expect(captured.req!.systemPrompt).toBe("system");

--- a/motor-drota/tests/pragmatic-selector.test.ts
+++ b/motor-drota/tests/pragmatic-selector.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+import { selectAction } from "../src/pragmatic-selector.js";
+import type {
+  ScoredContentItem,
+  SessionState,
+  ContentItem,
+} from "@ascendimacy/shared";
+import type { AssessmentResult } from "../src/unified-assessor.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+const stubState = (budget = 15): SessionState => ({
+  sessionId: "test",
+  trustLevel: 0.5,
+  budgetRemaining: budget,
+  eventLog: [],
+  turn: 1,
+});
+
+const stubAssessment = (
+  overrides: Partial<AssessmentResult> = {},
+): AssessmentResult => ({
+  mood: 6,
+  mood_confidence: "medium",
+  mood_method: "rule",
+  signals: [],
+  engagement: "medium",
+  assessment_method: "rule_only",
+  rationale: "neutro",
+  latency_ms: 0,
+  ...overrides,
+});
+
+const item = (
+  id: string,
+  cost: number,
+  score: number,
+): ScoredContentItem => ({
+  item: {
+    id,
+    type: "curiosity_hook",
+    domain: "test",
+    casel_target: ["SA"],
+    age_range: [7, 14],
+    surprise: 7,
+    verified: true,
+    base_score: 7,
+    fact: "",
+    bridge: "",
+    quest: "",
+    sacrifice_type: "reflect",
+    sacrifice_amount: cost,
+  } as ContentItem,
+  score,
+  reasons: [],
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pool vazio
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — pool vazio", () => {
+  it("escala Planejador com no_viable_action", () => {
+    const r = selectAction({
+      candidates: [],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_to).toBe("planner");
+    expect(r.escalate_reason).toBe("no_viable_action");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mood ≤ 3 → cost cap 3
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — mood ≤ 3 (cost cap 3)", () => {
+  it("filtra ações cost > 3 quando mood = 3", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 8, 9), item("light", 2, 5)],
+      assessment: stubAssessment({ mood: 3 }),
+      state: stubState(),
+    });
+    expect(r.selected?.item.id).toBe("light");
+    expect(r.viable_count).toBe(1);
+    expect(r.decision_path).toContain("mood=3");
+  });
+
+  it("filtra ações cost > 3 quando mood = 1 (crise)", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 5, 9), item("medium", 4, 7)],
+      assessment: stubAssessment({ mood: 1 }),
+      state: stubState(),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_to).toBe("planner");
+  });
+
+  it("permite ações cost ≤ 3 quando mood baixo", () => {
+    const r = selectAction({
+      candidates: [item("a", 1, 5), item("b", 2, 7), item("c", 3, 9)],
+      assessment: stubAssessment({ mood: 2 }),
+      state: stubState(),
+    });
+    expect(r.viable_count).toBe(3);
+    expect(r.selected?.item.id).toBe("a"); // menor custo
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Budget < 10 → cost cap 5
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — budget < 10 (cost cap 5)", () => {
+  it("filtra ações cost > 5 quando budget = 8", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 7, 9), item("light", 3, 5)],
+      assessment: stubAssessment({ mood: 6 }),
+      state: stubState(8),
+    });
+    expect(r.selected?.item.id).toBe("light");
+    expect(r.decision_path).toContain("budget=8");
+  });
+
+  it("budget < 10 mas todas ações > 5 → escala Planejador", () => {
+    const r = selectAction({
+      candidates: [item("h1", 7, 9), item("h2", 8, 5)],
+      assessment: stubAssessment({ mood: 6 }),
+      state: stubState(8),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_to).toBe("planner");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Engagement disengaging → cost cap 4
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — engagement disengaging (cost cap 4)", () => {
+  it("filtra ações cost > 4 quando engagement = disengaging", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 6, 9), item("ok", 3, 5)],
+      assessment: stubAssessment({ mood: 6, engagement: "disengaging" }),
+      state: stubState(15),
+    });
+    expect(r.selected?.item.id).toBe("ok");
+    expect(r.decision_path).toContain("disengaging");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Criticality seguranca → escala Bridge
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — criticality:seguranca (gate)", () => {
+  it("seguranca vai direto pra Bridge sem materializer", () => {
+    const r = selectAction({
+      candidates: [item("normal", 3, 9), item("crisis", 10, 5)],
+      assessment: stubAssessment(),
+      state: stubState(),
+      criticalityByItemId: { crisis: "seguranca" },
+    });
+    expect(r.selected?.item.id).toBe("crisis");
+    expect(r.escalate_to).toBe("bridge");
+    expect(r.escalate_reason).toBe("criticality_seguranca");
+  });
+
+  it("sem criticality:seguranca → fluxo normal", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 9)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.escalate_to).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Budget exausto → modo mínimo (cost ≤ 2)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — budget ≤ 0 modo mínimo", () => {
+  it("budget = 0 com cost ≤ 2 disponível → seleciona", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 5, 9), item("min", 2, 5), item("free", 1, 3)],
+      assessment: stubAssessment(),
+      state: stubState(0),
+    });
+    expect(r.selected?.item.id).toBe("free"); // menor cost
+    expect(r.decision_path).toContain("modo mínimo");
+  });
+
+  it("budget = 0 sem cost ≤ 2 → escala Planejador", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 5, 9), item("medium", 4, 5)],
+      assessment: stubAssessment(),
+      state: stubState(0),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_reason).toBe("budget_exhausted");
+  });
+
+  it("budget negativo também triggera modo mínimo", () => {
+    const r = selectAction({
+      candidates: [item("free", 1, 5)],
+      assessment: stubAssessment(),
+      state: stubState(-3),
+    });
+    expect(r.selected?.item.id).toBe("free");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sort menor custo + tie-break por score
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — sort + tie-break", () => {
+  it("menor cost vence", () => {
+    const r = selectAction({
+      candidates: [item("a", 5, 9), item("b", 3, 7), item("c", 7, 8)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.selected?.item.id).toBe("b");
+  });
+
+  it("empate cost → tie-break por score (maior vence)", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 7), item("b", 3, 9), item("c", 5, 10)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.selected?.item.id).toBe("b"); // cost=3, score=9 > a (cost=3, score=7)
+  });
+
+  it("decision_path indica empate quando há tied candidates", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 8), item("b", 3, 8.02)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.decision_path).toMatch(/empate|Pulso/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Budget deduction síncrona
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — budget deduction síncrona", () => {
+  it("newState.budgetRemaining < state.budgetRemaining após seleção", () => {
+    const r = selectAction({
+      candidates: [item("a", 4, 9)],
+      assessment: stubAssessment(),
+      state: stubState(15),
+    });
+    expect(r.budget_before).toBe(15);
+    expect(r.budget_after).toBeLessThan(15);
+    expect(r.newState.budgetRemaining).toBe(r.budget_after);
+  });
+
+  it("escalation NÃO deduz budget", () => {
+    const r = selectAction({
+      candidates: [item("h", 8, 5)],
+      assessment: stubAssessment({ mood: 2 }), // cap=3, action cost=8 → fora
+      state: stubState(15),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.budget_after).toBe(15);
+    expect(r.newState.budgetRemaining).toBe(15);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// decision_path legível por humano
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — decision_path legível", () => {
+  it("happy path inclui filter desc + selecionada", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 8)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.decision_path).toContain("a");
+    expect(r.decision_path).toContain("cost=3");
+  });
+
+  it("sempre retorna string não vazia", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 8)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.decision_path.length).toBeGreaterThan(10);
+  });
+});

--- a/motor-drota/tests/server-simplified-pipeline.test.ts
+++ b/motor-drota/tests/server-simplified-pipeline.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests pra Step 5 — feature flag side-by-side em server.ts.
+ *
+ * Como o handler `evaluate_and_select` é registrado dinamicamente em
+ * McpServer, os tests aqui exercitam diretamente `handleSimplifiedPipeline`
+ * (a função interna que o handler chama com flag on) + verificam que o
+ * código respeita a flag.
+ *
+ * Mock callGateway pra evitar LLM real (usa pattern de
+ * unified-assessor.test.ts e mood-extractor.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+  EvaluateAndSelectInput,
+  ScoredContentItem,
+  ContentItem,
+  PersonaDef,
+  AdquirenteDef,
+} from "@ascendimacy/shared";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mock callGateway
+// ─────────────────────────────────────────────────────────────────────────
+
+const mockState: {
+  responses: GatewayChatCompletionOutput[];
+  callCount: number;
+  capturedSteps: string[];
+} = {
+  responses: [],
+  callCount: 0,
+  capturedSteps: [],
+};
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: async (req: GatewayChatCompletionInput) => {
+      mockState.capturedSteps.push(req.step);
+      const response =
+        mockState.responses[mockState.callCount] ??
+        mockState.responses[mockState.responses.length - 1];
+      mockState.callCount += 1;
+      if (!response) {
+        throw new Error("test setup error: no mock response queued");
+      }
+      return response;
+    },
+  };
+});
+
+// Imports posteriores ao vi.mock (vitest hoists vi.mock factory)
+import { assess } from "../src/unified-assessor.js";
+import { selectAction } from "../src/pragmatic-selector.js";
+import { materialize } from "../src/constrained-materializer.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function buildLlmResponse(content: string): GatewayChatCompletionOutput {
+  return {
+    content,
+    tokens: { in: 100, out: 50, reasoning: 0 },
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    latency_ms: 150,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
+function stubItem(id: string, cost = 3): ScoredContentItem {
+  return {
+    item: {
+      id,
+      type: "curiosity_hook",
+      domain: "biology",
+      casel_target: ["SA"],
+      age_range: [7, 14],
+      surprise: 7,
+      verified: true,
+      base_score: 7,
+      fact: "Os golfinhos têm nomes próprios.",
+      bridge: "Que som você teria como nome?",
+      quest: "Pensa num apelido pra você.",
+      sacrifice_type: "reflect",
+      sacrifice_amount: cost,
+    } as ContentItem,
+    score: 8,
+    reasons: [],
+  };
+}
+
+function stubInput(
+  overrides: Partial<EvaluateAndSelectInput> = {},
+): EvaluateAndSelectInput {
+  return {
+    sessionId: "test-session",
+    contentPool: [stubItem("a", 3), stubItem("b", 5)],
+    state: {
+      sessionId: "test-session",
+      trustLevel: 0.5,
+      budgetRemaining: 15,
+      eventLog: [],
+      turn: 1,
+    },
+    persona: {
+      id: "ryo-001",
+      name: "Ryo",
+      age: 13,
+      profile: {},
+    } as PersonaDef,
+    strategicRationale: "",
+    contextHints: { last_user_message: "estou pensando em algo legal hoje" },
+    ...overrides,
+  } as EvaluateAndSelectInput;
+}
+
+const ORIG_FLAG = process.env["USE_SIMPLIFIED_PIPELINE"];
+
+beforeEach(() => {
+  mockState.responses = [];
+  mockState.callCount = 0;
+  mockState.capturedSteps = [];
+});
+
+afterEach(() => {
+  if (ORIG_FLAG === undefined) delete process.env["USE_SIMPLIFIED_PIPELINE"];
+  else process.env["USE_SIMPLIFIED_PIPELINE"] = ORIG_FLAG;
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Reaproveitamos os componentes individuais — testes de integração
+// validam que a stack inteira funciona quando flag on.
+// (Wholesale test do MCP server stdio fica fora de escopo; flag on/off
+// flow é testado via env var + chamada direta de handleSimplifiedPipeline
+// não-exportada não é viável; em vez disso testamos a composição.)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("Step 5 — composição assess → select → materialize (flag on)", () => {
+  it("happy path: 3 componentes encadeiam e produzem output", async () => {
+    process.env["USE_SIMPLIFIED_PIPELINE"] = "true";
+
+    // Assess responde happy path
+    mockState.responses.push(
+      buildLlmResponse(
+        `{"mood": 7, "mood_confidence": "high", "signals": ["voluntary_topic_deepening"], "engagement": "high", "rationale": "puxa fio"}`,
+      ),
+    );
+    // Materialize responde com texto direto
+    mockState.responses.push(
+      buildLlmResponse("Conta mais sobre essa ideia."),
+    );
+
+    const assessment = await assess({
+      message: "tenho pensado em qual personagem é mais forte",
+      recentTurns: [],
+    });
+    expect(assessment.mood).toBe(7);
+
+    const selection = selectAction({
+      candidates: [stubItem("a", 3), stubItem("b", 5)],
+      assessment,
+      state: stubInput().state,
+    });
+    expect(selection.selected?.item.id).toBeTruthy();
+    expect(selection.escalate_to).toBeNull();
+
+    const mat = await materialize({
+      action: selection.selected!,
+      subjectNameForm: "Ryo",
+      mood: assessment.mood,
+      engagement: assessment.engagement,
+      turnCount: 1,
+      budgetRemaining: selection.budget_after,
+      jurisdictionActive: "jp",
+    });
+    expect(mat.text).toContain("Conta mais");
+    expect(mat.fallback_triggered).toBe(false);
+
+    // Steps usados:
+    expect(mockState.capturedSteps).toContain("unified-assessor");
+    expect(mockState.capturedSteps).toContain("drota");
+  });
+});
+
+describe("Step 5 — flag controlling pipeline activation", () => {
+  it("flag undefined → pipeline antigo (assert flag check é estritamente true)", () => {
+    delete process.env["USE_SIMPLIFIED_PIPELINE"];
+    expect(process.env["USE_SIMPLIFIED_PIPELINE"]).toBeUndefined();
+    // server.ts checa `=== "true"` estritamente; outras strings → fluxo antigo
+  });
+
+  it("flag = 'false' → pipeline antigo", () => {
+    process.env["USE_SIMPLIFIED_PIPELINE"] = "false";
+    expect(process.env["USE_SIMPLIFIED_PIPELINE"]).not.toBe("true");
+  });
+
+  it("flag = 'true' → pipeline simplificado ativo", () => {
+    process.env["USE_SIMPLIFIED_PIPELINE"] = "true";
+    expect(process.env["USE_SIMPLIFIED_PIPELINE"]).toBe("true");
+  });
+
+  it("rollback: flag = 'true' → 'false' mid-test", () => {
+    process.env["USE_SIMPLIFIED_PIPELINE"] = "true";
+    expect(process.env["USE_SIMPLIFIED_PIPELINE"]).toBe("true");
+    process.env["USE_SIMPLIFIED_PIPELINE"] = "false";
+    expect(process.env["USE_SIMPLIFIED_PIPELINE"]).not.toBe("true");
+  });
+});
+
+describe("Step 5 — pool vazio handling (flag on)", () => {
+  it("ranked vazio + flag on → fallback conversacional (mesma string que fluxo antigo)", async () => {
+    // Verificamos que o fallback string é estável; assertion sobre a constante
+    // do server.ts não-exportada exige integration test do handler. Em vez disso,
+    // verificamos que selectAction com pool vazio escala (input pra simplified).
+    const result = selectAction({
+      candidates: [],
+      assessment: {
+        mood: 5,
+        mood_confidence: "low",
+        mood_method: "fallback",
+        signals: [],
+        engagement: "medium",
+        assessment_method: "fallback",
+        rationale: "",
+        latency_ms: 0,
+      },
+      state: stubInput().state,
+    });
+    expect(result.selected).toBeNull();
+    expect(result.escalate_to).toBe("planner");
+  });
+});
+
+describe("Step 5 — escalation propaga skipReason", () => {
+  it("budget exhausted + nada cost ≤ 2 → escala com escalate_reason", () => {
+    const result = selectAction({
+      candidates: [stubItem("heavy", 5)],
+      assessment: {
+        mood: 5,
+        mood_confidence: "medium",
+        mood_method: "rule",
+        signals: [],
+        engagement: "medium",
+        assessment_method: "rule_only",
+        rationale: "",
+        latency_ms: 0,
+      },
+      state: { ...stubInput().state, budgetRemaining: 0 },
+    });
+    expect(result.escalate_to).toBe("planner");
+    expect(result.escalate_reason).toBe("budget_exhausted");
+  });
+});
+
+describe("Step 5 — assess opera com mensagem ausente", () => {
+  it("last_user_message ausente em contextHints → assess recebe '' e não lança", async () => {
+    // Rule-based pre-pass cobre string vazia → mood neutro 5 + low confidence
+    const r = await assess({
+      message: "",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(5);
+    expect(r.mood_confidence).toBe("low");
+    expect(r.assessment_method).not.toBe("unified_haiku"); // rule cobriu
+  });
+});

--- a/motor-drota/tests/unified-assessor.test.ts
+++ b/motor-drota/tests/unified-assessor.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests pra unified-assessor (motor-simplificacao-v1 Step 1).
+ *
+ * Mock pattern espelha mood-extractor.test.ts: vi.mock de
+ * @ascendimacy/shared sobrescrevendo callGateway. Captura `req` em closure
+ * pra assertions sobre payload.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+} from "@ascendimacy/shared";
+
+const captured: { req?: GatewayChatCompletionInput } = {};
+let mockResponse: GatewayChatCompletionOutput | null = null;
+let mockError: Error | null = null;
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: async (req: GatewayChatCompletionInput) => {
+      captured.req = req;
+      if (mockError) throw mockError;
+      if (!mockResponse) {
+        throw new Error("test setup error: mockResponse not set");
+      }
+      return mockResponse;
+    },
+  };
+});
+
+import { assess, assessByRules, MOOD_FALLBACK } from "../src/unified-assessor.js";
+
+function buildLlmResponse(content: string): GatewayChatCompletionOutput {
+  return {
+    content,
+    tokens: { in: 100, out: 50, reasoning: 0 },
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    latency_ms: 150,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
+beforeEach(() => {
+  captured.req = undefined;
+  mockResponse = null;
+  mockError = null;
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Rule-based pre-pass
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assessByRules — distress markers PT", () => {
+  it.each(["tô mal", "estou triste", "que tédio", "tô cansado"])(
+    "'%s' → mood 2 + distress_marker_high (high conf)",
+    (text) => {
+      const r = assessByRules({ message: text, recentTurns: [] });
+      expect(r?.mood).toBe(2);
+      expect(r?.mood_confidence).toBe("high");
+      expect(r?.signals).toContain("distress_marker_high");
+      expect(r?.engagement).toBe("disengaging");
+    },
+  );
+});
+
+describe("assessByRules — distress markers JA", () => {
+  it.each(["疲れた", "嫌だ", "もういい", "つまらん"])(
+    "'%s' → mood 2 + distress",
+    (text) => {
+      const r = assessByRules({ message: text, recentTurns: [] });
+      expect(r?.mood).toBe(2);
+    },
+  );
+});
+
+describe("assessByRules — exit markers", () => {
+  it("'tchau' → mood 3 + deflection_thematic (high conf)", () => {
+    const r = assessByRules({ message: "tchau", recentTurns: [] });
+    expect(r?.mood).toBe(3);
+    expect(r?.signals).toContain("deflection_thematic");
+    expect(r?.mood_confidence).toBe("high");
+  });
+
+  it("'preciso ir' → mood 3", () => {
+    const r = assessByRules({ message: "preciso ir agora", recentTurns: [] });
+    expect(r?.mood).toBe(3);
+  });
+
+  it("'さよなら' → mood 3 (JA exit)", () => {
+    const r = assessByRules({ message: "さよなら", recentTurns: [] });
+    expect(r?.mood).toBe(3);
+  });
+});
+
+describe("assessByRules — entusiasmo + texto longo", () => {
+  it("texto longo com '!!' → mood 8 (high conf)", () => {
+    const text =
+      "Hoje vi um documentário sobre golfinhos e foi MUITO incrível!! eles falam usando padrões diferentes!!";
+    const r = assessByRules({ message: text, recentTurns: [] });
+    expect(r?.mood).toBe(8);
+    expect(r?.mood_confidence).toBe("high");
+    expect(r?.engagement).toBe("high");
+  });
+
+  it("texto curto com entusiasmo NÃO triggera regra (length<50)", () => {
+    const r = assessByRules({ message: "adorei!", recentTurns: [] });
+    // Curto → não bate threshold; cai pra outro caso ou null
+    expect(r?.mood).not.toBe(8);
+  });
+});
+
+describe("assessByRules — monosyllabic curto", () => {
+  it("'sim ok' → mood 4 + deflection_silence (medium conf)", () => {
+    const r = assessByRules({ message: "sim ok", recentTurns: [] });
+    expect(r?.mood).toBe(4);
+    expect(r?.mood_confidence).toBe("medium");
+    expect(r?.signals).toContain("deflection_silence");
+  });
+
+  it("'n sei' → mood 4", () => {
+    const r = assessByRules({ message: "n sei", recentTurns: [] });
+    expect(r?.mood).toBe(4);
+  });
+});
+
+describe("assessByRules — mensagem vazia", () => {
+  it("'' → mood neutro low confidence", () => {
+    const r = assessByRules({ message: "", recentTurns: [] });
+    expect(r?.mood).toBe(MOOD_FALLBACK);
+    expect(r?.mood_confidence).toBe("low");
+  });
+
+  it("whitespace only também", () => {
+    const r = assessByRules({ message: "   ", recentTurns: [] });
+    expect(r?.mood).toBe(MOOD_FALLBACK);
+  });
+});
+
+describe("assessByRules — ambíguo retorna null", () => {
+  it("texto neutro de tamanho médio → null (LLM resolve)", () => {
+    const r = assessByRules({
+      message: "estou pensando em qual personagem do anime é mais forte",
+      recentTurns: [],
+    });
+    expect(r).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM happy path
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assess — LLM happy path", () => {
+  it("rule null + LLM válido → assessment_method='unified_haiku', mood_method='llm'", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 7, "mood_confidence": "high", "signals": ["voluntary_topic_deepening"], "engagement": "high", "rationale": "explora tópico voluntariamente"}`,
+    );
+    const r = await assess({
+      message: "estou pensando em qual personagem do anime é mais forte e por quê",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(7);
+    expect(r.assessment_method).toBe("unified_haiku");
+    expect(r.mood_method).toBe("llm");
+    expect(r.signals).toContain("voluntary_topic_deepening");
+    expect(r.engagement).toBe("high");
+    expect(r.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("envia step='unified-assessor' + maxTokens=256 ao gateway", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 5, "mood_confidence": "medium", "signals": [], "engagement": "medium", "rationale": "neutro"}`,
+    );
+    await assess({
+      message: "estou pensando em coisas",
+      recentTurns: [],
+    });
+    expect(captured.req?.step).toBe("unified-assessor");
+    expect(captured.req?.maxTokens).toBe(256);
+  });
+
+  it("inclui recentTurns no userMessage", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 6, "mood_confidence": "medium", "signals": [], "engagement": "medium", "rationale": "ok"}`,
+    );
+    await assess({
+      message: "talvez",
+      recentTurns: [
+        { role: "assistant", content: "quer continuar?" },
+        { role: "user", content: "hm" },
+      ],
+      personaName: "Ryo",
+    });
+    expect(captured.req?.userMessage).toContain("Ryo");
+    expect(captured.req?.userMessage).toContain("quer continuar?");
+  });
+
+  it("clampa mood >10 vindo do LLM", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 15, "mood_confidence": "low", "signals": [], "engagement": "medium", "rationale": "fora range"}`,
+    );
+    const r = await assess({
+      message: "blah blah blah que coisa interessante",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(10);
+  });
+
+  it("filtra signals fora do vocabulário canônico", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 5, "mood_confidence": "medium", "signals": ["voluntary_topic_deepening", "alucinado_signal", "frame_synthesis"], "engagement": "medium", "rationale": "x"}`,
+    );
+    const r = await assess({
+      message: "que coisa interessante mesmo",
+      recentTurns: [],
+    });
+    expect(r.signals).toContain("voluntary_topic_deepening");
+    expect(r.signals).toContain("frame_synthesis");
+    expect(r.signals).not.toContain("alucinado_signal");
+  });
+
+  it("aceita JSON com markdown fences", async () => {
+    mockResponse = buildLlmResponse(
+      "```json\n{\"mood\": 7, \"mood_confidence\": \"high\", \"signals\": [], \"engagement\": \"medium\", \"rationale\": \"ok\"}\n```",
+    );
+    const r = await assess({
+      message: "aqui vou compartilhar uma reflexão minha",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(7);
+    expect(r.assessment_method).toBe("unified_haiku");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM fallback paths
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assess — LLM falha + rule-based foi medium → usa rule-based", () => {
+  it("LLM erro → fallback rule (medium conf preserva)", async () => {
+    mockError = new Error("gateway timeout");
+    const r = await assess({
+      message: "sim ok", // monosyllabic medium-conf rule
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(4);
+    expect(r.mood_method).toBe("rule");
+    expect(r.assessment_method).toBe("rule_only");
+    expect(r.rationale).toContain("LLM indisponível");
+  });
+});
+
+describe("assess — LLM falha + rule null → fallback degradado", () => {
+  it("LLM erro + texto ambíguo → mood neutro fallback", async () => {
+    mockError = new Error("gateway timeout");
+    const r = await assess({
+      message: "estou pensando em qual personagem é mais forte e por quê",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(MOOD_FALLBACK);
+    expect(r.mood_method).toBe("fallback");
+    expect(r.assessment_method).toBe("fallback");
+  });
+
+  it("LLM JSON inválido → fallback degradado", async () => {
+    mockResponse = buildLlmResponse("não consegui responder em JSON");
+    const r = await assess({
+      message: "estou pensando em coisas que talvez sejam interessantes",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(MOOD_FALLBACK);
+    expect(r.assessment_method).toBe("fallback");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Rule-only path (high conf evita LLM)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assess — rule-based high conf NÃO chama LLM", () => {
+  it("distress text → rule_only (sem chamar gateway)", async () => {
+    mockResponse = buildLlmResponse(`{"mood":99}`); // não deve ser usado
+    const r = await assess({
+      message: "tô mal",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(2); // do rule-based, não 99 do mock
+    expect(r.assessment_method).toBe("rule_only");
+    expect(r.mood_method).toBe("rule");
+    expect(captured.req).toBeUndefined(); // gateway NÃO foi chamado
+  });
+
+  it("exit marker → rule_only", async () => {
+    mockResponse = buildLlmResponse(`{"mood":99}`);
+    const r = await assess({ message: "tchau", recentTurns: [] });
+    expect(r.assessment_method).toBe("rule_only");
+    expect(r.mood).toBe(3);
+    expect(captured.req).toBeUndefined();
+  });
+});

--- a/motor-execucao/src/helix-repo.ts
+++ b/motor-execucao/src/helix-repo.ts
@@ -1,0 +1,129 @@
+/**
+ * kids_helix_state — persistência do Double Helix CASEL state por criança.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-22-double-helix-mapping.md §5
+ * Handoff: ascendimacy-ops/docs/handoffs/2026-05-04-helix-integration-handoff.md
+ * Issue: motor#66 [H1]
+ *
+ * Pattern: stand-alone functions + DDL const string (idêntico cards-repo.ts).
+ *
+ * Nota terminológica: schema usa `child_id`; HelixState tem campo `userId`.
+ * Convenção neste contexto: `userId === child_id`. MCP tools aceitam
+ * `childId` na API; load/save mapeiam pra/de userId no domain object.
+ */
+
+import type Database from "better-sqlite3";
+import type { HelixState, CaselDim, CaselLevel, DeferredEntry } from "@ascendimacy/shared";
+import type { HelixRepo } from "@ascendimacy/shared";
+
+export const HELIX_STATE_DDL = `
+CREATE TABLE IF NOT EXISTS kids_helix_state (
+  child_id TEXT PRIMARY KEY,
+  active_dimension TEXT NOT NULL,
+  active_level TEXT NOT NULL,
+  progress REAL NOT NULL DEFAULT 0,
+  cycle_day INTEGER NOT NULL DEFAULT 1,
+  cycle_start TEXT NOT NULL,
+  previous_dimension TEXT,
+  retrieval_done INTEGER NOT NULL DEFAULT 0,
+  estimated_cycle_days INTEGER NOT NULL DEFAULT 18,
+  queue_json TEXT NOT NULL DEFAULT '[]',
+  deferred_json TEXT NOT NULL DEFAULT '[]',
+  completed_json TEXT NOT NULL DEFAULT '[]',
+  vacation_mode_active INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+`;
+
+interface HelixRow {
+  child_id: string;
+  active_dimension: string;
+  active_level: string;
+  progress: number;
+  cycle_day: number;
+  cycle_start: string;
+  previous_dimension: string | null;
+  retrieval_done: number;
+  estimated_cycle_days: number;
+  queue_json: string;
+  deferred_json: string;
+  completed_json: string;
+  vacation_mode_active: number;
+  updated_at: string;
+}
+
+function rowToState(row: HelixRow): HelixState {
+  return {
+    userId: row.child_id,
+    activeDimension: row.active_dimension as CaselDim,
+    activeLevel: row.active_level as CaselLevel,
+    progress: row.progress,
+    cycleDay: row.cycle_day,
+    cycleStart: row.cycle_start,
+    previousDimension: row.previous_dimension as CaselDim | null,
+    retrievalDone: row.retrieval_done === 1,
+    estimatedCycleDays: row.estimated_cycle_days,
+    queue: JSON.parse(row.queue_json) as CaselDim[],
+    deferred: JSON.parse(row.deferred_json) as DeferredEntry[],
+    completed: JSON.parse(row.completed_json) as CaselDim[],
+    vacationModeActive: row.vacation_mode_active === 1,
+  };
+}
+
+/** Lê estado do child. Retorna null se não inicializado. */
+export function loadHelixState(db: Database.Database, childId: string): HelixState | null {
+  const row = db.prepare("SELECT * FROM kids_helix_state WHERE child_id = ?").get(childId) as HelixRow | undefined;
+  return row ? rowToState(row) : null;
+}
+
+/** Persiste estado (upsert por child_id). */
+export function saveHelixState(db: Database.Database, state: HelixState): void {
+  db.prepare(
+    `INSERT INTO kids_helix_state (
+       child_id, active_dimension, active_level, progress, cycle_day, cycle_start,
+       previous_dimension, retrieval_done, estimated_cycle_days,
+       queue_json, deferred_json, completed_json, vacation_mode_active, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(child_id) DO UPDATE SET
+       active_dimension = excluded.active_dimension,
+       active_level = excluded.active_level,
+       progress = excluded.progress,
+       cycle_day = excluded.cycle_day,
+       cycle_start = excluded.cycle_start,
+       previous_dimension = excluded.previous_dimension,
+       retrieval_done = excluded.retrieval_done,
+       estimated_cycle_days = excluded.estimated_cycle_days,
+       queue_json = excluded.queue_json,
+       deferred_json = excluded.deferred_json,
+       completed_json = excluded.completed_json,
+       vacation_mode_active = excluded.vacation_mode_active,
+       updated_at = excluded.updated_at`,
+  ).run(
+    state.userId,
+    state.activeDimension,
+    state.activeLevel,
+    state.progress,
+    state.cycleDay,
+    state.cycleStart,
+    state.previousDimension,
+    state.retrievalDone ? 1 : 0,
+    state.estimatedCycleDays,
+    JSON.stringify(state.queue),
+    JSON.stringify(state.deferred),
+    JSON.stringify(state.completed),
+    state.vacationModeActive ? 1 : 0,
+    new Date().toISOString(),
+  );
+}
+
+/** Adapter SQLite → HelixRepo (interface do shared, pra orchestrator). */
+export function sqliteHelixRepo(db: Database.Database): HelixRepo {
+  return {
+    async load(userId) {
+      return loadHelixState(db, userId);
+    },
+    async save(state) {
+      saveHelixState(db, state);
+    },
+  };
+}

--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -23,6 +23,8 @@ import {
   getEmittedCardsInRange,
   getNextSequence,
 } from "./cards-repo.js";
+import { loadHelixState as helixLoad, saveHelixState as helixSave } from "./helix-repo.js";
+import type { HelixState as HelixStateT } from "@ascendimacy/shared";
 import type {
   EmittedCard,
   CardArchetype,
@@ -299,6 +301,22 @@ server.registerTool("log_event", {
   const event = { timestamp: getNow(), type, data: data ?? {} };
   logEvent(sessionId, event);
   return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, event }) }] };
+});
+
+server.registerTool("get_helix_state", {
+  description: "Retorna HelixState da crianca ou null se nao inicializado (motor#66)",
+  inputSchema: { childId: z.string() } as any,
+}, async ({ childId }: { childId: string }) => {
+  const state = helixLoad(getDbInstance(), childId);
+  return { content: [{ type: "text" as const, text: JSON.stringify({ state }) }] };
+});
+
+server.registerTool("save_helix_state", {
+  description: "Persiste HelixState (upsert por userId/child_id). Usado pelo orchestrator no fim do turn (motor#66)",
+  inputSchema: { state: z.record(z.string(), z.unknown()) } as any,
+}, async ({ state }: { state: Record<string, unknown> }) => {
+  helixSave(getDbInstance(), state as unknown as HelixStateT);
+  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }] };
 });
 
 const transport = new StdioServerTransport();

--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -24,7 +24,17 @@ import {
   getNextSequence,
 } from "./cards-repo.js";
 import { loadHelixState as helixLoad, saveHelixState as helixSave } from "./helix-repo.js";
-import type { HelixState as HelixStateT } from "@ascendimacy/shared";
+import type { HelixState as HelixStateT, CaselDim } from "@ascendimacy/shared";
+import {
+  initHelix,
+  advanceProgress as helixAdvanceProgress,
+  checkBossFight as helixCheckBossFight,
+  completeCycle as helixCompleteCycle,
+  emitHelixCycleStarted,
+  emitRetrievalTriggered,
+  emitBossCompleted,
+  emitCycleCompleted,
+} from "@ascendimacy/shared";
 import type {
   EmittedCard,
   CardArchetype,
@@ -317,6 +327,57 @@ server.registerTool("save_helix_state", {
 }, async ({ state }: { state: Record<string, unknown> }) => {
   helixSave(getDbInstance(), state as unknown as HelixStateT);
   return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }] };
+});
+
+server.registerTool("init_helix", {
+  description: "Inicializa HelixState pra crianca (lazy bootstrap). Idempotente: se state existe, retorna existente; senao cria e emit helix.cycle.started (motor#H5)",
+  inputSchema: {
+    childId: z.string(),
+    firstDim: z.string().optional(),
+  } as any,
+}, async ({ childId, firstDim }: { childId: string; firstDim?: string }) => {
+  const existing = helixLoad(getDbInstance(), childId);
+  if (existing) {
+    return { content: [{ type: "text" as const, text: JSON.stringify({ state: existing, bootstrapped: false }) }] };
+  }
+  const newState = initHelix(childId, (firstDim as CaselDim | undefined) ?? "SA");
+  helixSave(getDbInstance(), newState);
+  emitHelixCycleStarted(newState);
+  return { content: [{ type: "text" as const, text: JSON.stringify({ state: newState, bootstrapped: true }) }] };
+});
+
+server.registerTool("advance_helix", {
+  description: "Avança Helix progress + detecta transitions retrieval/boss + completeCycle. Persistido. Retorna newState + transitions emitidos (motor#H5)",
+  inputSchema: {
+    childId: z.string(),
+    delta: z.number(),
+    mood: z.number(),
+  } as any,
+}, async ({ childId, delta, mood }: { childId: string; delta: number; mood: number }) => {
+  const current = helixLoad(getDbInstance(), childId);
+  if (!current) {
+    return { content: [{ type: "text" as const, text: JSON.stringify({ error: "no_helix_state", childId }) }] };
+  }
+  const transitions: string[] = [];
+  const before = current.progress;
+  const advanced = helixAdvanceProgress(current, delta, mood);
+
+  if (before < 0.5 && advanced.progress >= 0.5 && current.previousDimension) {
+    emitRetrievalTriggered(advanced, current.previousDimension);
+    transitions.push("retrieval");
+  }
+
+  let finalState = advanced;
+  if (advanced.progress >= 1.0 && helixCheckBossFight(advanced)) {
+    emitBossCompleted(advanced, advanced.activeDimension);
+    finalState = helixCompleteCycle(advanced);
+    emitCycleCompleted(finalState);
+    transitions.push("boss");
+    transitions.push("cycle_completed");
+  }
+
+  helixSave(getDbInstance(), finalState);
+  return { content: [{ type: "text" as const, text: JSON.stringify({ state: finalState, transitions }) }] };
 });
 
 const transport = new StdioServerTransport();

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -6,6 +6,7 @@ import { TREE_NODES_DDL, getStatusMatrix } from "./tree-nodes.js";
 import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
 import { PARENT_DECISIONS_DDL } from "./parent-decisions.js";
 import { EMITTED_CARDS_DDL } from "./cards-repo.js";
+import { HELIX_STATE_DDL } from "./helix-repo.js";
 import { getNow, resolveDbPath } from "./clock.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -38,6 +39,7 @@ function getDb(dbPath?: string): Database.Database {
       ${GARDNER_PROGRAM_DDL}
       ${PARENT_DECISIONS_DDL}
       ${EMITTED_CARDS_DDL}
+      ${HELIX_STATE_DDL}
     `);
   }
   return db;

--- a/motor-execucao/tests/helix-repo.test.ts
+++ b/motor-execucao/tests/helix-repo.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  HELIX_STATE_DDL,
+  loadHelixState,
+  saveHelixState,
+  sqliteHelixRepo,
+} from "../src/helix-repo.js";
+import { initHelix } from "@ascendimacy/shared";
+import type { HelixState } from "@ascendimacy/shared";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(HELIX_STATE_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("loadHelixState", () => {
+  it("returns null when child has no state", () => {
+    expect(loadHelixState(db, "ryo-001")).toBeNull();
+  });
+
+  it("returns persisted state after save", () => {
+    const state = initHelix("ryo-001", "SA");
+    saveHelixState(db, state);
+    const loaded = loadHelixState(db, "ryo-001");
+    expect(loaded).not.toBeNull();
+    expect(loaded?.userId).toBe("ryo-001");
+    expect(loaded?.activeDimension).toBe("SA");
+    expect(loaded?.activeLevel).toBe("emerging");
+    expect(loaded?.progress).toBe(0);
+    expect(loaded?.cycleDay).toBe(1);
+    expect(loaded?.queue).toEqual(["SOC", "SM", "REL", "DM"]);
+    expect(loaded?.completed).toEqual([]);
+    expect(loaded?.deferred).toEqual([]);
+    expect(loaded?.previousDimension).toBeNull();
+    expect(loaded?.retrievalDone).toBe(false);
+    expect(loaded?.vacationModeActive).toBe(false);
+  });
+});
+
+describe("saveHelixState upsert", () => {
+  it("updates existing row instead of inserting duplicate", () => {
+    const state = initHelix("ryo-001", "SA");
+    saveHelixState(db, state);
+    saveHelixState(db, { ...state, progress: 0.6, retrievalDone: true });
+    const loaded = loadHelixState(db, "ryo-001");
+    expect(loaded?.progress).toBe(0.6);
+    expect(loaded?.retrievalDone).toBe(true);
+    const count = db.prepare("SELECT COUNT(*) AS n FROM kids_helix_state").get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it("isolates state by child_id", () => {
+    saveHelixState(db, initHelix("ryo-001", "SA"));
+    saveHelixState(db, initHelix("kei-001", "SOC"));
+    expect(loadHelixState(db, "ryo-001")?.activeDimension).toBe("SA");
+    expect(loadHelixState(db, "kei-001")?.activeDimension).toBe("SOC");
+  });
+
+  it("roundtrips deferred and completed arrays", () => {
+    const base = initHelix("ryo-001", "SA");
+    const enriched: HelixState = {
+      ...base,
+      completed: ["SA", "SOC"],
+      deferred: [{ dimension: "DM", reason: "pair_did_not_activate", retryAfter: "2026-06-01" }],
+      previousDimension: "SOC",
+      retrievalDone: true,
+    };
+    saveHelixState(db, enriched);
+    const loaded = loadHelixState(db, "ryo-001");
+    expect(loaded?.completed).toEqual(["SA", "SOC"]);
+    expect(loaded?.deferred).toEqual([{ dimension: "DM", reason: "pair_did_not_activate", retryAfter: "2026-06-01" }]);
+    expect(loaded?.previousDimension).toBe("SOC");
+  });
+});
+
+describe("sqliteHelixRepo adapter", () => {
+  it("implements HelixRepo interface (load/save async)", async () => {
+    const repo = sqliteHelixRepo(db);
+    expect(await repo.load("ryo-001")).toBeNull();
+    await repo.save(initHelix("ryo-001", "SA"));
+    const loaded = await repo.load("ryo-001");
+    expect(loaded?.activeDimension).toBe("SA");
+  });
+});

--- a/orchestrator/src/mcp-clients.ts
+++ b/orchestrator/src/mcp-clients.ts
@@ -30,6 +30,20 @@ function buildEnv(): Record<string, string> {
     "SIGNAL_EXTRACTOR_MODEL",
     "HAIKU_TRIAGE_PROVIDER",
     "HAIKU_TRIAGE_MODEL",
+    "HAIKU_BULLYING_PROVIDER",
+    "HAIKU_BULLYING_MODEL",
+    "PERSONA_SIM_PROVIDER",
+    "PERSONA_SIM_MODEL",
+    "MOOD_EXTRACTOR_PROVIDER",
+    "MOOD_EXTRACTOR_MODEL",
+    "UNIFIED_ASSESSOR_PROVIDER",
+    "UNIFIED_ASSESSOR_MODEL",
+    // Local provider (vLLM / llama-server) — motor-simplificacao-v1
+    "LOCAL_LLM_BASE_URL",
+    "LOCAL_LLM_MODEL",
+    "LOCAL_LLM_API_KEY",
+    // Pipeline simplification flag (motor-simplificacao-v1 Step 5)
+    "USE_SIMPLIFIED_PIPELINE",
     // Gateway config (motor#28)
     "LLM_GATEWAY_RATE_INFOMANIAK",
     "LLM_GATEWAY_RATE_ANTHROPIC",

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -228,7 +228,7 @@ export async function runTurn(
       state,
       persona,
       strategicRationale: plan.strategicRationale,
-      contextHints: plan.contextHints,
+      contextHints: { ...(plan.contextHints ?? {}), last_user_message: message },
       instruction_addition: plan.instruction_addition ?? "",
     },
   });

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -4,8 +4,18 @@ import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
 import type { McpClients } from "./mcp-clients.js";
 import { initTrace, appendTurn, saveTrace } from "./trace-writer.js";
-import type { PersonaDef, AdquirenteDef, PlaybookIndex } from "@ascendimacy/shared";
-import { logDebugEvent } from "@ascendimacy/shared";
+import type { PersonaDef, AdquirenteDef, PlaybookIndex, HelixState } from "@ascendimacy/shared";
+import {
+  logDebugEvent,
+  initHelix,
+  advanceProgress,
+  checkBossFight,
+  completeCycle,
+  emitHelixCycleStarted,
+  emitRetrievalTriggered,
+  emitBossCompleted,
+  emitCycleCompleted,
+} from "@ascendimacy/shared";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = join(__dirname, "../../fixtures");
@@ -113,6 +123,8 @@ export async function runTurn(
   // event no event_log pra Trigger Evaluator consumir.
   // Read-only — fail-soft, qualquer erro vira signals=[].
   const tSig = Date.now();
+  // motor#68 H3: capturado em escopo outer pra Helix advance no fim do turn
+  let extractedSignals: string[] = [];
   try {
     const signalsResult = await clients.motorDrota.callTool({
       name: "extract_signals",
@@ -134,6 +146,7 @@ export async function runTurn(
       evidence?: Record<string, string>;
       overall_confidence?: number;
     }>(signalsResult);
+    if (sig.signals) extractedSignals = sig.signals;
     if (sig.signals && sig.signals.length > 0) {
       // Loga event no motor-execucao pra Trigger Evaluator ler na próxima call
       await clients.motorExecucao.callTool({
@@ -161,10 +174,33 @@ export async function runTurn(
   }
   void (Date.now() - tSig); // keep latency hint local — debug log captura via debug-mode
 
+  // motor#68 H3: carrega HelixState (lazy bootstrap se ausente).
+  // childId = persona.id por convenção (consistente com card emission).
+  let helixState: HelixState | null = null;
+  try {
+    const helixResult = await clients.motorExecucao.callTool({
+      name: "get_helix_state",
+      arguments: { childId: persona.id },
+    });
+    const parsed = parseToolText<{ state: HelixState | null }>(helixResult);
+    helixState = parsed.state;
+    if (!helixState) {
+      // Lazy bootstrap: criança nunca tocou Helix → inicia em SA (default rotation).
+      helixState = initHelix(persona.id);
+      await clients.motorExecucao.callTool({
+        name: "save_helix_state",
+        arguments: { state: helixState },
+      });
+      emitHelixCycleStarted(helixState);
+    }
+  } catch {
+    // Fail-soft: se motor-execucao sem Helix wired, segue sem helix (planejador fallback statusMatrix).
+  }
+
   const t1 = Date.now();
   const planResult = await clients.planejador.callTool({
     name: "plan_turn",
-    arguments: { sessionId, persona, adquirente, inventory, state, incomingMessage: message },
+    arguments: { sessionId, persona, adquirente, inventory, state, incomingMessage: message, helixState },
   });
   const plan = parseToolText<import("@ascendimacy/shared").PlanTurnOutput>(planResult);
   turnEntries.push({
@@ -266,6 +302,51 @@ export async function runTurn(
     },
     output: exec as unknown as Record<string, unknown>,
   });
+
+  // motor#68 H3: Helix advance no fim do turn.
+  // Heurística MVP — mood/engagement reais virão do unified-assessor expose
+  // no EvaluateAndSelectOutput numa iteração futura. Por ora:
+  //   delta = 0.05 base + 0.05 se signals positivos; 0 se signals de
+  //           desengajamento (loop conservador 10-20 turns/ciclo)
+  //   mood proxy = trustLevel >= 0.4 ? 8 : 2 (passa/bloqueia buffer day)
+  if (helixState && !helixState.vacationModeActive) {
+    const positiveSignals = ["voluntary_topic_deepening", "meta_cognitive_observation", "positive_engagement"];
+    const negativeSignals = ["disengagement", "confusion", "mood_drop"];
+    const hasPositive = extractedSignals.some((s) => positiveSignals.includes(s));
+    const hasNegative = extractedSignals.some((s) => negativeSignals.includes(s));
+    const delta = hasNegative ? 0 : hasPositive ? 0.10 : 0.05;
+    const moodProxy = state.trustLevel >= 0.4 ? 8 : 2;
+
+    try {
+      const beforeProgress = helixState.progress;
+      const afterAdvance = advanceProgress(helixState, delta, moodProxy);
+
+      // Detecta transition retrieval (cruzou 0.5)
+      if (
+        beforeProgress < 0.5 &&
+        afterAdvance.progress >= 0.5 &&
+        helixState.previousDimension
+      ) {
+        emitRetrievalTriggered(afterAdvance, helixState.previousDimension);
+      }
+
+      // Detecta boss + completeCycle
+      let finalState = afterAdvance;
+      if (afterAdvance.progress >= 1.0 && checkBossFight(afterAdvance)) {
+        emitBossCompleted(afterAdvance, afterAdvance.activeDimension);
+        finalState = completeCycle(afterAdvance);
+        emitCycleCompleted(finalState);
+      }
+
+      await clients.motorExecucao.callTool({
+        name: "save_helix_state",
+        arguments: { state: finalState },
+      });
+      helixState = finalState;
+    } catch {
+      // Fail-soft: Helix advance não trava o turn
+    }
+  }
 
   // v0.3: enriquece o turn com snapshots e resumos.
   const selectedItem = drota.selectedContent?.item;

--- a/planejador/src/llm-client.ts
+++ b/planejador/src/llm-client.ts
@@ -85,7 +85,8 @@ export async function callLlmMock(_systemPrompt: string, _userMessage: string): 
       contextHints: { language: "pt-br", mood: "receptive", urgency: "low" },
     }),
     tokens: { in: 0, out: 0, reasoning: 0 },
-    provider: "infomaniak",
+    // 2026-05-05: provider/model = "mock" pra distinguir de real call em traces
+    provider: "mock",
     model: "mock",
   };
 }

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -34,6 +34,8 @@ import {
   triageForParents,
   logDebugEvent,
   getProviderForStep,
+  getModelForStep,
+  isApiKeyMissing,
   checkRetrievalGate,
   checkBossFight,
 } from "@ascendimacy/shared";
@@ -211,12 +213,16 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   // motor#22: provider-aware mock detection — antes era hardcoded
   // !ANTHROPIC_API_KEY (legacy pré-router motor#21). Agora checa a key
   // do provider efetivamente configurado pra este step.
+  // 2026-05-05: usa isApiKeyMissing pra cobrir provider="local" (bug fix
+  // — antes provider=local caía no else infomaniak e ativava mock falso).
   const planejadorProvider = getProviderForStep("planejador");
-  const planejadorKeyMissing = planejadorProvider === "anthropic"
-    ? !process.env["ANTHROPIC_API_KEY"]
-    : !process.env["INFOMANIAK_API_KEY"];
-  const useMockLlm =
-    process.env["USE_MOCK_LLM"] === "true" || planejadorKeyMissing;
+  const planejadorKeyMissing = isApiKeyMissing(planejadorProvider);
+  const mockReason = process.env["USE_MOCK_LLM"] === "true"
+    ? "USE_MOCK_LLM=true"
+    : planejadorKeyMissing
+      ? `${planejadorProvider}_api_key_missing`
+      : null;
+  const useMockLlm = mockReason !== null;
   const parentalProfile = extractParentalProfile(input.persona);
   let triageMode: "rule_based" | "haiku" | "skipped" = "skipped";
   let triageRejectedIds: string[] = [];
@@ -246,16 +252,18 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   const rationale = parseRationale(llmResult.content);
 
   // motor#19: debug log (no-op se ASC_DEBUG_MODE off)
+  // 2026-05-05: provider/model agora refletem o efetivamente usado (mock vs real).
   logDebugEvent({
     side: "motor",
     step: "planejador",
     user_id: input.persona.id,
     session_id: input.sessionId,
     turn_number: input.state.turn,
-    model: process.env["PLANEJADOR_MODEL"] ?? "claude-sonnet-4-6",
-    provider: "anthropic",
+    model: useMockLlm ? "mock" : getModelForStep("planejador", planejadorProvider),
+    provider: useMockLlm ? "mock" : planejadorProvider,
     tokens: llmResult.tokens,
     latency_ms: llmLatency,
+    mock_reason: mockReason,
     prompt: systemPrompt + "\n\n[USER]\n" + userMessage,
     response: llmResult.content,
     reasoning: llmResult.reasoning,

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -52,8 +52,34 @@ function seedPath(): string | undefined {
   return process.env["CONTENT_SEED_PATH"];
 }
 
-function buildSystemPrompt(input: PlanTurnInput): string {
-  const { persona, state, incomingMessage } = input;
+/**
+ * Exportado pra testes. 2026-05-05 (bugfix-materializer-content-anchor):
+ * agora injeta `extracted_signals` (vindos do caller via input.contextHints)
+ * + bloco DEFLECTION ATIVO quando deflection_thematic / exit_marker_*
+ * estiverem presentes — o LLM precisa saber pra produzir rationale apropriado
+ * e adicionar contextHints.avoid.
+ */
+export function buildSystemPrompt(input: PlanTurnInput): string {
+  const { persona, state, incomingMessage, contextHints } = input;
+
+  const extractedSignals = Array.isArray(contextHints?.["extracted_signals"])
+    ? (contextHints["extracted_signals"] as string[])
+    : [];
+
+  const signalsBlock = extractedSignals.length > 0
+    ? `\nSINAIS DETECTADOS NO TURNO ATUAL: ${extractedSignals.join(", ")}`
+    : "";
+
+  const deflectionActive = extractedSignals.some(
+    (s) =>
+      s === "deflection_thematic" ||
+      s === "exit_marker_implicit" ||
+      s === "exit_marker_explicit",
+  );
+  const deflectionBlock = deflectionActive
+    ? `\n⚠️ DEFLECTION ATIVO: o sujeito desviou do tema anterior. O strategicRationale DEVE reconhecer o desvio e propor tema diferente. NÃO retorne ao tema que o sujeito evitou. Em contextHints, adicione:\n  "avoid": "não retornar ao tema que o sujeito acabou de desviar",\n  "tone": "leve, sem pressão".`
+    : "";
+
   return `Você é o Planejador do motor Ascendimacy. Seu papel é AUXILIAR de compositor:
 o scoring de content items é determinístico (feito no código). Você só emite:
 
@@ -63,7 +89,7 @@ o scoring de content items é determinístico (feito no código). Você só emit
 SUJEITO: ${persona.name}, ${persona.age} anos.
 Perfil: ${JSON.stringify(persona.profile, null, 2)}
 Estado: trust=${state.trustLevel.toFixed(2)}, turn=${state.turn}, budget=${state.budgetRemaining}
-Mensagem: "${incomingMessage}"
+Mensagem: "${incomingMessage}"${signalsBlock}${deflectionBlock}
 
 Detecte a língua do sujeito (ex: 'pt-br', 'pt-br limitado', 'pt-br basico', 'ja', 'en'). Se o perfil indica falante não-nativo (ex: japonês aprendendo pt-br), use 'pt-br limitado'.
 
@@ -291,10 +317,25 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   const gardnerInstruction = buildGardnerInstruction(input);
 
   // 5. Injeta status_gates + casel_focus + gardner meta + triage meta em contextHints.
+  // 2026-05-05 (sts-realista): upstream hints (extracted_signals, last_user_message)
+  // do caller têm prioridade — preservados via spread inicial. LLM rationale e
+  // status_gates layer-by-layer em cima sem sobrescrever.
   const contextHints: Record<string, unknown> = {
+    ...(input.contextHints ?? {}),
     ...rationale.contextHints,
     status_gates: allGates(statusMatrix),
   };
+  // Re-aplica extracted_signals/last_user_message/recent_turns vindas do caller
+  // para garantir que rationale.contextHints (LLM-generated) não sobrescreva.
+  if (input.contextHints?.["extracted_signals"]) {
+    contextHints["extracted_signals"] = input.contextHints["extracted_signals"];
+  }
+  if (input.contextHints?.["last_user_message"]) {
+    contextHints["last_user_message"] = input.contextHints["last_user_message"];
+  }
+  if (input.contextHints?.["recent_turns"]) {
+    contextHints["recent_turns"] = input.contextHints["recent_turns"];
+  }
   if (focusDim) {
     contextHints["casel_focus_dimension"] = focusDim;
     contextHints["casel_focus_targets"] = caselTargets;

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -34,6 +34,8 @@ import {
   triageForParents,
   logDebugEvent,
   getProviderForStep,
+  checkRetrievalGate,
+  checkBossFight,
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku } from "./llm-client.js";
 import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
@@ -178,7 +180,13 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   });
   const child = personaToChildProfile(input.persona, input.state);
   const statusMatrix = input.state.statusMatrix ?? defaultMatrix();
-  const focusDim = pickFocusDimension(statusMatrix);
+  // motor#67 H2: helixState (quando presente) declara dim ativa do meta-ciclo;
+  // sobrepõe pickFocusDimension(statusMatrix) que opera intra-sessão.
+  // Fallback statusMatrix mantido pra callers sem helix wired.
+  const helixState = input.helixState;
+  const focusDim = helixState
+    ? helixState.activeDimension
+    : pickFocusDimension(statusMatrix);
   const caselTargets = focusDim ? caselTargetsFor(focusDim) : [];
   // motor#23: extrai items já consumidos nesta sessão do event_log pra
   // penalizar reuso e forçar rotação (descoberta no smoke-3d-bumped onde
@@ -282,6 +290,22 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   if (focusDim) {
     contextHints["casel_focus_dimension"] = focusDim;
     contextHints["casel_focus_targets"] = caselTargets;
+  }
+  // motor#67 H2: helixState → contextHints (drota lê pra adaptar materializer).
+  if (helixState) {
+    const phase: "boss" | "retrieval" | "solo" = checkBossFight(helixState)
+      ? "boss"
+      : checkRetrievalGate(helixState)
+        ? "retrieval"
+        : "solo";
+    contextHints["helix_phase"] = phase;
+    contextHints["helix_progress"] = helixState.progress;
+    contextHints["helix_cycle_day"] = helixState.cycleDay;
+    contextHints["casel_focus_dim"] = helixState.activeDimension;
+    contextHints["casel_focus_level"] = helixState.activeLevel;
+    if (phase !== "solo" && helixState.previousDimension) {
+      contextHints["casel_retrieval_dim"] = helixState.previousDimension;
+    }
   }
   if (input.state.gardnerProgram?.current_week) {
     contextHints["gardner_program_active"] = gardnerInstruction.active;

--- a/planejador/src/server.ts
+++ b/planejador/src/server.ts
@@ -51,6 +51,8 @@ server.registerTool(
         partnerStatusMatrix: z.record(z.string(), z.string()).optional(),
       }),
       incomingMessage: z.string(),
+      helixState: z.record(z.string(), z.unknown()).nullable().optional(),
+      contextHints: z.record(z.string(), z.unknown()).optional(),
     } as any,
   },
   async (input: PlanTurnInput) => {

--- a/planejador/tests/plan.test.ts
+++ b/planejador/tests/plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { planTurn } from "../src/plan.js";
+import { planTurn, buildSystemPrompt } from "../src/plan.js";
 
 process.env["USE_MOCK_LLM"] = "true";
 
@@ -172,5 +172,67 @@ describe("planTurn — Bloco 2a (contentPool)", () => {
     });
     // emotional=brejo deve vir primeiro pela ordem de prioridade
     expect(output.contextHints["casel_focus_dimension"]).toBe("emotional");
+  });
+});
+
+// ─── 2026-05-05 (bugfix-materializer-content-anchor) ────────────────────────
+describe("buildSystemPrompt — extracted_signals + deflection", () => {
+  const baseInput = {
+    sessionId: "test-deflection",
+    persona: mockPersona,
+    adquirente: mockAdquirente,
+    inventory: mockInventory,
+    state: mockState,
+    incomingMessage: "tô melhor falando de tênis",
+  };
+
+  it("signal deflection_thematic → prompt contém aviso DEFLECTION ATIVO", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: {
+        extracted_signals: ["deflection_thematic", "peer_reference"],
+      },
+    });
+    expect(prompt).toContain("SINAIS DETECTADOS NO TURNO ATUAL");
+    expect(prompt).toContain("deflection_thematic");
+    expect(prompt).toContain("DEFLECTION ATIVO");
+    expect(prompt).toContain("não retornar ao tema");
+  });
+
+  it("exit_marker_implicit também ativa deflection block", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: { extracted_signals: ["exit_marker_implicit"] },
+    });
+    expect(prompt).toContain("DEFLECTION ATIVO");
+  });
+
+  it("signals presentes mas sem deflection → não tem bloco DEFLECTION ATIVO", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: {
+        extracted_signals: ["peer_reference", "voluntary_topic_deepening"],
+      },
+    });
+    expect(prompt).toContain("SINAIS DETECTADOS NO TURNO ATUAL");
+    expect(prompt).toContain("peer_reference");
+    expect(prompt).not.toContain("DEFLECTION ATIVO");
+  });
+
+  it("extracted_signals vazio → prompt sem bloco SINAIS DETECTADOS", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: { extracted_signals: [] },
+    });
+    expect(prompt).not.toContain("SINAIS DETECTADOS");
+    expect(prompt).not.toContain("DEFLECTION ATIVO");
+  });
+
+  it("contextHints undefined → comportamento legado preservado (sem signals)", () => {
+    const prompt = buildSystemPrompt(baseInput);
+    expect(prompt).not.toContain("SINAIS DETECTADOS");
+    expect(prompt).not.toContain("DEFLECTION ATIVO");
+    // Mas o prompt fundamental ainda está presente
+    expect(prompt).toContain("Planejador do motor Ascendimacy");
   });
 });

--- a/planejador/tests/plan.test.ts
+++ b/planejador/tests/plan.test.ts
@@ -87,6 +87,80 @@ describe("planTurn — Bloco 2a (contentPool)", () => {
     expect(output.contextHints["status_gates"]).toBeDefined();
   });
 
+  it("phase=solo helix injects casel_focus_dim and helix_phase", async () => {
+    const helixState = {
+      userId: "ryo",
+      activeDimension: "SA" as const,
+      activeLevel: "emerging" as const,
+      progress: 0.3,
+      cycleDay: 1,
+      cycleStart: "2026-05-01",
+      previousDimension: null,
+      retrievalDone: false,
+      estimatedCycleDays: 18,
+      queue: ["SOC", "SM", "REL", "DM"] as ("SA"|"SM"|"SOC"|"REL"|"DM")[],
+      deferred: [],
+      completed: [],
+      vacationModeActive: false,
+    };
+    const output = await planTurn({
+      sessionId: "test-001",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+      helixState,
+    });
+    expect(output.contextHints["helix_phase"]).toBe("solo");
+    expect(output.contextHints["helix_progress"]).toBe(0.3);
+    expect(output.contextHints["casel_focus_dim"]).toBe("SA");
+    expect(output.contextHints["casel_focus_level"]).toBe("emerging");
+    expect(output.contextHints["casel_retrieval_dim"]).toBeUndefined();
+  });
+
+  it("phase=retrieval helix exposes previousDimension when progress>=0.5", async () => {
+    const helixState = {
+      userId: "ryo",
+      activeDimension: "SOC" as const,
+      activeLevel: "emerging" as const,
+      progress: 0.6,
+      cycleDay: 8,
+      cycleStart: "2026-05-01",
+      previousDimension: "SA" as const,
+      retrievalDone: false,
+      estimatedCycleDays: 18,
+      queue: ["SM", "REL", "DM"] as ("SA"|"SM"|"SOC"|"REL"|"DM")[],
+      deferred: [],
+      completed: ["SA"] as ("SA"|"SM"|"SOC"|"REL"|"DM")[],
+      vacationModeActive: false,
+    };
+    const output = await planTurn({
+      sessionId: "test-001",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+      helixState,
+    });
+    expect(output.contextHints["helix_phase"]).toBe("retrieval");
+    expect(output.contextHints["casel_retrieval_dim"]).toBe("SA");
+  });
+
+  it("falls back to statusMatrix when helixState undefined", async () => {
+    const output = await planTurn({
+      sessionId: "test-001",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: { ...mockState, statusMatrix: { emotional: "brejo", social_with_ebrota: "baia" } },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["helix_phase"]).toBeUndefined();
+    expect(output.contextHints["casel_focus_dimension"]).toBe("emotional");
+  });
+
   it("injects casel_focus_dimension derived from status matrix", async () => {
     const output = await planTurn({
       sessionId: "test-001",

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -24,6 +24,12 @@ export interface PlanTurnInput {
    * undef → caller não suporta helix → fallback statusMatrix
    */
   helixState?: import("./helix-state.js").HelixState | null;
+  /**
+   * 2026-05-05 (sts-realista §2.1): contextHints upstream — caller
+   * (orchestrator/STS motor-client) injeta extracted_signals + last_user_message
+   * antes de plan_turn. Planejador merge no contextHints final.
+   */
+  contextHints?: Record<string, unknown>;
 }
 
 export interface PlanTurnOutput {
@@ -83,6 +89,20 @@ export interface EvaluateAndSelectOutput {
   skipReason?: string;
   /** motor#25: head do raw output pra debug log quando skipReason populado. */
   rawOutput?: string;
+  /**
+   * 2026-05-05 (sts-realista): assessment do Unified Assessor exposto pra caller
+   * (STS motor-client) usar mood real no Helix advance — antes proxy trustLevel.
+   * Populado APENAS no pipeline simplificado (USE_SIMPLIFIED_PIPELINE=true).
+   * Pipeline antigo deixa undefined.
+   */
+  assessment?: {
+    mood: number;
+    mood_confidence: "high" | "medium" | "low";
+    mood_method: "rule" | "llm" | "fallback";
+    signals: string[];
+    engagement: "high" | "medium" | "low" | "disengaging";
+    rationale: string;
+  };
 }
 
 export interface ExecutePlaybookInput {

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -14,6 +14,16 @@ export interface PlanTurnInput {
   inventory: PlaybookIndex[];
   state: SessionState;
   incomingMessage: string;
+  /**
+   * motor#67 H2: HelixState da criança (lido pelo orchestrator via
+   * motor-execucao.get_helix_state). Quando presente, planejador usa
+   * activeDimension pra direcionar caselTargets e popula contextHints
+   * com helix_phase/helix_progress/casel_focus_dim/casel_retrieval_dim.
+   *
+   * null  → child sem state (lazy bootstrap responsabilidade do orchestrator)
+   * undef → caller não suporta helix → fallback statusMatrix
+   */
+  helixState?: import("./helix-state.js").HelixState | null;
 }
 
 export interface PlanTurnOutput {

--- a/shared/src/debug-logger.ts
+++ b/shared/src/debug-logger.ts
@@ -56,6 +56,15 @@ export interface DebugEventInput {
   snapshots_post?: Record<string, unknown> | null;
   outcome: "ok" | "error" | "skip";
   error_class?: string | null;
+  /**
+   * 2026-05-05 bugfix: quando o evento foi servido por mock LLM (callLlmMock,
+   * heurística rule-based, ou stub), preencher com a razão. Permite distinguir
+   * "real LLM call" de "fallback mock" em traces — antes provider/model ficavam
+   * com label estático ("anthropic" / "claude-sonnet-4-6") mascarando a origem.
+   * Valores típicos: "USE_MOCK_LLM=true", "anthropic_api_key_missing",
+   * "infomaniak_api_key_missing", "rule_based_fallback".
+   */
+  mock_reason?: string | null;
 }
 
 export interface DebugEventLine {
@@ -83,6 +92,7 @@ export interface DebugEventLine {
   snapshots_post: Record<string, string> | null;
   outcome: "ok" | "error" | "skip";
   error_class: string | null;
+  mock_reason: string | null;
 }
 
 /** Computa sha256 hex + prefixo "sha256:". */
@@ -181,6 +191,7 @@ export function logDebugEvent(input: DebugEventInput): void {
       snapshots_post: snapshotsPostHashes,
       outcome: input.outcome,
       error_class: input.error_class ?? null,
+      mock_reason: input.mock_reason ?? null,
     };
 
     appendFileSync(join(root, "events.ndjson"), JSON.stringify(line) + "\n", "utf-8");

--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -146,13 +146,66 @@ async function getClient(): Promise<Client> {
   }
 }
 
+// ─── Mock awareness (USE_MOCK_LLM=true) ────────────────────────────────────
+// Quando flag liga, callGateway retorna stub determinístico per step,
+// SEM spawnar gateway nem chamar LLM real. Permite smoke end-to-end sem
+// custo de provider e sem dependência de rede/credenciais.
+//
+// Stubs são step-aware: retornam JSON estruturado válido pros parsers
+// downstream (unified-assessor JSON, mood-extractor JSON, etc).
+
+function isMockMode(): boolean {
+  return process.env["USE_MOCK_LLM"] === "true";
+}
+
+function buildMockContent(step: string): string {
+  switch (step) {
+    case "unified-assessor":
+      return `{"mood": 6, "mood_confidence": "medium", "signals": [], "engagement": "medium", "rationale": "mock"}`;
+    case "mood-extractor":
+      return `{"score": 5, "rationale": "mock"}`;
+    case "signal-extractor":
+      return `{"signals": [], "evidence": {}, "overall_confidence": 0.5}`;
+    case "haiku-triage":
+      return `{"approved_ids": [], "rejected_ids": []}`;
+    case "haiku-bullying":
+      return `{"flagged": false}`;
+    case "drota":
+      return `{"selectionRationale": "mock auto-select", "linguisticMaterialization": "Vamos pensar nisso juntos."}`;
+    case "planejador":
+      return `{"strategicRationale": "mock strategic", "contentPool": [], "contextHints": {}, "instruction_addition": ""}`;
+    case "persona-sim":
+      return `{"message": "(mock persona)", "thinking": null}`;
+    default:
+      return `{"mock": true, "step": "${step}"}`;
+  }
+}
+
+function buildMockResponse(req: GatewayChatCompletionInput): GatewayChatCompletionOutput {
+  return {
+    content: buildMockContent(req.step),
+    tokens: { in: 0, out: 0, reasoning: 0 },
+    provider: "infomaniak", // valor formal, não bate na rede
+    model: "mock",
+    latency_ms: 0,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
 /**
  * Chama o gateway. Lazy-spawn no primeiro call; reusa o mesmo processo
  * gateway pro resto da vida do processo caller.
+ *
+ * Quando USE_MOCK_LLM=true, retorna stub determinístico per step sem
+ * spawnar gateway nem chamar LLM real (smoke local zero-custo).
  */
 export async function callGateway(
   req: GatewayChatCompletionInput,
 ): Promise<GatewayChatCompletionOutput> {
+  if (isMockMode()) {
+    return buildMockResponse(req);
+  }
   const client = await getClient();
   const result = await client.callTool({
     name: "chat_completion",

--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -20,6 +20,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { join, dirname } from "node:path";
 import { createRequire } from "node:module";
 import type { LlmProvider } from "./llm-router.js";
+import { getProviderForStep } from "./llm-router.js";
 
 // Tipos espelham llm-gateway/src/types.ts. Mantidos sincronizados manualmente.
 export interface GatewayChatCompletionInput {
@@ -72,6 +73,9 @@ const PROPAGATED_ENV_KEYS = [
   "SIGNAL_EXTRACTOR_MODEL",
   "PERSONA_SIM_PROVIDER",
   "PERSONA_SIM_MODEL",
+  "LOCAL_LLM_BASE_URL",
+  "LOCAL_LLM_MODEL",
+  "LOCAL_LLM_API_KEY",
   "LLM_GATEWAY_RATE_INFOMANIAK",
   "LLM_GATEWAY_RATE_ANTHROPIC",
   "LLM_GATEWAY_PRIMARY_TIMEOUT_MS",
@@ -193,18 +197,104 @@ function buildMockResponse(req: GatewayChatCompletionInput): GatewayChatCompleti
   };
 }
 
+// ─── Local vLLM provider ───────────────────────────────────────────────────
+// Quando provider=local (resolved via getProviderForStep), bypassa o gateway
+// MCP e chama o endpoint OpenAI-compatible do vLLM diretamente via fetch.
+// Sem spawnar gateway, sem MCP, sem API keys externas.
+//
+// Env vars:
+//   LOCAL_LLM_BASE_URL  default: http://localhost:8000/v1
+//   LOCAL_LLM_MODEL     default: gpt-oss-20b
+//   LOCAL_LLM_API_KEY   default: "local" (vLLM não valida)
+//   ASC_LLM_TIMEOUT_SECONDS  default: 30 (override pra prefill longo turn 1)
+
+async function callLocalVllm(
+  req: GatewayChatCompletionInput,
+): Promise<GatewayChatCompletionOutput> {
+  const baseUrl =
+    process.env["LOCAL_LLM_BASE_URL"] ?? "http://localhost:8000/v1";
+  const model = process.env["LOCAL_LLM_MODEL"] ?? "gpt-oss-20b";
+  const apiKey = process.env["LOCAL_LLM_API_KEY"] ?? "local";
+
+  // Separação prefixo fixo / dinâmico — vLLM prefix caching opera sobre o
+  // prefixo do system message; partes fixas DEVEM ser idênticas entre turns.
+  const systemContent = req.cacheableSystemPrefix
+    ? `${req.cacheableSystemPrefix}\n\n${req.systemPrompt}`
+    : req.systemPrompt;
+
+  const messages: Array<{ role: string; content: string }> = [];
+  if (systemContent.trim()) {
+    messages.push({ role: "system", content: systemContent });
+  }
+  messages.push({ role: "user", content: req.userMessage });
+
+  const t0 = Date.now();
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: req.maxTokens ?? 512,
+      temperature: 0.7,
+    }),
+    signal: AbortSignal.timeout(
+      Number(process.env["ASC_LLM_TIMEOUT_SECONDS"] ?? 30) * 1_000,
+    ),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `vLLM local error: HTTP ${response.status} — ${body.slice(0, 200)}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
+  };
+
+  const content = data.choices?.[0]?.message?.content ?? "";
+  const tokens = {
+    in: data.usage?.prompt_tokens ?? 0,
+    out: data.usage?.completion_tokens ?? 0,
+    reasoning: 0,
+  };
+
+  return {
+    content,
+    tokens,
+    provider: "local",
+    model,
+    latency_ms: Date.now() - t0,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
 /**
  * Chama o gateway. Lazy-spawn no primeiro call; reusa o mesmo processo
  * gateway pro resto da vida do processo caller.
  *
- * Quando USE_MOCK_LLM=true, retorna stub determinístico per step sem
- * spawnar gateway nem chamar LLM real (smoke local zero-custo).
+ * Provider resolution:
+ *   - USE_MOCK_LLM=true → mock determinístico (smoke zero-custo)
+ *   - provider=local → callLocalVllm (vLLM local, bypassa gateway MCP)
+ *   - provider=anthropic|infomaniak → gateway MCP (com retry/fallback)
  */
 export async function callGateway(
   req: GatewayChatCompletionInput,
 ): Promise<GatewayChatCompletionOutput> {
   if (isMockMode()) {
     return buildMockResponse(req);
+  }
+  // Provider local: bypassa gateway MCP, chama vLLM direto via fetch
+  const provider = getProviderForStep(req.step);
+  if (provider === "local") {
+    return callLocalVllm(req);
   }
   const client = await getClient();
   const result = await client.callTool({

--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -240,6 +240,16 @@ async function callLocalVllm(
       messages,
       max_tokens: req.maxTokens ?? 512,
       temperature: 0.7,
+      // 2026-05-05: Qwen3 family supports hybrid thinking. Default ON
+      // adds 500-2000 reasoning tokens before content — drena max_tokens
+      // e infla latência. Desativar via chat_template_kwargs.enable_thinking=false
+      // (mecanismo oficial do Qwen3 chat template).
+      // Modelos sem suporte (Qwen2.5, Gemma3, etc.) ignoram silenciosamente.
+      // Override via LOCAL_LLM_THINKING=true se quiser thinking ativo.
+      chat_template_kwargs: {
+        enable_thinking:
+          process.env["LOCAL_LLM_THINKING"] === "true" ? true : false,
+      },
     }),
     signal: AbortSignal.timeout(
       Number(process.env["ASC_LLM_TIMEOUT_SECONDS"] ?? 30) * 1_000,

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -14,6 +14,7 @@ export * from "./helix-state.js";
 export * from "./helix-planner.js";
 export * from "./helix-events.js";
 export * from "./helix-repo-memory.js";
+export * from "./stable-state-cache.js";
 export * from "./db.js";
 export * from "./status-matrix-repo-pg.js";
 export * from "./sacrifice-budget.js";

--- a/shared/src/llm-config.ts
+++ b/shared/src/llm-config.ts
@@ -7,24 +7,21 @@
  * Override via env var por step ou global.
  */
 
-/** Timeouts default em ms, por step. */
+/** Timeouts default em ms, por step.
+ *
+ * Calibrados pra vLLM local (GPT-OSS-20B) — turn 1 prefill frio (~8-10k
+ * tokens) pode demorar 2-4s no Intel Arc B580; turns 2+ com prefix cache
+ * quente são <1s. Override per-step via ASC_LLM_TIMEOUT_<STEP> em segundos.
+ */
 export const LLM_TIMEOUT_DEFAULTS: Record<string, number> = {
-  // Sonnet 4.6 planejador — prompts moderados, reasoning budget 1024
-  planejador: 30_000,
-  // Haiku 4.5 rerank — prompts curtos
-  "haiku-triage": 15_000,
-  // Haiku 4.5 bullying check
-  "haiku-bullying": 15_000,
-  // Infomaniak reasoning models (Kimi K2.5, DeepSeek-R1) — reasoning chains longas
-  drota: 90_000,
-  // Sonnet 4.6 persona-simulator
-  "persona-sim": 30_000,
-  // motor#25 — Signal Extractor (Mistral3 default, classification curta)
-  "signal-extractor": 15_000,
-  // motor#35 PART B — Mood Extractor (Mistral3 default, classification curta)
-  "mood-extractor": 15_000,
-  // motor-simplificacao-v1 — Unified Assessor (Haiku, JSON estruturado)
-  "unified-assessor": 10_000,
+  planejador: 45_000, // local: prefill longo turn 1 pode chegar a 4s
+  "haiku-triage": 20_000,
+  "haiku-bullying": 20_000,
+  drota: 45_000, // local: turn 1 inaugural com contexto completo
+  "persona-sim": 45_000,
+  "signal-extractor": 20_000,
+  "mood-extractor": 20_000,
+  "unified-assessor": 20_000, // local: mesmo modelo que drota
 };
 
 /** MaxRetries default por step. */

--- a/shared/src/llm-config.ts
+++ b/shared/src/llm-config.ts
@@ -23,6 +23,8 @@ export const LLM_TIMEOUT_DEFAULTS: Record<string, number> = {
   "signal-extractor": 15_000,
   // motor#35 PART B — Mood Extractor (Mistral3 default, classification curta)
   "mood-extractor": 15_000,
+  // motor-simplificacao-v1 — Unified Assessor (Haiku, JSON estruturado)
+  "unified-assessor": 10_000,
 };
 
 /** MaxRetries default por step. */
@@ -34,6 +36,7 @@ export const LLM_MAX_RETRIES_DEFAULTS: Record<string, number> = {
   "persona-sim": 3,
   "signal-extractor": 2, // motor#25 — fail-fast, fallback rule-based existe
   "mood-extractor": 2, // motor#35 PART B — fail-fast, fallback rule-based existe
+  "unified-assessor": 2, // motor-simplificacao-v1 — fail-fast, rule-based degraded fallback
 };
 
 /**

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -34,53 +34,62 @@ export type LlmStep = (typeof LLM_STEPS)[number];
 
 /**
  * Default provider por step.
- * motor#21 + motor-simplificacao-v1: TUDO Infomaniak — zero Anthropic dependency.
  *
- * unified-assessor migrou de Anthropic Haiku → Infomaniak granite (Jun, 28-abr,
- * downsizing): zero custo Anthropic + um único provider em toda stack.
+ * motor-simplificacao-v1 (Jun, 28-abr — segunda iteração): TUDO Anthropic
+ * Haiku 4.5. Reverte tentativa anterior com Infomaniak granite por
+ * limitações em JSON estruturado + qualidade conversacional. Anthropic
+ * Haiku é small (1B-tier), rápido (~2-4s/call), bom em classification +
+ * geração curta. Custo aceitável após recarregar Anthropic.
  */
 export const DEFAULT_PROVIDERS: Record<LlmStep, LlmProvider> = {
-  planejador: "infomaniak",
-  drota: "infomaniak",
-  "persona-sim": "infomaniak",
-  "haiku-triage": "infomaniak",
-  "haiku-bullying": "infomaniak",
-  "signal-extractor": "infomaniak",
-  "mood-extractor": "infomaniak",
-  "unified-assessor": "infomaniak",
+  planejador: "anthropic",
+  drota: "anthropic",
+  "persona-sim": "anthropic",
+  "haiku-triage": "anthropic",
+  "haiku-bullying": "anthropic",
+  "signal-extractor": "anthropic",
+  "mood-extractor": "anthropic",
+  "unified-assessor": "anthropic",
 };
 
 /**
  * Default model por step.
  *
- * motor-simplificacao-v1 (Jun, 28-abr): TUDO `granite` (IBM small chat, ~3B,
- * ~3-5s/call). Downsizing radical: um único modelo em toda stack pra cortar
- * custos + simplificar debug. Trade-off conhecido: qualidade conversacional
- * cai vs Kimi K2.6 reasoning. Aceitável pra Kids (respostas curtas) e
- * classification (signal/mood/triage).
+ * motor-simplificacao-v1 (Jun, 28-abr — segunda iteração): TUDO Anthropic
+ * Haiku 4.5. Stack homogênea, debug simples, qualidade Anthropic.
  *
- * Override per-step via env <STEP>_MODEL (ex: DROTA_MODEL=moonshotai/Kimi-K2.6
- * pra subir qualidade só do drota).
+ * Trade-off: depende de ANTHROPIC_API_KEY válida + créditos. Sem key →
+ * use USE_MOCK_LLM=true (mock awareness em callGateway) ou override
+ * per-step via <STEP>_MODEL + <STEP>_PROVIDER pra Infomaniak.
+ *
+ * Override per-step preservado:
+ *   DROTA_PROVIDER=infomaniak DROTA_MODEL=moonshotai/Kimi-K2.6
  */
 export const DEFAULT_MODELS: Record<LlmStep, string> = {
-  planejador: "granite",
-  drota: "granite",
-  "persona-sim": "granite",
-  "haiku-triage": "granite",
-  "haiku-bullying": "granite",
-  "signal-extractor": "granite",
-  "mood-extractor": "granite",
-  "unified-assessor": "granite",
+  planejador: "claude-haiku-4-5-20251001",
+  drota: "claude-haiku-4-5-20251001",
+  "persona-sim": "claude-haiku-4-5-20251001",
+  "haiku-triage": "claude-haiku-4-5-20251001",
+  "haiku-bullying": "claude-haiku-4-5-20251001",
+  "signal-extractor": "claude-haiku-4-5-20251001",
+  "mood-extractor": "claude-haiku-4-5-20251001",
+  "unified-assessor": "claude-haiku-4-5-20251001",
 };
 
 /**
- * Anthropic-specific defaults (usado só se provider=anthropic).
- * Mapeamento: step → modelo Claude equivalente.
+ * Anthropic-specific defaults (usado quando provider=anthropic).
+ *
+ * motor-simplificacao-v1 segunda iteração: TUDO Haiku 4.5. Antes era split
+ * (Sonnet pra geração rica, Haiku pra classification). Agora homogêneo.
+ *
+ * Pra subir qualidade pontual (drota, persona-sim) com Sonnet:
+ *   DROTA_MODEL=claude-sonnet-4-6
+ *   PERSONA_SIM_MODEL=claude-sonnet-4-6
  */
 export const ANTHROPIC_FALLBACK_MODELS: Record<LlmStep, string> = {
-  planejador: "claude-sonnet-4-6",
-  drota: "claude-sonnet-4-6",
-  "persona-sim": "claude-sonnet-4-6",
+  planejador: "claude-haiku-4-5-20251001",
+  drota: "claude-haiku-4-5-20251001",
+  "persona-sim": "claude-haiku-4-5-20251001",
   "haiku-triage": "claude-haiku-4-5-20251001",
   "haiku-bullying": "claude-haiku-4-5-20251001",
   "signal-extractor": "claude-haiku-4-5-20251001",

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -28,6 +28,7 @@ export const LLM_STEPS = [
   "haiku-bullying",
   "signal-extractor", // motor#25 — captura signals semânticos antes de Environment Assessor
   "mood-extractor", // motor#35 — extração de mood absoluto da criança (F1-mood PART B)
+  "unified-assessor", // motor-simplificacao-v1 — Haiku unificado: signals + mood + engagement em 1 chamada
 ] as const;
 export type LlmStep = (typeof LLM_STEPS)[number];
 
@@ -43,6 +44,7 @@ export const DEFAULT_PROVIDERS: Record<LlmStep, LlmProvider> = {
   "haiku-bullying": "infomaniak",
   "signal-extractor": "infomaniak",
   "mood-extractor": "infomaniak",
+  "unified-assessor": "anthropic",
 };
 
 /**
@@ -62,6 +64,9 @@ export const DEFAULT_MODELS: Record<LlmStep, string> = {
   // Mood Extractor (motor#35 PART B): Mistral3 default — classificação curta
   // ("humor 1-10 + rationale"), não-reasoning. Mesmo perfil do signal-extractor.
   "mood-extractor": "mistral3",
+  // motor-simplificacao-v1: Haiku 4.5 — JSON estruturado (signals + mood +
+  // engagement em 1 chamada). DS-08 da spec: classificação, não geração.
+  "unified-assessor": "claude-haiku-4-5-20251001",
 };
 
 /**
@@ -76,6 +81,7 @@ export const ANTHROPIC_FALLBACK_MODELS: Record<LlmStep, string> = {
   "haiku-bullying": "claude-haiku-4-5-20251001",
   "signal-extractor": "claude-haiku-4-5-20251001",
   "mood-extractor": "claude-haiku-4-5-20251001",
+  "unified-assessor": "claude-haiku-4-5-20251001",
 };
 
 function envKey(step: string, suffix: string): string {

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -17,7 +17,7 @@
  *   PERSONA_SIM_MODEL=mistral3
  */
 
-export type LlmProvider = "anthropic" | "infomaniak";
+export type LlmProvider = "anthropic" | "infomaniak" | "local";
 
 /** Steps válidos com config defaults. */
 export const LLM_STEPS = [
@@ -112,9 +112,9 @@ function envKey(step: string, suffix: string): string {
  */
 export function getProviderForStep(step: string): LlmProvider {
   const perStep = process.env[envKey(step, "PROVIDER")];
-  if (perStep === "anthropic" || perStep === "infomaniak") return perStep;
+  if (perStep === "anthropic" || perStep === "infomaniak" || perStep === "local") return perStep;
   const global = process.env["LLM_PROVIDER"];
-  if (global === "anthropic" || global === "infomaniak") return global;
+  if (global === "anthropic" || global === "infomaniak" || global === "local") return global;
   return DEFAULT_PROVIDERS[step as LlmStep] ?? "infomaniak";
 }
 
@@ -140,6 +140,10 @@ export function getModelForStep(step: string, provider?: LlmProvider): string {
   if (legacy && process.env[legacy]) return process.env[legacy]!;
   // Fallback aware do provider escolhido
   const p = provider ?? getProviderForStep(step);
+  if (p === "local") {
+    // vLLM local: model único pra toda stack via env (default gpt-oss-20b)
+    return process.env["LOCAL_LLM_MODEL"] ?? "gpt-oss-20b";
+  }
   if (p === "anthropic") {
     return ANTHROPIC_FALLBACK_MODELS[step as LlmStep] ?? "claude-sonnet-4-6";
   }

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -34,7 +34,10 @@ export type LlmStep = (typeof LLM_STEPS)[number];
 
 /**
  * Default provider por step.
- * motor#21: TUDO Infomaniak por default — zero Anthropic dependency.
+ * motor#21 + motor-simplificacao-v1: TUDO Infomaniak — zero Anthropic dependency.
+ *
+ * unified-assessor migrou de Anthropic Haiku → Infomaniak granite (Jun, 28-abr,
+ * downsizing): zero custo Anthropic + um único provider em toda stack.
  */
 export const DEFAULT_PROVIDERS: Record<LlmStep, LlmProvider> = {
   planejador: "infomaniak",
@@ -44,29 +47,30 @@ export const DEFAULT_PROVIDERS: Record<LlmStep, LlmProvider> = {
   "haiku-bullying": "infomaniak",
   "signal-extractor": "infomaniak",
   "mood-extractor": "infomaniak",
-  "unified-assessor": "anthropic",
+  "unified-assessor": "infomaniak",
 };
 
 /**
  * Default model por step.
- * Reasoning models (Kimi K2.5) pra steps onde reasoning ajuda.
- * mistral3 (Mistral-Small-3.2-24B) pra triage/bullying — small, fast, deterministic.
+ *
+ * motor-simplificacao-v1 (Jun, 28-abr): TUDO `granite` (IBM small chat, ~3B,
+ * ~3-5s/call). Downsizing radical: um único modelo em toda stack pra cortar
+ * custos + simplificar debug. Trade-off conhecido: qualidade conversacional
+ * cai vs Kimi K2.6 reasoning. Aceitável pra Kids (respostas curtas) e
+ * classification (signal/mood/triage).
+ *
+ * Override per-step via env <STEP>_MODEL (ex: DROTA_MODEL=moonshotai/Kimi-K2.6
+ * pra subir qualidade só do drota).
  */
 export const DEFAULT_MODELS: Record<LlmStep, string> = {
-  planejador: "moonshotai/Kimi-K2.5",
-  drota: "moonshotai/Kimi-K2.5",
-  "persona-sim": "moonshotai/Kimi-K2.5",
-  "haiku-triage": "mistral3",
-  "haiku-bullying": "mistral3",
-  // Signal Extractor: Mistral3 default — não-reasoning, ~5s/call.
-  // Tarefa é classificação de signals em texto curto, não exige reasoning.
-  "signal-extractor": "mistral3",
-  // Mood Extractor (motor#35 PART B): Mistral3 default — classificação curta
-  // ("humor 1-10 + rationale"), não-reasoning. Mesmo perfil do signal-extractor.
-  "mood-extractor": "mistral3",
-  // motor-simplificacao-v1: Haiku 4.5 — JSON estruturado (signals + mood +
-  // engagement em 1 chamada). DS-08 da spec: classificação, não geração.
-  "unified-assessor": "claude-haiku-4-5-20251001",
+  planejador: "granite",
+  drota: "granite",
+  "persona-sim": "granite",
+  "haiku-triage": "granite",
+  "haiku-bullying": "granite",
+  "signal-extractor": "granite",
+  "mood-extractor": "granite",
+  "unified-assessor": "granite",
 };
 
 /**

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -17,7 +17,7 @@
  *   PERSONA_SIM_MODEL=mistral3
  */
 
-export type LlmProvider = "anthropic" | "infomaniak" | "local";
+export type LlmProvider = "anthropic" | "infomaniak" | "local" | "mock";
 
 /** Steps válidos com config defaults. */
 export const LLM_STEPS = [
@@ -116,6 +116,31 @@ export function getProviderForStep(step: string): LlmProvider {
   const global = process.env["LLM_PROVIDER"];
   if (global === "anthropic" || global === "infomaniak" || global === "local") return global;
   return DEFAULT_PROVIDERS[step as LlmStep] ?? "infomaniak";
+}
+
+/**
+ * Provider-aware API key check. Bug fix 2026-05-05 — antes a lógica
+ * `provider === "anthropic" ? !ANTHROPIC : !INFOMANIAK` deixava `provider==="local"`
+ * cair no else, pedindo INFOMANIAK_API_KEY. Resultado: `useMockLlm=true` mesmo com
+ * LLM_PROVIDER=local ativo, planejador caía em mock e o pipeline degenerava.
+ *
+ * - anthropic → exige ANTHROPIC_API_KEY
+ * - infomaniak → exige INFOMANIAK_API_KEY
+ * - local → não exige API key externa (vLLM/OVMS/llama-server endpoint local).
+ *           Falha em runtime se endpoint offline (callLocalVllm tem fail-soft).
+ */
+export function isApiKeyMissing(provider: LlmProvider): boolean {
+  switch (provider) {
+    case "anthropic":
+      return !process.env["ANTHROPIC_API_KEY"];
+    case "infomaniak":
+      return !process.env["INFOMANIAK_API_KEY"];
+    case "local":
+    case "mock":
+      return false;
+    default:
+      return true;
+  }
 }
 
 /**

--- a/shared/src/stable-state-cache.ts
+++ b/shared/src/stable-state-cache.ts
@@ -1,0 +1,120 @@
+/**
+ * Stable State Cache — campos cacheados por sessão pra alimentar
+ * Unified Assessor sem recalcular tudo a cada turn.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §3.6
+ *
+ * Distinção:
+ *   - StableStateFields: recalculados UMA VEZ por sessão (ou via evento explícito)
+ *   - VolatileStateFields: recalculados a cada turn pelo Unified Assessor
+ *
+ * Invalidação de stable: operador online/offline, transição status_matrix,
+ * fim de sessão. Não a cada turn.
+ *
+ * DT-SIM-02 (Jun, 28-abr): VoiceProfile ainda não existe como tipo canônico
+ * em shared/. Usa stub `Record<string, unknown>` aqui; refina quando voice
+ * profiles entrarem como tipo formal.
+ */
+
+import type { HelixState } from "./helix-state.js";
+import type { StatusMatrix } from "./status-matrix.js";
+import type { SemanticSignal } from "./semantic-signals.js";
+
+/** Jurisdição ativa do sujeito (afeta jurisdiction_respect). */
+export type Jurisdiction = "br" | "jp" | "ch";
+
+/** Engajamento derivado dos signals + mood. */
+export type EngagementLevel = "high" | "medium" | "low" | "disengaging";
+
+/**
+ * Campos estáveis — recalculados UMA VEZ por sessão.
+ * Invalidação só via evento explícito (transição, operador, fim de sessão).
+ */
+export interface StableStateFields {
+  /** ID canônico do sujeito (cross-session via motor#47). */
+  child_id: string;
+  /** 0.0-1.0 — derivado do trust-calculator.ts. */
+  trust_level: number;
+  /** Jurisdição ativa pra constraints de materialização. */
+  jurisdiction_active: Jurisdiction;
+  /** Flags de modificadores (futoko, incident, crisis_flag, etc.). */
+  modifier_flags: string[];
+  /** Operador humano disponível pra escalation. */
+  operator_online: boolean;
+  /**
+   * Voice profile do sujeito (cascade: ClientVoiceProfile → CulturalDefault
+   * → Universal). Estrutura formal pendente (DT-SIM-02). Stub Record por enquanto.
+   */
+  voice_profile: Record<string, unknown>;
+  /** Estado do Double Helix (atualiza só no fim da sessão). */
+  helix_state: HelixState;
+  /** Status matrix brejo/baia/pasto (atualiza só via transição detectada). */
+  status_matrix: StatusMatrix;
+  /** Timestamp do início da sessão (epoch ms). */
+  stable_computed_at: number;
+}
+
+/**
+ * Campos voláteis — recalculados a cada turn pelo Unified Assessor.
+ */
+export interface VolatileStateFields {
+  /** Mood absoluto 1-10 (do AssessmentResult). */
+  mood: number;
+  /** Últimos 3 valores de mood pra detectar drift. */
+  mood_window: number[];
+  /** Engajamento derivado dos signals. */
+  engagement: EngagementLevel;
+  /** Signals do turn atual (capturados pelo Unified Assessor). */
+  signals_last_turn: SemanticSignal[];
+  /** Budget restante (decrementado pelo Pragmatic Selector). */
+  budget_remaining: number;
+  /** Contador do turn atual na sessão. */
+  turn_count: number;
+}
+
+/**
+ * Cache em memória de StableStateFields por child_id.
+ *
+ * Nao thread-safe — assume single-process. Cada chamada
+ * createStableStateCache() cria store independente (isolamento em tests).
+ */
+export interface StableStateCache {
+  /** Lê campos estáveis pro child. Retorna null se não cacheado. */
+  get(childId: string): StableStateFields | null;
+  /** Persiste campos estáveis (cria ou atualiza). */
+  set(childId: string, fields: StableStateFields): void;
+  /** Invalida cache pro child (transição detectada, fim de sessão). */
+  invalidate(childId: string): void;
+  /** Invalida cache inteiro (debug, restart). */
+  invalidateAll(): void;
+  /** Retorna idade do cache em ms (Date.now() - stable_computed_at). */
+  age(childId: string): number | null;
+}
+
+/**
+ * Cria instância nova do cache. Map em memória; cada chamada cria store
+ * independente (útil em tests pra isolamento).
+ */
+export function createStableStateCache(): StableStateCache {
+  const store = new Map<string, StableStateFields>();
+
+  return {
+    get(childId: string): StableStateFields | null {
+      return store.get(childId) ?? null;
+    },
+    set(childId: string, fields: StableStateFields): void {
+      store.set(childId, fields);
+    },
+    invalidate(childId: string): void {
+      store.delete(childId);
+    },
+    invalidateAll(): void {
+      store.clear();
+    },
+    age(childId: string): number | null {
+      const fields = store.get(childId);
+      if (!fields) return null;
+      return Date.now() - fields.stable_computed_at;
+    },
+  };
+}

--- a/shared/src/trace-schema.ts
+++ b/shared/src/trace-schema.ts
@@ -109,6 +109,37 @@ export interface TurnTrace {
   parseFailure?: boolean;
   /** Razão (parse_failure | json_invalid_after_extract). */
   parseFailureReason?: string;
+
+  // ─── v0.3.4 — motor-simplificacao Steps 1-5 (feature flag) ───────────
+  /** Snapshot do Unified Assessor (Step 1). Preenchido só com flag on. */
+  assessmentSnapshot?: {
+    mood: number;
+    mood_method: "rule" | "llm" | "fallback";
+    mood_confidence: "high" | "medium" | "low";
+    signals: string[];
+    engagement: "high" | "medium" | "low" | "disengaging";
+    model_used?: string;
+    latency_ms: number;
+  };
+  /** Snapshot do Pragmatic Selector (Step 2). Preenchido só com flag on. */
+  selectionSnapshot?: {
+    decision_path: string;
+    candidates_count: number;
+    viable_count: number;
+    selected_id: string;
+    selected_cost: number;
+    budget_before: number;
+    budget_after: number;
+    pulso_emitted?: boolean;
+  };
+  /** Snapshot do Constrained Materializer (Step 3). Preenchido só com flag on. */
+  materializationSnapshot?: {
+    model_used: string;
+    fallback_triggered: boolean;
+    latency_ms: number;
+    token_count: number;
+    sanitization_applied?: boolean;
+  };
 }
 
 export interface SessionTrace {

--- a/shared/tests/gateway-client-local.test.ts
+++ b/shared/tests/gateway-client-local.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests pra provider "local" em callGateway (vLLM).
+ *
+ * Spec: ascendimacy-ops/docs/handoffs/2026-04-28-local-vllm-gpt-oss-motor-sts.md §6.2
+ *
+ * Provider local bypassa MCP gateway e chama vLLM direto via fetch.
+ * Mockamos global.fetch pra evitar dependência de container rodando.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { callGateway } from "../src/gateway-client.js";
+
+const ORIG_ENV: Record<string, string | undefined> = {
+  LLM_PROVIDER: process.env["LLM_PROVIDER"],
+  USE_MOCK_LLM: process.env["USE_MOCK_LLM"],
+  LOCAL_LLM_BASE_URL: process.env["LOCAL_LLM_BASE_URL"],
+  LOCAL_LLM_MODEL: process.env["LOCAL_LLM_MODEL"],
+  DROTA_PROVIDER: process.env["DROTA_PROVIDER"],
+};
+
+function buildVllmResponse(content: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => "",
+    json: async () => ({
+      choices: [{ message: { content } }],
+      usage: { prompt_tokens: 100, completion_tokens: 20 },
+    }),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  delete process.env["LLM_PROVIDER"];
+  delete process.env["USE_MOCK_LLM"];
+  delete process.env["LOCAL_LLM_BASE_URL"];
+  delete process.env["LOCAL_LLM_MODEL"];
+  delete process.env["DROTA_PROVIDER"];
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(ORIG_ENV)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("callGateway com provider=local (vLLM)", () => {
+  it("LLM_PROVIDER=local → fetch é chamado em /v1/chat/completions", async () => {
+    process.env["LLM_PROVIDER"] = "local";
+    process.env["LOCAL_LLM_BASE_URL"] = "http://localhost:8000/v1";
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(buildVllmResponse("Olá!"));
+
+    const result = await callGateway({
+      step: "drota",
+      systemPrompt: "system",
+      userMessage: "user",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:8000/v1/chat/completions",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result.provider).toBe("local");
+    expect(result.content).toBe("Olá!");
+    expect(result.tokens.in).toBe(100);
+    expect(result.tokens.out).toBe(20);
+  });
+
+  it("default base URL quando LOCAL_LLM_BASE_URL não setado", async () => {
+    process.env["LLM_PROVIDER"] = "local";
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(buildVllmResponse("ok"));
+
+    await callGateway({ step: "drota", systemPrompt: "", userMessage: "x" });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:8000/v1/chat/completions",
+      expect.any(Object),
+    );
+  });
+
+  it("body inclui model do LOCAL_LLM_MODEL", async () => {
+    process.env["LLM_PROVIDER"] = "local";
+    process.env["LOCAL_LLM_MODEL"] = "qwen3-8b";
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(buildVllmResponse("ok"));
+
+    await callGateway({ step: "drota", systemPrompt: "s", userMessage: "u" });
+
+    const callArgs = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const body = JSON.parse(callArgs.body as string);
+    expect(body.model).toBe("qwen3-8b");
+  });
+
+  it("cacheableSystemPrefix concatenado com systemPrompt no system message", async () => {
+    process.env["LLM_PROVIDER"] = "local";
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(buildVllmResponse("ok"));
+
+    await callGateway({
+      step: "drota",
+      systemPrompt: "DYNAMIC",
+      userMessage: "u",
+      cacheableSystemPrefix: "STABLE_PREFIX",
+    });
+
+    const callArgs = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const body = JSON.parse(callArgs.body as string);
+    expect(body.messages[0].role).toBe("system");
+    expect(body.messages[0].content).toBe("STABLE_PREFIX\n\nDYNAMIC");
+  });
+
+  it("USE_MOCK_LLM=true ainda retorna mock mesmo com provider=local", async () => {
+    process.env["USE_MOCK_LLM"] = "true";
+    process.env["LLM_PROVIDER"] = "local";
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    const result = await callGateway({
+      step: "drota",
+      systemPrompt: "",
+      userMessage: "",
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.model).toBe("mock");
+  });
+
+  it("HTTP error → throw com status + body slice", async () => {
+    process.env["LLM_PROVIDER"] = "local";
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: async () => "service unavailable",
+      json: async () => ({}),
+    } as unknown as Response);
+
+    await expect(
+      callGateway({ step: "drota", systemPrompt: "", userMessage: "u" }),
+    ).rejects.toThrow(/HTTP 503/);
+  });
+
+  it("DROTA_PROVIDER=local → só drota usa local; planejador segue default", async () => {
+    process.env["DROTA_PROVIDER"] = "local";
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(buildVllmResponse("ok"));
+
+    await callGateway({ step: "drota", systemPrompt: "", userMessage: "u" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Confirma que NÃO foi MCP gateway (sem callTool); fetch é a evidência.
+  });
+});

--- a/shared/tests/gateway-client-mock.test.ts
+++ b/shared/tests/gateway-client-mock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests pra mock awareness em callGateway (USE_MOCK_LLM=true).
+ *
+ * Quando flag liga, callGateway retorna stub determinístico per step
+ * sem spawnar gateway nem chamar LLM real. Smoke end-to-end zero custo.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { callGateway } from "../src/gateway-client.js";
+
+const ORIG_FLAG = process.env["USE_MOCK_LLM"];
+
+beforeEach(() => {
+  process.env["USE_MOCK_LLM"] = "true";
+});
+
+afterEach(() => {
+  if (ORIG_FLAG === undefined) delete process.env["USE_MOCK_LLM"];
+  else process.env["USE_MOCK_LLM"] = ORIG_FLAG;
+});
+
+describe("callGateway — mock awareness (USE_MOCK_LLM=true)", () => {
+  it("unified-assessor → JSON com mood + signals + engagement válidos", async () => {
+    const r = await callGateway({
+      step: "unified-assessor",
+      systemPrompt: "x",
+      userMessage: "y",
+    });
+    expect(r.model).toBe("mock");
+    expect(r.latency_ms).toBe(0);
+    const parsed = JSON.parse(r.content);
+    expect(parsed.mood).toBe(6);
+    expect(parsed.mood_confidence).toBe("medium");
+    expect(Array.isArray(parsed.signals)).toBe(true);
+    expect(parsed.engagement).toBe("medium");
+  });
+
+  it("mood-extractor → JSON com score + rationale", async () => {
+    const r = await callGateway({
+      step: "mood-extractor",
+      systemPrompt: "x",
+      userMessage: "y",
+    });
+    const parsed = JSON.parse(r.content);
+    expect(parsed.score).toBe(5);
+    expect(parsed.rationale).toBe("mock");
+  });
+
+  it("signal-extractor → JSON com signals array", async () => {
+    const r = await callGateway({
+      step: "signal-extractor",
+      systemPrompt: "x",
+      userMessage: "y",
+    });
+    const parsed = JSON.parse(r.content);
+    expect(Array.isArray(parsed.signals)).toBe(true);
+    expect(parsed.signals).toEqual([]);
+  });
+
+  it("drota → JSON com selectionRationale + linguisticMaterialization", async () => {
+    const r = await callGateway({
+      step: "drota",
+      systemPrompt: "x",
+      userMessage: "y",
+    });
+    const parsed = JSON.parse(r.content);
+    expect(typeof parsed.selectionRationale).toBe("string");
+    expect(typeof parsed.linguisticMaterialization).toBe("string");
+    expect(parsed.linguisticMaterialization.length).toBeGreaterThan(0);
+  });
+
+  it("planejador → JSON parseable com strategicRationale + contentPool", async () => {
+    const r = await callGateway({
+      step: "planejador",
+      systemPrompt: "x",
+      userMessage: "y",
+    });
+    const parsed = JSON.parse(r.content);
+    expect(typeof parsed.strategicRationale).toBe("string");
+    expect(Array.isArray(parsed.contentPool)).toBe(true);
+  });
+
+  it("step desconhecido → fallback genérico válido", async () => {
+    const r = await callGateway({
+      step: "step-novo-qualquer",
+      systemPrompt: "x",
+      userMessage: "y",
+    });
+    const parsed = JSON.parse(r.content);
+    expect(parsed.mock).toBe(true);
+    expect(parsed.step).toBe("step-novo-qualquer");
+  });
+
+  it("flag off (default) → tenta gateway real (que deve falhar sem env)", async () => {
+    delete process.env["USE_MOCK_LLM"];
+    // Quando flag não tá true, callGateway tenta spawnar gateway real.
+    // Se gateway não buildado, dá erro claro. Aqui só verificamos que NÃO
+    // retorna o mock JSON — a chamada lança ou tenta rede.
+    await expect(
+      callGateway({
+        step: "unified-assessor",
+        systemPrompt: "x",
+        userMessage: "y",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -174,8 +174,16 @@ describe("shouldEnableThinking", () => {
 });
 
 describe("constants exposure", () => {
-  it("DEFAULT_PROVIDERS é Infomaniak everywhere", () => {
-    for (const v of Object.values(DEFAULT_PROVIDERS)) expect(v).toBe("infomaniak");
+  it("DEFAULT_PROVIDERS é Infomaniak everywhere (exceto unified-assessor)", () => {
+    for (const [step, v] of Object.entries(DEFAULT_PROVIDERS)) {
+      // unified-assessor (motor-simplificacao-v1 DS-08): Haiku Anthropic
+      // por design — classificação JSON estruturada, modelo Anthropic-specific.
+      if (step === "unified-assessor") {
+        expect(v).toBe("anthropic");
+      } else {
+        expect(v).toBe("infomaniak");
+      }
+    }
   });
   it("DEFAULT_MODELS preenchido pra todos os steps", () => {
     expect(DEFAULT_MODELS["planejador"]).toBeTruthy();

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -77,15 +77,17 @@ describe("getProviderForStep", () => {
 });
 
 describe("getModelForStep", () => {
-  it("default Kimi K2.5 pra planejador/drota/persona-sim (Infomaniak)", () => {
-    expect(getModelForStep("planejador")).toBe("moonshotai/Kimi-K2.5");
-    expect(getModelForStep("drota")).toBe("moonshotai/Kimi-K2.5");
-    expect(getModelForStep("persona-sim")).toBe("moonshotai/Kimi-K2.5");
-  });
-
-  it("default mistral3 pra haiku-triage/haiku-bullying (rerank, sem reasoning)", () => {
-    expect(getModelForStep("haiku-triage")).toBe("mistral3");
-    expect(getModelForStep("haiku-bullying")).toBe("mistral3");
+  it("default granite em todos os steps Infomaniak (motor-simplificacao-v1)", () => {
+    // Pós-downsizing 28-abr: stack inteira em granite (IBM small chat).
+    // Override per-step via env <STEP>_MODEL pra subir qualidade onde valer.
+    expect(getModelForStep("planejador")).toBe("granite");
+    expect(getModelForStep("drota")).toBe("granite");
+    expect(getModelForStep("persona-sim")).toBe("granite");
+    expect(getModelForStep("haiku-triage")).toBe("granite");
+    expect(getModelForStep("haiku-bullying")).toBe("granite");
+    expect(getModelForStep("signal-extractor")).toBe("granite");
+    expect(getModelForStep("mood-extractor")).toBe("granite");
+    expect(getModelForStep("unified-assessor")).toBe("granite");
   });
 
   it("provider=anthropic → Claude fallback", () => {
@@ -174,15 +176,11 @@ describe("shouldEnableThinking", () => {
 });
 
 describe("constants exposure", () => {
-  it("DEFAULT_PROVIDERS é Infomaniak everywhere (exceto unified-assessor)", () => {
-    for (const [step, v] of Object.entries(DEFAULT_PROVIDERS)) {
-      // unified-assessor (motor-simplificacao-v1 DS-08): Haiku Anthropic
-      // por design — classificação JSON estruturada, modelo Anthropic-specific.
-      if (step === "unified-assessor") {
-        expect(v).toBe("anthropic");
-      } else {
-        expect(v).toBe("infomaniak");
-      }
+  it("DEFAULT_PROVIDERS é Infomaniak everywhere (incluindo unified-assessor pós-downsizing)", () => {
+    // motor-simplificacao-v1 (Jun, 28-abr): unified-assessor migrou de
+    // Anthropic Haiku → Infomaniak granite. Stack 100% Infomaniak agora.
+    for (const v of Object.values(DEFAULT_PROVIDERS)) {
+      expect(v).toBe("infomaniak");
     }
   });
   it("DEFAULT_MODELS preenchido pra todos os steps", () => {

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -34,18 +34,18 @@ afterEach(() => {
 });
 
 describe("getProviderForStep", () => {
-  it("default infomaniak pra todos os steps", () => {
-    expect(getProviderForStep("planejador")).toBe("infomaniak");
-    expect(getProviderForStep("drota")).toBe("infomaniak");
-    expect(getProviderForStep("persona-sim")).toBe("infomaniak");
-    expect(getProviderForStep("haiku-triage")).toBe("infomaniak");
-    expect(getProviderForStep("haiku-bullying")).toBe("infomaniak");
+  it("default anthropic pra todos os steps (motor-simplificacao-v1 Haiku-em-tudo)", () => {
+    expect(getProviderForStep("planejador")).toBe("anthropic");
+    expect(getProviderForStep("drota")).toBe("anthropic");
+    expect(getProviderForStep("persona-sim")).toBe("anthropic");
+    expect(getProviderForStep("haiku-triage")).toBe("anthropic");
+    expect(getProviderForStep("haiku-bullying")).toBe("anthropic");
   });
 
   it("PLANEJADOR_PROVIDER override per-step", () => {
-    process.env["PLANEJADOR_PROVIDER"] = "anthropic";
-    expect(getProviderForStep("planejador")).toBe("anthropic");
-    expect(getProviderForStep("drota")).toBe("infomaniak"); // não afeta outros
+    process.env["PLANEJADOR_PROVIDER"] = "infomaniak";
+    expect(getProviderForStep("planejador")).toBe("infomaniak");
+    expect(getProviderForStep("drota")).toBe("anthropic"); // não afeta outros
   });
 
   it("hyphen no step name vira underscore no env (haiku-triage → HAIKU_TRIAGE_PROVIDER)", () => {
@@ -66,32 +66,37 @@ describe("getProviderForStep", () => {
     expect(getProviderForStep("planejador")).toBe("anthropic"); // global ainda
   });
 
-  it("valor inválido em env → fallback default", () => {
+  it("valor inválido em env → fallback default (anthropic)", () => {
     process.env["PLANEJADOR_PROVIDER"] = "openai"; // não é "anthropic" nem "infomaniak"
-    expect(getProviderForStep("planejador")).toBe("infomaniak"); // default
+    expect(getProviderForStep("planejador")).toBe("anthropic"); // default
   });
 
-  it("step desconhecido → infomaniak fallback", () => {
+  it("step desconhecido → infomaniak fallback (legado pré-haiku-em-tudo)", () => {
+    // getProviderForStep tem fallback hardcoded "infomaniak" pra steps fora
+    // do enum. Step desconhecido não deveria existir em prática (LLM_STEPS
+    // é exhaustivo), mas o fallback é defensivo.
     expect(getProviderForStep("unknown-step")).toBe("infomaniak");
   });
 });
 
 describe("getModelForStep", () => {
-  it("default granite em todos os steps Infomaniak (motor-simplificacao-v1)", () => {
-    // Pós-downsizing 28-abr: stack inteira em granite (IBM small chat).
-    // Override per-step via env <STEP>_MODEL pra subir qualidade onde valer.
-    expect(getModelForStep("planejador")).toBe("granite");
-    expect(getModelForStep("drota")).toBe("granite");
-    expect(getModelForStep("persona-sim")).toBe("granite");
-    expect(getModelForStep("haiku-triage")).toBe("granite");
-    expect(getModelForStep("haiku-bullying")).toBe("granite");
-    expect(getModelForStep("signal-extractor")).toBe("granite");
-    expect(getModelForStep("mood-extractor")).toBe("granite");
-    expect(getModelForStep("unified-assessor")).toBe("granite");
+  it("default Haiku 4.5 em todos os steps (motor-simplificacao-v1 Haiku-em-tudo)", () => {
+    // Pós-downsizing 28-abr (segunda iteração): stack inteira em Anthropic
+    // Haiku 4.5. Override per-step via env <STEP>_MODEL + <STEP>_PROVIDER.
+    const HAIKU = "claude-haiku-4-5-20251001";
+    expect(getModelForStep("planejador")).toBe(HAIKU);
+    expect(getModelForStep("drota")).toBe(HAIKU);
+    expect(getModelForStep("persona-sim")).toBe(HAIKU);
+    expect(getModelForStep("haiku-triage")).toBe(HAIKU);
+    expect(getModelForStep("haiku-bullying")).toBe(HAIKU);
+    expect(getModelForStep("signal-extractor")).toBe(HAIKU);
+    expect(getModelForStep("mood-extractor")).toBe(HAIKU);
+    expect(getModelForStep("unified-assessor")).toBe(HAIKU);
   });
 
-  it("provider=anthropic → Claude fallback", () => {
-    expect(getModelForStep("planejador", "anthropic")).toBe("claude-sonnet-4-6");
+  it("provider=anthropic → Haiku 4.5 em todos (motor-simplificacao-v1)", () => {
+    // Pós-Haiku-em-tudo: ANTHROPIC_FALLBACK_MODELS é homogêneo.
+    expect(getModelForStep("planejador", "anthropic")).toBe("claude-haiku-4-5-20251001");
     expect(getModelForStep("haiku-triage", "anthropic")).toBe("claude-haiku-4-5-20251001");
   });
 
@@ -176,11 +181,12 @@ describe("shouldEnableThinking", () => {
 });
 
 describe("constants exposure", () => {
-  it("DEFAULT_PROVIDERS é Infomaniak everywhere (incluindo unified-assessor pós-downsizing)", () => {
-    // motor-simplificacao-v1 (Jun, 28-abr): unified-assessor migrou de
-    // Anthropic Haiku → Infomaniak granite. Stack 100% Infomaniak agora.
+  it("DEFAULT_PROVIDERS é Anthropic everywhere (motor-simplificacao-v1 Haiku-em-tudo)", () => {
+    // motor-simplificacao-v1 segunda iteração (Jun, 28-abr): stack inteira em
+    // Anthropic Haiku 4.5. Reverte tentativa Infomaniak granite por limitações
+    // em JSON estruturado + qualidade conversacional.
     for (const v of Object.values(DEFAULT_PROVIDERS)) {
-      expect(v).toBe("infomaniak");
+      expect(v).toBe("anthropic");
     }
   });
   it("DEFAULT_MODELS preenchido pra todos os steps", () => {

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -79,6 +79,48 @@ describe("getProviderForStep", () => {
   });
 });
 
+describe("getProviderForStep com provider local (vLLM)", () => {
+  it("LLM_PROVIDER=local → todos os steps retornam local", () => {
+    process.env["LLM_PROVIDER"] = "local";
+    expect(getProviderForStep("drota")).toBe("local");
+    expect(getProviderForStep("planejador")).toBe("local");
+    expect(getProviderForStep("unified-assessor")).toBe("local");
+  });
+
+  it("DROTA_PROVIDER=local → step específico, outros mantêm default", () => {
+    process.env["DROTA_PROVIDER"] = "local";
+    expect(getProviderForStep("drota")).toBe("local");
+    expect(getProviderForStep("planejador")).toBe("anthropic"); // default
+  });
+
+  it("step-specific local beats global anthropic", () => {
+    process.env["LLM_PROVIDER"] = "anthropic";
+    process.env["DROTA_PROVIDER"] = "local";
+    expect(getProviderForStep("drota")).toBe("local");
+    expect(getProviderForStep("planejador")).toBe("anthropic");
+  });
+});
+
+describe("getModelForStep com provider local (vLLM)", () => {
+  it("provider=local sem env → default gpt-oss-20b", () => {
+    delete process.env["LOCAL_LLM_MODEL"];
+    expect(getModelForStep("drota", "local")).toBe("gpt-oss-20b");
+  });
+
+  it("provider=local com LOCAL_LLM_MODEL → respeita env", () => {
+    process.env["LOCAL_LLM_MODEL"] = "qwen3-8b";
+    expect(getModelForStep("drota", "local")).toBe("qwen3-8b");
+  });
+
+  it("provider=local em todos os steps retorna mesmo modelo (single-model stack)", () => {
+    process.env["LOCAL_LLM_MODEL"] = "gpt-oss-20b";
+    expect(getModelForStep("planejador", "local")).toBe("gpt-oss-20b");
+    expect(getModelForStep("drota", "local")).toBe("gpt-oss-20b");
+    expect(getModelForStep("unified-assessor", "local")).toBe("gpt-oss-20b");
+    expect(getModelForStep("haiku-triage", "local")).toBe("gpt-oss-20b");
+  });
+});
+
 describe("getModelForStep", () => {
   it("default Haiku 4.5 em todos os steps (motor-simplificacao-v1 Haiku-em-tudo)", () => {
     // Pós-downsizing 28-abr (segunda iteração): stack inteira em Anthropic

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -9,6 +9,7 @@ import {
   getMaxTokensForStep,
   shouldEnableThinking,
   isReasoningModel,
+  isApiKeyMissing,
   DEFAULT_PROVIDERS,
   DEFAULT_MODELS,
   ANTHROPIC_FALLBACK_MODELS,
@@ -241,5 +242,50 @@ describe("constants exposure", () => {
   it("ANTHROPIC_FALLBACK_MODELS usa Claude", () => {
     expect(ANTHROPIC_FALLBACK_MODELS["planejador"]).toContain("claude");
     expect(ANTHROPIC_FALLBACK_MODELS["haiku-triage"]).toContain("haiku");
+  });
+});
+
+// 2026-05-05 bugfix: provider=local não exige API key externa.
+describe("isApiKeyMissing", () => {
+  it("provider=local → sempre false (endpoint local, sem API key externa)", () => {
+    delete process.env["ANTHROPIC_API_KEY"];
+    delete process.env["INFOMANIAK_API_KEY"];
+    delete process.env["LOCAL_LLM_BASE_URL"];
+    expect(isApiKeyMissing("local")).toBe(false);
+  });
+
+  it("provider=anthropic sem ANTHROPIC_API_KEY → true", () => {
+    delete process.env["ANTHROPIC_API_KEY"];
+    expect(isApiKeyMissing("anthropic")).toBe(true);
+  });
+
+  it("provider=anthropic com ANTHROPIC_API_KEY → false", () => {
+    process.env["ANTHROPIC_API_KEY"] = "sk-test";
+    expect(isApiKeyMissing("anthropic")).toBe(false);
+  });
+
+  it("provider=infomaniak sem INFOMANIAK_API_KEY → true", () => {
+    delete process.env["INFOMANIAK_API_KEY"];
+    expect(isApiKeyMissing("infomaniak")).toBe(true);
+  });
+
+  it("provider=infomaniak com INFOMANIAK_API_KEY → false", () => {
+    process.env["INFOMANIAK_API_KEY"] = "imk-test";
+    expect(isApiKeyMissing("infomaniak")).toBe(false);
+  });
+
+  it("provider=mock → false (mock não chama nada externo)", () => {
+    expect(isApiKeyMissing("mock")).toBe(false);
+  });
+
+  it("regression: LLM_PROVIDER=local + sem keys externas NÃO ativa mock keyMissing", () => {
+    // Cenário do bug original: LLM_PROVIDER=local mas falta API_KEY → useMockLlm=true falsamente.
+    // Após fix, isApiKeyMissing("local") retorna false mesmo sem keys.
+    process.env["LLM_PROVIDER"] = "local";
+    delete process.env["ANTHROPIC_API_KEY"];
+    delete process.env["INFOMANIAK_API_KEY"];
+    const provider = getProviderForStep("planejador");
+    expect(provider).toBe("local");
+    expect(isApiKeyMissing(provider)).toBe(false);
   });
 });

--- a/shared/tests/stable-state-cache.test.ts
+++ b/shared/tests/stable-state-cache.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { createStableStateCache } from "../src/stable-state-cache.js";
+import type { StableStateFields } from "../src/stable-state-cache.js";
+import { initHelix } from "../src/helix-planner.js";
+
+function buildFields(childId: string): StableStateFields {
+  return {
+    child_id: childId,
+    trust_level: 0.5,
+    jurisdiction_active: "jp",
+    modifier_flags: [],
+    operator_online: false,
+    voice_profile: {},
+    helix_state: initHelix(childId),
+    status_matrix: { emotional: "baia" },
+    stable_computed_at: Date.now(),
+  };
+}
+
+describe("StableStateCache", () => {
+  it("get retorna null pra childId não cacheado", () => {
+    const cache = createStableStateCache();
+    expect(cache.get("user-1")).toBeNull();
+  });
+
+  it("set + get roundtrip", () => {
+    const cache = createStableStateCache();
+    const fields = buildFields("user-1");
+    cache.set("user-1", fields);
+    expect(cache.get("user-1")).toEqual(fields);
+  });
+
+  it("isolamento entre child_ids", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", buildFields("user-1"));
+    cache.set("user-2", buildFields("user-2"));
+    expect(cache.get("user-1")?.child_id).toBe("user-1");
+    expect(cache.get("user-2")?.child_id).toBe("user-2");
+  });
+
+  it("invalidate remove entry específica", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", buildFields("user-1"));
+    cache.set("user-2", buildFields("user-2"));
+    cache.invalidate("user-1");
+    expect(cache.get("user-1")).toBeNull();
+    expect(cache.get("user-2")).not.toBeNull();
+  });
+
+  it("invalidateAll limpa cache inteiro", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", buildFields("user-1"));
+    cache.set("user-2", buildFields("user-2"));
+    cache.invalidateAll();
+    expect(cache.get("user-1")).toBeNull();
+    expect(cache.get("user-2")).toBeNull();
+  });
+
+  it("age retorna ms desde stable_computed_at", () => {
+    const cache = createStableStateCache();
+    const past = Date.now() - 5000;
+    cache.set("user-1", { ...buildFields("user-1"), stable_computed_at: past });
+    const age = cache.age("user-1");
+    expect(age).not.toBeNull();
+    expect(age!).toBeGreaterThanOrEqual(5000);
+  });
+
+  it("age retorna null pra child sem cache", () => {
+    const cache = createStableStateCache();
+    expect(cache.age("user-1")).toBeNull();
+  });
+
+  it("set sobrescreve idempotentemente", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", { ...buildFields("user-1"), trust_level: 0.3 });
+    cache.set("user-1", { ...buildFields("user-1"), trust_level: 0.8 });
+    expect(cache.get("user-1")?.trust_level).toBe(0.8);
+  });
+
+  it("instâncias separadas não compartilham state", () => {
+    const cache1 = createStableStateCache();
+    const cache2 = createStableStateCache();
+    cache1.set("user-1", buildFields("user-1"));
+    expect(cache2.get("user-1")).toBeNull();
+  });
+});

--- a/shared/voice/cultural-defaults/_neutral.yaml
+++ b/shared/voice/cultural-defaults/_neutral.yaml
@@ -1,0 +1,31 @@
+# Cultural Defaults — Neutral fallback (PT-BR plain)
+#
+# Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5.5
+#
+# Universal fallback quando ClientVoiceProfile + CulturalDefault específico
+# (ja.yaml, br-pt.yaml) ausentes. Tom direto, sem decoração cultural.
+
+cultural_default_provenance: universal_neutral
+language: pt
+locale: pt-BR
+
+inaugural:
+  greeting: "Oi"
+  greeting_with_name_format: "{greeting}, {name}."
+  purpose: |
+    Estou aqui pra pensar coisas com você. Não sou quem dá respostas — sou quem fala junto.
+  non_evaluation_clause: "Isso não é prova nem avaliação."
+  exit_right: "Se quiser parar, é só falar. Sem problema nenhum."
+  confirmation_invite_template: "Hoje, quer falar sobre {interest}?"
+  confirmation_invite_default: "O que tá rolando aí?"
+
+pulso:
+  type: plain
+  enabled: false
+  tie_threshold: 0.05
+  rng_seed_strategy: deterministic_session
+  vocabulary: []
+
+honorifics:
+  default_form: bare_name
+  available_options: [bare_name]

--- a/shared/voice/cultural-defaults/ja.yaml
+++ b/shared/voice/cultural-defaults/ja.yaml
@@ -1,0 +1,60 @@
+# Cultural Defaults — Japonês (JP)
+#
+# Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5.5
+# + 2026-04-26-pulso-spec-v0.md (omikuji v0)
+#
+# Status: v0 — pendente revisão Yuji/Yuko ANTES do piloto Nagareyama.
+# cultural_default_provenance: "claude_ai_v0_pending_family_anchor"
+#
+# Quando Yuji/Yuko revisarem, atualizar provenance para "family_anchor".
+
+cultural_default_provenance: claude_ai_v0_pending_family_anchor
+language: ja
+locale: ja-JP
+
+# ─── Inaugural template (turn 0 primeira sessão) ─────────────────────
+# Spec §5.5 — slots mínimos pro piloto Nagareyama.
+inaugural:
+  greeting: "こんにちは"
+  # subject_name_form é resolvido em runtime (sem honorífico por padrão JP;
+  # família revisa). Esta é apenas a forma de saudação.
+  greeting_with_name_format: "{greeting}、{name}。"
+
+  # Propósito (1-2 frases) — claude_ai_v0; family_anchor revisará tom.
+  purpose: |
+    僕はあなたと一緒に何かを考える相手だよ。
+    答えを教える人じゃなくて、一緒に気になることを話す相手。
+
+  # Cláusula de não-avaliação (obrigatória — não é teste).
+  non_evaluation_clause: "これはテストじゃないよ。"
+
+  # Direito de saída (sempre presente).
+  exit_right: "「もういい」って言えば、いつでも終われるよ。"
+
+  # Convite pra começar (ancorado em interesse — slot dinâmico {interest}).
+  confirmation_invite_template: "今日、{interest}について話したい?"
+  confirmation_invite_default: "今日は何が気になってる?"
+
+# ─── Pulso vocabulário cultural (omikuji v0) ─────────────────────────
+# Spec 2026-04-26-pulso-spec-v0.md DA-PULSO-03: 7 níveis (drop 半吉).
+pulso:
+  type: omikuji
+  enabled: true
+  tie_threshold: 0.05
+  rng_seed_strategy: deterministic_session
+  vocabulary:
+    - { symbol: "大吉", translation: "fortuna grande", weight: 1 }
+    - { symbol: "吉", translation: "fortuna boa", weight: 2 }
+    - { symbol: "中吉", translation: "fortuna média", weight: 3 }
+    - { symbol: "小吉", translation: "fortuna pequena", weight: 2 }
+    - { symbol: "末吉", translation: "fortuna distante", weight: 2 }
+    - { symbol: "凶", translation: "azar", weight: 1 }
+    - { symbol: "大凶", translation: "azar grande", weight: 1 }
+
+# ─── Honorific defaults ──────────────────────────────────────────────
+# Família revisa: padrão é SEM honorífico (familiaridade desejada).
+honorifics:
+  default_form: bare_name
+  available_options: [bare_name, kun, chan, san]
+  # Aviso: usar honorífico errado em JP é violação social leve; defer
+  # à família.

--- a/shared/voice/profiles/kids-jp.voice-profile.yaml
+++ b/shared/voice/profiles/kids-jp.voice-profile.yaml
@@ -1,0 +1,36 @@
+# Voice Profile — Kids JP
+#
+# Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §6.2
+# Cascade: ClientVoiceProfile (este) → CulturalDefault (ja.yaml) → Universal (_neutral.yaml)
+
+profile_id: kids-jp
+language: ja
+cultural_default_ref: shared/voice/cultural-defaults/ja.yaml
+
+# ─── Materializer config (DS-09) ─────────────────────────────────────
+# DT-SIM-05: spec mencionou "qwen" como default; v0 usa step "drota"
+# existente (Kimi K2.5 via Infomaniak). Refator pra ler model daqui
+# quando voice profile ganhar tipo formal.
+materializer:
+  step: drota
+  max_tokens: 300
+  temperature: 0.7
+
+# ─── Assessor config (DS-08) ─────────────────────────────────────────
+assessor:
+  step: unified-assessor
+  max_tokens: 256
+  temperature: 0.1
+
+# ─── Pulso config (motor#33, DA-PULSO-01..05) ────────────────────────
+pulso:
+  enabled: true
+  type: omikuji
+  tie_threshold: 0.05
+  rng_seed_strategy: deterministic_session
+  vocabulary_ref: shared/voice/cultural-defaults/ja.yaml#pulso
+
+# ─── Cliente-specific overrides (família Yuji+Yuko revisa) ───────────
+client_overrides:
+  honorific: bare_name # família escolhe; default JP é sem honorífico
+  inaugural_purpose_override: null # null = usa do cultural default


### PR DESCRIPTION
## Summary

Implementa **Steps 1-5** da spec [`2026-04-28-motor-simplificacao-llm-spec-v1.md`](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md) + Step 5 handoff [`step5-handoff.md`](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/handoffs/2026-04-28-motor-simplificacao-step5-handoff.md). Step 6 (smoke STS) requer env real — fora de escopo.

| Step | Descrição | Status |
|---|---|---|
| **1** | Unified Assessor + StableStateCache | ✅ |
| **2** | Pragmatic Selector (zero LLM) | ✅ |
| **3** | Constrained Materializer (constraints in-prompt + FALLBACK) | ✅ |
| **4** | Inaugural Template Resolver + ja.yaml + kids-jp.voice-profile.yaml | ✅ |
| **5** | Feature flag side-by-side (`USE_SIMPLIFIED_PIPELINE=true`) | ✅ |
| 6 | Smoke STS Ryo+Kei | ⏳ Jun executa local OU agente cloud |

## Estratégia Step 5: side-by-side via feature flag (estratégia B aprovada)

`USE_SIMPLIFIED_PIPELINE=true` no env desvia o fluxo interno do `evaluate_and_select` para os 3 novos componentes.

**Fluxo antigo PRESERVADO**: `selectFromPool`, `callLlm`, `parseDrotaOutput`, `STABLE_DROTA_PREFIX`, `extract_signals` MCP tool — todos intactos. Rollback = remover env var.

```
[evaluate_and_select handler]
  ├─ rankPool
  ├─ if USE_SIMPLIFIED_PIPELINE === "true":
  │    ├─ pool vazio → mesmo fallback que fluxo antigo
  │    └─ handleSimplifiedPipeline:
  │         ├─ assess() — Unified Assessor (1 chamada Haiku ou rule-based)
  │         ├─ selectAction() — Pragmatic Selector (zero LLM)
  │         ├─ Inaugural detect (turn=0 + flag) → resolveInauguralTemplate
  │         └─ materialize() — Constrained Materializer com FALLBACK:
  │       (return early, fluxo antigo NÃO executa)
  └─ fluxo antigo: selectFromPool → callLlm → parseDrotaOutput → ...
```

## DTs descobertos durante implementação

- **DT-SIM-01..06**: vide PR description anterior (signals divergentes, VoiceProfile stub, raw text rule-based, ScoredContentItem ≠ ActionCandidate, model "qwen" mapped to step "drota", profiles sem loader runtime)

## Mudanças resumidas

### Steps 1-4 (commits anteriores)
```
shared/src/stable-state-cache.ts                    (Step 1, types + cache)
motor-drota/src/unified-assessor.ts                 (Step 1, Haiku + rule-based)
motor-drota/src/pragmatic-selector.ts               (Step 2, deterministic)
motor-drota/src/constrained-materializer.ts         (Step 3, in-prompt constraints)
motor-drota/src/inaugural-template.ts               (Step 4, cascade resolver)
shared/voice/cultural-defaults/ja.yaml              (Step 4)
shared/voice/cultural-defaults/_neutral.yaml        (Step 4)
shared/voice/profiles/kids-jp.voice-profile.yaml    (Step 4)
+ tests
```

### Step 5 (commits novos)
```
motor-drota/src/server.ts                            +207 (handleSimplifiedPipeline + feature flag branch)
shared/src/trace-schema.ts                           +31  (assessment/selection/materialization snapshots opcionais)
motor-drota/tests/server-simplified-pipeline.test.ts +274 (9 tests composição + flag check)
```

## Validação

- ✅ `npm test --workspace shared` — 369/369 + 7 skipped
- ✅ `npm test --workspace motor-drota` — **170/170** (foi 84, +86 tests)
- ✅ `npm run build` — TS clean em ambos workspaces
- ✅ Fluxo antigo (flag off) inalterado — testes existentes verde

## Step 6 — Smoke STS pós-merge

Comando pra Jun rodar:

```bash
cd ascendimacy-motor
USE_SIMPLIFIED_PIPELINE=true USE_MOCK_LLM=false \
  INFOMANIAK_API_KEY=... \
  npx sts run-scenario scenarios/nagareyama-14d-v1.yaml --real-llm
```

Verificar:
- Personas Ryo (deflexivo) e Kei (filosófico) recebem sequências **diferentes** nas 3 sessões
- `mood_method` alterna entre `rule` e `llm` conforme mensagem
- Nenhum `FALLBACK:` inesperado no output
- `decision_path` legível em todos os turns

Resultado vai pra `ascendimacy-ops/docs/tests/2026-04-28-smoke-simplificacao.md`.

## Refs

- Spec: [`2026-04-28-motor-simplificacao-llm-spec-v1.md`](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md)
- Step 5 handoff: [`2026-04-28-motor-simplificacao-step5-handoff.md`](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/handoffs/2026-04-28-motor-simplificacao-step5-handoff.md)
- Tier N2 — Jun reviewa, não merge automático

## Test plan
- [x] 170/170 motor-drota + 369/369 shared verde
- [x] Build TS clean
- [x] Fluxo antigo inalterado (flag off)
- [ ] Jun aprova Step 5 wire approach
- [ ] Step 6 smoke STS (Jun executa OU agente cloud com env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)