### PR TITLE
[Sprint 0 PR4] C-N-01 helix correlation — session_id+turn_number required (S-N-01-02, stacked on #76)

### DIFF
--- a/shared/src/helix-events.ts
+++ b/shared/src/helix-events.ts
@@ -9,6 +9,11 @@
  * Eventos são no-op quando ASC_DEBUG_MODE off (debug-logger faz check
  * internamente).
  *
+ * Sprint 0 PR4 (motor#77, S-N-01-02): cada emitter requer correlationContext
+ * com session_id + turn_number obrigatórios. Garantia em compile time que
+ * helix.* events sempre carregam correlation context — resolve gap de F1-G5
+ * (ops#398) onde events sem session_id dificultam reconstrução de pareamento.
+ *
  * Spec: ascendimacy-ops/docs/specs/2026-04-22-double-helix-mapping.md
  *   §8.2 (event_log): helix.cycle.started, helix.retrieval.triggered,
  *   helix.boss.completed, helix.cycle.completed, helix.pair.deferred.
@@ -17,12 +22,26 @@
 import { logDebugEvent } from "./debug-logger.js";
 import type { CaselDim, HelixState } from "./helix-state.js";
 
+/** Sprint 0 PR4 (motor#77): correlation context obrigatório em todo helix.* event.
+ * Garante 100% population de session_id + turn_number no NDJSON output. */
+export interface HelixEventCorrelationContext {
+  /** ID da sessão atual (UUID ou similar). Não-null obrigatório. */
+  session_id: string;
+  /** Número da turn dentro da sessão (1..N). Não-null obrigatório. */
+  turn_number: number;
+}
+
 /** Emitted quando ciclo novo começa (initHelix ou completeCycle). */
-export function emitHelixCycleStarted(state: HelixState): void {
+export function emitHelixCycleStarted(
+  state: HelixState,
+  ctx: HelixEventCorrelationContext,
+): void {
   logDebugEvent({
     side: "motor",
     step: "helix.cycle.started",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -41,11 +60,14 @@ export function emitHelixCycleStarted(state: HelixState): void {
 export function emitRetrievalTriggered(
   state: HelixState,
   previous: CaselDim,
+  ctx: HelixEventCorrelationContext,
 ): void {
   logDebugEvent({
     side: "motor",
     step: "helix.retrieval.triggered",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -62,11 +84,14 @@ export function emitRetrievalTriggered(
 export function emitBossCompleted(
   state: HelixState,
   bossDimension: CaselDim,
+  ctx: HelixEventCorrelationContext,
 ): void {
   logDebugEvent({
     side: "motor",
     step: "helix.boss.completed",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -80,11 +105,16 @@ export function emitBossCompleted(
 }
 
 /** Emitted após completeCycle (ciclo encerrou, novo começou ou loop). */
-export function emitCycleCompleted(state: HelixState): void {
+export function emitCycleCompleted(
+  state: HelixState,
+  ctx: HelixEventCorrelationContext,
+): void {
   logDebugEvent({
     side: "motor",
     step: "helix.cycle.completed",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -103,11 +133,14 @@ export function emitPairDeferred(
   state: HelixState,
   deferredDim: CaselDim,
   reason: string,
+  ctx: HelixEventCorrelationContext,
 ): void {
   logDebugEvent({
     side: "motor",
     step: "helix.pair.deferred",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {

--- a/shared/tests/helix-events.unit.test.ts
+++ b/shared/tests/helix-events.unit.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests para helix-events emitters.
+ *
+ * Sprint 0 PR4 (motor#77). Story ops#503 (S-N-01-02).
+ * Capability ops#482 (C-N-01). Issue âncora ops#398 (F1-G5).
+ *
+ * Validação contratual: cada emitter requer correlationContext
+ * (session_id + turn_number) que é repassado ao NDJSON.
+ *
+ * Atualmente não há callers de produção dos emitters; este test garante
+ * que quando wiring for adicionado (motor#37 follow-up), o correlation
+ * context será propagado por TypeScript constraint.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  emitHelixCycleStarted,
+  emitRetrievalTriggered,
+  emitBossCompleted,
+  emitCycleCompleted,
+  emitPairDeferred,
+} from "../src/helix-events.js";
+import { setDebugRunId } from "../src/debug-logger.js";
+import type { HelixState } from "../src/helix-state.js";
+
+let tmpDir: string;
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "helix-events-unit-"));
+  delete process.env["ASC_DEBUG_MODE"];
+  delete process.env["ASC_DEBUG_RUN_ID"];
+  delete process.env["ASC_DEBUG_SCOPE_ID"];
+  process.env["ASC_DEBUG_DIR"] = tmpDir;
+  process.env["ASC_DEBUG_MODE"] = "true";
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(ORIG_ENV)) process.env[k] = v;
+});
+
+function makeState(): HelixState {
+  return {
+    userId: "ryo",
+    activeDimension: "SA",
+    activeLevel: "developing",
+    cycleStart: "2026-05-08",
+    progress: 0.3,
+    cycleDay: 6,
+    estimatedCycleDays: 18,
+    queue: ["SOC", "SM", "REL", "DM"],
+    completed: [],
+    deferred: [],
+    previousDimension: null,
+    retrievalDone: false,
+    vacationModeActive: false,
+  };
+}
+
+function readEvents(runId: string): Record<string, unknown>[] {
+  const ndjsonPath = join(tmpDir, runId, "events.ndjson");
+  return readFileSync(ndjsonPath, "utf-8")
+    .trim()
+    .split("\n")
+    .map((l) => JSON.parse(l));
+}
+
+describe("emitHelixCycleStarted — session_id + turn_number propagation", () => {
+  it("populates session_id e turn_number quando correlationContext é fornecido", () => {
+    setDebugRunId("helix-test-1");
+    emitHelixCycleStarted(makeState(), { session_id: "sess-abc", turn_number: 5 });
+    const events = readEvents("helix-test-1");
+    expect(events[0]!.session_id).toBe("sess-abc");
+    expect(events[0]!.turn_number).toBe(5);
+    expect(events[0]!.step).toBe("helix.cycle.started");
+  });
+});
+
+describe("emitRetrievalTriggered — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-2");
+    emitRetrievalTriggered(makeState(), "SM", { session_id: "sess-xyz", turn_number: 12 });
+    const events = readEvents("helix-test-2");
+    expect(events[0]!.session_id).toBe("sess-xyz");
+    expect(events[0]!.turn_number).toBe(12);
+    expect(events[0]!.step).toBe("helix.retrieval.triggered");
+  });
+});
+
+describe("emitBossCompleted — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-3");
+    emitBossCompleted(makeState(), "REL", { session_id: "boss-sess", turn_number: 22 });
+    const events = readEvents("helix-test-3");
+    expect(events[0]!.session_id).toBe("boss-sess");
+    expect(events[0]!.turn_number).toBe(22);
+    expect(events[0]!.step).toBe("helix.boss.completed");
+  });
+});
+
+describe("emitCycleCompleted — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-4");
+    emitCycleCompleted(makeState(), { session_id: "cycle-sess", turn_number: 30 });
+    const events = readEvents("helix-test-4");
+    expect(events[0]!.session_id).toBe("cycle-sess");
+    expect(events[0]!.turn_number).toBe(30);
+    expect(events[0]!.step).toBe("helix.cycle.completed");
+  });
+});
+
+describe("emitPairDeferred — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-5");
+    emitPairDeferred(makeState(), "DM", "queue empty", {
+      session_id: "deferred-sess",
+      turn_number: 7,
+    });
+    const events = readEvents("helix-test-5");
+    expect(events[0]!.session_id).toBe("deferred-sess");
+    expect(events[0]!.turn_number).toBe(7);
+    expect(events[0]!.step).toBe("helix.pair.deferred");
+  });
+});
+
+describe("100% coverage — todos os helix.* events têm correlation context populado", () => {
+  it("nenhum helix.* event emite com session_id ou turn_number null", () => {
+    setDebugRunId("coverage-test");
+    const ctx = { session_id: "sess-coverage", turn_number: 1 };
+    const state = makeState();
+
+    emitHelixCycleStarted(state, ctx);
+    emitRetrievalTriggered(state, "SM", { ...ctx, turn_number: 2 });
+    emitBossCompleted(state, "REL", { ...ctx, turn_number: 3 });
+    emitCycleCompleted(state, { ...ctx, turn_number: 4 });
+    emitPairDeferred(state, "DM", "test reason", { ...ctx, turn_number: 5 });
+
+    const events = readEvents("coverage-test");
+    expect(events).toHaveLength(5);
+    for (const event of events) {
+      expect(event.session_id).not.toBeNull();
+      expect(event.turn_number).not.toBeNull();
+      expect(event.session_id).toBeTruthy();
+      expect(typeof event.turn_number).toBe("number");
+    }
+  });
+});


### PR DESCRIPTION
## Sprint 0 PR4 — C-N-01 helix correlation context

Closes motor#77. Implementa story ops#503 (S-N-01-02). Capability ops#482. Endereça parcialmente ops#398 (F1-G5).

**Stacked em #76 (PR3).**

## Pre-PR audit

`shared/src/helix-events.ts` define 5 emit functions (`emitHelixCycleStarted`, `emitRetrievalTriggered`, `emitBossCompleted`, `emitCycleCompleted`, `emitPairDeferred`) mas **nenhum caller de produção ainda os invoca** (grep confirmou em todo o repo). Zero events `helix.*` chegam ao NDJSON hoje.

**Implicação para S-N-01-02:** o trabalho é **contratual** — enforce no schema que `session_id` e `turn_number` sejam obrigatórios. Quando wiring de produção for adicionado (motor#37 follow-up), correlation context é propagado por TypeScript constraint.

## Padrão TDD

| Commit | Tipo | Arquivo |
|---|---|---|
| `9cbb917` | red | `helix-events.unit.test.ts` (novo, 6 tests) |
| `93125e5` | green | `helix-events.ts` (5 emitters + interface) |

## Mudança de API

```diff
+export interface HelixEventCorrelationContext {
+  session_id: string;
+  turn_number: number;
+}
+
-export function emitHelixCycleStarted(state: HelixState): void
+export function emitHelixCycleStarted(state: HelixState, ctx: HelixEventCorrelationContext): void

-export function emitRetrievalTriggered(state: HelixState, previous: CaselDim): void
+export function emitRetrievalTriggered(state: HelixState, previous: CaselDim, ctx: HelixEventCorrelationContext): void

// ... análogo para emitBossCompleted, emitCycleCompleted, emitPairDeferred
```

Breaking signature change é seguro pois não há callers de produção atualmente.

## Critérios de aceitação

- [x] 6 tests novos: 1 por emitter + 1 coverage agregado
- [x] Schema constraint: `correlationContext` é parâmetro required nas 5 funções
- [x] NDJSON output: `helix.*` events têm `session_id` + `turn_number` não-null em 100% dos casos (validado em test "100% coverage")
- [x] Build verde
- [x] Suite shared: 438 passed | 8 skipped (446) — vs 432 antes
- [x] Backward compat: schema 1.1 (não bumpa)

## Não-escopo

- Wiring de callers (depende de motor#37 follow-up sobre Helix runtime integration)
- S-N-01-03/04/05 — PR5/PR6

## Refs

- ops#497 Sprint 0 tracker
- ops#482 C-N-01
- ops#503 S-N-01-02 story
- ops#398 F1-G5
- PR3 (stacked dependency) #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
