### PR TITLE
[Sprint 0 PR5] C-N-01 Zod validation + Mood enum (closes ops#408, rebased on main)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5147,7 +5147,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.2",
-        "pg": "^8.11.0"
+        "pg": "^8.11.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "*",
@@ -5155,6 +5156,15 @@
         "node-pg-migrate": "^7.0.0",
         "typescript": "*",
         "vitest": "*"
+      }
+    },
+    "shared/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "weekly-report": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -12,14 +12,15 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",
-    "pg": "^8.11.0"
+    "pg": "^8.11.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "typescript": "*",
-    "vitest": "*",
     "@types/node": "*",
     "@types/pg": "^8.11.0",
-    "node-pg-migrate": "^7.0.0"
+    "node-pg-migrate": "^7.0.0",
+    "typescript": "*",
+    "vitest": "*"
   },
   "exports": {
     ".": {

--- a/shared/src/debug-logger.ts
+++ b/shared/src/debug-logger.ts
@@ -11,6 +11,8 @@ import { createHash, randomUUID } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { z } from "zod";
+
 import { calculateCostUsd } from "./llm-config.js";
 
 export const DEBUG_MODE_SCHEMA_VERSION = "1.1"; // 1.1 — Sprint 0 PR3: adiciona scope_id (motor#75)
@@ -295,4 +297,82 @@ export function initDebugRun(opts: {
     console.error(`[debug-logger] initDebugRun failed: ${String(err).slice(0, 200)}`);
   }
   return runId;
+}
+
+// ============================================================================
+// Sprint 0 PR5 (motor#TBD) — Zod schema validation
+// Stories: ops#504 (S-N-01-03 model=null marker) + ops#505 (S-N-01-04 Zod validation)
+// Bundles fix ops#408 (mood_method enum violation)
+// ============================================================================
+
+const TokensSchema = z.object({
+  in: z.number().int().min(0),
+  out: z.number().int().min(0),
+  reasoning: z.number().int().min(0),
+});
+
+const HashSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+
+/**
+ * Zod schema espelhando DebugEventLine + invariantes runtime.
+ *
+ * Invariante S-N-01-04: se `model != null`, então `tokens` deve existir
+ * com `tokens.in > 0`. Stub steps DEVEM emitir `model: null`. Catches
+ * casos onde caller emite nome de modelo fictício pra step sem LLM real.
+ */
+export const DebugEventLineSchema = z
+  .object({
+    run_id: z.string().min(1),
+    scope_id: z.string().min(1),
+    seq: z.number().int().min(1),
+    ts: z.string().refine((s) => !Number.isNaN(Date.parse(s)), {
+      message: "ts must be ISO 8601",
+    }),
+    side: z.enum(["sts", "motor"]),
+    step: z.string().min(1),
+    user_id: z.string().min(1),
+    partner_user_id: z.string().nullable(),
+    user_kind: z.string().nullable(),
+    motor_target: z.string().nullable(),
+    session_id: z.string().nullable(),
+    scenario_day: z.number().int().nullable(),
+    turn_number: z.number().int().nullable(),
+    model: z.string().nullable(),
+    provider: z.string().nullable(),
+    tokens: TokensSchema.nullable(),
+    latency_ms: z.number().nullable(),
+    cost_usd_est: z.number().nullable(),
+    prompt_hash: HashSchema.nullable(),
+    response_hash: HashSchema.nullable(),
+    reasoning_hash: HashSchema.nullable(),
+    snapshots_pre: z.record(z.string(), z.string()).nullable(),
+    snapshots_post: z.record(z.string(), z.string()).nullable(),
+    outcome: z.enum(["ok", "error", "skip"]),
+    error_class: z.string().nullable(),
+  })
+  .refine(
+    (data) => {
+      // S-N-01-04: model != null implica tokens.in > 0
+      if (data.model != null) {
+        if (!data.tokens || data.tokens.in === 0) return false;
+      }
+      return true;
+    },
+    {
+      message:
+        "model != null requires tokens.in > 0 (stub steps must emit model: null) — S-N-01-04",
+      path: ["model"],
+    },
+  );
+
+/** Helper: validates a DebugEventLine, returns {ok, errors?}. */
+export function validateDebugEventLine(
+  data: unknown,
+): { ok: true } | { ok: false; errors: string[] } {
+  const result = DebugEventLineSchema.safeParse(data);
+  if (result.success) return { ok: true };
+  return {
+    ok: false,
+    errors: result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`),
+  };
 }

--- a/shared/src/mood.ts
+++ b/shared/src/mood.ts
@@ -39,6 +39,25 @@ export interface MoodReading {
   source: MoodSource;
 }
 
+// ============================================================================
+// Sprint 0 PR5 — Zod schemas para validação runtime
+// Bundles fix ops#408 (mood_method enum violation: 'rule' deve ser 'rule_based')
+// ============================================================================
+
+import { z } from "zod";
+
+/** Zod schema enforcing MoodSource enum literal. Rejeita 'rule' (ops#408). */
+export const MoodSourceSchema = z.enum(["llm", "rule_based", "manual"]);
+
+/** Zod schema para MoodReading completo. Score integer 1-10, at ISO 8601. */
+export const MoodReadingSchema = z.object({
+  score: z.number().int().min(MOOD_MIN).max(MOOD_MAX),
+  at: z.string().refine((s) => !Number.isNaN(Date.parse(s)) && /^\d{4}-\d{2}-\d{2}T/.test(s), {
+    message: "at must be ISO 8601 datetime string",
+  }),
+  source: MoodSourceSchema,
+});
+
 /**
  * Janela móvel de mood — agregações pra usar em prompt context e
  * comfort gate. Ambos podem ser null se sem leituras na janela.

--- a/shared/tests/debug-logger-zod.unit.test.ts
+++ b/shared/tests/debug-logger-zod.unit.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests para Zod schema validation em DebugEventLine.
+ *
+ * Sprint 0 PR5 (motor#TBD). Stories ops#504 (S-N-01-03) + ops#505 (S-N-01-04).
+ * Capability ops#482 (C-N-01). Bundles fix ops#408 (mood_method enum violation).
+ *
+ * Validações cobertas:
+ *  - model=null permitido (stub steps)
+ *  - model != null + tokens.in > 0 → válido
+ *  - model != null + tokens.in == 0 → REJEITA (S-N-01-04)
+ *  - model != null + tokens=null → REJEITA (tokens.in implícito 0)
+ *  - scope_id obrigatório, string não-vazia
+ *  - seq positivo
+ *  - outcome restrito a ok/error/skip
+ */
+
+import { describe, it, expect } from "vitest";
+import { DebugEventLineSchema, validateDebugEventLine } from "../src/debug-logger.js";
+
+const validBase = {
+  run_id: "test-run",
+  scope_id: "test-run-abcd1234",
+  seq: 1,
+  ts: "2026-05-09T10:00:00.000Z",
+  side: "motor" as const,
+  step: "drota",
+  user_id: "ryo",
+  partner_user_id: null,
+  user_kind: null,
+  motor_target: null,
+  session_id: null,
+  scenario_day: null,
+  turn_number: null,
+  model: null,
+  provider: null,
+  tokens: null,
+  latency_ms: null,
+  cost_usd_est: null,
+  prompt_hash: null,
+  response_hash: null,
+  reasoning_hash: null,
+  snapshots_pre: null,
+  snapshots_post: null,
+  outcome: "ok" as const,
+  error_class: null,
+};
+
+describe("DebugEventLineSchema — campos básicos", () => {
+  it("aceita evento mínimo válido (model=null, tokens=null)", () => {
+    const result = DebugEventLineSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejeita evento sem run_id", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, run_id: undefined });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejeita scope_id vazio", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, scope_id: "" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejeita seq negativo", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, seq: -1 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejeita seq zero (deve ser >= 1)", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, seq: 0 });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejeita side fora do enum", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, side: "frontend" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejeita outcome fora do enum", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, outcome: "pending" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("DebugEventLineSchema — model + tokens consistency (S-N-01-04)", () => {
+  it("aceita model=null + tokens=null (stub step sem LLM)", () => {
+    const r = DebugEventLineSchema.safeParse({
+      ...validBase,
+      model: null,
+      tokens: null,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("aceita model + tokens.in > 0 (chamada LLM real)", () => {
+    const r = DebugEventLineSchema.safeParse({
+      ...validBase,
+      model: "moonshotai/Kimi-K2.5",
+      tokens: { in: 100, out: 50, reasoning: 0 },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("REJEITA model != null com tokens.in == 0", () => {
+    const r = DebugEventLineSchema.safeParse({
+      ...validBase,
+      model: "kimi",
+      tokens: { in: 0, out: 0, reasoning: 0 },
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      // Mensagem deve indicar problema de model+tokens
+      const msg = r.error.issues.map((i) => i.message).join(" ");
+      expect(msg.toLowerCase()).toContain("model");
+    }
+  });
+
+  it("REJEITA model != null com tokens=null (in implicit 0)", () => {
+    const r = DebugEventLineSchema.safeParse({
+      ...validBase,
+      model: "kimi",
+      tokens: null,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("aceita model=null com tokens.in == 0 (stub explícito)", () => {
+    const r = DebugEventLineSchema.safeParse({
+      ...validBase,
+      model: null,
+      tokens: { in: 0, out: 0, reasoning: 0 },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("validateDebugEventLine — helper function", () => {
+  it("retorna {ok: true} para evento válido", () => {
+    const r = validateDebugEventLine(validBase);
+    expect(r.ok).toBe(true);
+  });
+
+  it("retorna {ok: false, errors} para inválido", () => {
+    const r = validateDebugEventLine({
+      ...validBase,
+      model: "kimi",
+      tokens: { in: 0, out: 0, reasoning: 0 },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/shared/tests/mood-zod.unit.test.ts
+++ b/shared/tests/mood-zod.unit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests para Zod schema validation em MoodReading + MoodSource.
+ *
+ * Sprint 0 PR5. Bundles fix ops#408 — mood_method enum violation:
+ * shared/src/mood.ts declara MoodSource = "llm" | "rule_based" | "manual",
+ * mas JSONs reais continham "rule" em 2/72 turns. Zod schema rejeita.
+ */
+
+import { describe, it, expect } from "vitest";
+import { MoodReadingSchema, MoodSourceSchema } from "../src/mood.js";
+
+describe("MoodSourceSchema — enum strict", () => {
+  it("aceita 'llm'", () => {
+    expect(MoodSourceSchema.safeParse("llm").success).toBe(true);
+  });
+
+  it("aceita 'rule_based'", () => {
+    expect(MoodSourceSchema.safeParse("rule_based").success).toBe(true);
+  });
+
+  it("aceita 'manual'", () => {
+    expect(MoodSourceSchema.safeParse("manual").success).toBe(true);
+  });
+
+  it("REJEITA 'rule' (ops#408 — caso real do trace nagareyama)", () => {
+    const r = MoodSourceSchema.safeParse("rule");
+    expect(r.success).toBe(false);
+  });
+
+  it("REJEITA string vazia", () => {
+    expect(MoodSourceSchema.safeParse("").success).toBe(false);
+  });
+
+  it("REJEITA null", () => {
+    expect(MoodSourceSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe("MoodReadingSchema — full reading", () => {
+  const valid = {
+    score: 7,
+    at: "2026-05-09T10:00:00.000Z",
+    source: "llm" as const,
+  };
+
+  it("aceita reading válida", () => {
+    expect(MoodReadingSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("aceita score nos limites (1 e 10)", () => {
+    expect(MoodReadingSchema.safeParse({ ...valid, score: 1 }).success).toBe(true);
+    expect(MoodReadingSchema.safeParse({ ...valid, score: 10 }).success).toBe(true);
+  });
+
+  it("REJEITA score 0 ou 11", () => {
+    expect(MoodReadingSchema.safeParse({ ...valid, score: 0 }).success).toBe(false);
+    expect(MoodReadingSchema.safeParse({ ...valid, score: 11 }).success).toBe(false);
+  });
+
+  it("REJEITA score decimal (LLM 7.5)", () => {
+    expect(MoodReadingSchema.safeParse({ ...valid, score: 7.5 }).success).toBe(false);
+  });
+
+  it("REJEITA source='rule' (ops#408 bundling)", () => {
+    expect(MoodReadingSchema.safeParse({ ...valid, source: "rule" }).success).toBe(false);
+  });
+
+  it("REJEITA at não-ISO", () => {
+    expect(MoodReadingSchema.safeParse({ ...valid, at: "yesterday" }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Sprint 0 — PR5 (de 6)

ascendimacy-ops#497 — Sprint 0 tracker

**Stacked em motor#78 (PR4).**

## Capability servida

ascendimacy-ops#482 — C-N-01 — Observabilidade correlatable cross-process

## Stories cobertas

- ascendimacy-ops#504 — S-N-01-03 — `model = null` marker para steps stub
- ascendimacy-ops#505 — S-N-01-04 — Validação Zod em `DebugEventLine`

## Issue âncora bundled

**Closes ascendimacy-ops#408** — F1-A020 mood_method enum violation: `'rule'` deve ser `'rule_based'`. Schema Zod rejeita strings fora do enum, capturando futura deriva.

## TDD em 3 camadas

| Commit | Tipo | Arquivo |
|---|---|---|
| `2fa8a8d` | red | `mood-zod.unit.test.ts` (novo, 9 tests) |
| `127f9ef` | red | `debug-logger-zod.unit.test.ts` (novo, 17 tests) |
| `9ae4164` | chore | zod^4 dep em shared/package.json |
| `e53b171` | green | mood.ts: MoodSourceSchema + MoodReadingSchema |
| `54c900a` | green | debug-logger.ts: DebugEventLineSchema + validateDebugEventLine |

## Invariante runtime central

```typescript
// S-N-01-04: model != null requires tokens.in > 0
// Stub steps (sem chamada LLM) DEVEM emitir model: null
.refine((data) => {
  if (data.model != null) {
    if (!data.tokens || data.tokens.in === 0) return false;
  }
  return true;
})
```

Rejeita o caso F1-A019 (sub-finding de ops#398): callers emitindo nome de modelo fictício pra step sem chamada LLM real, mascarando estrutura do trace.

## Bundling ops#408 (mood_method)

`MoodSourceSchema = z.enum(["llm", "rule_based", "manual"])` rejeita `"rule"` literal. Trace `nagareyama-realista-v1_2026-05-05T19-30-04Z` continha `mood_method = "rule"` em 2/72 turns; teste explícito `"REJEITA 'rule' (ops#408 — caso real do trace nagareyama)"` valida.

`motor-drota/src/mood-extractor.ts:105` já emite `"rule_based"` corretamente. Schema previne regressão.

## Critérios de aceitação

- [x] 26 tests novos commitados ANTES da implementação (TDD red→green visível no histórico)
- [x] Build verde: `npm run build` ✓
- [x] Suite shared: 464 passed | 8 skipped (472), 0 failed (vs 438 antes)
- [x] Suite full motor: 851 passed | 8 skipped, 0 failed
- [x] zod adicionado a `shared/package.json` (já estava em motor-drota)
- [x] Schema rejeita 'rule' string (ops#408 closure validada)

## Não-escopo

- Wiring runtime de `validateDebugEventLine` em `logDebugEvent` — manter fail-closed em produção é decisão separada (poderia silenciar logs em violação ou poderia bloquear write). Por ora schema é exposto pra uso explícito por callers + tests; PR6 ou follow-up cobre wiring.
- S-N-01-05 (replay tool adapt) — PR6.

## Refs

- ops#497 Sprint 0 tracker
- ops#482 C-N-01
- ops#504 S-N-01-03 story
- ops#505 S-N-01-04 story
- ops#408 mood_method enum violation (closes via bundling)
- ops#398 F1-G5 anchor (parcial)
- PR4 (stacked dependency) #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
