### PR TITLE
[Sprint 0 PR6] C-N-01 replay tool — (scope_id, seq) pareado (S-N-01-05, stacked on #82)

### DIFF
--- a/scripts/debug-timeline.mjs
+++ b/scripts/debug-timeline.mjs
@@ -34,6 +34,9 @@ function parseArgs(argv) {
     turn: null,
     day: null,
     session: null,
+    scopeId: null, // S-N-01-05: filter por scope_id
+    byScope: false, // S-N-01-05: agrupa output por scope
+    integrity: false, // S-N-01-05: valida gaps/duplicates por scope
     tokensOnly: false,
     reasoningOnly: false,
     noContent: false,
@@ -50,6 +53,9 @@ function parseArgs(argv) {
     else if (a === "--turn" && argv[i + 1]) opts.turn = parseInt(argv[++i], 10);
     else if (a === "--day" && argv[i + 1]) opts.day = parseInt(argv[++i], 10);
     else if (a === "--session" && argv[i + 1]) opts.session = argv[++i];
+    else if (a === "--scope-id" && argv[i + 1]) opts.scopeId = argv[++i];
+    else if (a === "--by-scope") opts.byScope = true;
+    else if (a === "--integrity") opts.integrity = true;
     else if (a === "--tokens-only") opts.tokensOnly = true;
     else if (a === "--reasoning-only") opts.reasoningOnly = true;
     else if (a === "--no-content") opts.noContent = true;
@@ -70,11 +76,14 @@ Filters:
   --turn <n>            Filter by turn_number
   --day <n>             Filter by scenario_day
   --session <id>        Filter by session_id prefix
+  --scope-id <id>       Filter by scope_id (S-N-01-05; multi-process runs)
 
 Views:
   --tokens-only         Summary of cost/latency per step, no content
   --reasoning-only      Only print reasoning blocks
   --no-content          Metadata only, no prompts/responses
+  --by-scope            Group output by scope_id (S-N-01-05)
+  --integrity           Validate gaps/duplicates per scope (S-N-01-05; ops#398)
   --list                List available runs
 
 Dir override:
@@ -132,8 +141,49 @@ function filterEvents(events, opts) {
     if (opts.turn !== null && e.turn_number !== opts.turn) return false;
     if (opts.day !== null && e.scenario_day !== opts.day) return false;
     if (opts.session && !e.session_id?.startsWith(opts.session)) return false;
+    if (opts.scopeId && e.scope_id !== opts.scopeId) return false; // S-N-01-05
     return true;
   });
+}
+
+// S-N-01-05: agrupa events por scope_id preservando ordem original
+function groupByScope(events) {
+  const out = new Map();
+  for (const e of events) {
+    const key = e.scope_id ?? "__no_scope__";
+    if (!out.has(key)) out.set(key, []);
+    out.get(key).push(e);
+  }
+  return out;
+}
+
+// S-N-01-05: detecta gaps + duplicates de seq dentro de cada scope
+function checkIntegrityByScope(events) {
+  const byScope = groupByScope(events);
+  const results = [];
+  for (const [scopeId, scoped] of byScope) {
+    const seqs = scoped.map((e) => e.seq);
+    const seen = new Set();
+    const dups = [];
+    for (const s of seqs) {
+      if (seen.has(s)) dups.push(s);
+      seen.add(s);
+    }
+    const min = Math.min(...seqs);
+    const max = Math.max(...seqs);
+    const gaps = [];
+    for (let i = min; i <= max; i++) if (!seen.has(i)) gaps.push(i);
+    results.push({
+      scope_id: scopeId,
+      observed: scoped.length,
+      expected: max - min + 1,
+      gaps,
+      duplicates: [...new Set(dups)].sort((a, b) => a - b),
+      min_seq: min,
+      max_seq: max,
+    });
+  }
+  return results;
 }
 
 function printTokensSummary(events) {
@@ -175,7 +225,8 @@ function printTokensSummary(events) {
 
 function printEvent(baseDir, runId, e, opts) {
   const tsShort = e.ts.slice(11, 23);
-  const header = `[${tsShort}] ${e.side} → ${e.step}`;
+  const seqTag = e.scope_id != null ? ` #${e.seq}@${e.scope_id.slice(-8)}` : "";
+  const header = `[${tsShort}${seqTag}] ${e.side} → ${e.step}`;
   const modelTag = e.model ? ` (${e.model}` : "";
   const latTag = e.latency_ms != null ? `, ${e.latency_ms}ms` : "";
   const tokTag = e.tokens
@@ -260,8 +311,32 @@ function main() {
     return;
   }
   const events = loadEvents(baseDir, opts.run);
-  events.sort((a, b) => a.ts.localeCompare(b.ts));
+  // Sort cronologically com desempate (scope_id, seq) — determinístico em runs concorrentes
+  events.sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts.localeCompare(b.ts);
+    if ((a.scope_id ?? "") !== (b.scope_id ?? ""))
+      return (a.scope_id ?? "").localeCompare(b.scope_id ?? "");
+    return (a.seq ?? 0) - (b.seq ?? 0);
+  });
   const filtered = filterEvents(events, opts);
+
+  if (opts.integrity) {
+    // S-N-01-05: relatório de integridade por scope
+    const results = checkIntegrityByScope(filtered);
+    console.log(`\n═══ Integrity check — Run: ${opts.run} ═══\n`);
+    let totalGaps = 0, totalDups = 0;
+    for (const r of results) {
+      const status = r.gaps.length === 0 && r.duplicates.length === 0 ? "✓" : "✗";
+      console.log(`${status} scope=${r.scope_id} observed=${r.observed} expected=${r.expected}`);
+      console.log(`  seq range: [${r.min_seq}, ${r.max_seq}]`);
+      if (r.gaps.length > 0) console.log(`  gaps (${r.gaps.length}): ${r.gaps.slice(0, 20).join(",")}${r.gaps.length > 20 ? "..." : ""}`);
+      if (r.duplicates.length > 0) console.log(`  duplicates (${r.duplicates.length}): ${r.duplicates.slice(0, 20).join(",")}${r.duplicates.length > 20 ? "..." : ""}`);
+      totalGaps += r.gaps.length;
+      totalDups += r.duplicates.length;
+    }
+    console.log(`\nTotal: ${results.length} scopes, ${totalGaps} gaps, ${totalDups} duplicates`);
+    return;
+  }
 
   if (opts.tokensOnly) {
     printTokensSummary(filtered);
@@ -271,8 +346,15 @@ function main() {
   console.log(`\n═══ Run: ${opts.run} ═══`);
   console.log(`Total events: ${events.length} (${filtered.length} after filters)\n`);
 
-  for (const e of filtered) {
-    printEvent(baseDir, opts.run, e, opts);
+  if (opts.byScope) {
+    // S-N-01-05: output agrupado por scope_id, cada scope cronológico próprio
+    const grouped = groupByScope(filtered);
+    for (const [scopeId, scoped] of grouped) {
+      console.log(`\n--- scope=${scopeId} (${scoped.length} events) ---\n`);
+      for (const e of scoped) printEvent(baseDir, opts.run, e, opts);
+    }
+  } else {
+    for (const e of filtered) printEvent(baseDir, opts.run, e, opts);
   }
   console.log("\n═══ End ═══");
 }

--- a/shared/src/helix-events.ts
+++ b/shared/src/helix-events.ts
@@ -9,6 +9,11 @@
  * Eventos são no-op quando ASC_DEBUG_MODE off (debug-logger faz check
  * internamente).
  *
+ * Sprint 0 PR4 (motor#77, S-N-01-02): cada emitter requer correlationContext
+ * com session_id + turn_number obrigatórios. Garantia em compile time que
+ * helix.* events sempre carregam correlation context — resolve gap de F1-G5
+ * (ops#398) onde events sem session_id dificultam reconstrução de pareamento.
+ *
  * Spec: ascendimacy-ops/docs/specs/2026-04-22-double-helix-mapping.md
  *   §8.2 (event_log): helix.cycle.started, helix.retrieval.triggered,
  *   helix.boss.completed, helix.cycle.completed, helix.pair.deferred.
@@ -17,12 +22,26 @@
 import { logDebugEvent } from "./debug-logger.js";
 import type { CaselDim, HelixState } from "./helix-state.js";
 
+/** Sprint 0 PR4 (motor#77): correlation context obrigatório em todo helix.* event.
+ * Garante 100% population de session_id + turn_number no NDJSON output. */
+export interface HelixEventCorrelationContext {
+  /** ID da sessão atual (UUID ou similar). Não-null obrigatório. */
+  session_id: string;
+  /** Número da turn dentro da sessão (1..N). Não-null obrigatório. */
+  turn_number: number;
+}
+
 /** Emitted quando ciclo novo começa (initHelix ou completeCycle). */
-export function emitHelixCycleStarted(state: HelixState): void {
+export function emitHelixCycleStarted(
+  state: HelixState,
+  ctx: HelixEventCorrelationContext,
+): void {
   logDebugEvent({
     side: "motor",
     step: "helix.cycle.started",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -41,11 +60,14 @@ export function emitHelixCycleStarted(state: HelixState): void {
 export function emitRetrievalTriggered(
   state: HelixState,
   previous: CaselDim,
+  ctx: HelixEventCorrelationContext,
 ): void {
   logDebugEvent({
     side: "motor",
     step: "helix.retrieval.triggered",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -62,11 +84,14 @@ export function emitRetrievalTriggered(
 export function emitBossCompleted(
   state: HelixState,
   bossDimension: CaselDim,
+  ctx: HelixEventCorrelationContext,
 ): void {
   logDebugEvent({
     side: "motor",
     step: "helix.boss.completed",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -80,11 +105,16 @@ export function emitBossCompleted(
 }
 
 /** Emitted após completeCycle (ciclo encerrou, novo começou ou loop). */
-export function emitCycleCompleted(state: HelixState): void {
+export function emitCycleCompleted(
+  state: HelixState,
+  ctx: HelixEventCorrelationContext,
+): void {
   logDebugEvent({
     side: "motor",
     step: "helix.cycle.completed",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {
@@ -103,11 +133,14 @@ export function emitPairDeferred(
   state: HelixState,
   deferredDim: CaselDim,
   reason: string,
+  ctx: HelixEventCorrelationContext,
 ): void {
   logDebugEvent({
     side: "motor",
     step: "helix.pair.deferred",
     user_id: state.userId,
+    session_id: ctx.session_id,
+    turn_number: ctx.turn_number,
     motor_target: "kids",
     outcome: "ok",
     snapshots_post: {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -29,6 +29,7 @@ export * from "./bullying-check.js";
 export * from "./debug-logger.js";
 export * from "./llm-config.js";
 export * from "./cost-aggregator.js";
+export * from "./replay-utils.js";
 export * from "./llm-router.js";
 export * from "./semantic-signals.js";
 export * from "./transitions-schema.js";

--- a/shared/src/replay-utils.ts
+++ b/shared/src/replay-utils.ts
@@ -1,0 +1,116 @@
+/**
+ * Replay utilities — primitivas reutilizáveis para tooling de replay
+ * de NDJSON (debug-timeline.mjs e variantes).
+ *
+ * Sprint 0 PR6 (motor#TBD). Story ops#506 (S-N-01-05).
+ * Capability ops#482 (C-N-01).
+ *
+ * Exposed para permitir:
+ *  - Filtragem por scope_id (essencial pós S-N-01-01 onde múltiplos
+ *    scopes coexistem em mesmo NDJSON em runs concorrentes)
+ *  - Agrupamento por scope (reconstrução cronológica por escopo)
+ *  - Detecção de gaps/duplicates por scope (validação de integridade)
+ *  - Ordenação cronológica determinística (desempate por scope_id + seq)
+ */
+
+/** Subset mínimo de DebugEventLine consumido por replay tooling. */
+export interface ReplayEvent {
+  run_id: string;
+  scope_id: string;
+  seq: number;
+  ts: string;
+  side: "sts" | "motor";
+  step: string;
+  user_id: string;
+  outcome: "ok" | "error" | "skip";
+  // Campos opcionais — replay não exige (mas pode usar se presentes)
+  partner_user_id?: string | null;
+  session_id?: string | null;
+  turn_number?: number | null;
+  model?: string | null;
+  tokens?: { in: number; out: number; reasoning: number } | null;
+  latency_ms?: number | null;
+  cost_usd_est?: number | null;
+  [k: string]: unknown;
+}
+
+/** Filtra events do scope alvo apenas. Não muta input. */
+export function filterByScopeId(events: readonly ReplayEvent[], scopeId: string): ReplayEvent[] {
+  return events.filter((e) => e.scope_id === scopeId);
+}
+
+/** Agrupa events por scope_id. Preserva ordem de aparição dentro de cada grupo. */
+export function groupEventsByScope(events: readonly ReplayEvent[]): Map<string, ReplayEvent[]> {
+  const out = new Map<string, ReplayEvent[]>();
+  for (const e of events) {
+    const list = out.get(e.scope_id);
+    if (list) list.push(e);
+    else out.set(e.scope_id, [e]);
+  }
+  return out;
+}
+
+/**
+ * Ordena events cronologicamente por `ts` ascendente.
+ * Desempate determinístico por (scope_id ASC, seq ASC) quando `ts` é igual
+ * — relevante quando múltiplos eventos compartilham timestamp ms-truncado.
+ * NÃO muta input array.
+ */
+export function sortChronologically(events: readonly ReplayEvent[]): ReplayEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts.localeCompare(b.ts);
+    if (a.scope_id !== b.scope_id) return a.scope_id.localeCompare(b.scope_id);
+    return a.seq - b.seq;
+  });
+}
+
+export interface GapDetectionResult {
+  scope_id: string;
+  observed: number;
+  expected: number;
+  gaps: number[];
+  duplicates: number[];
+  min_seq: number | null;
+  max_seq: number | null;
+}
+
+/**
+ * Detecta gaps + duplicates de seq dentro de um scope específico.
+ * Útil para validação de integridade NDJSON pós-runs concorrentes
+ * (cenário ops#398 F1-G5: 200 gaps + 20 duplicates em 6 scopes).
+ *
+ * `expected` = max(seq) - min(seq) + 1 (contagem ideal sem gaps).
+ * `observed` = quantidade de events do scope.
+ * Discrepância expected-observed indica gaps/duplicates.
+ */
+export function detectGapsInScope(
+  events: readonly ReplayEvent[],
+  scopeId: string,
+): GapDetectionResult {
+  const scoped = events.filter((e) => e.scope_id === scopeId);
+  if (scoped.length === 0) {
+    return { scope_id: scopeId, observed: 0, expected: 0, gaps: [], duplicates: [], min_seq: null, max_seq: null };
+  }
+  const seqs = scoped.map((e) => e.seq);
+  const seen = new Set<number>();
+  const dups: number[] = [];
+  for (const s of seqs) {
+    if (seen.has(s)) dups.push(s);
+    seen.add(s);
+  }
+  const min = Math.min(...seqs);
+  const max = Math.max(...seqs);
+  const gaps: number[] = [];
+  for (let i = min; i <= max; i++) {
+    if (!seen.has(i)) gaps.push(i);
+  }
+  return {
+    scope_id: scopeId,
+    observed: scoped.length,
+    expected: max - min + 1,
+    gaps,
+    duplicates: [...new Set(dups)].sort((a, b) => a - b),
+    min_seq: min,
+    max_seq: max,
+  };
+}

--- a/shared/tests/helix-events.unit.test.ts
+++ b/shared/tests/helix-events.unit.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests para helix-events emitters.
+ *
+ * Sprint 0 PR4 (motor#77). Story ops#503 (S-N-01-02).
+ * Capability ops#482 (C-N-01). Issue âncora ops#398 (F1-G5).
+ *
+ * Validação contratual: cada emitter requer correlationContext
+ * (session_id + turn_number) que é repassado ao NDJSON.
+ *
+ * Atualmente não há callers de produção dos emitters; este test garante
+ * que quando wiring for adicionado (motor#37 follow-up), o correlation
+ * context será propagado por TypeScript constraint.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  emitHelixCycleStarted,
+  emitRetrievalTriggered,
+  emitBossCompleted,
+  emitCycleCompleted,
+  emitPairDeferred,
+} from "../src/helix-events.js";
+import { setDebugRunId } from "../src/debug-logger.js";
+import type { HelixState } from "../src/helix-state.js";
+
+let tmpDir: string;
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "helix-events-unit-"));
+  delete process.env["ASC_DEBUG_MODE"];
+  delete process.env["ASC_DEBUG_RUN_ID"];
+  delete process.env["ASC_DEBUG_SCOPE_ID"];
+  process.env["ASC_DEBUG_DIR"] = tmpDir;
+  process.env["ASC_DEBUG_MODE"] = "true";
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(ORIG_ENV)) process.env[k] = v;
+});
+
+function makeState(): HelixState {
+  return {
+    userId: "ryo",
+    activeDimension: "SA",
+    activeLevel: "developing",
+    cycleStart: "2026-05-08",
+    progress: 0.3,
+    cycleDay: 6,
+    estimatedCycleDays: 18,
+    queue: ["SOC", "SM", "REL", "DM"],
+    completed: [],
+    deferred: [],
+    previousDimension: null,
+    retrievalDone: false,
+    vacationModeActive: false,
+  };
+}
+
+function readEvents(runId: string): Record<string, unknown>[] {
+  const ndjsonPath = join(tmpDir, runId, "events.ndjson");
+  return readFileSync(ndjsonPath, "utf-8")
+    .trim()
+    .split("\n")
+    .map((l) => JSON.parse(l));
+}
+
+describe("emitHelixCycleStarted — session_id + turn_number propagation", () => {
+  it("populates session_id e turn_number quando correlationContext é fornecido", () => {
+    setDebugRunId("helix-test-1");
+    emitHelixCycleStarted(makeState(), { session_id: "sess-abc", turn_number: 5 });
+    const events = readEvents("helix-test-1");
+    expect(events[0]!.session_id).toBe("sess-abc");
+    expect(events[0]!.turn_number).toBe(5);
+    expect(events[0]!.step).toBe("helix.cycle.started");
+  });
+});
+
+describe("emitRetrievalTriggered — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-2");
+    emitRetrievalTriggered(makeState(), "SM", { session_id: "sess-xyz", turn_number: 12 });
+    const events = readEvents("helix-test-2");
+    expect(events[0]!.session_id).toBe("sess-xyz");
+    expect(events[0]!.turn_number).toBe(12);
+    expect(events[0]!.step).toBe("helix.retrieval.triggered");
+  });
+});
+
+describe("emitBossCompleted — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-3");
+    emitBossCompleted(makeState(), "REL", { session_id: "boss-sess", turn_number: 22 });
+    const events = readEvents("helix-test-3");
+    expect(events[0]!.session_id).toBe("boss-sess");
+    expect(events[0]!.turn_number).toBe(22);
+    expect(events[0]!.step).toBe("helix.boss.completed");
+  });
+});
+
+describe("emitCycleCompleted — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-4");
+    emitCycleCompleted(makeState(), { session_id: "cycle-sess", turn_number: 30 });
+    const events = readEvents("helix-test-4");
+    expect(events[0]!.session_id).toBe("cycle-sess");
+    expect(events[0]!.turn_number).toBe(30);
+    expect(events[0]!.step).toBe("helix.cycle.completed");
+  });
+});
+
+describe("emitPairDeferred — correlation context", () => {
+  it("populates session_id + turn_number", () => {
+    setDebugRunId("helix-test-5");
+    emitPairDeferred(makeState(), "DM", "queue empty", {
+      session_id: "deferred-sess",
+      turn_number: 7,
+    });
+    const events = readEvents("helix-test-5");
+    expect(events[0]!.session_id).toBe("deferred-sess");
+    expect(events[0]!.turn_number).toBe(7);
+    expect(events[0]!.step).toBe("helix.pair.deferred");
+  });
+});
+
+describe("100% coverage — todos os helix.* events têm correlation context populado", () => {
+  it("nenhum helix.* event emite com session_id ou turn_number null", () => {
+    setDebugRunId("coverage-test");
+    const ctx = { session_id: "sess-coverage", turn_number: 1 };
+    const state = makeState();
+
+    emitHelixCycleStarted(state, ctx);
+    emitRetrievalTriggered(state, "SM", { ...ctx, turn_number: 2 });
+    emitBossCompleted(state, "REL", { ...ctx, turn_number: 3 });
+    emitCycleCompleted(state, { ...ctx, turn_number: 4 });
+    emitPairDeferred(state, "DM", "test reason", { ...ctx, turn_number: 5 });
+
+    const events = readEvents("coverage-test");
+    expect(events).toHaveLength(5);
+    for (const event of events) {
+      expect(event.session_id).not.toBeNull();
+      expect(event.turn_number).not.toBeNull();
+      expect(event.session_id).toBeTruthy();
+      expect(typeof event.turn_number).toBe("number");
+    }
+  });
+});

--- a/shared/tests/replay-utils.unit.test.ts
+++ b/shared/tests/replay-utils.unit.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests para replay-utils — primitivas reutilizáveis pelo
+ * scripts/debug-timeline.mjs e outros tooling de replay.
+ *
+ * Sprint 0 PR6 (motor#TBD). Story ops#506 (S-N-01-05).
+ * Capability ops#482 (C-N-01).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  filterByScopeId,
+  groupEventsByScope,
+  sortChronologically,
+  detectGapsInScope,
+  type ReplayEvent,
+} from "../src/replay-utils.js";
+
+const E = (overrides: Partial<ReplayEvent>): ReplayEvent => ({
+  run_id: "test-run",
+  scope_id: "scope-A",
+  seq: 1,
+  ts: "2026-05-09T10:00:00.000Z",
+  side: "motor",
+  step: "drota",
+  user_id: "ryo",
+  outcome: "ok",
+  ...overrides,
+});
+
+describe("filterByScopeId", () => {
+  it("filtra events do scope alvo apenas", () => {
+    const events = [
+      E({ scope_id: "scope-A", seq: 1 }),
+      E({ scope_id: "scope-B", seq: 1 }),
+      E({ scope_id: "scope-A", seq: 2 }),
+    ];
+    const r = filterByScopeId(events, "scope-A");
+    expect(r).toHaveLength(2);
+    expect(r.every((e) => e.scope_id === "scope-A")).toBe(true);
+  });
+
+  it("retorna [] para scope inexistente", () => {
+    expect(filterByScopeId([E({})], "scope-zzz")).toEqual([]);
+  });
+
+  it("array vazio entra, array vazio sai", () => {
+    expect(filterByScopeId([], "scope-A")).toEqual([]);
+  });
+});
+
+describe("groupEventsByScope", () => {
+  it("agrupa events por scope_id", () => {
+    const events = [
+      E({ scope_id: "alpha", seq: 1 }),
+      E({ scope_id: "beta", seq: 1 }),
+      E({ scope_id: "alpha", seq: 2 }),
+      E({ scope_id: "beta", seq: 2 }),
+    ];
+    const grouped = groupEventsByScope(events);
+    expect(grouped.size).toBe(2);
+    expect(grouped.get("alpha")).toHaveLength(2);
+    expect(grouped.get("beta")).toHaveLength(2);
+  });
+
+  it("preserva ordem original dentro de cada grupo", () => {
+    const events = [
+      E({ scope_id: "x", seq: 3, ts: "2026-05-09T10:00:03Z" }),
+      E({ scope_id: "x", seq: 1, ts: "2026-05-09T10:00:01Z" }),
+      E({ scope_id: "x", seq: 2, ts: "2026-05-09T10:00:02Z" }),
+    ];
+    const grouped = groupEventsByScope(events);
+    const xEvents = grouped.get("x")!;
+    expect(xEvents.map((e) => e.seq)).toEqual([3, 1, 2]); // ordem preservada
+  });
+
+  it("Map vazio para input vazio", () => {
+    expect(groupEventsByScope([]).size).toBe(0);
+  });
+});
+
+describe("sortChronologically", () => {
+  it("ordena por ts ascending", () => {
+    const events = [
+      E({ ts: "2026-05-09T10:00:03Z", seq: 3 }),
+      E({ ts: "2026-05-09T10:00:01Z", seq: 1 }),
+      E({ ts: "2026-05-09T10:00:02Z", seq: 2 }),
+    ];
+    const sorted = sortChronologically(events);
+    expect(sorted.map((e) => e.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("desempate por (scope_id, seq) quando ts é igual", () => {
+    const events = [
+      E({ ts: "2026-05-09T10:00:00Z", scope_id: "z", seq: 1 }),
+      E({ ts: "2026-05-09T10:00:00Z", scope_id: "a", seq: 2 }),
+      E({ ts: "2026-05-09T10:00:00Z", scope_id: "a", seq: 1 }),
+    ];
+    const sorted = sortChronologically(events);
+    expect(sorted.map((e) => `${e.scope_id}#${e.seq}`)).toEqual(["a#1", "a#2", "z#1"]);
+  });
+
+  it("não muta input array", () => {
+    const events = [
+      E({ ts: "2026-05-09T10:00:02Z", seq: 2 }),
+      E({ ts: "2026-05-09T10:00:01Z", seq: 1 }),
+    ];
+    const original = [...events];
+    sortChronologically(events);
+    expect(events).toEqual(original);
+  });
+});
+
+describe("detectGapsInScope", () => {
+  it("retorna {gaps: [], duplicates: []} para scope monotônico sem gaps", () => {
+    const events = [E({ scope_id: "x", seq: 1 }), E({ scope_id: "x", seq: 2 }), E({ scope_id: "x", seq: 3 })];
+    const r = detectGapsInScope(events, "x");
+    expect(r.gaps).toEqual([]);
+    expect(r.duplicates).toEqual([]);
+    expect(r.expected).toBe(3);
+    expect(r.observed).toBe(3);
+  });
+
+  it("detecta gap (seq missing)", () => {
+    const events = [E({ scope_id: "x", seq: 1 }), E({ scope_id: "x", seq: 3 })];
+    const r = detectGapsInScope(events, "x");
+    expect(r.gaps).toContain(2);
+    expect(r.duplicates).toEqual([]);
+  });
+
+  it("detecta duplicates (seq repetido)", () => {
+    const events = [
+      E({ scope_id: "x", seq: 1 }),
+      E({ scope_id: "x", seq: 2 }),
+      E({ scope_id: "x", seq: 2 }),
+    ];
+    const r = detectGapsInScope(events, "x");
+    expect(r.duplicates).toContain(2);
+    expect(r.gaps).toEqual([]);
+  });
+
+  it("detecta múltiplos gaps em sequência longa (cenário ops#398 F1-G5)", () => {
+    const events = [
+      E({ scope_id: "y", seq: 1 }),
+      E({ scope_id: "y", seq: 5 }), // gap 2,3,4
+      E({ scope_id: "y", seq: 7 }), // gap 6
+      E({ scope_id: "y", seq: 7 }), // dup 7
+    ];
+    const r = detectGapsInScope(events, "y");
+    expect(r.gaps).toEqual([2, 3, 4, 6]);
+    expect(r.duplicates).toEqual([7]);
+  });
+
+  it("ignora events de outros scopes", () => {
+    const events = [
+      E({ scope_id: "x", seq: 1 }),
+      E({ scope_id: "y", seq: 5 }), // não conta para x
+      E({ scope_id: "x", seq: 2 }),
+    ];
+    const r = detectGapsInScope(events, "x");
+    expect(r.gaps).toEqual([]);
+    expect(r.observed).toBe(2);
+  });
+});


### PR DESCRIPTION
## Sprint 0 PR6 (final) — C-N-01 replay tool adapt

Closes motor#TBD. Implementa story ops#506 (S-N-01-05). Capability ops#482. Endereça ops#398.

**Stacked em motor#82 (PR5).** Encerra Sprint 0.

## TDD

| Commit | Tipo | Arquivo |
|---|---|---|
| 3e22fec | red | replay-utils.unit.test.ts (14 tests) |
| 18c25c5 | green | shared/src/replay-utils.ts (novo módulo) |
| c225d8d | green | scripts/debug-timeline.mjs (3 novos flags) |

## API exposta

```typescript
import {
  filterByScopeId,
  groupEventsByScope,
  sortChronologically,
  detectGapsInScope,
  type ReplayEvent,
} from '@ascendimacy/shared';
```

## Novos flags do tool

- `--scope-id <id>` — filtra por scope (multi-process runs)
- `--by-scope` — output agrupado por scope
- `--integrity` — relatório gaps/duplicates por scope

## Critérios de aceitação

- [x] 14 tests novos commitados ANTES da impl
- [x] Build verde + suite shared 478 passing (vs 464 PR5 base)
- [x] Suite full motor 865 passing | 8 skipped, 0 failed
- [x] Header de event mostra scope_id short suffix
- [x] Sort determinístico ts ASC + (scope_id, seq) desempate

## Sprint 0 — encerramento

PR6 fecha Sprint 0:
- PR1 #72 cost foundation
- PR2 #74 cost completion + aggregator
- PR3 #76 scope_id pareamento
- PR4 #78 helix correlation (orphaned post-deprecation, mantido pra revisão)
- PR5 #82 Zod validation + ops#408
- PR6 (este) replay tool adapt

Após merge sequencial: capabilities C-N-01 + C-J-01 → "Em validação" no Sprint 0 tracker (#497).

## Refs

- ops#497 Sprint 0 tracker
- ops#482 C-N-01
- ops#506 S-N-01-05 story
- ops#398 F1-G5 anchor
- PR5 (stacked dependency) #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)