### PR TITLE
[Sprint 1 PR1] C-T-09 schema + scaffolding — ActionMenu Zod schema + persistence (closes S-T-09-01, S-T-09-05)

### DIFF
--- a/fixtures/profiles/exemplo-menu.json
+++ b/fixtures/profiles/exemplo-menu.json
@@ -1,0 +1,44 @@
+{
+  "persona_id": "exemplo",
+  "schema_version": "v0.1.0",
+  "generated_at": "2026-05-11T13:00:00.000Z",
+  "valid_until": "2026-05-25T13:00:00.000Z",
+  "source": {
+    "trust_level": 0.42,
+    "profile_hash": "sha256:exemplo-profile-hash",
+    "eixos_state_hash": "sha256:exemplo-eixos-hash"
+  },
+  "items": [
+    {
+      "id": "curio-01",
+      "type": "curiosity",
+      "content": "Por que o ângulo do grip muda o cross-court? Conversar com o pai depois do treino.",
+      "weight": 0.8
+    },
+    {
+      "id": "challenge-01",
+      "type": "challenge",
+      "content": "Tentar nomear em 1 palavra o que sentiu no ponto perdido.",
+      "weight": 0.65,
+      "expires_at": "2026-05-25T13:00:00.000Z"
+    },
+    {
+      "id": "strategy-01",
+      "type": "strategy",
+      "content": "Quando o sujeito reclama do silêncio do pai, ancorar em ação concreta (ex: 'o que mudou no grip hoje?').",
+      "weight": 0.7
+    },
+    {
+      "id": "play-01",
+      "type": "play",
+      "content": "Convidar a desmontar mentalmente uma jogada do dia em 3 etapas.",
+      "weight": 0.55
+    },
+    {
+      "id": "diamond-01",
+      "type": "cultural_diamond",
+      "content": "Suzuki Daisetz — relação mestre/discípulo no kendo: a transmissão acontece no gesto, não na fala.",
+      "weight": 0.45
+    }
+  ]
+}

--- a/planejador/src/strategist/action-menu-persistence.ts
+++ b/planejador/src/strategist/action-menu-persistence.ts
@@ -1,0 +1,69 @@
+/**
+ * ActionMenu persistence helpers (S-T-09-05).
+ *
+ * Convenção de filename: `{persona_id}-menu.json`, sibling do profile JSON
+ * sob `fixtures/profiles/`. Validação Zod corre tanto no save (rejeita
+ * antes de gravar) quanto no load (rejeita JSON malformado / fora do
+ * schema).
+ *
+ * Operações `null` em vez de throw quando o arquivo não existe — caller
+ * decide se isso é triggers C-T-09-03/04 (gerar pela primeira vez) ou
+ * fallback C-T-10 (pool scoring antigo).
+ *
+ * Refs: ops#989 (capability C-T-09), ops#991 (Sprint 1 tracker).
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  parseActionMenu,
+  type ActionMenu,
+} from "./action-menu-schema.js";
+
+/** Nome canônico do arquivo de menu pra um persona_id. */
+export function actionMenuFilename(personaId: string): string {
+  return `${personaId}-menu.json`;
+}
+
+/** Path completo, sibling do profile JSON sob `baseDir`. */
+export function actionMenuPath(personaId: string, baseDir: string): string {
+  return path.join(baseDir, actionMenuFilename(personaId));
+}
+
+/**
+ * Persiste menu validado. Cria `baseDir` se ausente. Retorna o path
+ * absoluto/relativo gravado.
+ *
+ * Throws se `menu` não passa no schema — falha loud antes de escrever.
+ */
+export async function saveActionMenu(
+  menu: ActionMenu,
+  baseDir: string,
+): Promise<string> {
+  const validated = parseActionMenu(menu);
+  const target = actionMenuPath(validated.persona_id, baseDir);
+  await mkdir(baseDir, { recursive: true });
+  await writeFile(target, `${JSON.stringify(validated, null, 2)}\n`, "utf-8");
+  return target;
+}
+
+/**
+ * Carrega menu validado. Retorna `null` quando o arquivo não existe
+ * (ENOENT) — sinaliza "menu não gerado ainda". Throws em JSON inválido
+ * ou schema mismatch.
+ */
+export async function loadActionMenu(
+  personaId: string,
+  baseDir: string,
+): Promise<ActionMenu | null> {
+  const target = actionMenuPath(personaId, baseDir);
+  let raw: string;
+  try {
+    raw = await readFile(target, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  return parseActionMenu(JSON.parse(raw));
+}

--- a/planejador/src/strategist/action-menu-schema.ts
+++ b/planejador/src/strategist/action-menu-schema.ts
@@ -1,0 +1,96 @@
+/**
+ * ActionMenu schema (S-T-09-01).
+ *
+ * Estrutura do menu de ação pré-cozido pelo Estrategista pós-compaction:
+ * cinco categorias de itens (curiosidades, desafios, estratégias, jogadas
+ * oportunas, diamantes culturais), cada um com `weight` e `expires_at`
+ * opcional. Per-turn lookup determinístico (C-T-10) substitui pool scoring
+ * com base nesses itens — ver ops#990.
+ *
+ * Validação Zod é fronteira de runtime: invocada em load de fixture
+ * (action-menu-persistence.ts) e antes de qualquer save. Per-turn lookup
+ * NÃO revalida (assume schema-valid em memória).
+ *
+ * Refs: ops#989 (capability C-T-09), ops#991 (Sprint 1 tracker).
+ */
+
+import { z } from "zod";
+
+/** Cinco categorias canônicas — mapeamento direto da spec C-T-09. */
+export const ACTION_MENU_ITEM_TYPES = [
+  "curiosity",
+  "challenge",
+  "strategy",
+  "play",
+  "cultural_diamond",
+] as const;
+
+export const ActionMenuItemTypeSchema = z.enum(ACTION_MENU_ITEM_TYPES);
+export type ActionMenuItemType = z.infer<typeof ActionMenuItemTypeSchema>;
+
+const ISO_8601_PREFIX = /^\d{4}-\d{2}-\d{2}T/;
+
+const iso8601String = z.string().refine(
+  (s) => !Number.isNaN(Date.parse(s)) && ISO_8601_PREFIX.test(s),
+  { message: "must be ISO 8601 datetime string" },
+);
+
+export const ActionMenuItemSchema = z.object({
+  id: z.string().min(1),
+  type: ActionMenuItemTypeSchema,
+  content: z.string().min(1),
+  /** Peso de relevância normalizado em [0, 1]. */
+  weight: z.number().min(0).max(1),
+  /** ISO 8601. Item ignorado pelo lookup quando `now > expires_at`. */
+  expires_at: iso8601String.optional(),
+});
+export type ActionMenuItem = z.infer<typeof ActionMenuItemSchema>;
+
+/**
+ * Procedência do menu — facilita audit (qual hash de profile / eixos)
+ * e fallback (se trust_level baixo, lookup pode ser conservador).
+ */
+export const ActionMenuSourceSchema = z.object({
+  trust_level: z.number().min(0).max(1),
+  profile_hash: z.string().optional(),
+  eixos_state_hash: z.string().optional(),
+});
+export type ActionMenuSource = z.infer<typeof ActionMenuSourceSchema>;
+
+/**
+ * Schema do menu inteiro. `superRefine` enforce unicidade de item ids
+ * (lookup determinístico precisa de chave única).
+ */
+export const ActionMenuSchema = z
+  .object({
+    persona_id: z.string().min(1),
+    /** Bump quando o shape muda. Consumers checam antes de parse. */
+    schema_version: z.string().min(1),
+    generated_at: iso8601String,
+    /** Quando `now > valid_until`, o menu inteiro é considerado stale. */
+    valid_until: iso8601String.optional(),
+    source: ActionMenuSourceSchema,
+    items: z.array(ActionMenuItemSchema),
+  })
+  .superRefine((menu, ctx) => {
+    const seen = new Set<string>();
+    for (const [i, item] of menu.items.entries()) {
+      if (seen.has(item.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `duplicate item id "${item.id}"`,
+          path: ["items", i, "id"],
+        });
+      }
+      seen.add(item.id);
+    }
+  });
+export type ActionMenu = z.infer<typeof ActionMenuSchema>;
+
+/** Versão atual do schema serializado. Bumpa em quebras de compat. */
+export const ACTION_MENU_SCHEMA_VERSION = "v0.1.0";
+
+/** Parse + throw em invalido. Usado em load e antes de save. */
+export function parseActionMenu(raw: unknown): ActionMenu {
+  return ActionMenuSchema.parse(raw);
+}

--- a/planejador/src/strategist/index.ts
+++ b/planejador/src/strategist/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Strategist — gera e persiste o ActionMenu pós-compaction.
+ *
+ * PR1 (S-T-09-01 + S-T-09-05): schema + persistência.
+ * PRs futuros: generation LLM-backed (S-T-09-02), triggers (S-T-09-03/04),
+ * telemetria (S-T-09-07), LLM-LOCAL integration (S-T-09-06).
+ *
+ * Refs: ops#989, ops#991.
+ */
+
+export {
+  ACTION_MENU_ITEM_TYPES,
+  ACTION_MENU_SCHEMA_VERSION,
+  ActionMenuItemSchema,
+  ActionMenuItemTypeSchema,
+  ActionMenuSchema,
+  ActionMenuSourceSchema,
+  parseActionMenu,
+  type ActionMenu,
+  type ActionMenuItem,
+  type ActionMenuItemType,
+  type ActionMenuSource,
+} from "./action-menu-schema.js";
+
+export {
+  actionMenuFilename,
+  actionMenuPath,
+  loadActionMenu,
+  saveActionMenu,
+} from "./action-menu-persistence.js";

--- a/planejador/tests/action-menu-persistence.unit.test.ts
+++ b/planejador/tests/action-menu-persistence.unit.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests — ActionMenu persistence helpers (S-T-09-05).
+ *
+ * Cobre round-trip save→load, filename canônico {persona_id}-menu.json,
+ * load de arquivo ausente retorna null, e validação no read (rejeita JSON
+ * malformado contra o schema). Usa diretório temporário por teste pra
+ * isolar IO de fixtures/ reais.
+ *
+ * Refs: ops#991, ops#989 (capability C-T-09).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  actionMenuFilename,
+  actionMenuPath,
+  loadActionMenu,
+  saveActionMenu,
+} from "../src/strategist/action-menu-persistence.js";
+import {
+  ACTION_MENU_SCHEMA_VERSION,
+  type ActionMenu,
+} from "../src/strategist/action-menu-schema.js";
+
+let scratchDir: string;
+
+beforeEach(async () => {
+  scratchDir = await mkdtemp(path.join(tmpdir(), "action-menu-persist-"));
+});
+
+afterEach(async () => {
+  await rm(scratchDir, { recursive: true, force: true });
+});
+
+function makeMenu(personaId = "ryo-ochiai"): ActionMenu {
+  return {
+    persona_id: personaId,
+    schema_version: ACTION_MENU_SCHEMA_VERSION,
+    generated_at: "2026-05-11T13:00:00.000Z",
+    source: { trust_level: 0.5, profile_hash: "sha256:deadbeef" },
+    items: [
+      {
+        id: "challenge-01",
+        type: "challenge",
+        content: "Tente aprimorar o cross-court hoje",
+        weight: 0.75,
+      },
+      {
+        id: "diamond-01",
+        type: "cultural_diamond",
+        content: "Suzuki Daisetz — relação mestre/discípulo no kendo",
+        weight: 0.4,
+      },
+    ],
+  };
+}
+
+describe("actionMenuFilename / actionMenuPath", () => {
+  it("builds canonical filename {persona_id}-menu.json", () => {
+    expect(actionMenuFilename("ryo-ochiai")).toBe("ryo-ochiai-menu.json");
+  });
+
+  it("builds path under given baseDir", () => {
+    const p = actionMenuPath("kei-ochiai", "/tmp/profiles");
+    expect(p).toBe(path.join("/tmp/profiles", "kei-ochiai-menu.json"));
+  });
+});
+
+describe("saveActionMenu / loadActionMenu — round-trip", () => {
+  it("save then load returns deep-equal menu", async () => {
+    const menu = makeMenu();
+    const target = await saveActionMenu(menu, scratchDir);
+    expect(target).toBe(actionMenuPath(menu.persona_id, scratchDir));
+    const loaded = await loadActionMenu(menu.persona_id, scratchDir);
+    expect(loaded).toEqual(menu);
+  });
+
+  it("save creates the file at the canonical path", async () => {
+    const menu = makeMenu("kei-ochiai");
+    await saveActionMenu(menu, scratchDir);
+    const expected = path.join(scratchDir, "kei-ochiai-menu.json");
+    const info = await stat(expected);
+    expect(info.isFile()).toBe(true);
+  });
+
+  it("save creates baseDir if missing", async () => {
+    const nested = path.join(scratchDir, "nested", "profiles");
+    const menu = makeMenu();
+    await saveActionMenu(menu, nested);
+    const loaded = await loadActionMenu(menu.persona_id, nested);
+    expect(loaded?.persona_id).toBe(menu.persona_id);
+  });
+
+  it("save rejects an invalid menu before writing", async () => {
+    const bad = makeMenu();
+    (bad as unknown as { persona_id: string }).persona_id = "";
+    await expect(saveActionMenu(bad, scratchDir)).rejects.toThrow();
+  });
+});
+
+describe("loadActionMenu — edge cases", () => {
+  it("returns null when the file does not exist", async () => {
+    const loaded = await loadActionMenu("ghost-persona", scratchDir);
+    expect(loaded).toBeNull();
+  });
+
+  it("rejects malformed JSON on disk with a parse error", async () => {
+    const target = actionMenuPath("ryo-ochiai", scratchDir);
+    await writeFile(target, "{ not valid json", "utf-8");
+    await expect(loadActionMenu("ryo-ochiai", scratchDir)).rejects.toThrow();
+  });
+
+  it("rejects JSON that violates the schema", async () => {
+    const target = actionMenuPath("ryo-ochiai", scratchDir);
+    const invalid = { persona_id: "", items: [] };
+    await writeFile(target, JSON.stringify(invalid), "utf-8");
+    await expect(loadActionMenu("ryo-ochiai", scratchDir)).rejects.toThrow();
+  });
+
+  it("writes deterministic JSON (pretty-printed, trailing newline)", async () => {
+    const menu = makeMenu();
+    await saveActionMenu(menu, scratchDir);
+    const raw = await readFile(actionMenuPath(menu.persona_id, scratchDir), "utf-8");
+    expect(raw.endsWith("\n")).toBe(true);
+    expect(raw).toContain("\n  ");
+  });
+});

--- a/planejador/tests/action-menu-schema.unit.test.ts
+++ b/planejador/tests/action-menu-schema.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests — ActionMenu Zod schema (S-T-09-01).
+ *
+ * Cobre casos positivos (menu válido completo / mínimo / todos os tipos)
+ * e negativos (id vazio, weight fora de [0,1], tipo desconhecido, data
+ * inválida, ids duplicados). Validação determinística, zero rede.
+ *
+ * Refs: ops#991, ops#989 (capability C-T-09).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ACTION_MENU_ITEM_TYPES,
+  ACTION_MENU_SCHEMA_VERSION,
+  ActionMenuSchema,
+  parseActionMenu,
+  type ActionMenu,
+  type ActionMenuItem,
+} from "../src/strategist/action-menu-schema.js";
+
+function baseValidMenu(): ActionMenu {
+  return {
+    persona_id: "ryo-ochiai",
+    schema_version: ACTION_MENU_SCHEMA_VERSION,
+    generated_at: "2026-05-11T13:00:00.000Z",
+    source: { trust_level: 0.42 },
+    items: [
+      {
+        id: "curio-01",
+        type: "curiosity",
+        content: "Por que o backhand cross-court engana o adversário?",
+        weight: 0.8,
+      },
+    ],
+  };
+}
+
+describe("ActionMenuSchema — positive cases", () => {
+  it("accepts a fully populated menu with all optional fields", () => {
+    const menu: ActionMenu = {
+      persona_id: "kei-ochiai",
+      schema_version: ACTION_MENU_SCHEMA_VERSION,
+      generated_at: "2026-05-11T13:00:00.000Z",
+      valid_until: "2026-05-18T13:00:00.000Z",
+      source: {
+        trust_level: 0.67,
+        profile_hash: "sha256:abcdef",
+        eixos_state_hash: "sha256:123456",
+      },
+      items: ACTION_MENU_ITEM_TYPES.map((type, i) => ({
+        id: `item-${i}`,
+        type,
+        content: `seed content for ${type}`,
+        weight: 0.5,
+        expires_at: "2026-05-18T13:00:00.000Z",
+      })),
+    };
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("accepts a minimal menu without optional fields", () => {
+    expect(() => parseActionMenu(baseValidMenu())).not.toThrow();
+  });
+
+  it("accepts an empty items array", () => {
+    const menu = baseValidMenu();
+    menu.items = [];
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("accepts weight at boundaries 0 and 1", () => {
+    const menu = baseValidMenu();
+    menu.items = [
+      { id: "a", type: "challenge", content: "min", weight: 0 },
+      { id: "b", type: "strategy", content: "max", weight: 1 },
+    ];
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("exposes all five item types in the canonical enum", () => {
+    expect(new Set(ACTION_MENU_ITEM_TYPES)).toEqual(
+      new Set([
+        "curiosity",
+        "challenge",
+        "strategy",
+        "play",
+        "cultural_diamond",
+      ]),
+    );
+  });
+});
+
+describe("ActionMenuSchema — negative cases", () => {
+  it("rejects empty persona_id", () => {
+    const menu = baseValidMenu();
+    menu.persona_id = "";
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("rejects weight > 1", () => {
+    const menu = baseValidMenu();
+    menu.items[0]!.weight = 1.1;
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("rejects weight < 0", () => {
+    const menu = baseValidMenu();
+    menu.items[0]!.weight = -0.01;
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("rejects unknown item type", () => {
+    const menu = baseValidMenu();
+    (menu.items[0] as unknown as { type: string }).type = "metaphor";
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("rejects non-ISO generated_at", () => {
+    const menu = baseValidMenu();
+    menu.generated_at = "11/05/2026";
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("rejects duplicate item ids", () => {
+    const menu = baseValidMenu();
+    const dup: ActionMenuItem = {
+      id: "curio-01",
+      type: "challenge",
+      content: "duplicate id",
+      weight: 0.5,
+    };
+    menu.items.push(dup);
+    expect(() => parseActionMenu(menu)).toThrow(/duplicate item id/);
+  });
+
+  it("rejects trust_level > 1", () => {
+    const menu = baseValidMenu();
+    menu.source.trust_level = 1.5;
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("returns a SafeParse error result without throwing when using safeParse", () => {
+    const menu = baseValidMenu();
+    menu.persona_id = "";
+    const result = ActionMenuSchema.safeParse(menu);
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Sumário

Primeiro PR do Sprint 1 (ops#991), capability C-T-09. Entrega o **scaffolding** do Estrategista — schema declarativo do ActionMenu + helpers de persistência em `fixtures/profiles/{persona_id}-menu.json`. Sem geração LLM, sem triggers, sem telemetria (esses ficam para PR2-PR4 do Sprint 1).

Stories fechadas:

- [x] **S-T-09-01** — Schema TypeScript do ActionMenu + Zod validation
- [x] **S-T-09-05** — Persistência em `fixtures/profiles/{persona_id}-menu.json`

Refs: ops#991 (tracker), ops#989 (capability C-T-09).

## Mudanças

### `planejador/src/strategist/`
- `action-menu-schema.ts` — Zod schema + types. Cinco categorias canônicas (`curiosity`, `challenge`, `strategy`, `play`, `cultural_diamond`), cada item com `weight` em [0,1] e `expires_at` opcional. `superRefine` enforce unicidade de item ids (lookup determinístico em C-T-10 precisa de chave única). Constante `ACTION_MENU_SCHEMA_VERSION = "v0.1.0"`.
- `action-menu-persistence.ts` — `saveActionMenu`/`loadActionMenu`/`actionMenuPath`. Validação Zod corre tanto no save (rejeita antes de gravar) quanto no load (rejeita JSON malformado / fora do schema). `loadActionMenu` retorna `null` em ENOENT — caller decide se isso aciona trigger (C-T-09-03/04) ou fallback pro pool scoring antigo (C-T-10).
- `index.ts` — barrel export.

### `planejador/tests/`
- `action-menu-schema.unit.test.ts` — 13 tests (positivos + negativos + boundaries).
- `action-menu-persistence.unit.test.ts` — 10 tests (round-trip, baseDir auto-create, ENOENT→null, malformed JSON, schema violation, formato pretty-printed).

### `fixtures/profiles/exemplo-menu.json`
Fixture canônico de referência (persona_id=`exemplo`, 5 items, um por tipo). Sanity-check feito via `loadActionMenu`.

## Padrão TDD 3 camadas

1. **Audit** — `npm test` workspaces shared+planejador antes de tocar nada: 478 + 97 = 575 tests passando, zero regressão prévia conhecida.
2. **Red phase** — Tests escritos primeiro contra módulos inexistentes, confirmado fail.
3. **Green phase** — Schema + persistência implementados, tests passam.

## Saída

- `npm run build --workspace shared --workspace planejador` ✅ tsc limpo
- `npm test --workspace planejador` ✅ **120/120 passa** (97 prévios + **23 novos**, ≥8 requeridos)
- Property-like coverage no schema: boundaries de weight, enum violations, ISO 8601, duplicate ids, trust_level
- `exemplo-menu.json` carrega via `loadActionMenu` sem warning

**Nota:** repo não tem script `lint` configurado. Proxy adotado: build via `tsc -p tsconfig.build.json` em ambos workspaces sai sem erro. Se Jun quiser ESLint, abro issue separada.

## Diff

4 commits temáticos, todos buildable. ~516 linhas (~472 strategist + 44 fixture). Acima do alvo de 500 marginalmente, mas split em commits temáticos como o mandato permite. Squash merge friendly.

## Não nesta PR

Conforme escopo do prompt CC-Strategist:

- ❌ `*.integration.test.ts` → PR2+
- ❌ `*.llm-local.integration.test.ts` → PR2+ (depende stack Qwen3)
- ❌ Telemetria `menu_generated` → PR2 (após Pre-Sprint #1008 mergear; consome envelope de `motor/src/contracts`)
- ❌ Geração LLM (`generateActionMenu`) → PR2 (S-T-09-02)
- ❌ Triggers post-compaction / post-onboarding → PR3 (S-T-09-03 + S-T-09-04)

## Ownership

Strict — só toquei:
- `planejador/src/strategist/*` (criado)
- `planejador/tests/action-menu-*.unit.test.ts` (criado)
- `fixtures/profiles/exemplo-menu.json` (criado)

Não toquei `shared/src/contracts/*` (CC-Foundation, ops#1008), `plano-tatico/*` (CC-Foundation, ops#1010), `jogadas/*`, `recovery/*`, `sts/*`.

## Test plan

- [ ] `npm test --workspace planejador` → 120/120 green
- [ ] `npm run build --workspace shared --workspace planejador` → tsc limpo
- [ ] Carregar `fixtures/profiles/exemplo-menu.json` via `loadActionMenu` em REPL → retorna ActionMenu válido

🤖 Generated with [Claude Code](https://claude.com/claude-code)