### PR TITLE
[motor#88 H-AC-02 + ops#993 S-T-09-02] generateActionMenu LLM-backed com rotulagem ISA

### DIFF
--- a/fixtures/profiles/kei-ochiai.pre-phase2.json
+++ b/fixtures/profiles/kei-ochiai.pre-phase2.json
@@ -1,0 +1,122 @@
+{
+  "sessions_seen": [
+    {
+      "session_id": "6a1e9b3d-04aa-4a6d-8670-8ebdecb4e359",
+      "started_at": "2026-05-07T18:53:33.215Z",
+      "completed_at": "2026-05-07T19:20:42.592Z",
+      "total_turns": 12,
+      "trace_file": "kei-ochiai-2026-05-07T19-20-42-592Z.json"
+    },
+    {
+      "session_id": "4e7ccb82-783e-4fff-9ca7-2b3bb28def24",
+      "started_at": "2026-05-07T19:51:22.729Z",
+      "completed_at": "2026-05-07T20:15:43.779Z",
+      "total_turns": 9,
+      "trace_file": "kei-ochiai-2026-05-07T20-15-43-779Z.json"
+    }
+  ],
+  "profile": {
+    "preferences": {
+      "interests": [
+        "tênis",
+        "movimentos corporais e técnicas de jogo",
+        "comunicação não verbal (olhares, gestos)",
+        "relação com o pai durante treinos",
+        "processos de transformação sutil (como mudanças no grip da raquete)",
+        "mecânica (especialmente desmontar componentes de máquina)",
+        "ajustes precisos em ações físicas",
+        "entender como o corpo e o alinhamento afetam resultados",
+        "aplicar conhecimento prático (como o que o pai ensina sobre ângulo e equilíbrio)"
+      ],
+      "aversions": [
+        "conversas abstratas sem conexão com experiências concretas",
+        "perguntas que parecem vagas ou sem contexto claro",
+        "situações de pressão para expressar emoções imediatamente",
+        "perguntas abstratas sem conexão clara com ação concreta",
+        "mudanças bruscas de tema sem transição",
+        "falta de foco ou objetividade",
+        "atividades que parecem sem propósito ou sem resultado visível"
+      ],
+      "learning_style": "aprende melhor por meio de ações concretas, experimentação prática e ajustes físicos, com foco em resultados tangíveis e processos mensuráveis. Rejeita abordagens teóricas ou metafóricas sem ligação direta com o que está fazendo."
+    },
+    "family_anchors": [
+      {
+        "name": "pai",
+        "role": "pai",
+        "gestures_observed": [
+          "olhar após um ponto",
+          "treinar com o filho sem falar",
+          "mudar o grip da raquete",
+          "sorrir apenas quando o filho acerta o backhand",
+          "ensina sobre ângulo do lançamento no tênis",
+          "ensina sobre equilíbrio e alinhamento no corpo",
+          "ensina sobre ajustes precisos em mecânica (ex: filtro de ar)"
+        ],
+        "emotional_role": "figura de autoridade prática, fonte de conhecimento concreto e orientação técnica, representando sabedoria aplicada em ações do dia a dia."
+      }
+    ],
+    "recurring_themes": [
+      "comunicação não verbal",
+      "relação silenciosa com o pai",
+      "mudanças sutis que só são percebidas depois",
+      "emoções não ditas (raiva, frustração, orgulho)",
+      "conexão por meio do movimento e do olhar no tênis",
+      "ajuste físico e alinhamento para obter resultados corretos",
+      "importância do equilíbrio e do ângulo em ações",
+      "necessidade de clareza e propósito em qualquer atividade",
+      "desconfiança de abordagens sem objetividade ou resultado visível"
+    ],
+    "emotional_arcs": [
+      {
+        "session_id": "6a1e9b3d-04aa-4a6d-8670-8ebdecb4e359",
+        "opening_tone": "impaciente",
+        "closing_tone": "distraído",
+        "key_disclosures": [
+          "o silêncio entre ele e o pai durante o treino é carregado de significado",
+          "ele sente emoções (como raiva ou frustração) mas não tem palavras para nomeá-las",
+          "ele reconhece que o que sente está 'perdido no vazio entre os termos'"
+        ],
+        "flags": [
+          "dificuldade em nomear emoções",
+          "dependência de contextos físicos (como tênis) para expressar conexão",
+          "relação emocional com o pai baseada em silêncio e não em afeto verbal ou físico"
+        ]
+      },
+      {
+        "session_id": "4e7ccb82-783e-4fff-9ca7-2b3bb28def24",
+        "opening_tone": "curioso mas cauteloso, com desconfiança em relação à falta de clareza",
+        "closing_tone": "entediado e frustrado, com sinal de desinteresse por mudanças de foco",
+        "key_disclosures": [
+          "o pai ensina sobre ângulo e equilíbrio no tênis e em mecânica",
+          "o Ryo riu de verdade quando caiu no treino — momento de imprevisibilidade",
+          "sente que as perguntas não levam a lugar algum se não houver um ponto claro"
+        ],
+        "flags": [
+          "dificuldade em manter foco quando o tema muda sem transição",
+          "pressão por clareza e objetividade extrema",
+          "sinal de fome e preocupação com o tempo (Ryo no treino), indicando possível sobrecarga ou priorização de atividades reais"
+        ]
+      }
+    ],
+    "open_loops": [
+      "a necessidade de encontrar 5 palavras diferentes para o que sente agora (não foi concluído)",
+      "a possibilidade de explorar como ele nomeia emoções em outros contextos além do tênis",
+      "a ideia de como o silêncio no treino afeta sua autoconsciência emocional",
+      "não foi possível concluir a reflexão sobre o ajuste no tênis ou na mecânica, pois o tema foi interrompido",
+      "a pergunta sobre o riso e a justiça sem números foi deixada sem resposta",
+      "a ideia de pensar em decisões sustentáveis em sete gerações foi rejeitada sem exploração"
+    ],
+    "off_screen_completions": [
+      "treinar tênis com o pai",
+      "praticar o backhand",
+      "pegar uma bola de tênis e tentar acertar um alvo no quintal",
+      "desmontar o filtro de ar de um carro (atividade já realizada)"
+    ],
+    "notes_for_next_session": [
+      "começar com uma ação concreta e clara (ex: ajustar algo no tênis ou em um objeto físico)",
+      "evitar mudanças bruscas de tema; manter o foco no que foi iniciado",
+      "lembrar de perguntar como foi o treino do Ryo e se ele riu de novo, para conectar com o momento emocional anterior"
+    ]
+  },
+  "last_updated": "2026-05-07T23:32:14.465Z"
+}

--- a/fixtures/profiles/ryo-ochiai.pre-phase2.json
+++ b/fixtures/profiles/ryo-ochiai.pre-phase2.json
@@ -1,0 +1,178 @@
+{
+  "sessions_seen": [
+    {
+      "session_id": "5e8a7505-d055-4ee9-9286-fd50fff72ae0",
+      "started_at": "2026-05-07T18:32:30.256Z",
+      "completed_at": "2026-05-07T18:53:33.177Z",
+      "total_turns": 12,
+      "trace_file": "ryo-ochiai-2026-05-07T18-53-33-177Z.json"
+    },
+    {
+      "session_id": "0ac76202-6ae6-41ca-82d7-a54ad19110e7",
+      "started_at": "2026-05-07T19:20:42.626Z",
+      "completed_at": "2026-05-07T19:51:22.682Z",
+      "total_turns": 12,
+      "trace_file": "ryo-ochiai-2026-05-07T19-51-22-682Z.json"
+    },
+    {
+      "session_id": "a610ac08-4e31-44ea-aa72-d545953a3b32",
+      "started_at": "2026-05-07T20:15:43.833Z",
+      "completed_at": "2026-05-07T20:48:05.872Z",
+      "total_turns": 12,
+      "trace_file": "ryo-ochiai-2026-05-07T20-48-05-873Z.json"
+    }
+  ],
+  "profile": {
+    "preferences": {
+      "interests": [
+        "tênis",
+        "animes (especialmente Dragon Ball, com foco em Gohan e Cell)",
+        "relações fraternas (com Kei)",
+        "silêncio como forma de expressão",
+        "gestos não verbais e presença física",
+        "ver o Gohan no Cell (momento épico da série)",
+        "relacionamento com o irmão Kei",
+        "silêncio compartilhado durante o jantar",
+        "gestos não verbais de afeto (como o arroz no prato)",
+        "transformação e força interior (associada a Gohan)",
+        "animação e histórias de Dragon Ball (especialmente Gohan no Cell Saga)",
+        "tênis e rotina esportiva",
+        "relações com o irmão Kei",
+        "gestos simbólicos de afeto (como deixar a raquete no lugar certo)",
+        "exploração de identidade e emoções por meio de metáforas (ex: fogo vs ferrugem)"
+      ],
+      "aversions": [
+        "ser ignorado",
+        "não ser visto ou entendido sem falar",
+        "pressão para se comparar ao Kei",
+        "situações de conflito sem apoio emocional",
+        "ser ignorado ou não visto pelo Kei",
+        "pensar em responsabilidades futuras (sete gerações)",
+        "expressar emoções complexas sem palavras",
+        "situações de pressão que exigem decisão imediata",
+        "sentir que não é igual aos outros (especialmente ao irmão Kei)",
+        "não saber como fazer alguém rir",
+        "sentir que sua raiva é algo negativo ou problemático"
+      ],
+      "learning_style": "aprende melhor por meio de metáforas narrativas, comparações com personagens de histórias e reflexão sobre gestos cotidianos, especialmente quando conectados a emoções profundas."
+    },
+    "family_anchors": [
+      {
+        "name": "Kei",
+        "role": "irmão",
+        "gestures_observed": [
+          "aparecer no banheiro depois do incidente",
+          "dizer apenas 'tô aqui' sem palavras",
+          "compartilhar raquete sem pedir",
+          "está sempre no treino",
+          "não olha para o kid",
+          "coloca mais arroz no prato do kid sem falar",
+          "esquece o uniforme e corre pra casa",
+          "ri da cara de bosta que Ryo faz no treino",
+          "diz que Ryo é igual a ele, mas Ryo sente que não é"
+        ],
+        "emotional_role": "fonte de conexão afetiva, mesmo que por meio de humor e ironia; representa um espelho que Ryo tenta se igualar, mas que também o faz questionar sua própria identidade."
+      },
+      {
+        "name": "papai",
+        "role": "pai",
+        "gestures_observed": [
+          "deixa a raquete de Ryo no lugar certo após o jogo"
+        ],
+        "emotional_role": "representa afeto silencioso e presente em pequenos gestos, sem palavras, o que Ryo valoriza profundamente como forma de cuidado."
+      }
+    ],
+    "recurring_themes": [
+      "desejo de ser visto sem precisar gritar",
+      "pressão de se comparar ao irmão (Kei)",
+      "valor do silêncio como força",
+      "necessidade de reconhecimento emocional",
+      "sentimento de invisibilidade em contextos sociais",
+      "espera pelo Kei",
+      "silêncio no jantar como forma de presença",
+      "desejo de ser visto e reconhecido, como Gohan no Cell",
+      "raiva guardada e transformação interna",
+      "afeto expresso por gestos simples, não palavras",
+      "diferença entre si e o irmão Kei",
+      "afeto expresso por gestos silenciosos",
+      "raiva como força que pode ser transformadora",
+      "identidade pessoal ligada a atos únicos (como a cara de bosta)",
+      "transformação sob pressão (Gohan no Cell Saga como modelo)"
+    ],
+    "emotional_arcs": [
+      {
+        "session_id": "5e8a7505-d055-4ee9-9286-fd50fff72ae0",
+        "opening_tone": "distraído, com desinteresse e cansaço",
+        "closing_tone": "aberto e vulnerável, com um desejo claro de ser compreendido",
+        "key_disclosures": [
+          "ficou no banheiro da escola após um conflito e foi procurado apenas pelo Kei",
+          "revelou que sente que está presente mesmo sem falar, mas quer que alguém entenda isso",
+          "expressou que o silêncio é uma forma de tentar achar o jeito certo de ser"
+        ],
+        "flags": [
+          "sentimento persistente de invisibilidade",
+          "isolamento emocional após conflitos",
+          "dificuldade em buscar apoio, mesmo quando necessário",
+          "necessidade de validação não verbal"
+        ]
+      },
+      {
+        "session_id": "0ac76202-6ae6-41ca-82d7-a54ad19110e7",
+        "opening_tone": "distraído, passivo, com foco na espera",
+        "closing_tone": "entediado com um fio de vulnerabilidade",
+        "key_disclosures": [
+          "desejo de ser visto pelo Kei, como Gohan é visto no Cell",
+          "sentir que carrega tudo sozinho",
+          "reconhecer que a raiva é uma força que pode se tornar incontrolável"
+        ],
+        "flags": [
+          "desejo intenso de reconhecimento que não é atendido",
+          "sentimento de invisibilidade dentro da família",
+          "pressão emocional acumulada, expressa por silêncio e metáforas de explosão"
+        ]
+      },
+      {
+        "session_id": "a610ac08-4e31-44ea-aa72-d545953a3b32",
+        "opening_tone": "distraído, com foco no fim da aula de tênis e no desejo de ver o episódio",
+        "closing_tone": "refletivo e vulnerável, com consciência de suas emoções e identidade",
+        "key_disclosures": [
+          "não lembra da última vez que fez alguém rir",
+          "sentimento de que não é igual ao irmão Kei, mesmo quando ele diz que são iguais",
+          "aceitação de que sua raiva é explosiva, mas que pode ser usada por algo que vale a pena"
+        ],
+        "flags": [
+          "sentimento de inadequação em relação ao irmão",
+          "dificuldade em expressar afeto ou criar conexões emocionais positivas",
+          "pressão interna sobre a raiva como força negativa, mas também como potencial de transformação"
+        ]
+      }
+    ],
+    "open_loops": [
+      "desejo de ser entendido sem falar",
+      "exploração do que significa 'estar presente' no dia a dia",
+      "como o silêncio pode ser uma forma de força no tênis e na vida",
+      "o desejo de ser visto como Gohan no Cell — queria explorar esse momento de transformação e reconhecimento",
+      "a possibilidade de usar a raiva como força, não como destruição — aberto para diálogo sobre isso",
+      "a busca por palavras para nomear o que sente — ainda não encontrou vocabulário emocional",
+      "desejo de ver o novo episódio do Gohan no Cell Saga — pode ser um gancho para próxima sessão",
+      "reflexão sobre como usar sua 'diferença' como força, especialmente em relação ao irmão Kei",
+      "possível interesse em explorar mais sobre o que significa ser 'forte' de forma não violenta, como Gohan"
+    ],
+    "off_screen_completions": [
+      "ficar no banheiro da escola após um conflito",
+      "trocar de raquete com o Kei durante o treino",
+      "observar o Kei em momentos de jogo e comparação",
+      "esperar o Kei terminar o treino",
+      "comer juntos em casa",
+      "assistir ao Gohan no Cell",
+      "assistir ao novo episódio do Gohan no Cell Saga",
+      "refletir sobre a divisão de chocolate com Kei como gesto de confiança"
+    ],
+    "notes_for_next_session": [
+      "Perguntar como foi assistir ao episódio do Gohan no Cell Saga e o que Ryo sentiu sobre a transformação de Gohan.",
+      "Explorar mais o que significa ser 'igual' ou 'diferente' em relação ao irmão Kei, com foco em valorização da singularidade.",
+      "Sugerir uma atividade criativa: desenhar ou contar uma cena onde Ryo escolhe dividir algo com Kei, como um ato de confiança."
+    ]
+  },
+  "last_updated": "2026-05-07T23:39:29.458Z"
+}

--- a/motor-drota/src/menu-generator.ts
+++ b/motor-drota/src/menu-generator.ts
@@ -1,0 +1,513 @@
+/**
+ * generateActionMenu — gerador LLM-backed do ActionMenu pós-compaction.
+ *
+ * Sprint 1 PR2 — S-T-09-02 (ops#993) combinada com H-AC-02 (motor#88).
+ *
+ * Função pura (mod. LLM side-effect): recebe profile + trustLevel + eixos +
+ * onboarding + persona_hint, chama LLM via gateway, valida output contra
+ * schema v0.2 (shared/contracts/action-menu), aplica regras auto de
+ * is_critical, e devolve ActionMenu pronto pra persistir.
+ *
+ * Comportamento de robustez:
+ *
+ * 1. **Retry once on Zod failure**: se primeiro output do LLM falhar parse,
+ *    re-pede com instrução de correção explícita (mensagem do Zod no prompt).
+ *
+ * 2. **Graceful degradation on retry failure**: se segundo output também
+ *    falhar SÓ pelos campos ISA opcionais (`played_as`/`intensity`/
+ *    `is_critical`), o gerador *strips* esses campos e tenta parse de novo.
+ *    Items sem rótulo continuam válidos (campos opcionais no schema v0.2);
+ *    warning `isa_labels_stripped` emitido.
+ *
+ * 3. **Null on hard failure**: LLM lança em ambas as tentativas, OU output
+ *    não é JSON parseável de jeito nenhum, OU schema rejeita por motivo
+ *    estrutural (não-ISA) → retorna `null` + warning.
+ *
+ * 4. **Auto is_critical** (regra do prompt §3): item com `played_as=recovery`
+ *    OU `played_as=diamante` + `intensity=firm` é forçado a `is_critical=true`
+ *    mesmo se LLM omitir.
+ *
+ * Telemetria: emite evento `menu_generation` via `logDebugEvent` (NDJSON)
+ * com cost/latency/tokens — visível no painel longitudinal futuro (H-AC-08).
+ *
+ * Refs:
+ * - ops#993 (S-T-09-02 — escopo da gen function)
+ * - motor#88 (H-AC-02 — rotulagem ISA)
+ * - motor#89 (H-AC-01 — schema v0.2)
+ * - ops#991 (Sprint 1 tracker)
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ACTION_MENU_SCHEMA_VERSION,
+  ActionMenuSchema,
+  logDebugEvent,
+  type ActionMenu,
+  type ActionMenuItem,
+  type Intensity,
+  type LlmProvider,
+  type PlayedAs,
+} from "@ascendimacy/shared";
+
+import { callLlm, type LlmCallResult } from "./llm-client.js";
+import {
+  renderPersonaHintForPrompt,
+  type PersonaHint,
+} from "./persona-hints.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Caminho default do template — em prod/test vem do mesmo lugar. */
+const PROMPT_TEMPLATE_PATH = join(
+  __dirname,
+  "prompts",
+  "menu-generator-v0.1.txt",
+);
+
+/** Versão do prompt — bump quando estrutura mudar (não conteúdo). */
+export const PROMPT_TEMPLATE_VERSION = "v0.1";
+
+/** Input canônico do gerador. */
+export interface GenerateActionMenuInput {
+  personaId: string;
+  /** Trust level em [0, 1]. */
+  trustLevel: number;
+  /** Profile do learner (shape livre v0; consumer principal é o LLM). */
+  profile: unknown;
+  /** Snapshot opcional do estado de eixos. */
+  eixosState?: unknown;
+  /** Snapshot opcional do onboarding. */
+  onboarding?: unknown;
+  /**
+   * Calibração persona-aware. Quando ausente, gerador faz lookup via
+   * `resolvePersonaHint(personaId)`; se ainda assim ausente, gerador
+   * roda sem hint (LLM cai em distribuição neutra).
+   */
+  personaHint?: PersonaHint;
+  /**
+   * Trace correlation. Quando fornecido, o evento de telemetria inclui
+   * este `session_id`. Default: undefined (debug-logger usa scope global).
+   */
+  sessionId?: string;
+}
+
+/** Tipo do callback de telemetria/warning. */
+export interface MenuGeneratorWarning {
+  code:
+    | "invalid_input"
+    | "llm_error"
+    | "parse_error_first"
+    | "parse_error_retry"
+    | "schema_error_first"
+    | "schema_error_retry"
+    | "isa_labels_stripped";
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+/** Tipo do LLM call — injetável para testes (mock). */
+export type LlmCall = (
+  systemPrompt: string,
+  userMessage: string,
+) => Promise<LlmCallResult>;
+
+export interface GenerateActionMenuOptions {
+  llmCall?: LlmCall;
+  onWarning?: (w: MenuGeneratorWarning) => void;
+  /** Override path do template (testes). */
+  promptTemplatePath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Lê template + cacheia em memória (idempotente entre chamadas).
+ *
+ * Robusto a dois layouts:
+ * 1. Execução via vitest direto sobre `src/` — `__dirname` é `.../src`,
+ *    template ao lado em `src/prompts/`.
+ * 2. Execução via build em `dist/` (smoke script, MCP server) — TypeScript
+ *    não copia `.txt` para dist/. Fallback resolve para `src/prompts/`
+ *    relativo ao dist/. Se desejável copiar no build, adicionar postbuild
+ *    step (não bloqueante hoje).
+ */
+let _cachedTemplate: string | null = null;
+function loadPromptTemplate(pathOverride?: string): string {
+  if (pathOverride) return readFileSync(pathOverride, "utf-8");
+  if (_cachedTemplate) return _cachedTemplate;
+  if (existsSync(PROMPT_TEMPLATE_PATH)) {
+    _cachedTemplate = readFileSync(PROMPT_TEMPLATE_PATH, "utf-8");
+    return _cachedTemplate;
+  }
+  // Fallback: rodando de dist/, .txt fica em src/.
+  const fromDistToSrc = PROMPT_TEMPLATE_PATH.replace(
+    `${join("/", "dist", "/")}`,
+    `${join("/", "src", "/")}`,
+  );
+  _cachedTemplate = readFileSync(fromDistToSrc, "utf-8");
+  return _cachedTemplate;
+}
+
+/** Substitui `{{var}}` no template. */
+function fillTemplate(
+  tpl: string,
+  vars: Record<string, string>,
+): string {
+  let out = tpl;
+  for (const [k, v] of Object.entries(vars)) {
+    out = out.split(`{{${k}}}`).join(v);
+  }
+  return out;
+}
+
+/** Constrói o system + user prompts para a chamada LLM. */
+function buildPrompts(input: GenerateActionMenuInput, templatePath?: string): {
+  systemPrompt: string;
+  userMessage: string;
+} {
+  const template = loadPromptTemplate(templatePath);
+  const personaHintBlock = input.personaHint
+    ? renderPersonaHintForPrompt(input.personaHint)
+    : "(sem hint registrado para este persona — distribuição neutra)";
+
+  const filled = fillTemplate(template, {
+    persona_hint_block: personaHintBlock,
+    trust_level: String(input.trustLevel),
+    profile_json: JSON.stringify(input.profile, null, 2),
+    eixos_state_json: JSON.stringify(input.eixosState ?? null, null, 2),
+    onboarding_json: JSON.stringify(input.onboarding ?? null, null, 2),
+  });
+
+  // O template inteiro vira system prompt; user message é gatilho curto.
+  const systemPrompt = filled;
+  const userMessage =
+    `Gere agora o ActionMenu para persona_id="${input.personaId}". ` +
+    "Retorne SOMENTE o JSON, sem code fence, sem comentários fora do JSON.";
+  return { systemPrompt, userMessage };
+}
+
+/** Extrai JSON de string que pode vir com code fence ou prosa. */
+function extractJson(raw: string): string | null {
+  const trimmed = raw.trim();
+  // Tenta direto.
+  if (trimmed.startsWith("{")) {
+    return trimmed;
+  }
+  // Tenta ```json ... ``` fence.
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    return fenceMatch[1]!.trim();
+  }
+  // Tenta primeiro { ... } balanceado (best-effort).
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    return trimmed.slice(start, end + 1).trim();
+  }
+  return null;
+}
+
+/** Aplica regras auto de is_critical (idempotente). */
+function applyAutoCritical(menu: ActionMenu): ActionMenu {
+  for (const item of menu.items) {
+    if (item.played_as === "recovery") {
+      item.is_critical = true;
+    } else if (item.played_as === "diamante" && item.intensity === "firm") {
+      item.is_critical = true;
+    }
+  }
+  return menu;
+}
+
+/** Strip campos ISA opcionais de todos os items. Mutação in-place. */
+function stripIsaLabels(raw: unknown): unknown {
+  if (typeof raw !== "object" || raw === null) return raw;
+  const obj = raw as Record<string, unknown>;
+  const items = obj["items"];
+  if (!Array.isArray(items)) return raw;
+  for (const item of items) {
+    if (item && typeof item === "object") {
+      const it = item as Record<string, unknown>;
+      delete it["played_as"];
+      delete it["intensity"];
+      delete it["is_critical"];
+    }
+  }
+  return raw;
+}
+
+/**
+ * Tenta extrair + parsear menu. Retorna discriminated union.
+ */
+function tryParseMenu(
+  llmContent: string,
+): { ok: true; menu: ActionMenu } | { ok: false; reason: "no_json"; raw: string } | { ok: false; reason: "schema_invalid"; rawJson: string; zodMessage: string } {
+  const jsonStr = extractJson(llmContent);
+  if (!jsonStr) {
+    return { ok: false, reason: "no_json", raw: llmContent };
+  }
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(jsonStr);
+  } catch {
+    return { ok: false, reason: "no_json", raw: llmContent };
+  }
+  const safe = ActionMenuSchema.safeParse(parsedJson);
+  if (!safe.success) {
+    return {
+      ok: false,
+      reason: "schema_invalid",
+      rawJson: jsonStr,
+      zodMessage: safe.error.message,
+    };
+  }
+  return { ok: true, menu: safe.data };
+}
+
+/** Constrói mensagem de retry com instrução de correção explícita. */
+function buildRetryPrompt(
+  originalUserMessage: string,
+  zodMessage: string,
+): string {
+  return [
+    originalUserMessage,
+    "",
+    "**RETRY — o JSON anterior foi INVÁLIDO contra o schema v0.2.**",
+    "",
+    "Erro reportado pelo validador:",
+    "```",
+    zodMessage,
+    "```",
+    "",
+    "Corrija o JSON. Atenção especial aos enums:",
+    "- `played_as`: APENAS bridge | espelho | canal | diamante | arena | recovery",
+    "- `intensity`: APENAS soft | medium | firm",
+    "- `is_critical`: APENAS true | false (booleano)",
+    "",
+    "Se em dúvida sobre algum item, OMITA os campos ISA opcionais nesse " +
+      "item (eles são opcionais; melhor um item sem rótulo do que rótulo " +
+      "inválido). Retorne SOMENTE o JSON corrigido.",
+  ].join("\n");
+}
+
+/** Tenta emitir telemetria — silencia falhas (telemetria não pode quebrar prod). */
+function emitTelemetry(args: {
+  personaId: string;
+  sessionId?: string;
+  result?: LlmCallResult;
+  latencyMs: number;
+  outcome: "ok" | "ok-retry" | "degraded" | "error";
+  prompt?: string;
+  response?: string;
+}): void {
+  try {
+    logDebugEvent({
+      side: "motor",
+      step: "menu_generation",
+      user_id: args.personaId,
+      motor_target: "planejador-strategist",
+      session_id: args.sessionId,
+      provider: args.result?.provider as LlmProvider | undefined,
+      model: args.result?.model,
+      tokens: args.result?.tokens,
+      latency_ms: args.latencyMs,
+      prompt: args.prompt,
+      response: args.response,
+      outcome: args.outcome === "error" ? "error" : "ok",
+    });
+  } catch {
+    // No-op — telemetria não pode quebrar produção.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Gera ActionMenu via LLM para o persona dado.
+ *
+ * @returns ActionMenu válido (schema v0.2) ou `null` em falha hard.
+ *   Warnings detalhados via `options.onWarning` callback.
+ */
+export async function generateActionMenu(
+  input: GenerateActionMenuInput,
+  options: GenerateActionMenuOptions = {},
+): Promise<ActionMenu | null> {
+  const warn = (w: MenuGeneratorWarning): void => {
+    options.onWarning?.(w);
+  };
+
+  // Validação de input — antes de gastar LLM call.
+  if (!input.personaId || input.personaId.trim().length === 0) {
+    warn({ code: "invalid_input", message: "personaId é obrigatório" });
+    return null;
+  }
+  if (input.trustLevel < 0 || input.trustLevel > 1) {
+    warn({
+      code: "invalid_input",
+      message: `trustLevel fora de [0,1]: ${input.trustLevel}`,
+    });
+    return null;
+  }
+
+  const llmCall: LlmCall = options.llmCall ?? callLlm;
+  const { systemPrompt, userMessage } = buildPrompts(
+    input,
+    options.promptTemplatePath,
+  );
+
+  const t0 = Date.now();
+  let attempt1: LlmCallResult;
+  try {
+    attempt1 = await llmCall(systemPrompt, userMessage);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    warn({ code: "llm_error", message: `LLM call failed (attempt 1): ${msg}` });
+    emitTelemetry({
+      personaId: input.personaId,
+      sessionId: input.sessionId,
+      latencyMs: Date.now() - t0,
+      outcome: "error",
+    });
+    // Retry once on LLM error too.
+    try {
+      attempt1 = await llmCall(systemPrompt, userMessage);
+    } catch (err2) {
+      const msg2 = err2 instanceof Error ? err2.message : String(err2);
+      warn({
+        code: "llm_error",
+        message: `LLM call failed (retry): ${msg2}`,
+      });
+      return null;
+    }
+  }
+
+  const parsed1 = tryParseMenu(attempt1.content);
+  if (parsed1.ok) {
+    const menu = applyAutoCritical(parsed1.menu);
+    emitTelemetry({
+      personaId: input.personaId,
+      sessionId: input.sessionId,
+      result: attempt1,
+      latencyMs: Date.now() - t0,
+      outcome: "ok",
+      prompt: systemPrompt + "\n---\n" + userMessage,
+      response: attempt1.content,
+    });
+    return menu;
+  }
+
+  // Primeiro parse falhou — retry com correção.
+  const retryUserMessage =
+    parsed1.reason === "schema_invalid"
+      ? buildRetryPrompt(userMessage, parsed1.zodMessage)
+      : buildRetryPrompt(
+          userMessage,
+          "JSON não foi reconhecido na resposta — verifique se retornou " +
+            "apenas o JSON puro, sem code fence ou prosa ao redor.",
+        );
+
+  if (parsed1.reason === "schema_invalid") {
+    warn({
+      code: "schema_error_first",
+      message: "Schema invalid on first attempt; retrying with correction",
+      details: { zodMessage: parsed1.zodMessage },
+    });
+  } else {
+    warn({
+      code: "parse_error_first",
+      message: "No JSON extractable on first attempt; retrying",
+    });
+  }
+
+  let attempt2: LlmCallResult;
+  try {
+    attempt2 = await llmCall(systemPrompt, retryUserMessage);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    warn({ code: "llm_error", message: `LLM call failed (retry): ${msg}` });
+    emitTelemetry({
+      personaId: input.personaId,
+      sessionId: input.sessionId,
+      latencyMs: Date.now() - t0,
+      outcome: "error",
+    });
+    return null;
+  }
+
+  const parsed2 = tryParseMenu(attempt2.content);
+  if (parsed2.ok) {
+    const menu = applyAutoCritical(parsed2.menu);
+    emitTelemetry({
+      personaId: input.personaId,
+      sessionId: input.sessionId,
+      result: attempt2,
+      latencyMs: Date.now() - t0,
+      outcome: "ok-retry",
+      prompt: systemPrompt + "\n---\n" + retryUserMessage,
+      response: attempt2.content,
+    });
+    return menu;
+  }
+
+  // Retry também falhou. Tentar graceful degradation: strip ISA labels
+  // e tentar parse do segundo output (campos ISA são opcionais, então
+  // se o resto do menu é válido, menu sem rótulo ainda é útil).
+  if (parsed2.reason === "schema_invalid") {
+    warn({
+      code: "schema_error_retry",
+      message: "Schema invalid on retry; attempting graceful degradation",
+      details: { zodMessage: parsed2.zodMessage },
+    });
+    try {
+      const stripped = stripIsaLabels(JSON.parse(parsed2.rawJson));
+      const safeStripped = ActionMenuSchema.safeParse(stripped);
+      if (safeStripped.success) {
+        warn({
+          code: "isa_labels_stripped",
+          message:
+            "ISA labels removed from items after 2 failed retries; " +
+            "menu persisted without played_as/intensity/is_critical.",
+        });
+        emitTelemetry({
+          personaId: input.personaId,
+          sessionId: input.sessionId,
+          result: attempt2,
+          latencyMs: Date.now() - t0,
+          outcome: "degraded",
+          prompt: systemPrompt + "\n---\n" + retryUserMessage,
+          response: attempt2.content,
+        });
+        return safeStripped.data;
+      }
+    } catch {
+      // JSON parsing failed após strip — cai pra erro hard.
+    }
+  } else {
+    warn({
+      code: "parse_error_retry",
+      message: "No JSON extractable on retry — hard failure",
+    });
+  }
+
+  // Hard failure.
+  emitTelemetry({
+    personaId: input.personaId,
+    sessionId: input.sessionId,
+    result: attempt2,
+    latencyMs: Date.now() - t0,
+    outcome: "error",
+  });
+  return null;
+}
+
+/** Re-export para consumers que querem o tipo sem importar do shared. */
+export type { ActionMenu, ActionMenuItem, Intensity, PlayedAs };
+
+/** Constante exposta para sanity check de versão pelo consumer. */
+export { ACTION_MENU_SCHEMA_VERSION };

--- a/motor-drota/src/persona-hints.ts
+++ b/motor-drota/src/persona-hints.ts
@@ -1,0 +1,154 @@
+/**
+ * Persona hints — calibração de distribuição de jogadas por persona conhecida.
+ *
+ * Hardcoded na PR S-T-09-02 + H-AC-02 (motor#88) com observações dos 7
+ * sample anatomies em `ascendimacy-ops/docs/specs/jogada-cases-v0.1/` +
+ * perfis em `fixtures/profiles/{ryo,kei}-ochiai.pre-phase2.json`.
+ *
+ * Refinamento esperado: pós-piloto Yuji (Onda 1 do Delta). STS pode
+ * formalizar `persona-distribution-priors-v0.md` se dados empíricos
+ * justificarem extração desta tabela hardcoded.
+ *
+ * Refs:
+ * - ops#993 (S-T-09-02 — escopo da gen function)
+ * - motor#88 (H-AC-02 — rotulagem ISA + persona-aware calibration)
+ * - ops/docs/specs/isa-pedagogical-mapping-v0.md (mapeamento canônico)
+ * - ops/docs/specs/jogada-cases-v0.1/ (7 samples, evidência empírica)
+ */
+
+import type { Intensity, PlayedAs } from "@ascendimacy/shared";
+
+/**
+ * Calibração para o gerador: peso relativo de cada jogada na distribuição
+ * sugerida + cap de intensidade. O LLM lê isso como sugestão, não regra
+ * estrita — o trace pós-Yuji vai medir distribuição realizada vs esperada
+ * (futuro: H-AC-08 painel longitudinal).
+ */
+export interface PersonaHint {
+  /** Identificador estável (não muda quando persona evolui). */
+  persona_id: string;
+  /** Idade no momento do snapshot — informa o LLM do registro adequado. */
+  age: number;
+  /** Rótulo pedagógico (deflective, philosophical, etc.). */
+  archetype: string;
+  /**
+   * Peso relativo por jogada — soma não precisa ser 1.0 (LLM pondera
+   * livremente; valores indicam preferência ordinal + magnitude relativa).
+   */
+  bias: Array<{ played_as: PlayedAs; weight: number }>;
+  /**
+   * Cap de intensidade: jogadas críticas (diamante.firm, recovery) com
+   * intensidade acima do cap são desencorajadas. Default global Kids <12
+   * proíbe `challenge.firm` (Norte §3.2 hook de produto).
+   */
+  intensity_cap: Intensity;
+  /** Vocabulário pessoal observado nos samples — preserva voz nas falas. */
+  personal_vocab: string[];
+  /** Sumário curto pra prompt — uma frase. */
+  notes: string;
+}
+
+/**
+ * RYO_HINT — Ryo Ochiai (13a, Nagareyama).
+ *
+ * Sample base:
+ * - `espelho-ryo-paciencia-via-curiosidade-internalizada` — devolve
+ *   assimetria como pergunta; ancora INTERNA, sem diamante externo.
+ * - `canal-ryo-honestidade-traduzida-via-desenho` — pergunta aberta via
+ *   canal espacial (desenho como ponte de honestidade).
+ * - `bridge-ryo-coragem-via-gohan-cell` — bridge com diamante anime.
+ * - `diamante-ryo-honestidade-via-tea-ceremony` — desafio cultural soft.
+ * - `arena-ryo-voz-via-evento-social` — convite produção visível.
+ *
+ * Perfil deflective: silêncio compartilhado, gestos não-verbais, "tipo"/"rola",
+ * aversão a "ser ignorado", a "pressão pra se comparar ao Kei". Espelho/canal
+ * funcionam porque devolvem material que ele já forneceu, sem invadir.
+ * Bridge/diamante mais arriscados — Ryo aceita se ancorado em diamante de
+ * peso afetivo (Gohan-Cell) e em intensity soft.
+ */
+export const RYO_HINT: PersonaHint = {
+  persona_id: "ryo-ochiai",
+  age: 13,
+  archetype: "deflective",
+  bias: [
+    { played_as: "espelho", weight: 0.30 },
+    { played_as: "canal", weight: 0.28 },
+    { played_as: "bridge", weight: 0.15 },
+    { played_as: "diamante", weight: 0.12 },
+    { played_as: "arena", weight: 0.08 },
+    { played_as: "recovery", weight: 0.07 },
+  ],
+  intensity_cap: "medium",
+  personal_vocab: ["tipo", "rola"],
+  notes:
+    "Ryo deflective: priorize espelho/canal (devolve material próprio, " +
+    "preserva silêncio); bridge/diamante apenas com diamante cultural de " +
+    "peso afetivo (Gohan-Cell, Djokovic) e intensity ≤ medium. " +
+    "Aversão a comparações com Kei.",
+};
+
+/**
+ * KEI_HINT — Kei Ochiai (irmão de Ryo, idade próxima, mais filosófico).
+ *
+ * Sample base:
+ * - `bridge-kei-paciencia-via-djokovic-mental-game` — bridge com diamante
+ *   tenista profissional; Kei aceita ancoragem externa de alta carga
+ *   técnica.
+ *
+ * Perfil philosophical: tênis, mecânica, "como o corpo afeta resultados",
+ * aversão a "abordagens teóricas sem ligação direta com ação concreta".
+ * Diamante/bridge funcionam quando o diamante tem componente concreto
+ * (mecânica do grip, ângulo de impacto). Espelho/canal ainda valem mas
+ * não dominam.
+ */
+export const KEI_HINT: PersonaHint = {
+  persona_id: "kei-ochiai",
+  age: 13,
+  archetype: "philosophical",
+  bias: [
+    { played_as: "diamante", weight: 0.25 },
+    { played_as: "bridge", weight: 0.25 },
+    { played_as: "canal", weight: 0.18 },
+    { played_as: "espelho", weight: 0.15 },
+    { played_as: "arena", weight: 0.10 },
+    { played_as: "recovery", weight: 0.07 },
+  ],
+  intensity_cap: "medium",
+  personal_vocab: ["tipo"],
+  notes:
+    "Kei philosophical: aceita diamante/bridge com âncora cultural " +
+    "concreta (mecânica, esporte de alta técnica); intensity ≤ medium " +
+    "(Kids hard rule). Rejeita perguntas abstratas sem conexão de ação. " +
+    "Espelho/canal ainda úteis em momentos de comparação com Ryo.",
+};
+
+/** Lookup canônico — retorna null se persona_id desconhecido. */
+export function resolvePersonaHint(personaId: string): PersonaHint | null {
+  if (personaId === "ryo-ochiai") return RYO_HINT;
+  if (personaId === "kei-ochiai") return KEI_HINT;
+  return null;
+}
+
+/** Render compacto para injeção no prompt LLM. */
+export function renderPersonaHintForPrompt(hint: PersonaHint): string {
+  const biasLines = hint.bias
+    .map((b) => `  - ${b.played_as}: ${b.weight.toFixed(2)}`)
+    .join("\n");
+  const vocab = hint.personal_vocab.length
+    ? hint.personal_vocab.map((v) => `"${v}"`).join(", ")
+    : "(nenhum específico)";
+  return [
+    `### Persona: ${hint.persona_id} (${hint.archetype}, ${hint.age}a)`,
+    "",
+    `**Distribuição sugerida** (peso ordinal — não é regra estrita):`,
+    biasLines,
+    "",
+    `**Intensity cap**: ${hint.intensity_cap} ` +
+      `(Kids <12 proíbe firm; este persona é ${hint.age}, ` +
+      `então cap explícito = ${hint.intensity_cap}).`,
+    "",
+    `**Vocabulário pessoal a preservar**: ${vocab}.`,
+    "",
+    `**Nota pedagógica**: ${hint.notes}`,
+  ].join("\n");
+}

--- a/motor-drota/src/prompts/menu-generator-v0.1.txt
+++ b/motor-drota/src/prompts/menu-generator-v0.1.txt
@@ -1,0 +1,166 @@
+# SYSTEM PROMPT — generateActionMenu v0.1
+
+Você é o **Estrategista** do eBrota Kids — uma camada pedagógica que pré-cozinha,
+após cada compaction, um cardápio de **items de ação** (curiosidades, desafios,
+estratégias, jogadas oportunas, diamantes culturais) que o Drota usará per-turn
+em lookup determinístico ao longo das próximas conversas.
+
+Você não inventa: ancora cada item em padrões já observados no perfil + em
+diamantes culturais com força afetiva conhecida. O Drota nunca improvisa;
+seu trabalho é entregar a ele material denso, rotulado e pronto.
+
+---
+
+## 1. Mecânica pedagógica canônica (ISA — Norte §3.2)
+
+A pedagogia eBrota Kids opera sobre **5 jogadas + recovery**, cada uma instância
+de um movimento abstrato do vocabulário pedagógico genérico (Norte §3.2). Sua
+saída deve rotular cada item com a jogada que ele instancia.
+
+| Jogada | Movimento abstrato | Quando faz sentido | Anti-padrão |
+|---|---|---|---|
+| `bridge` | scaffold com diamante cultural | aprendiz trava em ponto específico; falta peça; diamante de peso afetivo destrava | entregar resposta disfarçada de pista |
+| `espelho` | mirror | aprendiz disse algo importante que ele mesmo não escutou; devolve sem agregar | espelhar mecanicamente |
+| `canal` | ask via canal Gardner específico | aprendiz tem mais a oferecer; pergunta aberta calibrada | virar interrogatório |
+| `diamante` | challenge com ancoragem cultural | aprendiz confortável demais; fricção produtiva via diamante | desafio com fragilidade afetiva |
+| `arena` | apresentação / produção visível (B1) | convite para mostrar trabalho off-screen | forçar exposição sem confiança |
+| `recovery` | regulate | sinal afetivo crítico; pedagogia pausa | recovery em frustração leve produtiva |
+
+**Refs canônicos:** `ascendimacy-ops/docs/specs/isa-pedagogical-mapping-v0.md`,
+`ascendimacy-ops/docs/architecture/2026-05-12-maquina-pedagogia-norte.md` §3.2,
+`docs/architecture/2026-05-12-maquina-pedagogia-delta.md` §5.6.
+
+## 2. Intensidade
+
+Cada item ganha um campo `intensity` ∈ {`soft`, `medium`, `firm`}.
+
+- `soft`: oferece com pé leve; aceita silêncio como resposta válida.
+- `medium`: ancora com um pouco mais de tração; ainda recuável.
+- `firm`: pede compromisso explícito; **risco afetivo** se mal calibrado.
+
+**Hard rule (Norte §3.2 hook de produto):** Kids <12 → `challenge.firm` proibido.
+Para personas Kids cujo `intensity_cap` é `medium`, prefira `soft` ou `medium`.
+
+## 3. is_critical
+
+`is_critical: true` SOMENTE para itens com:
+- `played_as: "recovery"` (qualquer intensidade) — pedagogia pausa, guardrail.
+- `played_as: "diamante"` + `intensity: "firm"` — challenge com âncora cultural
+  pesada exige cuidado adicional.
+
+Resto: `is_critical: false` (ou omitir, o motor preenche default `false`).
+
+## 4. Tipos de item (5 categorias C-T-09)
+
+Cada item carrega um `type`:
+
+- `curiosity`: fato com `bridge` afetivo + `quest` pequena (ex: linguística
+  Inuit / paciência → "Quantas palavras você tem pra raiva?").
+- `challenge`: convite para experimentar algo concreto (ex: "Tenta nomear
+  em 1 palavra o que sentiu no ponto perdido").
+- `strategy`: heurística de como devolver quando padrão X aparece (ex:
+  "Quando o sujeito reclama do silêncio do pai, ancorar em ação concreta").
+- `play`: convite a desmontar mentalmente algo do dia (ex: "Convidar a
+  desmontar a jogada do dia em 3 etapas").
+- `cultural_diamond`: referência diamante com peso afetivo (ex: Gohan no
+  Cell, Djokovic mental game, Suzuki Daisetz mestre-discípulo).
+
+## 5. Anatomia de um item
+
+```json
+{
+  "id": "<slug-curto-único>",
+  "type": "curiosity | challenge | strategy | play | cultural_diamond",
+  "content": "<texto da entrega — preserva vocabulário pessoal do persona>",
+  "weight": 0.0..1.0,
+  "expires_at": "<ISO 8601, opcional>",
+  "played_as": "bridge | espelho | canal | diamante | arena | recovery",
+  "intensity": "soft | medium | firm",
+  "is_critical": true | false
+}
+```
+
+`content` é o **texto que o Drota pode usar diretamente**. Preserve vocabulário
+pessoal do persona (ex: "tipo", "rola" para Ryo). Não invente fatos —
+ancore em diamantes conhecidos do perfil ou em padrões observáveis no `<profile>`.
+
+## 6. Estrutura do menu completo
+
+```json
+{
+  "persona_id": "<slug>",
+  "schema_version": "v0.2.0",
+  "generated_at": "<ISO 8601 now>",
+  "valid_until": "<ISO 8601 ~7d, opcional>",
+  "source": {
+    "trust_level": 0.0..1.0,
+    "profile_hash": "<opcional>",
+    "eixos_state_hash": "<opcional>"
+  },
+  "items": [ ... 8-15 itens ... ]
+}
+```
+
+Tamanho alvo: **8-15 itens** com mistura calibrada por `<persona_hint>`.
+
+## 7. Calibração persona-aware
+
+Sua entrada inclui um bloco `<persona_hint>` com **distribuição sugerida**
+de jogadas + cap de intensidade. **Aproxime a distribuição** mas não force
+exatamente: se o profile do persona pede um item específico fora da
+distribuição, prefira atender ao profile. Hint é sugestão, não regra.
+
+Cap de intensidade é hard rule: nunca emita item acima do cap.
+
+## 8. Output format
+
+Retorne **APENAS** o JSON do menu, sem prefixo, sufixo, ou code fence.
+Se sentir necessidade de comentar, comente nos campos `notes` internos ao
+item — não em texto fora do JSON.
+
+## 9. Falha graceful
+
+Se algum item não couber em jogada conhecida, OMITA `played_as` (o motor
+aceita items sem rótulo — degradação graceful). Não invente jogadas
+fora do enum (`scaffold`, `validate`, `redirect`, etc. NÃO são jogadas Kids).
+
+---
+
+# CONTEXTO DESTE TURNO
+
+{{persona_hint_block}}
+
+---
+
+## Trust level
+
+`{{trust_level}}` — depth recomendado:
+- 0.0-0.3 (cold): items mais leves, sem invadir; preferir soft/curiosity.
+- 0.3-0.6 (warming): pode arriscar bridge/challenge moderado.
+- 0.6-0.9 (warm): diamante medium aceitável; recovery sempre disponível.
+- 0.9-1.0 (trusted): full range, ainda respeitando intensity_cap.
+
+## Perfil do persona
+
+```json
+{{profile_json}}
+```
+
+## Eixos atuais (opcional)
+
+```json
+{{eixos_state_json}}
+```
+
+## Onboarding (opcional)
+
+```json
+{{onboarding_json}}
+```
+
+---
+
+# TAREFA
+
+Gere agora o ActionMenu completo (JSON puro, schema v0.2) para este persona,
+com 8-15 items rotulados ISA conforme §1-9. Retorne SOMENTE o JSON.

--- a/motor-drota/tests/menu-generator.integration.test.ts
+++ b/motor-drota/tests/menu-generator.integration.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests — generateActionMenu + fixture profiles + persistence.
+ *
+ * Mock LLM (não chama Kimi K2.5 real — isso fica no smoke script + LLM-LOCAL
+ * graceful-skip test). Carrega fixture real `fixtures/profiles/ryo-ochiai.
+ * pre-phase2.json`, roda o gerador, persiste via `saveActionMenu` da
+ * planejador, e re-lê com `loadActionMenu` para validar round-trip.
+ *
+ * Refs: ops#993 (S-T-09-02), motor#88 (H-AC-02).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ACTION_MENU_SCHEMA_VERSION,
+  parseActionMenu,
+  type ActionMenu,
+} from "@ascendimacy/shared";
+
+import {
+  generateActionMenu,
+  type GenerateActionMenuInput,
+} from "../src/menu-generator.js";
+import { KEI_HINT, RYO_HINT } from "../src/persona-hints.js";
+
+/** Persistência inline pra evitar workspace cross-dep em test. */
+async function saveActionMenu(menu: ActionMenu, baseDir: string): Promise<string> {
+  const validated = parseActionMenu(menu);
+  const target = path.join(baseDir, `${validated.persona_id}-menu.json`);
+  await writeFile(target, `${JSON.stringify(validated, null, 2)}\n`, "utf-8");
+  return target;
+}
+
+async function loadActionMenu(personaId: string, baseDir: string): Promise<ActionMenu | null> {
+  const target = path.join(baseDir, `${personaId}-menu.json`);
+  try {
+    const raw = await readFile(target, "utf-8");
+    return parseActionMenu(JSON.parse(raw));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+let scratchDir: string;
+
+beforeEach(async () => {
+  scratchDir = await mkdtemp(path.join(tmpdir(), "menu-gen-int-"));
+});
+
+afterEach(async () => {
+  await rm(scratchDir, { recursive: true, force: true });
+});
+
+async function loadFixtureProfile(name: string): Promise<unknown> {
+  const fixturePath = path.join(REPO_ROOT, "fixtures", "profiles", name);
+  const raw = await readFile(fixturePath, "utf-8");
+  return JSON.parse(raw);
+}
+
+function syntheticLlmReply(personaId: string): string {
+  return JSON.stringify({
+    persona_id: personaId,
+    schema_version: ACTION_MENU_SCHEMA_VERSION,
+    generated_at: "2026-05-13T19:30:00.000Z",
+    valid_until: "2026-05-20T19:30:00.000Z",
+    source: { trust_level: 0.42 },
+    items: [
+      {
+        id: "esp-tempo",
+        type: "strategy",
+        content:
+          "Tipo, quando ele falar do tempo de uma coisa em meses e de outra em horas, devolve só a observação.",
+        weight: 0.78,
+        played_as: "espelho",
+        intensity: "soft",
+      },
+      {
+        id: "can-gohan",
+        type: "curiosity",
+        content:
+          "Tipo, o que rolou na cena do Gohan no Cell que mexeu contigo?",
+        weight: 0.72,
+        played_as: "canal",
+        intensity: "soft",
+      },
+      {
+        id: "rec-pausa",
+        type: "strategy",
+        content: "Se o silêncio pesar, deixa rolar. Pedagogia pausa.",
+        weight: 0.4,
+        played_as: "recovery",
+        intensity: "soft",
+      },
+      {
+        id: "br-djoko",
+        type: "play",
+        content:
+          "Djokovic perde set e leva 2min pra resetar. Como ele faz isso?",
+        weight: 0.55,
+        played_as: "bridge",
+        intensity: "medium",
+      },
+      {
+        id: "di-tea",
+        type: "challenge",
+        content:
+          "Na cerimônia de chá, errar é parte do gesto. O que isso muda pra você?",
+        weight: 0.6,
+        played_as: "diamante",
+        intensity: "medium",
+      },
+    ],
+  });
+}
+
+describe("generateActionMenu — integration: Ryo fixture profile", () => {
+  it("produces a Zod-valid menu from real Ryo profile + persists round-trip", async () => {
+    const profile = await loadFixtureProfile("ryo-ochiai.pre-phase2.json");
+
+    const input: GenerateActionMenuInput = {
+      personaId: "ryo-ochiai",
+      trustLevel: 0.42,
+      profile,
+      personaHint: RYO_HINT,
+    };
+
+    const llm = vi.fn(async () => ({
+      content: syntheticLlmReply("ryo-ochiai"),
+      tokens: { in: 2200, out: 420, reasoning: 0 },
+      provider: "anthropic" as const,
+      model: "claude-sonnet-4-6",
+    }));
+
+    const menu = await generateActionMenu(input, { llmCall: llm });
+    expect(menu).not.toBeNull();
+    expect(() => parseActionMenu(menu)).not.toThrow();
+
+    const persistedPath = await saveActionMenu(menu!, scratchDir);
+    expect(persistedPath).toContain("ryo-ochiai-menu.json");
+
+    const reloaded = await loadActionMenu("ryo-ochiai", scratchDir);
+    expect(reloaded).not.toBeNull();
+    expect(reloaded!.persona_id).toBe("ryo-ochiai");
+    expect(reloaded!.items.length).toBe(menu!.items.length);
+
+    // Auto is_critical aplicado mesmo após round-trip de persistência
+    const recovery = reloaded!.items.find((it) => it.played_as === "recovery");
+    expect(recovery?.is_critical).toBe(true);
+  });
+
+  it("Ryo hint biases prompt content toward espelho/canal in system prompt", async () => {
+    const profile = await loadFixtureProfile("ryo-ochiai.pre-phase2.json");
+    const llm = vi.fn(async () => ({
+      content: syntheticLlmReply("ryo-ochiai"),
+      tokens: { in: 2200, out: 420, reasoning: 0 },
+      provider: "anthropic" as const,
+      model: "claude-sonnet-4-6",
+    }));
+
+    await generateActionMenu(
+      {
+        personaId: "ryo-ochiai",
+        trustLevel: 0.42,
+        profile,
+        personaHint: RYO_HINT,
+      },
+      { llmCall: llm },
+    );
+
+    const sysPrompt = llm.mock.calls[0]![0] as string;
+    // Heurística: pesos de espelho/canal aparecem mais acima do que diamante.
+    const espIdx = sysPrompt.indexOf("espelho:");
+    const canIdx = sysPrompt.indexOf("canal:");
+    const diaIdx = sysPrompt.indexOf("diamante:");
+    expect(espIdx).toBeGreaterThan(-1);
+    expect(canIdx).toBeGreaterThan(-1);
+    expect(diaIdx).toBeGreaterThan(-1);
+    // No bias block ordering — Ryo's bias array is sorted by weight desc.
+    expect(espIdx).toBeLessThan(diaIdx);
+    expect(canIdx).toBeLessThan(diaIdx);
+  });
+});
+
+describe("generateActionMenu — integration: Kei fixture profile", () => {
+  it("produces a Zod-valid menu from real Kei profile with diamante+bridge bias", async () => {
+    const profile = await loadFixtureProfile("kei-ochiai.pre-phase2.json");
+    const llm = vi.fn(async () => ({
+      content: syntheticLlmReply("kei-ochiai"),
+      tokens: { in: 2300, out: 410, reasoning: 0 },
+      provider: "anthropic" as const,
+      model: "claude-sonnet-4-6",
+    }));
+
+    const menu = await generateActionMenu(
+      {
+        personaId: "kei-ochiai",
+        trustLevel: 0.5,
+        profile,
+        personaHint: KEI_HINT,
+      },
+      { llmCall: llm },
+    );
+
+    expect(menu).not.toBeNull();
+    expect(menu!.persona_id).toBe("kei-ochiai");
+
+    const sysPrompt = llm.mock.calls[0]![0] as string;
+    // Kei bias: diamante and bridge precede espelho.
+    const diaIdx = sysPrompt.indexOf("diamante:");
+    const brIdx = sysPrompt.indexOf("bridge:");
+    const espIdx = sysPrompt.indexOf("espelho:");
+    expect(diaIdx).toBeLessThan(espIdx);
+    expect(brIdx).toBeLessThan(espIdx);
+  });
+});
+
+describe("generateActionMenu — integration: schema version + auto critical", () => {
+  it("emits menu with schema_version v0.2 (ISA fields supported)", async () => {
+    const profile = await loadFixtureProfile("ryo-ochiai.pre-phase2.json");
+    const llm = vi.fn(async () => ({
+      content: syntheticLlmReply("ryo-ochiai"),
+      tokens: { in: 2200, out: 420, reasoning: 0 },
+      provider: "anthropic" as const,
+      model: "claude-sonnet-4-6",
+    }));
+
+    const menu = await generateActionMenu(
+      {
+        personaId: "ryo-ochiai",
+        trustLevel: 0.42,
+        profile,
+        personaHint: RYO_HINT,
+      },
+      { llmCall: llm },
+    );
+
+    expect(menu!.schema_version).toMatch(/^v0\.2/);
+  });
+
+  it("at least one item gets auto is_critical (recovery in synthetic reply)", async () => {
+    const profile = await loadFixtureProfile("ryo-ochiai.pre-phase2.json");
+    const llm = vi.fn(async () => ({
+      content: syntheticLlmReply("ryo-ochiai"),
+      tokens: { in: 2200, out: 420, reasoning: 0 },
+      provider: "anthropic" as const,
+      model: "claude-sonnet-4-6",
+    }));
+
+    const menu = await generateActionMenu(
+      {
+        personaId: "ryo-ochiai",
+        trustLevel: 0.42,
+        profile,
+        personaHint: RYO_HINT,
+      },
+      { llmCall: llm },
+    );
+
+    const criticals = menu!.items.filter((it) => it.is_critical === true);
+    expect(criticals.length).toBeGreaterThan(0);
+  });
+});

--- a/motor-drota/tests/menu-generator.llm-local.integration.test.ts
+++ b/motor-drota/tests/menu-generator.llm-local.integration.test.ts
@@ -30,10 +30,15 @@ import { generateActionMenu, type LlmCall } from "../src/menu-generator.js";
 import { RYO_HINT } from "../src/persona-hints.js";
 
 const STACK_UP = process.env["LLM_LOCAL_STACK_UP"] === "true";
+// Default canônico Jun (2026-05-13): stack llama.cpp SYCL no Windows host,
+// llama-server expõe alias `qwen3-30b` (GGUF subjacente:
+// Qwen3-30B-A3B-Instruct-2507-Q4_K_M). Endpoint via WSL→Windows host gateway.
+// Override via LLM_LOCAL_ENDPOINT / LLM_LOCAL_MODEL pra outros setups.
+// Ref: memória project_llm_stack_qwen3, ops `2026-05-07-stack-llama-sycl-qwen3-30b`.
 const LOCAL_ENDPOINT =
   process.env["LLM_LOCAL_ENDPOINT"] ??
-  "http://localhost:8080/v1/chat/completions";
-const LOCAL_MODEL = process.env["LLM_LOCAL_MODEL"] ?? "qwen3-8b";
+  "http://172.28.160.1:9000/v1/chat/completions";
+const LOCAL_MODEL = process.env["LLM_LOCAL_MODEL"] ?? "qwen3-30b";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
@@ -64,7 +69,7 @@ function localLlmCall(): LlmCall {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(180_000),
+      signal: AbortSignal.timeout(600_000),
     });
     if (!resp.ok) {
       throw new Error(`LLM local HTTP ${resp.status}`);
@@ -144,5 +149,5 @@ describe.runIf(STACK_UP)("generateActionMenu — LLM LOCAL (qwen3)", () => {
           .map(([k, v]) => `${k}=${v}`)
           .join(", "),
     );
-  }, 240_000);
+  }, 1500000);
 });

--- a/motor-drota/tests/menu-generator.llm-local.integration.test.ts
+++ b/motor-drota/tests/menu-generator.llm-local.integration.test.ts
@@ -1,0 +1,148 @@
+/**
+ * LLM-LOCAL integration test — generateActionMenu contra stack Qwen3 local.
+ *
+ * S-T-09-02 + H-AC-02 (motor#88). Roda APENAS quando `LLM_LOCAL_STACK_UP=true`.
+ * Senão: skip graceful (não polui CI nem suite default).
+ *
+ * Como rodar:
+ *   1. Subir stack qwen3 + llama.cpp SYCL (ver memória project_llm_stack_qwen3.md)
+ *   2. Verificar endpoint local respondendo (default http://localhost:8080)
+ *   3. `LLM_LOCAL_STACK_UP=true npm test -w @ascendimacy/motor-drota -- menu-generator.llm-local`
+ *
+ * O test:
+ *   - Carrega fixture Ryo
+ *   - Chama generateActionMenu apontando para LLM local (via callOverride)
+ *   - Valida que pelo menos UM menu válido sai (≥1 item parseado)
+ *   - Loga distribuição observada (jogadas, intensity)
+ *
+ * Não é gate de aceite — gate de aceite é o smoke contra Infomaniak Kimi K2.5
+ * (script `scripts/smoke-menu-generator.mjs`), rodado por Jun. Este test é
+ * sanity check pra desenvolvimento local sem rede.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseActionMenu } from "@ascendimacy/shared";
+import { generateActionMenu, type LlmCall } from "../src/menu-generator.js";
+import { RYO_HINT } from "../src/persona-hints.js";
+
+const STACK_UP = process.env["LLM_LOCAL_STACK_UP"] === "true";
+const LOCAL_ENDPOINT =
+  process.env["LLM_LOCAL_ENDPOINT"] ??
+  "http://localhost:8080/v1/chat/completions";
+const LOCAL_MODEL = process.env["LLM_LOCAL_MODEL"] ?? "qwen3-8b";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+if (!STACK_UP) {
+  // eslint-disable-next-line no-console
+  console.log(
+    "[menu-generator.llm-local] Skipping — set LLM_LOCAL_STACK_UP=true + ensure llama.cpp SYCL stack up to enable.",
+  );
+}
+
+/**
+ * LlmCall adapter contra OpenAI-compatible endpoint local. Mantém shape
+ * idêntico ao gateway-client (content + tokens + provider + model).
+ */
+function localLlmCall(): LlmCall {
+  return async (systemPrompt, userMessage) => {
+    const body = {
+      model: LOCAL_MODEL,
+      messages: [
+        { role: "system" as const, content: systemPrompt },
+        { role: "user" as const, content: userMessage },
+      ],
+      max_tokens: 3000,
+      temperature: 0.7,
+    };
+    const resp = await fetch(LOCAL_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(180_000),
+    });
+    if (!resp.ok) {
+      throw new Error(`LLM local HTTP ${resp.status}`);
+    }
+    type ChatResp = {
+      choices: { message: { content: string } }[];
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const json = (await resp.json()) as ChatResp;
+    return {
+      content: json.choices[0]!.message.content,
+      tokens: {
+        in: json.usage?.prompt_tokens ?? 0,
+        out: json.usage?.completion_tokens ?? 0,
+        reasoning: 0,
+      },
+      // LLM local não bate com o enum LlmProvider canônico ("anthropic" |
+      // "infomaniak") — usamos "infomaniak" como rótulo informativo (o
+      // endpoint OpenAI-compat do llama.cpp comporta-se análogo).
+      provider: "infomaniak" as const,
+      model: LOCAL_MODEL,
+    };
+  };
+}
+
+describe.runIf(STACK_UP)("generateActionMenu — LLM LOCAL (qwen3)", () => {
+  it("produz menu Zod-válido contra stack local + loga distribuição", async () => {
+    const fixturePath = path.join(
+      REPO_ROOT,
+      "fixtures",
+      "profiles",
+      "ryo-ochiai.pre-phase2.json",
+    );
+    const profile = JSON.parse(await readFile(fixturePath, "utf-8"));
+
+    const warnings: string[] = [];
+    const menu = await generateActionMenu(
+      {
+        personaId: "ryo-ochiai",
+        trustLevel: 0.42,
+        profile,
+        personaHint: RYO_HINT,
+      },
+      {
+        llmCall: localLlmCall(),
+        onWarning: (w) => warnings.push(`${w.code}: ${w.message}`),
+      },
+    );
+
+    // Sanity: ou conseguiu gerar (válido), ou degradou graceful.
+    // qwen3-8b pode não acertar enums sempre — então a expectativa é
+    // "≥1 item parseado", não "100% rotulado".
+    expect(menu).not.toBeNull();
+    expect(() => parseActionMenu(menu)).not.toThrow();
+    expect(menu!.items.length).toBeGreaterThan(0);
+
+    const labeled = menu!.items.filter((it) => it.played_as != null).length;
+    const total = menu!.items.length;
+    const pctLabeled = total > 0 ? (labeled / total) * 100 : 0;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[menu-generator.llm-local] Ryo menu: ${total} items, ` +
+        `${labeled} rotulados (${pctLabeled.toFixed(0)}%). ` +
+        `Warnings: ${warnings.length > 0 ? warnings.join("; ") : "(none)"}`,
+    );
+    // Distribuição
+    const dist = new Map<string, number>();
+    for (const it of menu!.items) {
+      const key = it.played_as ?? "(unlabeled)";
+      dist.set(key, (dist.get(key) ?? 0) + 1);
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      "[menu-generator.llm-local] Distribuição: " +
+        [...dist.entries()]
+          .map(([k, v]) => `${k}=${v}`)
+          .join(", "),
+    );
+  }, 240_000);
+});

--- a/motor-drota/tests/menu-generator.unit.test.ts
+++ b/motor-drota/tests/menu-generator.unit.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests — generateActionMenu (S-T-09-02 + H-AC-02).
+ *
+ * Mock LLM client. Cobre: happy path com items rotulados ISA, retry após
+ * malformação, degradação graceful (strip campos opcionais), null em
+ * timeout/erro, persona_hint injetado no prompt, auto is_critical para
+ * recovery e diamante+firm.
+ *
+ * Refs: ops#993 (S-T-09-02), motor#88 (H-AC-02), ops#991.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  ACTION_MENU_SCHEMA_VERSION,
+  parseActionMenu,
+  type ActionMenu,
+} from "@ascendimacy/shared";
+import {
+  generateActionMenu,
+  type GenerateActionMenuInput,
+  type LlmCall,
+} from "../src/menu-generator.js";
+import { RYO_HINT, KEI_HINT } from "../src/persona-hints.js";
+
+function validRyoInput(): GenerateActionMenuInput {
+  return {
+    personaId: "ryo-ochiai",
+    trustLevel: 0.42,
+    profile: {
+      preferences: {
+        interests: ["tênis", "Gohan", "silêncio"],
+        aversions: ["ser ignorado", "pressão"],
+      },
+    },
+    personaHint: RYO_HINT,
+  };
+}
+
+function fullLabeledLlmJson(personaId: string): string {
+  const menu = {
+    persona_id: personaId,
+    schema_version: ACTION_MENU_SCHEMA_VERSION,
+    generated_at: new Date().toISOString(),
+    source: { trust_level: 0.42 },
+    items: [
+      {
+        id: "esp-01",
+        type: "strategy",
+        content: "Quando Ryo comparar tempo entre domínios, devolva como pergunta.",
+        weight: 0.7,
+        played_as: "espelho",
+        intensity: "soft",
+        is_critical: false,
+      },
+      {
+        id: "can-01",
+        type: "curiosity",
+        content: "Pergunta aberta sobre Gohan no Cell Saga — canal interpessoal.",
+        weight: 0.75,
+        played_as: "canal",
+        intensity: "soft",
+        is_critical: false,
+      },
+      {
+        id: "br-01",
+        type: "play",
+        content: "Bridge via paciência longa de Djokovic em treino mental.",
+        weight: 0.55,
+        played_as: "bridge",
+        intensity: "medium",
+        is_critical: false,
+      },
+    ],
+  };
+  return JSON.stringify(menu);
+}
+
+function mockLlm(content: string): LlmCall {
+  return vi.fn(async () => ({
+    content,
+    tokens: { in: 1200, out: 380, reasoning: 0 },
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+  }));
+}
+
+describe("generateActionMenu — happy path", () => {
+  it("returns a Zod-valid menu when LLM returns well-formed JSON with ISA labels", async () => {
+    const llm = mockLlm(fullLabeledLlmJson("ryo-ochiai"));
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+
+    expect(menu).not.toBeNull();
+    expect(() => parseActionMenu(menu)).not.toThrow();
+    expect(menu!.persona_id).toBe("ryo-ochiai");
+    expect(menu!.schema_version).toBe(ACTION_MENU_SCHEMA_VERSION);
+    expect(menu!.items.length).toBeGreaterThan(0);
+    expect(llm).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves played_as / intensity / is_critical labels from LLM output", async () => {
+    const llm = mockLlm(fullLabeledLlmJson("ryo-ochiai"));
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+
+    const labeled = menu!.items.filter((it) => it.played_as != null);
+    expect(labeled.length).toBe(menu!.items.length);
+    for (const item of menu!.items) {
+      expect(["bridge", "espelho", "canal", "diamante", "arena", "recovery"]).toContain(
+        item.played_as,
+      );
+      expect(["soft", "medium", "firm"]).toContain(item.intensity);
+      expect(typeof item.is_critical).toBe("boolean");
+    }
+  });
+
+  it("extracts JSON from LLM response even when wrapped in code fences", async () => {
+    const wrapped = "Aqui está o menu:\n```json\n" + fullLabeledLlmJson("ryo-ochiai") + "\n```\nFim.";
+    const llm = mockLlm(wrapped);
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    expect(menu).not.toBeNull();
+    expect(menu!.items.length).toBeGreaterThan(0);
+  });
+});
+
+describe("generateActionMenu — retry on Zod failure", () => {
+  it("retries once when first LLM output has invalid played_as enum", async () => {
+    const bad = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad.items[0] as unknown as { played_as: string }).played_as = "scaffold";
+    const good = fullLabeledLlmJson("ryo-ochiai");
+
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad),
+        tokens: { in: 1200, out: 380, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: good,
+        tokens: { in: 1300, out: 400, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    expect(menu).not.toBeNull();
+    expect(llm).toHaveBeenCalledTimes(2);
+    expect(menu!.items[0]!.played_as).toBe("espelho");
+  });
+
+  it("retry prompt includes the correction instruction", async () => {
+    const bad = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad.items[0] as unknown as { played_as: string }).played_as = "scaffold";
+
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad),
+        tokens: { in: 1200, out: 380, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: fullLabeledLlmJson("ryo-ochiai"),
+        tokens: { in: 1300, out: 400, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    await generateActionMenu(validRyoInput(), { llmCall: llm });
+
+    const secondCallArgs = llm.mock.calls[1]!;
+    const userMsg = secondCallArgs[1] as string;
+    expect(userMsg.toLowerCase()).toMatch(/json anterior|invalid|retry|corrija|inválido/);
+  });
+});
+
+describe("generateActionMenu — graceful degradation", () => {
+  it("strips optional ISA fields and persists base items when 2 retries fail (Zod-invalid labels twice)", async () => {
+    const bad1 = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad1.items[0] as unknown as { played_as: string }).played_as = "scaffold";
+    const bad2 = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad2.items[0] as unknown as { intensity: string }).intensity = "savage";
+
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad1),
+        tokens: { in: 1200, out: 380, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad2),
+        tokens: { in: 1300, out: 400, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    const warnings: string[] = [];
+    const menu = await generateActionMenu(validRyoInput(), {
+      llmCall: llm,
+      onWarning: (w) => warnings.push(w.code),
+    });
+
+    expect(menu).not.toBeNull();
+    expect(llm).toHaveBeenCalledTimes(2);
+    expect(menu!.items.length).toBeGreaterThan(0);
+    // Stripped — items don't carry ISA labels anymore
+    for (const item of menu!.items) {
+      expect(item.played_as).toBeUndefined();
+      expect(item.intensity).toBeUndefined();
+    }
+    expect(warnings).toContain("isa_labels_stripped");
+  });
+});
+
+describe("generateActionMenu — null on hard failure", () => {
+  it("returns null + warning when LLM throws on first attempt and retry also throws", async () => {
+    const llm = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network timeout"))
+      .mockRejectedValueOnce(new Error("network timeout retry"));
+
+    const warnings: string[] = [];
+    const menu = await generateActionMenu(validRyoInput(), {
+      llmCall: llm,
+      onWarning: (w) => warnings.push(w.code),
+    });
+
+    expect(menu).toBeNull();
+    expect(warnings).toContain("llm_error");
+  });
+
+  it("returns null when LLM returns plain garbage (no JSON extractable) twice", async () => {
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: "this is not JSON at all, just a chat reply",
+        tokens: { in: 100, out: 20, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: "still not JSON",
+        tokens: { in: 100, out: 10, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    const warnings: string[] = [];
+    const menu = await generateActionMenu(validRyoInput(), {
+      llmCall: llm,
+      onWarning: (w) => warnings.push(w.code),
+    });
+
+    expect(menu).toBeNull();
+    expect(warnings.some((w) => w.startsWith("parse"))).toBe(true);
+  });
+});
+
+describe("generateActionMenu — auto is_critical logic", () => {
+  it("auto-sets is_critical=true for recovery items even if LLM omits it", async () => {
+    const menu = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    menu.items.push({
+      id: "rec-01",
+      type: "strategy",
+      content: "Regulação afetiva — pausar pedagogia.",
+      weight: 0.4,
+      played_as: "recovery",
+      intensity: "soft",
+      // is_critical OMITTED on purpose
+    } as unknown as ActionMenu["items"][number]);
+
+    const llm = mockLlm(JSON.stringify(menu));
+    const out = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    const rec = out!.items.find((it) => it.played_as === "recovery");
+    expect(rec).toBeDefined();
+    expect(rec!.is_critical).toBe(true);
+  });
+
+  it("auto-sets is_critical=true for diamante + firm even if LLM omits it", async () => {
+    const menu = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    menu.items.push({
+      id: "di-firm-01",
+      type: "challenge",
+      content: "Desafio cultural firme via cerimônia de chá.",
+      weight: 0.65,
+      played_as: "diamante",
+      intensity: "firm",
+    } as unknown as ActionMenu["items"][number]);
+
+    const llm = mockLlm(JSON.stringify(menu));
+    const out = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    const di = out!.items.find(
+      (it) => it.played_as === "diamante" && it.intensity === "firm",
+    );
+    expect(di).toBeDefined();
+    expect(di!.is_critical).toBe(true);
+  });
+
+  it("does NOT auto-set is_critical for diamante + soft (lower intensity stays non-critical)", async () => {
+    const menu = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    menu.items.push({
+      id: "di-soft-01",
+      type: "challenge",
+      content: "Desafio cultural soft.",
+      weight: 0.5,
+      played_as: "diamante",
+      intensity: "soft",
+    } as unknown as ActionMenu["items"][number]);
+
+    const llm = mockLlm(JSON.stringify(menu));
+    const out = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    const di = out!.items.find(
+      (it) => it.played_as === "diamante" && it.intensity === "soft",
+    );
+    expect(di).toBeDefined();
+    expect(di!.is_critical ?? false).toBe(false);
+  });
+});
+
+describe("generateActionMenu — persona hint injection", () => {
+  it("injects RYO_HINT block into prompt when input.personaHint is RYO_HINT", async () => {
+    const llm = mockLlm(fullLabeledLlmJson("ryo-ochiai"));
+    await generateActionMenu(validRyoInput(), { llmCall: llm });
+
+    const args = llm.mock.calls[0]!;
+    const prompt = (args[0] as string) + "\n" + (args[1] as string);
+    expect(prompt.toLowerCase()).toMatch(/ryo|deflective|espelho|canal/);
+  });
+
+  it("injects KEI_HINT block into prompt when input.personaHint is KEI_HINT", async () => {
+    const llm = mockLlm(fullLabeledLlmJson("kei-ochiai"));
+    const input: GenerateActionMenuInput = {
+      ...validRyoInput(),
+      personaId: "kei-ochiai",
+      personaHint: KEI_HINT,
+    };
+    await generateActionMenu(input, { llmCall: llm });
+
+    const args = llm.mock.calls[0]!;
+    const prompt = (args[0] as string) + "\n" + (args[1] as string);
+    expect(prompt.toLowerCase()).toMatch(/kei|philosophical|diamante|bridge/);
+  });
+
+  it("includes the played_as / intensity enums in the prompt regardless of hint", async () => {
+    const llm = mockLlm(fullLabeledLlmJson("ryo-ochiai"));
+    await generateActionMenu(validRyoInput(), { llmCall: llm });
+
+    const args = llm.mock.calls[0]!;
+    const prompt = args[0] as string;
+    for (const v of ["bridge", "espelho", "canal", "diamante", "arena", "recovery"]) {
+      expect(prompt).toContain(v);
+    }
+    for (const v of ["soft", "medium", "firm"]) {
+      expect(prompt).toContain(v);
+    }
+  });
+});
+
+describe("generateActionMenu — input validation", () => {
+  it("returns null when personaId is empty", async () => {
+    const llm = mockLlm(fullLabeledLlmJson(""));
+    const warnings: string[] = [];
+    const menu = await generateActionMenu(
+      { ...validRyoInput(), personaId: "" },
+      { llmCall: llm, onWarning: (w) => warnings.push(w.code) },
+    );
+    expect(menu).toBeNull();
+    expect(warnings).toContain("invalid_input");
+    expect(llm).not.toHaveBeenCalled();
+  });
+
+  it("returns null when trustLevel is out of [0, 1]", async () => {
+    const llm = mockLlm(fullLabeledLlmJson("ryo-ochiai"));
+    const warnings: string[] = [];
+    const menu = await generateActionMenu(
+      { ...validRyoInput(), trustLevel: 1.5 },
+      { llmCall: llm, onWarning: (w) => warnings.push(w.code) },
+    );
+    expect(menu).toBeNull();
+    expect(warnings).toContain("invalid_input");
+  });
+});

--- a/planejador/src/strategist/action-menu-persistence.ts
+++ b/planejador/src/strategist/action-menu-persistence.ts
@@ -19,7 +19,7 @@ import path from "node:path";
 import {
   parseActionMenu,
   type ActionMenu,
-} from "./action-menu-schema.js";
+} from "@ascendimacy/shared";
 
 /** Nome canônico do arquivo de menu pra um persona_id. */
 export function actionMenuFilename(personaId: string): string {

--- a/planejador/src/strategist/index.ts
+++ b/planejador/src/strategist/index.ts
@@ -1,11 +1,17 @@
 /**
  * Strategist — gera e persiste o ActionMenu pós-compaction.
  *
- * PR1 (S-T-09-01 + S-T-09-05): schema + persistência.
- * PRs futuros: generation LLM-backed (S-T-09-02), triggers (S-T-09-03/04),
- * telemetria (S-T-09-07), LLM-LOCAL integration (S-T-09-06).
+ * - PR1 (S-T-09-01 + S-T-09-05): schema + persistência.
+ * - PR2 (S-T-09-02 + H-AC-02, motor#88): schema movido para
+ *   `@ascendimacy/shared/contracts/action-menu` (cross-workspace);
+ *   generator vive em motor-drota. Persistência permanece aqui (única
+ *   consumer da fronteira disco).
  *
- * Refs: ops#989, ops#991.
+ * Re-export dos símbolos canônicos via shared para preservar a API
+ * pública anterior (consumers ainda importam de `@ascendimacy/planejador`
+ * por compatibilidade, embora shared seja a fonte canônica).
+ *
+ * Refs: ops#989, ops#991, ops#993, motor#88.
  */
 
 export {
@@ -26,7 +32,7 @@ export {
   type ActionMenuSource,
   type Intensity,
   type PlayedAs,
-} from "./action-menu-schema.js";
+} from "@ascendimacy/shared";
 
 export {
   actionMenuFilename,

--- a/planejador/tests/action-menu-persistence.unit.test.ts
+++ b/planejador/tests/action-menu-persistence.unit.test.ts
@@ -22,7 +22,7 @@ import {
 import {
   ACTION_MENU_SCHEMA_VERSION,
   type ActionMenu,
-} from "../src/strategist/action-menu-schema.js";
+} from "@ascendimacy/shared";
 
 let scratchDir: string;
 

--- a/planejador/tests/action-menu-schema.unit.test.ts
+++ b/planejador/tests/action-menu-schema.unit.test.ts
@@ -18,7 +18,7 @@ import {
   parseActionMenu,
   type ActionMenu,
   type ActionMenuItem,
-} from "../src/strategist/action-menu-schema.js";
+} from "@ascendimacy/shared";
 
 function baseValidMenu(): ActionMenu {
   return {

--- a/scripts/smoke-menu-generator.mjs
+++ b/scripts/smoke-menu-generator.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Smoke test — generateActionMenu contra Infomaniak Kimi K2.5 real.
+ *
+ * **Gate de aceite da PR motor#88 (H-AC-02).** Roda manualmente por Jun
+ * antes de mergear; CC não executa esse script autonomamente porque
+ * (a) custa LLM real, (b) requer credenciais Infomaniak.
+ *
+ * Critério: ≥90% items rotulados com `played_as` válido (enum
+ * bridge / espelho / canal / diamante / arena / recovery).
+ *
+ * Como rodar:
+ *   1. Garantir build atual: `npm run build`
+ *   2. Garantir credenciais Infomaniak exportadas:
+ *        export INFOMANIAK_API_KEY=...
+ *        export INFOMANIAK_PRODUCT_ID=...
+ *      (ver `shared/src/llm-router.ts` para outras envs específicas)
+ *   3. Rodar:  `node scripts/smoke-menu-generator.mjs [ryo|kei|both]`
+ *      Default: both
+ *
+ * Output:
+ *   - Imprime menu gerado + distribuição (jogada x count, intensity x count)
+ *   - Calcula pct_labeled; falha se < 90%
+ *   - Salva menu em fixtures/profiles/{persona_id}-menu.json (escolha de Jun)
+ *
+ * Refs: motor#88, ops#993, ops#991.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+// Import via build output (built TypeScript).
+const { generateActionMenu } = await import(
+  path.join(REPO_ROOT, "motor-drota", "dist", "menu-generator.js")
+);
+const { RYO_HINT, KEI_HINT } = await import(
+  path.join(REPO_ROOT, "motor-drota", "dist", "persona-hints.js")
+);
+
+const PERSONAS = {
+  ryo: {
+    personaId: "ryo-ochiai",
+    trustLevel: 0.42,
+    fixture: "ryo-ochiai.pre-phase2.json",
+    hint: RYO_HINT,
+  },
+  kei: {
+    personaId: "kei-ochiai",
+    trustLevel: 0.5,
+    fixture: "kei-ochiai.pre-phase2.json",
+    hint: KEI_HINT,
+  },
+};
+
+function loadProfile(fixtureName) {
+  const p = path.join(REPO_ROOT, "fixtures", "profiles", fixtureName);
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+function summarize(menu, personaId) {
+  if (!menu) {
+    console.log(`[${personaId}] FALHA: generator retornou null.`);
+    return { ok: false };
+  }
+  const total = menu.items.length;
+  const labeled = menu.items.filter((it) => it.played_as != null).length;
+  const pct = total > 0 ? (labeled / total) * 100 : 0;
+
+  const distPlayed = new Map();
+  const distIntensity = new Map();
+  let criticals = 0;
+  for (const it of menu.items) {
+    const k = it.played_as ?? "(unlabeled)";
+    distPlayed.set(k, (distPlayed.get(k) ?? 0) + 1);
+    const i = it.intensity ?? "(none)";
+    distIntensity.set(i, (distIntensity.get(i) ?? 0) + 1);
+    if (it.is_critical) criticals++;
+  }
+
+  console.log(`\n=== ${personaId} ===`);
+  console.log(`Total items: ${total}`);
+  console.log(`Items rotulados (played_as): ${labeled} / ${total} (${pct.toFixed(1)}%)`);
+  console.log(`Distribuição played_as:`);
+  for (const [k, v] of [...distPlayed.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${k}: ${v}`);
+  }
+  console.log(`Distribuição intensity:`);
+  for (const [k, v] of [...distIntensity.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${k}: ${v}`);
+  }
+  console.log(`is_critical: ${criticals}`);
+  console.log(`schema_version: ${menu.schema_version}`);
+
+  const passes = pct >= 90;
+  console.log(`Gate ≥90% rotulado: ${passes ? "PASS" : "FAIL"}`);
+  return { ok: passes, pct, labeled, total };
+}
+
+async function runPersona(key) {
+  const { personaId, trustLevel, fixture, hint } = PERSONAS[key];
+  console.log(`\n[${personaId}] Carregando fixture ${fixture}…`);
+  const profile = loadProfile(fixture);
+
+  const warnings = [];
+  console.log(`[${personaId}] Chamando generateActionMenu (LLM real)…`);
+  const t0 = Date.now();
+  const menu = await generateActionMenu(
+    { personaId, trustLevel, profile, personaHint: hint },
+    {
+      onWarning: (w) => {
+        warnings.push(`${w.code}: ${w.message}`);
+        console.warn(`[${personaId}] WARN: ${w.code}: ${w.message}`);
+      },
+    },
+  );
+  const elapsedMs = Date.now() - t0;
+  console.log(`[${personaId}] Latência: ${elapsedMs} ms`);
+  if (warnings.length) {
+    console.log(`[${personaId}] Warnings emitidos: ${warnings.length}`);
+  }
+
+  const summary = summarize(menu, personaId);
+
+  if (menu) {
+    const outPath = path.join(REPO_ROOT, "fixtures", "profiles", `${personaId}-menu.json`);
+    writeFileSync(outPath, `${JSON.stringify(menu, null, 2)}\n`, "utf-8");
+    console.log(`[${personaId}] Salvo em ${path.relative(REPO_ROOT, outPath)}`);
+  }
+
+  return summary;
+}
+
+async function main() {
+  const targetArg = process.argv[2] ?? "both";
+  const targets =
+    targetArg === "both" ? ["ryo", "kei"] : [targetArg];
+
+  for (const t of targets) {
+    if (!PERSONAS[t]) {
+      console.error(`Unknown persona target: ${t}. Valid: ryo, kei, both.`);
+      process.exit(2);
+    }
+  }
+
+  const results = [];
+  for (const t of targets) {
+    results.push(await runPersona(t));
+  }
+
+  console.log("\n=== Resumo geral ===");
+  for (let i = 0; i < targets.length; i++) {
+    const r = results[i];
+    console.log(
+      `${targets[i]}: ${r.ok ? "PASS" : "FAIL"} ` +
+        `(${r.labeled}/${r.total} = ${r.pct?.toFixed(1) ?? "-"}%)`,
+    );
+  }
+
+  const allPass = results.every((r) => r.ok);
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Smoke test failed:", err);
+  process.exit(1);
+});

--- a/shared/src/contracts/action-menu.ts
+++ b/shared/src/contracts/action-menu.ts
@@ -1,5 +1,5 @@
 /**
- * ActionMenu schema (S-T-09-01).
+ * ActionMenu schema — contrato compartilhado entre workspaces.
  *
  * Estrutura do menu de ação pré-cozido pelo Estrategista pós-compaction:
  * cinco categorias de itens (curiosidades, desafios, estratégias, jogadas
@@ -11,7 +11,15 @@
  * (action-menu-persistence.ts) e antes de qualquer save. Per-turn lookup
  * NÃO revalida (assume schema-valid em memória).
  *
- * Refs: ops#989 (capability C-T-09), ops#991 (Sprint 1 tracker).
+ * **Histórico de localização:**
+ * - S-T-09-01 (motor#85): nascimento em `planejador/src/strategist/`.
+ * - H-AC-01 (motor#87 → #89): bump v0.2 com campos ISA opcionais.
+ * - S-T-09-02 + H-AC-02 (motor#88): movido para `shared/src/contracts/` —
+ *   motor-drota também passa a consumir (gerador LLM), schema vira
+ *   contrato cross-workspace canônico.
+ *
+ * Refs: ops#989 (capability C-T-09), ops#991 (Sprint 1 tracker), ops#993
+ * (S-T-09-02), motor#88 (H-AC-02).
  */
 
 import { z } from "zod";

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -29,3 +29,23 @@ export {
   type TelemetryEvent,
   type TelemetryEventType,
 } from "./telemetry-event.js";
+
+export {
+  ACTION_MENU_ITEM_TYPES,
+  ACTION_MENU_SCHEMA_VERSION,
+  ActionMenuItemSchema,
+  ActionMenuItemTypeSchema,
+  ActionMenuSchema,
+  ActionMenuSourceSchema,
+  INTENSITY_VALUES,
+  IntensitySchema,
+  parseActionMenu,
+  PLAYED_AS_VALUES,
+  PlayedAsSchema,
+  type ActionMenu,
+  type ActionMenuItem,
+  type ActionMenuItemType,
+  type ActionMenuSource,
+  type Intensity,
+  type PlayedAs,
+} from "./action-menu.js";


### PR DESCRIPTION
Closes #88. Implementa também ops#993 (S-T-09-02 — combinada per decisão Jun 2026-05-13).

## Resumo

Função `generateActionMenu(input): Promise<ActionMenu | null>` em `motor-drota/src/menu-generator.ts` que produz **ActionMenu schema v0.2** já rotulado com `played_as` + `intensity` + `is_critical` em cada item.

Robustez: retry once on Zod failure → graceful degradation (strip ISA labels) → null on hard failure. Auto `is_critical=true` para `recovery` e `diamante.firm`. Telemetria via `logDebugEvent(step="menu_generation")` no NDJSON com cost/latency/tokens.

Tier 2: **CC entregou, Jun valida via smoke + merge**.

## Padrão TDD em 3 camadas

### Camada 1 — Baseline (motor main pré-PR)

Suite completa: **7 workspaces, 891 passed + 8 skipped (LLM-LOCAL graceful)**.
motor-drota especificamente: **10 files, 85 tests**.

### Camada 2 — Red phase (commits 79849e8, fe34ffe, 986c71b)

3 test files cobrindo 21 cases + 1 graceful-skip:

**Unit (mock LLM) — 16 tests:**
- Happy path: menu Zod-válido com items rotulados
- LLM JSON extraction (direto, code fence, prosa)
- Retry once on Zod enum failure
- Retry prompt inclui instrução de correção
- Graceful degradation: 2 retries falham só pelos ISA → strip + persist
- Null em LLM throw 2x
- Null em JSON garbage 2x
- Auto `is_critical=true` para `recovery` (mesmo se omitido)
- Auto `is_critical=true` para `diamante` + `firm`
- NÃO auto-set para `diamante` + `soft`
- Persona hint injection (RYO + KEI no prompt)
- Enums no prompt independente do hint
- Input validation: personaId vazio → null
- Input validation: trustLevel fora de [0,1] → null

**Integration (fixtures reais, mock LLM) — 5 tests:**
- Ryo fixture → menu Zod-válido + round-trip persistência
- Ryo bias: espelho/canal precedem diamante no system prompt
- Kei fixture → menu válido + bias diamante/bridge precedem espelho
- Schema version `v0.2` emergente
- Auto is_critical aplicado após round-trip

**LLM-LOCAL graceful-skip — 1 case:**
- Pattern `.llm-local.integration.test.ts` (segue `shared/tests/cost-calc.llm-local.integration.test.ts`)
- Skip default; `LLM_LOCAL_STACK_UP=true` ativa contra Qwen3 + llama.cpp SYCL local
- Sanity check de dev — NÃO é gate de aceite

### Camada 3 — Green phase (commits 5068c68, 03d563b, acb0922)

**`motor-drota/src/prompts/menu-generator-v0.1.txt`** (~150 linhas, 9 seções):

1. Mecânica pedagógica canônica (tabela 5 jogadas + recovery: quando-funciona / anti-padrão / movimento ISA)
2. Intensidade (`soft`/`medium`/`firm`) + hard rule Kids <12 `!firm`
3. `is_critical` (recovery sempre, diamante+firm)
4. 5 tipos de item (`curiosity`/`challenge`/`strategy`/`play`/`cultural_diamond`)
5. Anatomia JSON do item
6. Estrutura do menu (target 8-15 items)
7. Calibração persona-aware (hint é sugestão, não regra; cap é hard)
8. Output format (JSON puro, sem code fence)
9. Falha graceful (omite `played_as` se não couber; NÃO inventa fora do enum)

Refs canônicos embutidos: `isa-pedagogical-mapping-v0.md` (recém-mergeada em ops#1051), Norte §3.2, Delta §5.6.

**`motor-drota/src/persona-hints.ts`** — hardcoded calibração baseada em evidência empírica:

| Persona | Archetype | Bias dominante | Cap |
|---|---|---|---|
| ryo-ochiai | deflective | espelho 0.30, canal 0.28 | medium |
| kei-ochiai | philosophical | diamante 0.25, bridge 0.25 | medium |

`resolvePersonaHint(personaId)` + `renderPersonaHintForPrompt(hint)`.

**`motor-drota/src/menu-generator.ts`** — implementação principal (~510 linhas):

- LLM via `callLlm` (gateway-client) com `step="drota"` → Infomaniak Kimi K2.5 default
- Template loader resiliente (src/ direto OR fallback de dist→src)
- JSON extraction tolerante (direto / fence / balanceado)
- Retry com mensagem de correção do Zod
- Graceful degradation: strip ISA, parse rasante
- Auto `is_critical` rule espelhada do prompt §3
- Telemetria NDJSON via `logDebugEvent` (silent fail — não pode quebrar prod)
- Tipos exportados pra consumers

### Precondição arquitetural — schema move (commits da5e3b3..73047a5)

Action menu schema **moveu de `planejador/src/strategist/` → `shared/src/contracts/`**. Justificativa:

1. Schema é contrato cross-workspace (planejador persiste, motor-drota gera).
2. Localização original em `planejador/strategist/` era acidental — motor#85 (S-T-09-01) só tinha planejador como consumer, então o schema nasceu no consumer único.
3. Posição correta é junto com `plano-tatico-delta`, `jogada-step`, `telemetry-event` na fronteira `shared/contracts/`.

6 commits no schema move, **0 alteração de shape** (apenas reorganização de fronteira de módulo). Re-exports preservam API pública pra consumers que importam de `@ascendimacy/planejador` (transparente).

## Antes / depois (full suite)

| Workspace | Antes | Depois |
|---|---|---|
| shared | 486 / 8 skip | **486 / 8 skip** |
| planejador | 132 | **132** |
| motor-drota | 85 | **106 / 1 skip** (+21 tests + 1 LLM-local skip) |
| motor-execucao | 86 | **86** |
| orchestrator | 2 | **2** |
| weekly-report | 58 | **58** |
| llm-gateway | 42 | **42** |
| **Total** | **891 / 8 skip** | **912 / 9 skip** |

0 regressions. Build verde em 7 workspaces.

## Smoke test (gate de aceite — Jun executa)

```bash
# Pré: npm run build, INFOMANIAK_API_KEY + INFOMANIAK_PRODUCT_ID exportados.
node scripts/smoke-menu-generator.mjs both
```

Output esperado: distribuição played_as + intensity + is_critical por persona,
gate **≥90% items rotulados com `played_as` válido**. Exit 1 se falhar.

Menu salvo em `fixtures/profiles/{persona_id}-menu.json`.

CC NÃO roda esse script autonomamente — custa LLM real + requer credenciais.

## Snapshot do prompt (excerto)

```
# SYSTEM PROMPT — generateActionMenu v0.1

Você é o **Estrategista** do eBrota Kids — uma camada pedagógica que pré-cozinha,
após cada compaction, um cardápio de **items de ação** (curiosidades, desafios,
estratégias, jogadas oportunas, diamantes culturais) que o Drota usará per-turn
em lookup determinístico ao longo das próximas conversas.

Você não inventa: ancora cada item em padrões já observados no perfil + em
diamantes culturais com força afetiva conhecida. O Drota nunca improvisa;
seu trabalho é entregar a ele material denso, rotulado e pronto.

## 1. Mecânica pedagógica canônica (ISA — Norte §3.2)

| Jogada | Movimento abstrato | Quando faz sentido | Anti-padrão |
|---|---|---|---|
| `bridge` | scaffold com diamante cultural | aprendiz trava em ponto específico; falta peça; diamante de peso afetivo destrava | entregar resposta disfarçada de pista |
| `espelho` | mirror | aprendiz disse algo importante que ele mesmo não escutou; devolve sem agregar | espelhar mecanicamente |
[...]

## 9. Falha graceful

Se algum item não couber em jogada conhecida, OMITA `played_as` (o motor
aceita items sem rótulo — degradação graceful). Não invente jogadas
fora do enum (`scaffold`, `validate`, `redirect`, etc. NÃO são jogadas Kids).
```

Texto completo em [`motor-drota/src/prompts/menu-generator-v0.1.txt`](motor-drota/src/prompts/menu-generator-v0.1.txt).

## Não-escopo desta PR

- Trigger de geração pós-compaction → S-T-09-03/04 (ops#994 etc., futuras)
- Per-turn lookup determinístico consumindo o menu → C-T-10 (capability separada)
- Evento `move_emitted` no trace quando Drota seleciona item rotulado → H-AC-03 (futura)
- Métrica longitudinal de distribuição esperada vs realizada → H-AC-08 (painel)
- Recategorização de fixtures pré-existentes → follow-up se necessário
- Postbuild step que copia `prompts/*.txt` para `dist/` → fallback resolver cobre o caso por enquanto

## Refs

- ops#993 (S-T-09-02 — combinada)
- motor#88 (H-AC-02 — escopo principal)
- motor#89 (H-AC-01 schema v0.2, mergeado)
- ops#1050 (multiplas-competencias-v0.2 disponível em main, mergeado)
- ops#1051 (isa-pedagogical-mapping-v0, mergeado)
- ops#991 (Sprint 1 tracker)
- ops#1008 (Pre-Sprint Bootstrap, contracts disponíveis)
- `docs/handoffs/2026-05-13-industrialization-tiers-v0.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)