### PR TITLE
[D-5-PBLD] postbuild copia prompts/*.txt para dist/ + remove fallback resolver

### DIFF
--- a/motor-drota/package.json
+++ b/motor-drota/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/server.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "postbuild": "mkdir -p dist/prompts && cp src/prompts/*.txt dist/prompts/",
     "test": "vitest run",
     "start": "node dist/server.js",
     "clean": "rm -rf dist"

--- a/motor-drota/src/menu-generator.ts
+++ b/motor-drota/src/menu-generator.ts
@@ -37,7 +37,7 @@
  * - ops#991 (Sprint 1 tracker)
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -127,28 +127,15 @@ export interface GenerateActionMenuOptions {
 
 /** Lê template + cacheia em memória (idempotente entre chamadas).
  *
- * Robusto a dois layouts:
- * 1. Execução via vitest direto sobre `src/` — `__dirname` é `.../src`,
- *    template ao lado em `src/prompts/`.
- * 2. Execução via build em `dist/` (smoke script, MCP server) — TypeScript
- *    não copia `.txt` para dist/. Fallback resolve para `src/prompts/`
- *    relativo ao dist/. Se desejável copiar no build, adicionar postbuild
- *    step (não bloqueante hoje).
+ * `postbuild` em motor-drota/package.json copia `src/prompts/*.txt` para
+ * `dist/prompts/`, então `__dirname/prompts/` resolve igual em dev (vitest
+ * sobre src/) e prod (Node sobre dist/). Ref: ops#1057 (D-5-PBLD).
  */
 let _cachedTemplate: string | null = null;
 function loadPromptTemplate(pathOverride?: string): string {
   if (pathOverride) return readFileSync(pathOverride, "utf-8");
   if (_cachedTemplate) return _cachedTemplate;
-  if (existsSync(PROMPT_TEMPLATE_PATH)) {
-    _cachedTemplate = readFileSync(PROMPT_TEMPLATE_PATH, "utf-8");
-    return _cachedTemplate;
-  }
-  // Fallback: rodando de dist/, .txt fica em src/.
-  const fromDistToSrc = PROMPT_TEMPLATE_PATH.replace(
-    `${join("/", "dist", "/")}`,
-    `${join("/", "src", "/")}`,
-  );
-  _cachedTemplate = readFileSync(fromDistToSrc, "utf-8");
+  _cachedTemplate = readFileSync(PROMPT_TEMPLATE_PATH, "utf-8");
   return _cachedTemplate;
 }
 


### PR DESCRIPTION
Closes ops#1057 (D-5-PBLD, tier:1-autonomous).

## Resumo

Substitui o fallback resolver de 18 linhas em `loadPromptTemplate` (motor#90, motor-drota/src/menu-generator.ts) por um postbuild step idiomático em `motor-drota/package.json` que copia `src/prompts/*.txt` → `dist/prompts/`.

## Mudanças

**`motor-drota/package.json`** — adiciona postbuild:
\`\`\`json
"postbuild": "mkdir -p dist/prompts && cp src/prompts/*.txt dist/prompts/"
\`\`\`

**`motor-drota/src/menu-generator.ts`** — remove `existsSync` + fallback dist→src:
- Antes: 21 linhas (try dist, fallback to src via path manipulation)
- Depois: 6 linhas (readFileSync direto + cache)

## Validação

\`\`\`
$ npm run clean -w @ascendimacy/motor-drota
$ npm run build -w @ascendimacy/motor-drota
> postbuild
> mkdir -p dist/prompts && cp src/prompts/*.txt dist/prompts/

$ ls motor-drota/dist/prompts/
menu-generator-v0.1.txt

$ npm test -w @ascendimacy/motor-drota
 Test Files  12 passed | 1 skipped (13)
      Tests  106 passed | 1 skipped (107)
\`\`\`

Smoke script (`scripts/smoke-menu-generator.mjs`) continua importando de `motor-drota/dist/`; o postbuild garante que o `.txt` está lá.

## Não-escopo

- Não trata Windows nativo (POSIX `cp`/`mkdir -p` é suficiente para CI Linux + WSL2; sem demanda atual)
- Não muda o formato do prompt nem o caminho de override (`options.promptTemplatePath` continua funcionando)

## Refs

- ops#1057 (D-5-PBLD)
- motor#90 (origem do fallback resolver, mergeado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)