### PR TITLE
[D-4-TELO] outcome granular ok|ok-retry|degraded|error (NDJSON menu_generation)

### DIFF
--- a/motor-drota/src/menu-generator.ts
+++ b/motor-drota/src/menu-generator.ts
@@ -294,7 +294,19 @@ function buildRetryPrompt(
   ].join("\n");
 }
 
-/** Tenta emitir telemetria — silencia falhas (telemetria não pode quebrar prod). */
+/**
+ * Tenta emitir telemetria — silencia falhas (telemetria não pode quebrar prod).
+ *
+ * D-4-TELO (ops#1056): outcome passa direto, sem colapsar:
+ *  - "ok"       — sucesso na primeira tentativa (1 LLM call)
+ *  - "ok-retry" — sucesso após retry (2 LLM calls; primeiro output rejeitado)
+ *  - "degraded" — sucesso parcial: ISA labels stripped após 2 retries falharem
+ *  - "error"    — falha hard: null retornado, exception, ou JSON garbage 2x
+ *
+ * Granularidade necessária pra análise longitudinal (H-AC-08 painel, H-AC-12
+ * pass-rate). Antes a função colapsava tudo não-"error" em "ok", perdendo
+ * sinal entre runs saudáveis e runs que precisaram de retry/degradação.
+ */
 function emitTelemetry(args: {
   personaId: string;
   sessionId?: string;
@@ -317,7 +329,7 @@ function emitTelemetry(args: {
       latency_ms: args.latencyMs,
       prompt: args.prompt,
       response: args.response,
-      outcome: args.outcome === "error" ? "error" : "ok",
+      outcome: args.outcome,
     });
   } catch {
     // No-op — telemetria não pode quebrar produção.

--- a/motor-drota/tests/menu-generator.unit.test.ts
+++ b/motor-drota/tests/menu-generator.unit.test.ts
@@ -9,7 +9,26 @@
  * Refs: ops#993 (S-T-09-02), motor#88 (H-AC-02), ops#991.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+// Mock pontual de logDebugEvent — permite asserções sobre o outcome
+// granular emitido pelo menu-generator (D-4-TELO, ops#1056). Não afeta
+// os outros testes do arquivo: logDebugEvent é no-op default (debug mode
+// off), então substituir por mock preserva o comportamento observável.
+const { mockLogDebugEvent } = vi.hoisted(() => ({
+  mockLogDebugEvent: vi.fn(),
+}));
+
+vi.mock("@ascendimacy/shared", async () => {
+  const actual = await vi.importActual<typeof import("@ascendimacy/shared")>(
+    "@ascendimacy/shared",
+  );
+  return {
+    ...actual,
+    logDebugEvent: mockLogDebugEvent,
+  };
+});
+
 import {
   ACTION_MENU_SCHEMA_VERSION,
   parseActionMenu,
@@ -21,6 +40,10 @@ import {
   type LlmCall,
 } from "../src/menu-generator.js";
 import { RYO_HINT, KEI_HINT } from "../src/persona-hints.js";
+
+beforeEach(() => {
+  mockLogDebugEvent.mockClear();
+});
 
 function validRyoInput(): GenerateActionMenuInput {
   return {
@@ -381,5 +404,96 @@ describe("generateActionMenu — input validation", () => {
     );
     expect(menu).toBeNull();
     expect(warnings).toContain("invalid_input");
+  });
+});
+
+// D-4-TELO (ops#1056): outcome granular emitido para logDebugEvent.
+describe("generateActionMenu — telemetria outcome granular", () => {
+  it("emite outcome=\"ok\" no happy path (sucesso na 1a tentativa)", async () => {
+    const llm = mockLlm(fullLabeledLlmJson("ryo-ochiai"));
+    await generateActionMenu(validRyoInput(), { llmCall: llm });
+
+    // Pega o último evento emitido (handle de mock cumulative durante o test)
+    const calls = mockLogDebugEvent.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const lastEvent = calls[calls.length - 1]![0] as { outcome: string; step: string };
+    expect(lastEvent.step).toBe("menu_generation");
+    expect(lastEvent.outcome).toBe("ok");
+  });
+
+  it("emite outcome=\"ok-retry\" quando 1o output falha schema e retry recupera", async () => {
+    const bad = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad.items[0] as unknown as { played_as: string }).played_as = "scaffold";
+    const good = fullLabeledLlmJson("ryo-ochiai");
+
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad),
+        tokens: { in: 1200, out: 380, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: good,
+        tokens: { in: 1300, out: 400, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    await generateActionMenu(validRyoInput(), { llmCall: llm });
+    const calls = mockLogDebugEvent.mock.calls;
+    const lastEvent = calls[calls.length - 1]![0] as { outcome: string };
+    expect(lastEvent.outcome).toBe("ok-retry");
+  });
+
+  it("emite outcome=\"degraded\" quando 2 retries falham e ISA labels são stripped", async () => {
+    const bad1 = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad1.items[0] as unknown as { played_as: string }).played_as = "scaffold";
+    const bad2 = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad2.items[0] as unknown as { intensity: string }).intensity = "savage";
+
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad1),
+        tokens: { in: 1200, out: 380, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad2),
+        tokens: { in: 1300, out: 400, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    await generateActionMenu(validRyoInput(), { llmCall: llm });
+    const calls = mockLogDebugEvent.mock.calls;
+    const lastEvent = calls[calls.length - 1]![0] as { outcome: string };
+    expect(lastEvent.outcome).toBe("degraded");
+  });
+
+  it("emite outcome=\"error\" quando ambas as tentativas retornam garbage", async () => {
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: "not JSON",
+        tokens: { in: 100, out: 20, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: "still not JSON",
+        tokens: { in: 100, out: 10, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    expect(menu).toBeNull();
+    const calls = mockLogDebugEvent.mock.calls;
+    const lastEvent = calls[calls.length - 1]![0] as { outcome: string };
+    expect(lastEvent.outcome).toBe("error");
   });
 });

--- a/shared/src/debug-logger.ts
+++ b/shared/src/debug-logger.ts
@@ -90,7 +90,17 @@ export interface DebugEventInput {
   reasoning?: string | null;
   snapshots_pre?: Record<string, unknown> | null;
   snapshots_post?: Record<string, unknown> | null;
-  outcome: "ok" | "error" | "skip";
+  /**
+   * Granularidade de outcome (D-4-TELO, ops#1056):
+   *  - "ok"       — sucesso na primeira tentativa
+   *  - "ok-retry" — sucesso após retry (ex: schema invalid no primeiro output, recuperado)
+   *  - "degraded" — sucesso parcial (ex: ISA labels stripped, dados secundários perdidos)
+   *  - "error"    — falha hard (null retornado, exception)
+   *  - "skip"     — step ignorado (config/feature flag)
+   *
+   * Legado ("ok" | "error" | "skip") continua válido — só amplia o enum.
+   */
+  outcome: "ok" | "ok-retry" | "degraded" | "error" | "skip";
   error_class?: string | null;
 }
 
@@ -121,7 +131,8 @@ export interface DebugEventLine {
   reasoning_hash: string | null;
   snapshots_pre: Record<string, string> | null;
   snapshots_post: Record<string, string> | null;
-  outcome: "ok" | "error" | "skip";
+  /** Mesma semântica granular do DebugEventInput.outcome (ver acima, D-4-TELO). */
+  outcome: "ok" | "ok-retry" | "degraded" | "error" | "skip";
   error_class: string | null;
 }
 
@@ -347,7 +358,9 @@ export const DebugEventLineSchema = z
     reasoning_hash: HashSchema.nullable(),
     snapshots_pre: z.record(z.string(), z.string()).nullable(),
     snapshots_post: z.record(z.string(), z.string()).nullable(),
-    outcome: z.enum(["ok", "error", "skip"]),
+    // D-4-TELO (ops#1056): outcome ganha "ok-retry" e "degraded" entre
+    // sucesso e falha. Legado ("ok" | "error" | "skip") continua válido.
+    outcome: z.enum(["ok", "ok-retry", "degraded", "error", "skip"]),
     error_class: z.string().nullable(),
   })
   .refine(

--- a/shared/tests/debug-logger-zod.unit.test.ts
+++ b/shared/tests/debug-logger-zod.unit.test.ts
@@ -80,6 +80,24 @@ describe("DebugEventLineSchema — campos básicos", () => {
     const r = DebugEventLineSchema.safeParse({ ...validBase, outcome: "pending" });
     expect(r.success).toBe(false);
   });
+
+  // D-4-TELO (ops#1056): outcome ganha "ok-retry" e "degraded" granular.
+  it("aceita outcome \"ok-retry\" (sucesso após retry)", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, outcome: "ok-retry" });
+    expect(r.success).toBe(true);
+  });
+
+  it("aceita outcome \"degraded\" (sucesso parcial — ISA labels stripped)", () => {
+    const r = DebugEventLineSchema.safeParse({ ...validBase, outcome: "degraded" });
+    expect(r.success).toBe(true);
+  });
+
+  it("legado \"ok\" / \"error\" / \"skip\" continua válido (back-compat)", () => {
+    for (const v of ["ok", "error", "skip"]) {
+      const r = DebugEventLineSchema.safeParse({ ...validBase, outcome: v });
+      expect(r.success).toBe(true);
+    }
+  });
 });
 
 describe("DebugEventLineSchema — model + tokens consistency (S-N-01-04)", () => {


### PR DESCRIPTION
Closes ops#1056 (D-4-TELO, tier:2-semi-autonomous).

## Resumo

Estende o enum `outcome` no NDJSON de telemetria de `\"ok\" | \"error\" | \"skip\"` para `\"ok\" | \"ok-retry\" | \"degraded\" | \"error\" | \"skip\"`, e ajusta `emitTelemetry` no menu-generator (motor#90) para passar o outcome granular **sem colapsar**.

## Por que importa

Durante smoke local do motor#90, 2 runs idênticos contra Qwen3-30B produziram outcomes internos diferentes (`ok-retry` vs `degraded`) mas o NDJSON registrou ambos como `\"ok\"`. Análise longitudinal de pass-rate / recovery-rate / degradation-rate ficava cega — exato problema que H-AC-12 (variância) e H-AC-08 (painel) vão precisar resolver.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `shared/src/debug-logger.ts` | `DebugEventInput.outcome` + `DebugEventLine.outcome` + Zod schema ganham 2 valores. Docstring inline explica semântica dos 5 outcomes. |
| `motor-drota/src/menu-generator.ts` | `emitTelemetry`: outcome passa direto (antes: ternário colapsava em ok/error). |
| `shared/tests/debug-logger-zod.unit.test.ts` | 3 tests novos: aceita "ok-retry", aceita "degraded", back-compat dos 3 legados. |
| `motor-drota/tests/menu-generator.unit.test.ts` | 4 tests novos via `vi.mock` de `logDebugEvent`: happy=\"ok\", retry recuperado=\"ok-retry\", ISA stripped=\"degraded\", garbage 2x=\"error\". |

## Validação

\`\`\`
shared:        489 / 8 skip  (era 486 / 8 skip — +3)
planejador:    132            (estável)
motor-drota:   110 / 1 skip   (era 106 / 1 skip — +4)
motor-execucao: 86             (estável)
orchestrator:    2             (estável)
weekly-report:  58             (estável)
llm-gateway:    42             (estável)
Total:         919 / 9 skip   (+7 tests, 0 regressions)
\`\`\`

Build verde 7 workspaces.

## Back-compat

NDJSONs de PRs anteriores (com outcome em `{ok, error, skip}`) continuam parseando pelo Zod schema. Consumer downstream que assume `outcome === \"ok\"` vai precisar ser atualizado para reconhecer `\"ok-retry\"` e `\"degraded\"` quando rodar no painel — mas o NDJSON em si é forward-compatible.

## Não-escopo

- Não muda outro `step` da telemetria (só `menu_generation` consome a granularidade nova)
- Não cria painel / dashboard — isso é H-AC-08
- Não muda back-fill de eventos antigos

## Refs

- ops#1056 (D-4-TELO)
- motor#90 (mergeado, origem do gap)
- ops#1058 (H-AC-12, blocked by this PR)
- H-AC-08 painel longitudinal (futura, consome o sinal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)