### PR TITLE
[D-3-PROV] LlmProvider ganha "openai-compat" + cost=0 (corrige label mentiroso no NDJSON)

### DIFF
--- a/llm-gateway/src/router.ts
+++ b/llm-gateway/src/router.ts
@@ -9,7 +9,12 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { getProviderForStep, getModelForStep, type LlmProvider } from "@ascendimacy/shared";
+import {
+  getProviderForStep,
+  getModelForStep,
+  type GatewayLlmProvider,
+  type LlmProvider,
+} from "@ascendimacy/shared";
 import {
   type ChatCompletionInput,
   type ChatCompletionOutput,
@@ -43,17 +48,20 @@ export interface RouterOptions {
 
 interface DegradedState {
   /** Map provider → ts when degraded was set; expires after degradedTtlMs. */
-  marks: Map<LlmProvider, number>;
+  marks: Map<GatewayLlmProvider, number>;
 }
 
-const FALLBACK_MAP: Record<LlmProvider, LlmProvider> = {
+// D-3-PROV (ops#1055): GatewayLlmProvider narrow exclui openai-compat —
+// LLM local não passa pelo gateway, então fallback/buckets só conhecem
+// anthropic ↔ infomaniak. Invariante preserved.
+const FALLBACK_MAP: Record<GatewayLlmProvider, GatewayLlmProvider> = {
   anthropic: "infomaniak",
   infomaniak: "anthropic",
 };
 
 export class Router {
-  private readonly providers: Record<LlmProvider, ProviderClient>;
-  private readonly buckets: Record<LlmProvider, TokenBucket>;
+  private readonly providers: Record<GatewayLlmProvider, ProviderClient>;
+  private readonly buckets: Record<GatewayLlmProvider, TokenBucket>;
   private readonly logger: GatewayLogger;
   private readonly primaryHardTimeoutMs: number;
   private readonly totalBudgetMs: number;
@@ -84,7 +92,20 @@ export class Router {
     const runId = req.run_id ?? randomUUID();
     const t0 = this.now();
 
-    const primary = req.provider ?? getProviderForStep(req.step);
+    const resolved = req.provider ?? getProviderForStep(req.step);
+    // D-3-PROV (ops#1055): gateway só conhece anthropic/infomaniak.
+    // openai-compat é LLM local — accessed direto per-callsite, não
+    // tem SDK/bucket/retry coordenado aqui. Caller que mandar openai-compat
+    // pro gateway está usando o componente errado.
+    if (resolved === "openai-compat") {
+      throw new GatewayError(
+        "PROVIDER_DOWN",
+        `provider="openai-compat" não é roteável pelo llm-gateway — ` +
+          `LLM local deve ser chamado direto (LLM_LOCAL_ENDPOINT, sem retry/fallback). ` +
+          `step=${req.step}`,
+      );
+    }
+    const primary: GatewayLlmProvider = resolved;
     const fallback = FALLBACK_MAP[primary];
     const primaryDegraded = this.isDegraded(primary);
 
@@ -142,14 +163,14 @@ export class Router {
   }
 
   private async callOnce(args: {
-    providerName: LlmProvider;
+    providerName: GatewayLlmProvider;
     req: ChatCompletionInput;
     requestId: string;
     runId: string;
     startTs: number;
     budgetMs: number;
     wasFallback: boolean;
-    primaryAttempted?: LlmProvider;
+    primaryAttempted?: GatewayLlmProvider;
   }): Promise<ChatCompletionOutput> {
     const { providerName, req, requestId, runId, budgetMs, wasFallback, primaryAttempted } = args;
     const provider = this.providers[providerName];
@@ -233,7 +254,7 @@ export class Router {
     }
   }
 
-  private isDegraded(provider: LlmProvider): boolean {
+  private isDegraded(provider: GatewayLlmProvider): boolean {
     const ts = this.degraded.marks.get(provider);
     if (ts === undefined) return false;
     if (this.now() - ts > this.degradedTtlMs) {
@@ -243,7 +264,7 @@ export class Router {
     return true;
   }
 
-  private markDegraded(provider: LlmProvider): void {
+  private markDegraded(provider: GatewayLlmProvider): void {
     this.degraded.marks.set(provider, this.now());
   }
 }

--- a/motor-drota/tests/menu-generator.llm-local.integration.test.ts
+++ b/motor-drota/tests/menu-generator.llm-local.integration.test.ts
@@ -86,10 +86,9 @@ function localLlmCall(): LlmCall {
         out: json.usage?.completion_tokens ?? 0,
         reasoning: 0,
       },
-      // LLM local não bate com o enum LlmProvider canônico ("anthropic" |
-      // "infomaniak") — usamos "infomaniak" como rótulo informativo (o
-      // endpoint OpenAI-compat do llama.cpp comporta-se análogo).
-      provider: "infomaniak" as const,
+      // D-3-PROV (ops#1055): provider canônico para LLM local. Antes
+      // (workaround pre-PR) cast pra "infomaniak" — mentia no NDJSON.
+      provider: "openai-compat",
       model: LOCAL_MODEL,
     };
   };

--- a/shared/src/debug-logger.ts
+++ b/shared/src/debug-logger.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { z } from "zod";
 
 import { calculateCostUsd } from "./llm-config.js";
+import type { LlmProvider } from "./llm-router.js";
 
 export const DEBUG_MODE_SCHEMA_VERSION = "1.1"; // 1.1 — Sprint 0 PR3: adiciona scope_id (motor#75)
 
@@ -229,7 +230,14 @@ export function logDebugEvent(input: DebugEventInput): void {
       cost_usd_est:
         input.cost_usd_est ??
         (input.tokens
-          ? calculateCostUsd(input.model ?? null, input.tokens.in ?? 0, input.tokens.out ?? 0)
+          ? calculateCostUsd(
+              input.model ?? null,
+              input.tokens.in ?? 0,
+              input.tokens.out ?? 0,
+              // D-3-PROV (ops#1055): passa provider pro cost calc — distingue
+              // LLM local (openai-compat → 0) de modelo desconhecido (null).
+              input.provider as LlmProvider | null | undefined,
+            )
           : null),
       prompt_hash: promptHash,
       response_hash: responseHash,

--- a/shared/src/llm-config.ts
+++ b/shared/src/llm-config.ts
@@ -8,6 +8,8 @@
  * Override via env var por step ou global.
  */
 
+import type { LlmProvider } from "./llm-router.js";
+
 /** Timeouts default em ms, por step. */
 export const LLM_TIMEOUT_DEFAULTS: Record<string, number> = {
   // Sonnet 4.6 planejador — prompts moderados, reasoning budget 1024
@@ -213,25 +215,39 @@ export function getPricesForModel(model: string): ModelPricing | null {
   return PRICING_TABLE[model] ?? null;
 }
 
-/** Calcula cost_usd_est dado modelo + tokens de input/output.
+/** Calcula cost_usd_est dado modelo + tokens de input/output (+ provider).
  *
  * Retorno:
  *  - 0 se ambos tokens=0 (steps stub não custam — distingue 'sem tokens'
  *    de 'modelo desconhecido'; S-J-01-03)
+ *  - 0 se provider="openai-compat" (LLM local, sem custo de API —
+ *    D-3-PROV ops#1055; distingue de `null` que é "modelo desconhecido")
  *  - null se model é null OR modelo desconhecido (com warn na console)
- *  - número positivo caso contrário (qwen3-8b sempre = 0 por price=0)
+ *  - número positivo caso contrário (qwen3-8b sempre = 0 por price=0
+ *    mesmo sem passar provider)
  *
- * Tokens negativos são tratados como 0 (defensivo — não deve acontecer em produção
- * mas evita cost negativo se serializer falhar). */
+ * O parâmetro `provider` é OPCIONAL pra preservar back-compat com callers
+ * pré-D-3-PROV. Quando ausente, a lookup pela PRICING_TABLE continua
+ * autoritativa (qwen3-8b cadastrado lá com price=0).
+ *
+ * Tokens negativos são tratados como 0 (defensivo — não deve acontecer
+ * em produção mas evita cost negativo se serializer falhar). */
 export function calculateCostUsd(
   model: string | null,
   tokensIn: number,
   tokensOut: number,
+  provider?: LlmProvider | null,
 ): number | null {
   const safeIn = Math.max(0, tokensIn);
   const safeOut = Math.max(0, tokensOut);
   // S-J-01-03: zero tokens overrides everything — sem tokens consumidos = sem custo
   if (safeIn === 0 && safeOut === 0) return 0;
+  // D-3-PROV: openai-compat = LLM local, custo de API = 0 mesmo se modelo
+  // não estiver cadastrado no PRICING_TABLE. Resolve o caso de runtime
+  // alias do llama-server (qwen3-30b, ministral-q4, etc.) sem precisar
+  // de whitelist por modelo. Cadastro explícito na PRICING_TABLE continua
+  // sendo defensive layer pros casos onde caller não passa provider.
+  if (provider === "openai-compat") return 0;
   if (model == null) return null;
   const prices = getPricesForModel(model);
   if (prices == null) {

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -17,7 +17,28 @@
  *   PERSONA_SIM_MODEL=mistral3
  */
 
-export type LlmProvider = "anthropic" | "infomaniak";
+/**
+ * Provider canônicos:
+ *  - "anthropic"      — Anthropic API direta (claude-sonnet-4-6, etc.)
+ *  - "infomaniak"     — Infomaniak OpenAI-compat (Kimi K2.5, Mistral3, etc.)
+ *  - "openai-compat"  — endpoint OpenAI-compat genérico (LLM local
+ *                       llama.cpp SYCL, vLLM-XPU, etc.). Não tem entrada
+ *                       no DEFAULT_PROVIDERS porque é override per-callsite
+ *                       (ex: LLM-LOCAL integration tests, dev iteration).
+ *                       D-3-PROV (ops#1055).
+ */
+export type LlmProvider = "anthropic" | "infomaniak" | "openai-compat";
+
+/**
+ * Subconjunto de `LlmProvider` que passa pelo `llm-gateway` (rede paga,
+ * retry/fallback/bucket coordinado). `openai-compat` NÃO faz parte —
+ * é local, accessed direto per-callsite, sem retry coordenado.
+ *
+ * Usado pelos maps exhaustivos do Router (`FALLBACK_MAP`, `providers`,
+ * `buckets`). Mantém invariante: gateway só conhece anthropic/infomaniak.
+ * D-3-PROV (ops#1055).
+ */
+export type GatewayLlmProvider = "anthropic" | "infomaniak";
 
 /** Steps válidos com config defaults. */
 export const LLM_STEPS = [
@@ -93,9 +114,13 @@ function envKey(step: string, suffix: string): string {
  */
 export function getProviderForStep(step: string): LlmProvider {
   const perStep = process.env[envKey(step, "PROVIDER")];
-  if (perStep === "anthropic" || perStep === "infomaniak") return perStep;
+  if (perStep === "anthropic" || perStep === "infomaniak" || perStep === "openai-compat") {
+    return perStep;
+  }
   const global = process.env["LLM_PROVIDER"];
-  if (global === "anthropic" || global === "infomaniak") return global;
+  if (global === "anthropic" || global === "infomaniak" || global === "openai-compat") {
+    return global;
+  }
   return DEFAULT_PROVIDERS[step as LlmStep] ?? "infomaniak";
 }
 
@@ -123,6 +148,13 @@ export function getModelForStep(step: string, provider?: LlmProvider): string {
   const p = provider ?? getProviderForStep(step);
   if (p === "anthropic") {
     return ANTHROPIC_FALLBACK_MODELS[step as LlmStep] ?? "claude-sonnet-4-6";
+  }
+  // D-3-PROV (ops#1055): openai-compat = LLM local. Modelo vem da env
+  // específica LLM_LOCAL_MODEL (canônico nos LLM-LOCAL integration tests),
+  // não dos defaults por step. "unknown" quando env ausente — força
+  // o operador a setar explicitamente o modelo que está rodando.
+  if (p === "openai-compat") {
+    return process.env["LLM_LOCAL_MODEL"] ?? "unknown";
   }
   return DEFAULT_MODELS[step as LlmStep] ?? "moonshotai/Kimi-K2.5";
 }
@@ -173,6 +205,9 @@ export function getMaxTokensForStep(step: string, model: string): number {
  * haiku-* (rerank simples, thinking custa latência).
  */
 export function shouldEnableThinking(step: string, provider: LlmProvider, debugMode: boolean): boolean {
+  // D-3-PROV (ops#1055): openai-compat (LLM local) não tem thinking mode
+  // equivalente — qwen3-30b-a3b-instruct-2507 não emite reasoning_content
+  // separado do conteúdo. Sempre false; tratado igual a infomaniak.
   if (provider !== "anthropic") return false;
   if (!debugMode) return false;
   const noThinkSteps = new Set(["haiku-triage", "haiku-bullying"]);

--- a/shared/tests/llm-config.test.ts
+++ b/shared/tests/llm-config.test.ts
@@ -274,6 +274,36 @@ describe("calculateCostUsd — aritmética de cost (S-J-01-02)", () => {
     // Aceita 0 ou cost negativo determinístico — apenas não pode crashar
     expect(typeof cost === "number" || cost === null).toBe(true);
   });
+
+  // D-3-PROV (ops#1055): provider=openai-compat → 0 mesmo p/ modelo desconhecido.
+  it("provider=openai-compat → 0 mesmo para modelo desconhecido (LLM local)", () => {
+    // qwen3-30b não está cadastrado no PRICING_TABLE; sem o provider seria null.
+    expect(calculateCostUsd("qwen3-30b", 1000, 500, "openai-compat")).toBe(0);
+    expect(calculateCostUsd("ministral-q4", 50000, 20000, "openai-compat")).toBe(0);
+    // null model + openai-compat ainda assim → 0 (distinção do "modelo unknown").
+    expect(calculateCostUsd(null, 1000, 500, "openai-compat")).toBe(0);
+  });
+
+  it("provider=openai-compat respeita zero-tokens override (S-J-01-03)", () => {
+    // Mesmo openai-compat com 0 tokens retorna 0 (curto-circuito anterior).
+    expect(calculateCostUsd("qwen3-30b", 0, 0, "openai-compat")).toBe(0);
+  });
+
+  it("provider=anthropic/infomaniak: comportamento legado preservado (back-compat)", () => {
+    // Passar provider explícito mas conhecido NÃO muda a lógica do PRICING_TABLE.
+    expect(calculateCostUsd("modelo-desconhecido", 100, 50, "infomaniak")).toBeNull();
+    expect(calculateCostUsd("modelo-desconhecido", 100, 50, "anthropic")).toBeNull();
+    // Modelo conhecido + provider explícito: aritmética normal.
+    const cost = calculateCostUsd("moonshotai/Kimi-K2.5", 1000, 500, "infomaniak");
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeGreaterThan(0);
+  });
+
+  it("provider omitido: caller pré-D-3-PROV continua funcionando (back-compat)", () => {
+    // Garantia explícita: o parâmetro provider é opcional.
+    expect(calculateCostUsd("qwen3-8b", 1000, 500)).toBe(0); // via PRICING_TABLE
+    expect(calculateCostUsd("modelo-desconhecido", 100, 50)).toBeNull();
+  });
 });
 
 // ============================================================================

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -67,12 +67,38 @@ describe("getProviderForStep", () => {
   });
 
   it("valor inválido em env → fallback default", () => {
-    process.env["PLANEJADOR_PROVIDER"] = "openai"; // não é "anthropic" nem "infomaniak"
+    process.env["PLANEJADOR_PROVIDER"] = "openai-direct"; // não bate com nenhum enum
     expect(getProviderForStep("planejador")).toBe("infomaniak"); // default
   });
 
   it("step desconhecido → infomaniak fallback", () => {
     expect(getProviderForStep("unknown-step")).toBe("infomaniak");
+  });
+
+  // D-3-PROV (ops#1055): openai-compat habilitado para LLM local.
+  it("aceita openai-compat em env per-step", () => {
+    process.env["DROTA_PROVIDER"] = "openai-compat";
+    expect(getProviderForStep("drota")).toBe("openai-compat");
+    expect(getProviderForStep("planejador")).toBe("infomaniak"); // não afeta outros
+  });
+
+  it("aceita openai-compat em LLM_PROVIDER global", () => {
+    process.env["LLM_PROVIDER"] = "openai-compat";
+    expect(getProviderForStep("planejador")).toBe("openai-compat");
+    expect(getProviderForStep("drota")).toBe("openai-compat");
+  });
+
+  it("defaults inalterados: openai-compat NÃO entra em DEFAULT_PROVIDERS", () => {
+    // Garantia explícita: prod continua infomaniak sem env override.
+    for (const step of [
+      "planejador",
+      "drota",
+      "persona-sim",
+      "haiku-triage",
+      "haiku-bullying",
+    ]) {
+      expect(DEFAULT_PROVIDERS[step as keyof typeof DEFAULT_PROVIDERS]).toBe("infomaniak");
+    }
   });
 });
 
@@ -107,6 +133,25 @@ describe("getModelForStep", () => {
     process.env["DROTA_MODEL"] = "qwen3";
     process.env["MOTOR_DROTA_MODEL"] = "mistral3";
     expect(getModelForStep("drota")).toBe("qwen3");
+  });
+
+  // D-3-PROV (ops#1055): provider=openai-compat resolve model via LLM_LOCAL_MODEL.
+  it("provider=openai-compat resolve model via LLM_LOCAL_MODEL env", () => {
+    process.env["LLM_LOCAL_MODEL"] = "qwen3-30b";
+    expect(getModelForStep("drota", "openai-compat")).toBe("qwen3-30b");
+    expect(getModelForStep("planejador", "openai-compat")).toBe("qwen3-30b");
+  });
+
+  it("provider=openai-compat sem LLM_LOCAL_MODEL retorna \"unknown\"", () => {
+    delete process.env["LLM_LOCAL_MODEL"];
+    expect(getModelForStep("drota", "openai-compat")).toBe("unknown");
+  });
+
+  it("env per-step (DROTA_MODEL) beats LLM_LOCAL_MODEL no openai-compat", () => {
+    process.env["DROTA_MODEL"] = "qwen3-14b";
+    process.env["LLM_LOCAL_MODEL"] = "qwen3-30b";
+    // Per-step explicit é resolvido antes de checar provider.
+    expect(getModelForStep("drota", "openai-compat")).toBe("qwen3-14b");
   });
 });
 
@@ -170,6 +215,14 @@ describe("shouldEnableThinking", () => {
   it("OFF em haiku-triage/haiku-bullying mesmo com Anthropic + debug ON", () => {
     expect(shouldEnableThinking("haiku-triage", "anthropic", true)).toBe(false);
     expect(shouldEnableThinking("haiku-bullying", "anthropic", true)).toBe(false);
+  });
+
+  // D-3-PROV (ops#1055): openai-compat sempre OFF (qwen3-30b-a3b-instruct-2507
+  // não tem thinking mode equivalente). Tratamento igual a infomaniak.
+  it("OFF se provider=openai-compat (mesmo em debug, mesmo em steps reasoning)", () => {
+    expect(shouldEnableThinking("planejador", "openai-compat", true)).toBe(false);
+    expect(shouldEnableThinking("drota", "openai-compat", true)).toBe(false);
+    expect(shouldEnableThinking("persona-sim", "openai-compat", false)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes ops#1055 (D-3-PROV, tier:2-semi-autonomous).

## Resumo

Estende `LlmProvider` de `\"anthropic\" | \"infomaniak\"` para incluir `\"openai-compat\"` — endpoint OpenAI-compat genérico (LLM local llama.cpp SYCL, vLLM-XPU). Corrige o workaround pre-PR onde o LLM-LOCAL test castava o provider pra `\"infomaniak\"` (mentindo no NDJSON).

## Por que importa

Smoke local do motor#90 registrava:

\`\`\`json
{
  \"step\": \"menu_generation\",
  \"model\": \"qwen3-30b\",
  \"provider\": \"infomaniak\",   ← MENTIRA (request foi pro Qwen3 local)
  \"cost_usd_est\": null,       ← modelo desconhecido pelo pricing table
  \"latency_ms\": 471274
}
\`\`\`

H-AC-08 painel longitudinal não consegue distinguir \"rodou local de graça\" de \"modelo caro mas faltou cadastro\". Esta PR limpa o sinal.

## Mudanças

### Tipos
- **`shared/src/llm-router.ts`**: `LlmProvider` aceita 3° valor `\"openai-compat\"`. Novo type `GatewayLlmProvider` = narrow `\"anthropic\" | \"infomaniak\"` para o llm-gateway (que só conhece esses dois — openai-compat não passa pelo gateway).

### Helpers
- `getProviderForStep`: aceita `\"openai-compat\"` em `<STEP>_PROVIDER` ou `LLM_PROVIDER`. **DEFAULT_PROVIDERS continua infomaniak em todos os steps** (regression test guard).
- `getModelForStep`: quando provider=openai-compat, resolve model via `LLM_LOCAL_MODEL` env. Default `\"unknown\"` quando env ausente — força operador a setar explicitamente.
- `shouldEnableThinking`: openai-compat sempre false (qwen3-30b-a3b-instruct-2507 sem thinking mode equivalente).

### Cost
- **`shared/src/llm-config.ts`**: `calculateCostUsd` ganha 4° parâmetro **opcional** `provider`. Quando openai-compat → `0` mesmo com modelo desconhecido. Quando omitido (back-compat com callers pré-D-3-PROV), lógica PRICING_TABLE preservada.
- **`shared/src/debug-logger.ts`**: passa `input.provider` pro cost calc.

### Gateway
- **`llm-gateway/src/router.ts`**: Router usa `GatewayLlmProvider` narrow nos maps internos (FALLBACK_MAP, providers, buckets, marks). Guard em `chatCompletion`: se caller envia `\"openai-compat\"`, throw `GatewayError(\"PROVIDER_DOWN\")` com mensagem explicando que LLM local deve ser chamado direto.

### Test
- **`motor-drota/tests/menu-generator.llm-local.integration.test.ts`**: remove cast `\"infomaniak\" as const` → usa `\"openai-compat\"` honestamente.

### Cobertura nova
- **`shared/tests/llm-router.test.ts`**: 7 cases novos (openai-compat em per-step / global / defaults inalterados / model resolution / shouldEnableThinking).
- **`shared/tests/llm-config.test.ts`**: 4 cases (provider-aware cost, zero-tokens override, anthropic/infomaniak back-compat, provider omitido back-compat).

## Validação

\`\`\`
shared:        497 / 8 skip  (era 486 / 8 skip — +11)
planejador:    132            (estável)
motor-drota:   106 / 1 skip   (estável)
motor-execucao: 86             (estável)
orchestrator:    2             (estável)
weekly-report:  58             (estável)
llm-gateway:    42             (estável — guard novo não quebrou tests existentes)
Total:         923 / 9 skip   (+11 tests, 0 regressions)
\`\`\`

Build verde 7 workspaces.

## Próximo passo (Jun executa)

Re-rodar smoke local após merge:
\`\`\`
LLM_LOCAL_STACK_UP=true npm test -w @ascendimacy/motor-drota -- menu-generator.llm-local
\`\`\`

NDJSON resultante deve mostrar `provider: \"openai-compat\"` + `cost_usd_est: 0` (não null).

## Back-compat

- Callers de `calculateCostUsd(model, in, out)` sem provider continuam funcionando (parâmetro opcional)
- NDJSONs de PRs anteriores continuam parseando — Zod do debug-logger não restringe valor de `provider` (`string | null`)
- DEFAULT_PROVIDERS prod inalterados (regression test guarda)
- llm-gateway rejeita openai-compat explicitamente — sem comportamento silencioso ruim

## Não-escopo

- Não cadastra modelos local-específicos no pricing table (Qwen3-30B, Ministral, etc.) — provider-aware short-circuit cobre genericamente
- Não muda defaults de produção
- Não toca outros providers (vLLM-XPU, etc.) — escopo apenas OpenAI-compat genérico

## Refs

- ops#1055 (D-3-PROV)
- motor#90 (mergeado, origem do workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)