### PR TITLE
[H-AC-12] measure-menu-variance.mjs + KPIs/report libs + workflows manual-only

### DIFF
--- a/.github/workflows/h-ac-12-pre-merge.yml
+++ b/.github/workflows/h-ac-12-pre-merge.yml
@@ -1,0 +1,67 @@
+# H-AC-12 pre-merge gate — variância de geração contra Kimi K2.5
+#
+# Spec: ascendimacy-ops/docs/specs/H-AC-12-variancia-geracao-v0.md (v1)
+# Issue: ascendimacy-ops#1058
+#
+# **v0 STATUS**: workflow_dispatch only (manual). Cron + paths-trigger
+# ficam comentados até Jun setar INFOMANIAK_API_KEY no repo + ativar.
+# Tracker: ops#1058 / ops#TBD (issue follow-up "ativar automação H-AC-12").
+#
+# Modo: --quick (N=10 por persona, só Kimi). Roda em GitHub-hosted runner.
+# Self-hosted Windows runner é apenas pro workflow weekly (Qwen3 local).
+
+name: H-AC-12 pre-merge gate (variance vs Kimi K2.5)
+
+on:
+  workflow_dispatch:
+    inputs:
+      persona:
+        description: "Persona a medir (ryo | kei | both)"
+        required: false
+        default: "both"
+      comment_on:
+        description: "Posta comment em ref (ex: ops#1058) — vazio = só stdout"
+        required: false
+        default: ""
+
+  # TODO v0.1: ativar após Jun confirmar INFOMANIAK_API_KEY no repo settings
+  # pull_request:
+  #   paths:
+  #     - 'motor-drota/src/prompts/**'
+  #     - 'motor-drota/src/persona-hints.ts'
+  #     - 'motor-drota/src/menu-generator.ts'
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install
+        run: npm ci --workspaces --include-workspace-root
+
+      - name: Build (postbuild copia prompts pra dist/)
+        run: npm run build
+
+      - name: Run pre-merge variance gate (--quick)
+        env:
+          INFOMANIAK_API_KEY: ${{ secrets.INFOMANIAK_API_KEY }}
+          INFOMANIAK_PRODUCT_ID: ${{ secrets.INFOMANIAK_PRODUCT_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARGS="--quick --persona ${{ github.event.inputs.persona || 'both' }}"
+          if [ -n "${{ github.event.inputs.comment_on }}" ]; then
+            ARGS="$ARGS --comment-on ${{ github.event.inputs.comment_on }}"
+          fi
+          node scripts/measure-menu-variance.mjs $ARGS

--- a/.github/workflows/h-ac-12-weekly.yml
+++ b/.github/workflows/h-ac-12-weekly.yml
@@ -1,0 +1,76 @@
+# H-AC-12 weekly variance — Kimi K2.5 + Qwen3-30B-A3B local
+#
+# Spec: ascendimacy-ops/docs/specs/H-AC-12-variancia-geracao-v0.md (v1)
+# Issue: ascendimacy-ops#1058
+#
+# **v0 STATUS**: workflow_dispatch only (manual). Cron seg 03:00 UTC fica
+# comentado até Jun:
+#   (1) Setar INFOMANIAK_API_KEY + INFOMANIAK_PRODUCT_ID em repo secrets
+#   (2) Configurar self-hosted Windows runner com llama.cpp SYCL up
+#       servindo qwen3-30b em http://172.28.160.1:9000 (ou config equivalente)
+#   (3) Ativar cron + remover `if: false`
+#
+# Modo: --full (N=30 por persona × 2 modelos). Self-hosted Windows runner
+# por causa do Qwen3-30B local. Tempo estimado: ~3-4h sob PSU cap atual.
+
+name: H-AC-12 weekly variance (Kimi + Qwen3 local)
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Mode (full=N30, quick=N10)"
+        required: false
+        default: "full"
+      comment_on:
+        description: "Posta comment em ref (default: ops#1058 — feed longitudinal)"
+        required: false
+        default: "ops#1058"
+
+  # TODO v0.1: ativar cron após Jun confirmar secrets + self-hosted runner up.
+  # schedule:
+  #   - cron: "0 3 * * 1"  # segunda 03:00 UTC
+
+jobs:
+  measure:
+    # TODO v0.1: trocar pra self-hosted Windows runner com stack Qwen3 up
+    runs-on: self-hosted
+    timeout-minutes: 360
+    if: false  # guard: NÃO roda automaticamente até Jun habilitar
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install
+        run: npm ci --workspaces --include-workspace-root
+
+      - name: Build
+        run: npm run build
+
+      - name: Confirm Qwen3 stack up (sanity check)
+        env:
+          LLM_LOCAL_ENDPOINT: ${{ vars.LLM_LOCAL_ENDPOINT || 'http://172.28.160.1:9000' }}
+        run: |
+          curl -fsS "${LLM_LOCAL_ENDPOINT}/v1/models" > /dev/null || {
+            echo "Qwen3 stack offline em ${LLM_LOCAL_ENDPOINT}; falhando run cedo."
+            exit 1
+          }
+
+      - name: Run weekly variance (--full)
+        env:
+          INFOMANIAK_API_KEY: ${{ secrets.INFOMANIAK_API_KEY }}
+          INFOMANIAK_PRODUCT_ID: ${{ secrets.INFOMANIAK_PRODUCT_ID }}
+          LLM_LOCAL_ENDPOINT: ${{ vars.LLM_LOCAL_ENDPOINT || 'http://172.28.160.1:9000/v1/chat/completions' }}
+          LLM_LOCAL_MODEL: "qwen3-30b"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/measure-menu-variance.mjs \
+            --${{ github.event.inputs.mode || 'full' }} \
+            --comment-on ${{ github.event.inputs.comment_on || 'ops#1058' }}

--- a/motor-drota/src/variance/index.ts
+++ b/motor-drota/src/variance/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Variance — agregadores de KPI longitudinal pra H-AC-12 (ops#1058).
+ *
+ * Funções puras (kpis.ts) + renderer (report.ts) — consumidos pelo
+ * `scripts/measure-menu-variance.mjs` e potencialmente por outros
+ * agregadores (H-AC-08 painel futuro).
+ */
+
+export {
+  computeCostStats,
+  computeDistAlignment,
+  computeKpis,
+  deriveOutcome,
+  emptyDistribution,
+  klDivergence,
+  KPI_THRESHOLDS_V0,
+  normalizeDistribution,
+  observedDistribution,
+  passesV0Thresholds,
+  type CostStats,
+  type KpiSummary,
+  type Outcome,
+  type PlayedAsDistribution,
+  type RunResult,
+} from "./kpis.js";
+
+export {
+  renderReport,
+  type CellInput,
+  type ReportConfig,
+} from "./report.js";

--- a/motor-drota/src/variance/kpis.ts
+++ b/motor-drota/src/variance/kpis.ts
@@ -1,0 +1,275 @@
+/**
+ * Variância KPIs — H-AC-12 (spec ratificada v1, ops#1058).
+ *
+ * Funções puras pra agregar runs do `generateActionMenu` em métricas
+ * longitudinais. Consumido por `scripts/measure-menu-variance.mjs` e
+ * possivelmente outros agregadores futuros (H-AC-08 painel).
+ *
+ * Métricas (Opção B da spec §4 — ratificada Jun 2026-05-13):
+ *  - pass_rate_first  — outcome=ok primeiro try (limiar v0 ≥50%)
+ *  - recovery_rate    — outcome=ok-retry (limiar v0 ≤40%)
+ *  - degradation_rate — outcome=degraded (ISA stripped, limiar v0 ≤10%)
+ *  - error_rate       — outcome=error (null retornado, limiar v0 ≤5%)
+ *  - dist_alignment   — KL divergence entre distribuição realizada e hint
+ *                       (limiar v0 ≤0.3)
+ */
+
+import type { ActionMenu, PlayedAs } from "@ascendimacy/shared";
+
+/** Outcome granular conforme D-4-TELO (motor#92). */
+export type Outcome = "ok" | "ok-retry" | "degraded" | "error";
+
+/** Códigos de warning emitidos pelo generateActionMenu. */
+type GeneratorWarningCode =
+  | "invalid_input"
+  | "llm_error"
+  | "parse_error_first"
+  | "parse_error_retry"
+  | "schema_error_first"
+  | "schema_error_retry"
+  | "isa_labels_stripped";
+
+/** Resultado de um run individual de generateActionMenu. */
+export interface RunResult {
+  menu: ActionMenu | null;
+  warnings: ReadonlyArray<GeneratorWarningCode>;
+  latencyMs: number;
+  tokensIn: number;
+  tokensOut: number;
+  costUsdEst: number;
+}
+
+/**
+ * Deriva o outcome granular a partir do resultado do run.
+ *
+ * Algoritmo (espelha menu-generator.ts):
+ *  - menu null               → "error"
+ *  - menu OK + isa_stripped  → "degraded"
+ *  - menu OK + qualquer erro → "ok-retry"
+ *  - menu OK sem erro        → "ok"
+ */
+export function deriveOutcome(run: RunResult): Outcome {
+  if (run.menu === null) return "error";
+  if (run.warnings.includes("isa_labels_stripped")) return "degraded";
+  const retryIndicators: GeneratorWarningCode[] = [
+    "parse_error_first",
+    "schema_error_first",
+    "parse_error_retry",
+    "schema_error_retry",
+    "llm_error",
+  ];
+  if (run.warnings.some((w) => retryIndicators.includes(w))) return "ok-retry";
+  return "ok";
+}
+
+/** Agrupa runs por outcome + computa rates. */
+export interface KpiSummary {
+  total: number;
+  passRateFirst: number;   // [0, 1]
+  recoveryRate: number;
+  degradationRate: number;
+  errorRate: number;
+}
+
+export function computeKpis(runs: ReadonlyArray<RunResult>): KpiSummary {
+  const total = runs.length;
+  if (total === 0) {
+    return {
+      total: 0,
+      passRateFirst: 0,
+      recoveryRate: 0,
+      degradationRate: 0,
+      errorRate: 0,
+    };
+  }
+  const counts = { ok: 0, "ok-retry": 0, degraded: 0, error: 0 };
+  for (const r of runs) {
+    counts[deriveOutcome(r)] += 1;
+  }
+  return {
+    total,
+    passRateFirst: counts.ok / total,
+    recoveryRate: counts["ok-retry"] / total,
+    degradationRate: counts.degraded / total,
+    errorRate: counts.error / total,
+  };
+}
+
+/** Limiares relaxados v0 — Jun ratificou Opção B 2026-05-13. */
+export const KPI_THRESHOLDS_V0 = {
+  passRateFirstMin: 0.50,
+  recoveryRateMax: 0.40,
+  degradationRateMax: 0.10,
+  errorRateMax: 0.05,
+  distAlignmentMax: 0.3,
+} as const;
+
+/** Verdadeiro se KPI summary passa pelos limiares v0. */
+export function passesV0Thresholds(
+  kpis: KpiSummary,
+  distAlignment: number,
+): { ok: true } | { ok: false; failures: string[] } {
+  const failures: string[] = [];
+  if (kpis.passRateFirst < KPI_THRESHOLDS_V0.passRateFirstMin) {
+    failures.push(
+      `pass_rate_first ${(kpis.passRateFirst * 100).toFixed(0)}% < ${KPI_THRESHOLDS_V0.passRateFirstMin * 100}%`,
+    );
+  }
+  if (kpis.recoveryRate > KPI_THRESHOLDS_V0.recoveryRateMax) {
+    failures.push(
+      `recovery_rate ${(kpis.recoveryRate * 100).toFixed(0)}% > ${KPI_THRESHOLDS_V0.recoveryRateMax * 100}%`,
+    );
+  }
+  if (kpis.degradationRate > KPI_THRESHOLDS_V0.degradationRateMax) {
+    failures.push(
+      `degradation_rate ${(kpis.degradationRate * 100).toFixed(0)}% > ${KPI_THRESHOLDS_V0.degradationRateMax * 100}%`,
+    );
+  }
+  if (kpis.errorRate > KPI_THRESHOLDS_V0.errorRateMax) {
+    failures.push(
+      `error_rate ${(kpis.errorRate * 100).toFixed(0)}% > ${KPI_THRESHOLDS_V0.errorRateMax * 100}%`,
+    );
+  }
+  if (distAlignment > KPI_THRESHOLDS_V0.distAlignmentMax) {
+    failures.push(
+      `dist_alignment ${distAlignment.toFixed(2)} > ${KPI_THRESHOLDS_V0.distAlignmentMax}`,
+    );
+  }
+  return failures.length === 0 ? { ok: true } : { ok: false, failures };
+}
+
+/** Distribuição observada de played_as em N runs (não normalizada). */
+export type PlayedAsDistribution = Record<PlayedAs, number>;
+
+const PLAYED_AS_KEYS: ReadonlyArray<PlayedAs> = [
+  "bridge",
+  "espelho",
+  "canal",
+  "diamante",
+  "arena",
+  "recovery",
+];
+
+export function emptyDistribution(): PlayedAsDistribution {
+  return {
+    bridge: 0,
+    espelho: 0,
+    canal: 0,
+    diamante: 0,
+    arena: 0,
+    recovery: 0,
+  };
+}
+
+/**
+ * Agrega played_as de todos os items de todos os runs com menu válido.
+ * Items sem `played_as` (graceful degradation) são ignorados — não
+ * contam pra distribuição, mas continuam contando no degradation_rate.
+ */
+export function observedDistribution(runs: ReadonlyArray<RunResult>): PlayedAsDistribution {
+  const dist = emptyDistribution();
+  for (const run of runs) {
+    if (run.menu === null) continue;
+    for (const item of run.menu.items) {
+      if (item.played_as != null) {
+        dist[item.played_as] += 1;
+      }
+    }
+  }
+  return dist;
+}
+
+/** Normaliza distribuição absoluta em probabilidade [0, 1]. */
+export function normalizeDistribution(
+  dist: PlayedAsDistribution,
+): Record<PlayedAs, number> {
+  const total = Object.values(dist).reduce((s, v) => s + v, 0);
+  if (total === 0) return { ...dist };
+  const out = {} as Record<PlayedAs, number>;
+  for (const k of PLAYED_AS_KEYS) {
+    out[k] = dist[k] / total;
+  }
+  return out;
+}
+
+/**
+ * KL divergence D(p || q) = Σ p_i × log(p_i / q_i).
+ *
+ * p = distribuição realizada (observed); q = distribuição esperada (hint).
+ *
+ * Convenção: 0 × log(0) = 0 (matemática padrão). Para evitar log(0)
+ * quando q_i = 0 mas p_i > 0, aplica laplace smoothing pequeno (epsilon
+ * 1e-6) — caso extremo improvável em N=30 com 6 jogadas, mas defensivo.
+ *
+ * Resultado em **nats** (log natural). Quanto menor, mais aderente p é a q.
+ *
+ * Limiar Jun ratificou: ≤ 0.3 (v0).
+ */
+export function klDivergence(
+  observedNorm: Record<PlayedAs, number>,
+  expectedNorm: Record<PlayedAs, number>,
+): number {
+  const epsilon = 1e-6;
+  let kl = 0;
+  for (const k of PLAYED_AS_KEYS) {
+    const p = observedNorm[k];
+    const q = expectedNorm[k];
+    if (p === 0) continue;          // 0 × log(0/q) = 0 convencional
+    const qSmooth = q === 0 ? epsilon : q;
+    kl += p * Math.log(p / qSmooth);
+  }
+  return kl;
+}
+
+/**
+ * Helper end-to-end: dado runs + hint, computa KL diretamente.
+ * `personaHintBias` é o `bias` array do PersonaHint (RYO_HINT.bias etc).
+ */
+export function computeDistAlignment(
+  runs: ReadonlyArray<RunResult>,
+  personaHintBias: ReadonlyArray<{ played_as: PlayedAs; weight: number }>,
+): number {
+  const observedNorm = normalizeDistribution(observedDistribution(runs));
+
+  // Hint bias → distribuição esperada normalizada.
+  const expected = emptyDistribution();
+  for (const b of personaHintBias) {
+    expected[b.played_as] = b.weight;
+  }
+  const expectedNorm = normalizeDistribution(expected);
+
+  return klDivergence(observedNorm, expectedNorm);
+}
+
+/** Cost stats agregado (mean + total). */
+export interface CostStats {
+  totalUsd: number;
+  meanUsdPerRun: number;
+  meanLatencyMs: number;
+  meanTokensIn: number;
+  meanTokensOut: number;
+}
+
+export function computeCostStats(runs: ReadonlyArray<RunResult>): CostStats {
+  const total = runs.length;
+  if (total === 0) {
+    return {
+      totalUsd: 0,
+      meanUsdPerRun: 0,
+      meanLatencyMs: 0,
+      meanTokensIn: 0,
+      meanTokensOut: 0,
+    };
+  }
+  const sumUsd = runs.reduce((s, r) => s + r.costUsdEst, 0);
+  const sumLatency = runs.reduce((s, r) => s + r.latencyMs, 0);
+  const sumIn = runs.reduce((s, r) => s + r.tokensIn, 0);
+  const sumOut = runs.reduce((s, r) => s + r.tokensOut, 0);
+  return {
+    totalUsd: sumUsd,
+    meanUsdPerRun: sumUsd / total,
+    meanLatencyMs: sumLatency / total,
+    meanTokensIn: sumIn / total,
+    meanTokensOut: sumOut / total,
+  };
+}

--- a/motor-drota/src/variance/report.ts
+++ b/motor-drota/src/variance/report.ts
@@ -1,0 +1,191 @@
+/**
+ * Variância report — renderiza markdown agregado p/ H-AC-12.
+ *
+ * Spec ratificada v1 (ops#1058 §5.2): comment em PR (trigger-por-mudança)
+ * ou em ops#1058 (scheduled semanal). NÃO commitar em docs/measurements/.
+ */
+
+import type { PlayedAs } from "@ascendimacy/shared";
+
+import {
+  computeCostStats,
+  computeDistAlignment,
+  computeKpis,
+  observedDistribution,
+  normalizeDistribution,
+  passesV0Thresholds,
+  type RunResult,
+} from "./kpis.js";
+
+/** Spec de uma célula (modelo × persona) no relatório. */
+export interface CellInput {
+  model: string;
+  modelLabel: string;            // ex: "Kimi K2.5"
+  personaId: string;
+  personaLabel: string;          // ex: "Ryo (deflective)"
+  personaHintBias: ReadonlyArray<{ played_as: PlayedAs; weight: number }>;
+  runs: ReadonlyArray<RunResult>;
+}
+
+/** Configuração de rendering. */
+export interface ReportConfig {
+  promptVersion: string;          // ex: "v0.1" (motor#90)
+  mode: "quick" | "full" | "manual";
+  timestamp: string;              // ISO 8601 do início da execução
+  runId: string;                  // ex: "hac12-2026-05-20T03-00-00"
+  cells: ReadonlyArray<CellInput>;
+}
+
+const PLAYED_AS_KEYS: ReadonlyArray<PlayedAs> = [
+  "bridge",
+  "espelho",
+  "canal",
+  "diamante",
+  "arena",
+  "recovery",
+];
+
+function pct(x: number): string {
+  return `${(x * 100).toFixed(0)}%`;
+}
+
+function top2(dist: Record<PlayedAs, number>): string {
+  const sorted = [...PLAYED_AS_KEYS].sort((a, b) => dist[b] - dist[a]);
+  return sorted.slice(0, 2).join(", ");
+}
+
+function passEmoji(ok: boolean): string {
+  return ok ? "PASS" : "FAIL";
+}
+
+/**
+ * Renderiza markdown completo do relatório, ready pra ser passado pra
+ * `gh pr comment --body-file` ou `gh issue comment --body-file`.
+ */
+export function renderReport(config: ReportConfig): string {
+  const date = config.timestamp.split("T")[0];
+  const lines: string[] = [];
+
+  lines.push(`# H-AC-12 — Variância de geração — ${date}`);
+  lines.push("");
+  lines.push(
+    `**Mode:** \`${config.mode}\` | **Prompt:** \`${config.promptVersion}\` | ` +
+      `**Run:** \`${config.runId}\``,
+  );
+  lines.push("");
+
+  // === Resumo (tabela principal) ===
+  lines.push("## Resumo");
+  lines.push("");
+  lines.push(
+    "| Modelo | Persona | N | pass_first | recovery | degraded | error | dist_align | Pass? |",
+  );
+  lines.push("|---|---|---|---|---|---|---|---|---|");
+
+  let allPass = true;
+  const cellResults: Array<{
+    cell: CellInput;
+    kpis: ReturnType<typeof computeKpis>;
+    distAlignment: number;
+    pass: ReturnType<typeof passesV0Thresholds>;
+    cost: ReturnType<typeof computeCostStats>;
+  }> = [];
+
+  for (const cell of config.cells) {
+    const kpis = computeKpis(cell.runs);
+    const distAlignment = computeDistAlignment(cell.runs, cell.personaHintBias);
+    const pass = passesV0Thresholds(kpis, distAlignment);
+    const cost = computeCostStats(cell.runs);
+    cellResults.push({ cell, kpis, distAlignment, pass, cost });
+    if (!pass.ok) allPass = false;
+
+    lines.push(
+      `| ${cell.modelLabel} | ${cell.personaLabel} | ${kpis.total} | ` +
+        `${pct(kpis.passRateFirst)} | ${pct(kpis.recoveryRate)} | ` +
+        `${pct(kpis.degradationRate)} | ${pct(kpis.errorRate)} | ` +
+        `${distAlignment.toFixed(2)} | ${passEmoji(pass.ok)} |`,
+    );
+  }
+
+  lines.push("");
+  lines.push(
+    `**Resultado global:** ${allPass ? "PASS — todos os limiares v0 atendidos" : "FAIL — pelo menos uma célula reprovou (detalhes abaixo)"}`,
+  );
+  lines.push("");
+
+  // === Distribuição played_as por célula ===
+  lines.push("## Distribuição played_as (realizada × esperada)");
+  lines.push("");
+  for (const { cell } of cellResults) {
+    const observed = normalizeDistribution(observedDistribution(cell.runs));
+    const expectedMap: Record<PlayedAs, number> = {
+      bridge: 0,
+      espelho: 0,
+      canal: 0,
+      diamante: 0,
+      arena: 0,
+      recovery: 0,
+    };
+    for (const b of cell.personaHintBias) expectedMap[b.played_as] = b.weight;
+    const expected = normalizeDistribution(expectedMap);
+
+    lines.push(`### ${cell.modelLabel} × ${cell.personaLabel}`);
+    lines.push("");
+    lines.push("| jogada | realizada | esperada (hint) | Δ |");
+    lines.push("|---|---|---|---|");
+    for (const k of PLAYED_AS_KEYS) {
+      const delta = observed[k] - expected[k];
+      const sign = delta >= 0 ? "+" : "";
+      lines.push(`| ${k} | ${pct(observed[k])} | ${pct(expected[k])} | ${sign}${(delta * 100).toFixed(0)}pp |`);
+    }
+    lines.push("");
+    lines.push(`Top-2 realizado: **${top2(observed)}** vs esperado: **${top2(expected)}**.`);
+    lines.push("");
+  }
+
+  // === Sinais acionáveis (só aparecem se algum KPI falha) ===
+  const actionable = cellResults.filter((r) => !r.pass.ok);
+  if (actionable.length > 0) {
+    lines.push("## Sinais acionáveis");
+    lines.push("");
+    for (const r of actionable) {
+      lines.push(`### ${r.cell.modelLabel} × ${r.cell.personaLabel} — FAIL`);
+      lines.push("");
+      if (!r.pass.ok) {
+        for (const f of r.pass.failures) {
+          lines.push(`- ${f}`);
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  // === Custo + latência ===
+  lines.push("## Custo + latência");
+  lines.push("");
+  lines.push(
+    "| Modelo | Persona | total $ | $/run | mean latency | mean tokens (in/out) |",
+  );
+  lines.push("|---|---|---|---|---|---|");
+  let totalCost = 0;
+  for (const { cell, cost } of cellResults) {
+    totalCost += cost.totalUsd;
+    lines.push(
+      `| ${cell.modelLabel} | ${cell.personaLabel} | ` +
+        `$${cost.totalUsd.toFixed(3)} | $${cost.meanUsdPerRun.toFixed(4)} | ` +
+        `${(cost.meanLatencyMs / 1000).toFixed(1)}s | ` +
+        `${Math.round(cost.meanTokensIn)}/${Math.round(cost.meanTokensOut)} |`,
+    );
+  }
+  lines.push("");
+  lines.push(`**Total execução:** $${totalCost.toFixed(2)}`);
+  lines.push("");
+
+  // === Footer ===
+  lines.push("---");
+  lines.push(
+    `_Gerado por \`scripts/measure-menu-variance.mjs\` em \`${config.timestamp}\` — spec H-AC-12 ratificada v1 (ops#1058)._`,
+  );
+
+  return lines.join("\n");
+}

--- a/motor-drota/tests/variance-kpis.unit.test.ts
+++ b/motor-drota/tests/variance-kpis.unit.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests — variance/kpis.ts (H-AC-12, ops#1058).
+ *
+ * Cobre deriveOutcome / computeKpis / dist_alignment KL / passesV0Thresholds.
+ * Tudo funções puras, mock-free.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type { ActionMenu, PlayedAs } from "@ascendimacy/shared";
+
+import {
+  computeCostStats,
+  computeDistAlignment,
+  computeKpis,
+  deriveOutcome,
+  emptyDistribution,
+  klDivergence,
+  KPI_THRESHOLDS_V0,
+  normalizeDistribution,
+  observedDistribution,
+  passesV0Thresholds,
+  type RunResult,
+} from "../src/variance/kpis.js";
+
+function mockMenu(items: Array<{ played_as?: PlayedAs }>): ActionMenu {
+  return {
+    persona_id: "ryo-ochiai",
+    schema_version: "v0.2.0",
+    generated_at: "2026-05-13T20:00:00.000Z",
+    source: { trust_level: 0.42 },
+    items: items.map((it, i) => ({
+      id: `it-${i}`,
+      type: "curiosity" as const,
+      content: `mock-${i}`,
+      weight: 0.5,
+      ...it,
+    })),
+  };
+}
+
+function mockRun(
+  menu: ActionMenu | null,
+  warnings: ReadonlyArray<string> = [],
+  overrides: Partial<RunResult> = {},
+): RunResult {
+  return {
+    menu,
+    warnings: warnings as RunResult["warnings"],
+    latencyMs: 1000,
+    tokensIn: 4000,
+    tokensOut: 1500,
+    costUsdEst: 0.08,
+    ...overrides,
+  };
+}
+
+describe("deriveOutcome", () => {
+  it("menu null → error", () => {
+    expect(deriveOutcome(mockRun(null))).toBe("error");
+  });
+
+  it("menu OK + isa_labels_stripped → degraded", () => {
+    expect(deriveOutcome(mockRun(mockMenu([{}]), ["isa_labels_stripped"]))).toBe(
+      "degraded",
+    );
+  });
+
+  it("menu OK + schema_error_first (retry recuperou) → ok-retry", () => {
+    expect(
+      deriveOutcome(mockRun(mockMenu([{}]), ["schema_error_first"])),
+    ).toBe("ok-retry");
+  });
+
+  it("menu OK + parse_error_first → ok-retry", () => {
+    expect(
+      deriveOutcome(mockRun(mockMenu([{}]), ["parse_error_first"])),
+    ).toBe("ok-retry");
+  });
+
+  it("menu OK + llm_error (recuperado) → ok-retry", () => {
+    expect(deriveOutcome(mockRun(mockMenu([{}]), ["llm_error"]))).toBe(
+      "ok-retry",
+    );
+  });
+
+  it("menu OK + sem warnings → ok", () => {
+    expect(deriveOutcome(mockRun(mockMenu([{}]), []))).toBe("ok");
+  });
+
+  it("prioridade: isa_labels_stripped > retry warnings (degraded vence)", () => {
+    expect(
+      deriveOutcome(
+        mockRun(mockMenu([{}]), ["schema_error_first", "isa_labels_stripped"]),
+      ),
+    ).toBe("degraded");
+  });
+});
+
+describe("computeKpis", () => {
+  it("totaliza outcomes e calcula rates", () => {
+    const runs = [
+      mockRun(mockMenu([{}])),                                          // ok
+      mockRun(mockMenu([{}])),                                          // ok
+      mockRun(mockMenu([{}]), ["schema_error_first"]),                  // ok-retry
+      mockRun(mockMenu([{}]), ["isa_labels_stripped"]),                 // degraded
+      mockRun(null),                                                    // error
+    ];
+    const kpis = computeKpis(runs);
+    expect(kpis.total).toBe(5);
+    expect(kpis.passRateFirst).toBe(0.4);
+    expect(kpis.recoveryRate).toBe(0.2);
+    expect(kpis.degradationRate).toBe(0.2);
+    expect(kpis.errorRate).toBe(0.2);
+    // Soma exata = 1.0
+    expect(
+      kpis.passRateFirst + kpis.recoveryRate + kpis.degradationRate + kpis.errorRate,
+    ).toBeCloseTo(1, 10);
+  });
+
+  it("array vazio → zeros", () => {
+    const kpis = computeKpis([]);
+    expect(kpis.total).toBe(0);
+    expect(kpis.passRateFirst).toBe(0);
+  });
+});
+
+describe("passesV0Thresholds — Opção B (multi-KPI)", () => {
+  const baselineHealthy = {
+    total: 30,
+    passRateFirst: 0.7,
+    recoveryRate: 0.2,
+    degradationRate: 0.05,
+    errorRate: 0.01,
+  };
+
+  it("KPIs saudáveis + dist OK → pass", () => {
+    const r = passesV0Thresholds(baselineHealthy, 0.15);
+    expect(r.ok).toBe(true);
+  });
+
+  it("pass_rate_first abaixo do limiar → fail", () => {
+    const r = passesV0Thresholds(
+      { ...baselineHealthy, passRateFirst: 0.4 },
+      0.15,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.failures.join(" ")).toMatch(/pass_rate_first/);
+    }
+  });
+
+  it("recovery_rate acima do limiar → fail", () => {
+    const r = passesV0Thresholds(
+      { ...baselineHealthy, recoveryRate: 0.5 },
+      0.15,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.failures.join(" ")).toMatch(/recovery_rate/);
+    }
+  });
+
+  it("degradation_rate acima do limiar → fail", () => {
+    const r = passesV0Thresholds(
+      { ...baselineHealthy, degradationRate: 0.15 },
+      0.15,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.failures.join(" ")).toMatch(/degradation_rate/);
+    }
+  });
+
+  it("error_rate acima do limiar → fail", () => {
+    const r = passesV0Thresholds({ ...baselineHealthy, errorRate: 0.1 }, 0.15);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.failures.join(" ")).toMatch(/error_rate/);
+    }
+  });
+
+  it("dist_alignment acima do limiar → fail", () => {
+    const r = passesV0Thresholds(baselineHealthy, 0.5);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.failures.join(" ")).toMatch(/dist_alignment/);
+    }
+  });
+
+  it("multiple failures todas reportadas", () => {
+    const r = passesV0Thresholds(
+      {
+        total: 30,
+        passRateFirst: 0.2,
+        recoveryRate: 0.6,
+        degradationRate: 0.15,
+        errorRate: 0.1,
+      },
+      0.8,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.failures.length).toBe(5);
+    }
+  });
+
+  it("constantes KPI_THRESHOLDS_V0 expostas e válidas", () => {
+    expect(KPI_THRESHOLDS_V0.passRateFirstMin).toBe(0.5);
+    expect(KPI_THRESHOLDS_V0.recoveryRateMax).toBe(0.4);
+    expect(KPI_THRESHOLDS_V0.degradationRateMax).toBe(0.1);
+    expect(KPI_THRESHOLDS_V0.errorRateMax).toBe(0.05);
+    expect(KPI_THRESHOLDS_V0.distAlignmentMax).toBe(0.3);
+  });
+});
+
+describe("observedDistribution", () => {
+  it("agrega played_as de todos os items de todos os runs", () => {
+    const runs = [
+      mockRun(mockMenu([{ played_as: "espelho" }, { played_as: "canal" }])),
+      mockRun(mockMenu([{ played_as: "espelho" }, { played_as: "bridge" }])),
+    ];
+    const dist = observedDistribution(runs);
+    expect(dist.espelho).toBe(2);
+    expect(dist.canal).toBe(1);
+    expect(dist.bridge).toBe(1);
+    expect(dist.diamante).toBe(0);
+    expect(dist.arena).toBe(0);
+    expect(dist.recovery).toBe(0);
+  });
+
+  it("ignora items sem played_as (graceful degradation)", () => {
+    const runs = [mockRun(mockMenu([{ played_as: "espelho" }, {}]))];
+    const dist = observedDistribution(runs);
+    expect(dist.espelho).toBe(1);
+    expect(Object.values(dist).reduce((s, v) => s + v, 0)).toBe(1);
+  });
+
+  it("ignora runs com menu null", () => {
+    const runs = [mockRun(null), mockRun(mockMenu([{ played_as: "canal" }]))];
+    const dist = observedDistribution(runs);
+    expect(dist.canal).toBe(1);
+  });
+});
+
+describe("klDivergence", () => {
+  it("KL(p, p) = 0 (mesma distribuição)", () => {
+    const p = { bridge: 0.2, espelho: 0.3, canal: 0.3, diamante: 0.1, arena: 0.05, recovery: 0.05 };
+    expect(klDivergence(p, p)).toBeCloseTo(0, 8);
+  });
+
+  it("KL > 0 quando p diverge de q", () => {
+    const observed = { bridge: 0.5, espelho: 0.1, canal: 0.1, diamante: 0.1, arena: 0.1, recovery: 0.1 };
+    const expected = { bridge: 0.1, espelho: 0.5, canal: 0.2, diamante: 0.1, arena: 0.05, recovery: 0.05 };
+    expect(klDivergence(observed, expected)).toBeGreaterThan(0);
+  });
+
+  it("p_i = 0 não contribui (convenção 0 × log = 0)", () => {
+    const p = { bridge: 0, espelho: 0.5, canal: 0.5, diamante: 0, arena: 0, recovery: 0 };
+    const q = { bridge: 0, espelho: 0.5, canal: 0.5, diamante: 0, arena: 0, recovery: 0 };
+    expect(klDivergence(p, q)).toBe(0);
+  });
+
+  it("q_i = 0 com p_i > 0 não explode (laplace smoothing)", () => {
+    const p = { bridge: 0.5, espelho: 0.5, canal: 0, diamante: 0, arena: 0, recovery: 0 };
+    const q = { bridge: 0.5, espelho: 0.5, canal: 0, diamante: 0, arena: 0, recovery: 0 };
+    // Mesmas duas distribuições — KL = 0
+    expect(klDivergence(p, q)).toBeCloseTo(0, 8);
+
+    // Agora p tem peso em canal mas q não — KL deve ser finito (não Infinity)
+    const pCanal = { bridge: 0.3, espelho: 0.3, canal: 0.4, diamante: 0, arena: 0, recovery: 0 };
+    const qSemCanal = { bridge: 0.5, espelho: 0.5, canal: 0, diamante: 0, arena: 0, recovery: 0 };
+    const result = klDivergence(pCanal, qSemCanal);
+    expect(Number.isFinite(result)).toBe(true);
+    expect(result).toBeGreaterThan(1); // grande pq smoothing 1e-6 é log(0.4 / 1e-6) ≈ 12.9
+  });
+});
+
+describe("computeDistAlignment (e2e KL pipeline)", () => {
+  it("Ryo deflective (hint pende espelho/canal) — distribuição realizada similar → KL baixo", () => {
+    const runs = [
+      mockRun(mockMenu([
+        { played_as: "espelho" },
+        { played_as: "espelho" },
+        { played_as: "canal" },
+        { played_as: "canal" },
+        { played_as: "bridge" },
+        { played_as: "diamante" },
+      ])),
+    ];
+    const ryoBias: Array<{ played_as: PlayedAs; weight: number }> = [
+      { played_as: "espelho", weight: 0.30 },
+      { played_as: "canal", weight: 0.28 },
+      { played_as: "bridge", weight: 0.15 },
+      { played_as: "diamante", weight: 0.12 },
+      { played_as: "arena", weight: 0.08 },
+      { played_as: "recovery", weight: 0.07 },
+    ];
+    const kl = computeDistAlignment(runs, ryoBias);
+    expect(kl).toBeLessThan(0.3); // dentro do limiar v0
+  });
+
+  it("distribuição inversa do hint → KL alto", () => {
+    const runs = [
+      mockRun(mockMenu([
+        { played_as: "diamante" },
+        { played_as: "diamante" },
+        { played_as: "bridge" },
+        { played_as: "bridge" },
+      ])),
+    ];
+    const ryoBias: Array<{ played_as: PlayedAs; weight: number }> = [
+      { played_as: "espelho", weight: 0.30 },
+      { played_as: "canal", weight: 0.28 },
+      { played_as: "bridge", weight: 0.15 },
+      { played_as: "diamante", weight: 0.12 },
+      { played_as: "arena", weight: 0.08 },
+      { played_as: "recovery", weight: 0.07 },
+    ];
+    const kl = computeDistAlignment(runs, ryoBias);
+    expect(kl).toBeGreaterThan(0.5);
+  });
+});
+
+describe("normalizeDistribution", () => {
+  it("normaliza pra soma = 1", () => {
+    const dist = { bridge: 5, espelho: 10, canal: 5, diamante: 0, arena: 0, recovery: 0 };
+    const norm = normalizeDistribution(dist);
+    expect(Object.values(norm).reduce((s, v) => s + v, 0)).toBeCloseTo(1, 10);
+    expect(norm.espelho).toBeCloseTo(0.5, 10);
+    expect(norm.bridge).toBeCloseTo(0.25, 10);
+  });
+
+  it("dist toda zero → retorna dist toda zero (não NaN)", () => {
+    const norm = normalizeDistribution(emptyDistribution());
+    for (const v of Object.values(norm)) {
+      expect(v).toBe(0);
+      expect(Number.isNaN(v)).toBe(false);
+    }
+  });
+});
+
+describe("computeCostStats", () => {
+  it("agrega cost total + mean + latency + tokens", () => {
+    const runs = [
+      mockRun(mockMenu([{}]), [], {
+        costUsdEst: 0.05,
+        latencyMs: 1000,
+        tokensIn: 4000,
+        tokensOut: 1000,
+      }),
+      mockRun(mockMenu([{}]), [], {
+        costUsdEst: 0.10,
+        latencyMs: 3000,
+        tokensIn: 5000,
+        tokensOut: 1500,
+      }),
+    ];
+    const stats = computeCostStats(runs);
+    expect(stats.totalUsd).toBeCloseTo(0.15, 5);
+    expect(stats.meanUsdPerRun).toBeCloseTo(0.075, 5);
+    expect(stats.meanLatencyMs).toBe(2000);
+    expect(stats.meanTokensIn).toBe(4500);
+    expect(stats.meanTokensOut).toBe(1250);
+  });
+
+  it("array vazio → zeros (não NaN)", () => {
+    const stats = computeCostStats([]);
+    expect(stats.totalUsd).toBe(0);
+    expect(stats.meanUsdPerRun).toBe(0);
+    expect(Number.isNaN(stats.meanLatencyMs)).toBe(false);
+  });
+});

--- a/motor-drota/tests/variance-report.unit.test.ts
+++ b/motor-drota/tests/variance-report.unit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests — variance/report.ts (H-AC-12, ops#1058).
+ *
+ * Smoke tests rendering: contém células PASS/FAIL, distribuições, custo.
+ * Não testa formato exato (frágil) — testa presença de campos chave.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ActionMenu, PlayedAs } from "@ascendimacy/shared";
+import { renderReport, type CellInput } from "../src/variance/report.js";
+import type { RunResult } from "../src/variance/kpis.js";
+
+function mockMenu(items: Array<{ played_as?: PlayedAs }>): ActionMenu {
+  return {
+    persona_id: "ryo-ochiai",
+    schema_version: "v0.2.0",
+    generated_at: "2026-05-13T20:00:00.000Z",
+    source: { trust_level: 0.42 },
+    items: items.map((it, i) => ({
+      id: `it-${i}`,
+      type: "curiosity" as const,
+      content: `mock-${i}`,
+      weight: 0.5,
+      ...it,
+    })),
+  };
+}
+
+function mockRun(
+  menu: ActionMenu | null,
+  warnings: ReadonlyArray<string> = [],
+): RunResult {
+  return {
+    menu,
+    warnings: warnings as RunResult["warnings"],
+    latencyMs: 1000,
+    tokensIn: 4000,
+    tokensOut: 1500,
+    costUsdEst: 0.08,
+  };
+}
+
+const RYO_BIAS: ReadonlyArray<{ played_as: PlayedAs; weight: number }> = [
+  { played_as: "espelho", weight: 0.30 },
+  { played_as: "canal", weight: 0.28 },
+  { played_as: "bridge", weight: 0.15 },
+  { played_as: "diamante", weight: 0.12 },
+  { played_as: "arena", weight: 0.08 },
+  { played_as: "recovery", weight: 0.07 },
+];
+
+function healthyRyoCell(): CellInput {
+  // 30 runs Ryo, distribuição alinhada com hint, todos ok
+  const runs: RunResult[] = [];
+  const dist: PlayedAs[] = ["espelho", "canal", "bridge", "diamante", "arena", "recovery"];
+  const counts = [10, 9, 5, 4, 1, 1];
+  for (let i = 0; i < dist.length; i++) {
+    for (let j = 0; j < counts[i]!; j++) {
+      runs.push(mockRun(mockMenu([{ played_as: dist[i] }])));
+    }
+  }
+  return {
+    model: "kimi",
+    modelLabel: "Kimi K2.5",
+    personaId: "ryo-ochiai",
+    personaLabel: "Ryo (deflective)",
+    personaHintBias: RYO_BIAS,
+    runs,
+  };
+}
+
+function failingCell(): CellInput {
+  // Cell com errors → falha em error_rate
+  const runs: RunResult[] = [
+    ...Array.from({ length: 5 }, () => mockRun(mockMenu([{ played_as: "bridge" }]))),
+    ...Array.from({ length: 5 }, () => mockRun(null)), // 50% error
+  ];
+  return {
+    model: "qwen3-30b",
+    modelLabel: "Qwen3-30B Q4",
+    personaId: "ryo-ochiai",
+    personaLabel: "Ryo (deflective)",
+    personaHintBias: RYO_BIAS,
+    runs,
+  };
+}
+
+describe("renderReport — happy path", () => {
+  it("renderiza header com prompt version + run id + mode", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "full",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-001",
+      cells: [healthyRyoCell()],
+    });
+
+    expect(md).toContain("# H-AC-12");
+    expect(md).toContain("2026-05-20");
+    expect(md).toMatch(/`v0\.1`/);
+    expect(md).toContain("hac12-test-001");
+    expect(md).toContain("`full`");
+  });
+
+  it("inclui tabela de Resumo com colunas obrigatórias", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "full",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-001",
+      cells: [healthyRyoCell()],
+    });
+
+    expect(md).toContain("## Resumo");
+    expect(md).toContain("pass_first");
+    expect(md).toContain("recovery");
+    expect(md).toContain("degraded");
+    expect(md).toContain("dist_align");
+    expect(md).toContain("Pass?");
+    expect(md).toContain("Kimi K2.5");
+    expect(md).toContain("Ryo (deflective)");
+  });
+
+  it("cell saudável aparece como PASS no Resumo global", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "quick",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-002",
+      cells: [healthyRyoCell()],
+    });
+
+    expect(md).toMatch(/PASS — todos os limiares v0 atendidos/);
+  });
+
+  it("inclui distribuição played_as realizada vs esperada", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "full",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-003",
+      cells: [healthyRyoCell()],
+    });
+
+    expect(md).toContain("Distribuição played_as");
+    expect(md).toContain("realizada");
+    expect(md).toContain("esperada");
+    expect(md).toContain("Top-2 realizado");
+    // Todas as 6 jogadas aparecem na tabela
+    for (const j of ["bridge", "espelho", "canal", "diamante", "arena", "recovery"]) {
+      expect(md).toContain(`| ${j} |`);
+    }
+  });
+
+  it("seção Custo + latência presente com totais", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "full",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-004",
+      cells: [healthyRyoCell()],
+    });
+
+    expect(md).toContain("## Custo + latência");
+    expect(md).toContain("Total execução");
+    expect(md).toMatch(/\$\d+\.\d{2}/);
+  });
+
+  it("Sinais acionáveis NÃO aparece quando todas as células passam", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "quick",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-005",
+      cells: [healthyRyoCell()],
+    });
+
+    expect(md).not.toContain("Sinais acionáveis");
+  });
+});
+
+describe("renderReport — failing cell", () => {
+  it("cell falhando aparece como FAIL global + seção Sinais acionáveis", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "full",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-006",
+      cells: [failingCell()],
+    });
+
+    expect(md).toMatch(/FAIL — pelo menos uma célula reprovou/);
+    expect(md).toContain("## Sinais acionáveis");
+    expect(md).toContain("Qwen3-30B Q4");
+    // Pelo menos um KPI falhou (error_rate provavelmente)
+    expect(md).toMatch(/error_rate.*>.*5/);
+  });
+
+  it("multi-cell com 1 PASS + 1 FAIL → global FAIL", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "full",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-007",
+      cells: [healthyRyoCell(), failingCell()],
+    });
+
+    expect(md).toMatch(/FAIL/);
+    expect(md).toContain("Kimi K2.5");
+    expect(md).toContain("Qwen3-30B");
+  });
+});
+
+describe("renderReport — footer + provenance", () => {
+  it("footer cita o script + spec ratificada", () => {
+    const md = renderReport({
+      promptVersion: "v0.1",
+      mode: "quick",
+      timestamp: "2026-05-20T03:00:00.000Z",
+      runId: "hac12-test-008",
+      cells: [healthyRyoCell()],
+    });
+
+    expect(md).toMatch(/measure-menu-variance\.mjs/);
+    expect(md).toMatch(/ratificada v1.*ops#1058/);
+  });
+});

--- a/scripts/measure-menu-variance.mjs
+++ b/scripts/measure-menu-variance.mjs
@@ -87,9 +87,12 @@ function parseArgs(argv) {
     args.n = args.mode === "quick" ? 10 : args.mode === "full" ? 30 : 30;
   }
   if (!args.model) {
+    // Decisão Jun 2026-05-13: default de --manual é LOCAL (qwen3), não Kimi.
+    // Local é grátis e disponível pra iteração de prompt sem custo.
+    // --quick e --full preservam semântica fixa (Kimi pra gate, both pra weekly).
     args.model =
       args.mode === "quick" ? "kimi" :
-      args.mode === "full" ? "both" : "kimi";
+      args.mode === "full" ? "both" : "qwen3";
   }
   return args;
 }
@@ -106,7 +109,7 @@ Modes:
 Options:
   --n <N>                   tamanho de amostra
   --persona <ryo|kei|both>  default: both
-  --model <kimi|qwen3|both> default: depende do mode
+  --model <kimi|qwen3|both> default: --quick=kimi, --full=both, --manual=qwen3
   --comment-on <ref>        posta comment via gh CLI; ex: "ops#1058" ou "motor#42"
   --output <path>           salva markdown em arquivo (além do stdout)
   --prompt-version <vX.Y>   default: v0.1

--- a/scripts/measure-menu-variance.mjs
+++ b/scripts/measure-menu-variance.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+/**
+ * measure-menu-variance — H-AC-12 (spec ratificada v1, ops#1058).
+ *
+ * Roda N execuções de `generateActionMenu` por (modelo × persona), agrega
+ * em KPIs longitudinais + dist_alignment KL, e emite markdown report.
+ *
+ * Modes:
+ *   --quick      N=10, só Kimi K2.5 (pre-merge gate, GitHub-hosted runner)
+ *   --full       N=30, Kimi + Qwen3-30B local (scheduled semanal, self-hosted runner)
+ *   --manual     N customizável, modelo + persona específicos
+ *
+ * Flags principais:
+ *   --n <N>                     tamanho de amostra (default depende do mode)
+ *   --persona <ryo|kei|both>    default: both
+ *   --model <kimi|qwen3|both>   default: depende do mode
+ *   --comment-on <pr|issue>#N   posta markdown como comment via gh CLI
+ *   --output <path>             salva markdown em arquivo (default: stdout only)
+ *   --prompt-version <vX.Y>     metadata pro report (default v0.1)
+ *
+ * Exit code:
+ *   0 — todos os limiares v0 passaram (PASS)
+ *   1 — algum limiar reprovou (FAIL) OU erro de execução
+ *
+ * Spec: ascendimacy-ops/docs/specs/H-AC-12-variancia-geracao-v0.md
+ * Issue: ascendimacy-ops#1058
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync, spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+// Imports do build output do motor-drota (postbuild copia prompts/).
+const { generateActionMenu } = await import(
+  path.join(REPO_ROOT, "motor-drota", "dist", "menu-generator.js")
+);
+const { RYO_HINT, KEI_HINT } = await import(
+  path.join(REPO_ROOT, "motor-drota", "dist", "persona-hints.js")
+);
+const variance = await import(
+  path.join(REPO_ROOT, "motor-drota", "dist", "variance", "index.js")
+);
+
+// ============================================================================
+// Args parsing
+// ============================================================================
+
+function parseArgs(argv) {
+  const args = {
+    mode: null,
+    n: null,
+    persona: "both",
+    model: null,
+    commentOn: null,
+    output: null,
+    promptVersion: "v0.1",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--quick": args.mode = "quick"; break;
+      case "--full":  args.mode = "full"; break;
+      case "--manual": args.mode = "manual"; break;
+      case "--n": args.n = Number.parseInt(argv[++i], 10); break;
+      case "--persona": args.persona = argv[++i]; break;
+      case "--model": args.model = argv[++i]; break;
+      case "--comment-on": args.commentOn = argv[++i]; break;
+      case "--output": args.output = argv[++i]; break;
+      case "--prompt-version": args.promptVersion = argv[++i]; break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+    }
+  }
+  if (!args.mode) {
+    console.error("Erro: especifique --quick, --full ou --manual.");
+    printHelp();
+    process.exit(2);
+  }
+  // Defaults por modo
+  if (args.n == null) {
+    args.n = args.mode === "quick" ? 10 : args.mode === "full" ? 30 : 30;
+  }
+  if (!args.model) {
+    args.model =
+      args.mode === "quick" ? "kimi" :
+      args.mode === "full" ? "both" : "kimi";
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`
+Usage: node scripts/measure-menu-variance.mjs <mode> [options]
+
+Modes:
+  --quick                   N=10, Kimi only (pre-merge gate)
+  --full                    N=30, Kimi + Qwen3-30B (scheduled semanal)
+  --manual                  N customizável
+
+Options:
+  --n <N>                   tamanho de amostra
+  --persona <ryo|kei|both>  default: both
+  --model <kimi|qwen3|both> default: depende do mode
+  --comment-on <ref>        posta comment via gh CLI; ex: "ops#1058" ou "motor#42"
+  --output <path>           salva markdown em arquivo (além do stdout)
+  --prompt-version <vX.Y>   default: v0.1
+  -h, --help                este help
+
+Spec: ascendimacy-ops/docs/specs/H-AC-12-variancia-geracao-v0.md
+`);
+}
+
+// ============================================================================
+// LLM call adapters (Kimi via gateway, Qwen3 via local HTTP)
+// ============================================================================
+
+async function loadKimiLlmCall() {
+  // Importa direto da build do motor-drota — gateway client + step="drota"
+  const { callLlm } = await import(
+    path.join(REPO_ROOT, "motor-drota", "dist", "llm-client.js")
+  );
+  return callLlm; // (system, user) => Promise<LlmCallResult>
+}
+
+function makeQwen3LocalLlmCall() {
+  const endpoint =
+    process.env.LLM_LOCAL_ENDPOINT ??
+    "http://172.28.160.1:9000/v1/chat/completions";
+  const model = process.env.LLM_LOCAL_MODEL ?? "qwen3-30b";
+  return async (systemPrompt, userMessage) => {
+    const body = {
+      model,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userMessage },
+      ],
+      max_tokens: 3000,
+      temperature: 0.7,
+    };
+    const resp = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(600_000),
+    });
+    if (!resp.ok) throw new Error(`LLM local HTTP ${resp.status}`);
+    const json = await resp.json();
+    return {
+      content: json.choices[0].message.content,
+      tokens: {
+        in: json.usage?.prompt_tokens ?? 0,
+        out: json.usage?.completion_tokens ?? 0,
+        reasoning: 0,
+      },
+      provider: "openai-compat",
+      model,
+    };
+  };
+}
+
+// ============================================================================
+// Run loop
+// ============================================================================
+
+function loadProfile(fixtureName) {
+  const p = path.join(REPO_ROOT, "fixtures", "profiles", fixtureName);
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+const PERSONAS = {
+  ryo: {
+    personaId: "ryo-ochiai",
+    personaLabel: "Ryo (deflective)",
+    trustLevel: 0.42,
+    fixture: "ryo-ochiai.pre-phase2.json",
+    hint: RYO_HINT,
+  },
+  kei: {
+    personaId: "kei-ochiai",
+    personaLabel: "Kei (philosophical)",
+    trustLevel: 0.5,
+    fixture: "kei-ochiai.pre-phase2.json",
+    hint: KEI_HINT,
+  },
+};
+
+async function runOnce(personaSpec, llmCall) {
+  const warnings = [];
+  const t0 = Date.now();
+  let lastCallTokens = { in: 0, out: 0 };
+  let lastCallCost = 0;
+  let lastCallModel = "unknown";
+  let lastCallProvider = "unknown";
+
+  // Wrap llmCall pra capturar tokens/cost por chamada (sem confiar no NDJSON)
+  const wrappedCall = async (sys, user) => {
+    const r = await llmCall(sys, user);
+    lastCallTokens = r.tokens;
+    lastCallModel = r.model;
+    lastCallProvider = r.provider;
+    return r;
+  };
+
+  const menu = await generateActionMenu(
+    {
+      personaId: personaSpec.personaId,
+      trustLevel: personaSpec.trustLevel,
+      profile: loadProfile(personaSpec.fixture),
+      personaHint: personaSpec.hint,
+    },
+    {
+      llmCall: wrappedCall,
+      onWarning: (w) => warnings.push(w.code),
+    },
+  );
+  const latencyMs = Date.now() - t0;
+
+  // Cost: para Qwen3 local sempre 0 (openai-compat); para Kimi calcular
+  // via PRICING_TABLE.
+  if (lastCallProvider === "openai-compat") {
+    lastCallCost = 0;
+  } else {
+    // Lookup heurístico — sem importar shared/llm-config aqui (script .mjs);
+    // assume Kimi K2.5 com preço aproximado. Reportagem é estimativa.
+    if (lastCallModel.toLowerCase().includes("kimi")) {
+      // Kimi K2.5: ~$0.6/M input, ~$2.5/M output (Infomaniak pricing)
+      lastCallCost =
+        (lastCallTokens.in * 0.0000006) + (lastCallTokens.out * 0.0000025);
+    } else {
+      lastCallCost = 0;
+    }
+  }
+
+  return {
+    menu,
+    warnings,
+    latencyMs,
+    tokensIn: lastCallTokens.in,
+    tokensOut: lastCallTokens.out,
+    costUsdEst: lastCallCost,
+  };
+}
+
+async function runCell(modelKey, modelLabel, personaSpec, n, llmCall) {
+  console.error(`\n[${modelLabel} × ${personaSpec.personaLabel}] N=${n}…`);
+  const runs = [];
+  for (let i = 0; i < n; i++) {
+    process.stderr.write(`  run ${i + 1}/${n}…`);
+    try {
+      const r = await runOnce(personaSpec, llmCall);
+      runs.push(r);
+      const outcome = variance.deriveOutcome(r);
+      process.stderr.write(` ${outcome} (${(r.latencyMs / 1000).toFixed(1)}s)\n`);
+    } catch (err) {
+      console.error(` THROW: ${err.message}`);
+      // Conta como error
+      runs.push({
+        menu: null,
+        warnings: ["llm_error"],
+        latencyMs: 0,
+        tokensIn: 0,
+        tokensOut: 0,
+        costUsdEst: 0,
+      });
+    }
+  }
+  return {
+    model: modelKey,
+    modelLabel,
+    personaId: personaSpec.personaId,
+    personaLabel: personaSpec.personaLabel,
+    personaHintBias: personaSpec.hint.bias,
+    runs,
+  };
+}
+
+// ============================================================================
+// gh CLI integration (comment posting)
+// ============================================================================
+
+function postComment(commentOnRef, markdown) {
+  // Ref format: "ops#1058" ou "motor#42"
+  const match = commentOnRef.match(/^(ops|motor)#(\d+)$/);
+  if (!match) {
+    console.error(`--comment-on: formato inválido "${commentOnRef}". Use ops#N ou motor#N.`);
+    return false;
+  }
+  const repoMap = { ops: "ascendimacy/ascendimacy-ops", motor: "ascendimacy/ascendimacy-motor" };
+  const repo = repoMap[match[1]];
+  const num = match[2];
+
+  // Tenta primeiro como issue, fallback pra PR. gh issue comment funciona em ambos.
+  const tempFile = path.join(REPO_ROOT, `.tmp-hac12-comment-${Date.now()}.md`);
+  writeFileSync(tempFile, markdown, "utf-8");
+  const r = spawnSync(
+    "gh",
+    ["issue", "comment", num, "--repo", repo, "--body-file", tempFile],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  try { execSync(`rm -f ${tempFile}`); } catch {}
+  if (r.status === 0) {
+    console.error(`\n✓ Posted comment: ${r.stdout.toString().trim()}`);
+    return true;
+  }
+  console.error(`\n✗ Failed to post comment: ${r.stderr.toString()}`);
+  return false;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const personasToRun =
+    args.persona === "both" ? ["ryo", "kei"] :
+    args.persona === "ryo"  ? ["ryo"] :
+    args.persona === "kei"  ? ["kei"] : null;
+  if (!personasToRun) {
+    console.error(`--persona inválido: ${args.persona}. Use ryo, kei, ou both.`);
+    process.exit(2);
+  }
+
+  const modelsToRun =
+    args.model === "both"  ? ["kimi", "qwen3"] :
+    args.model === "kimi"  ? ["kimi"] :
+    args.model === "qwen3" ? ["qwen3"] : null;
+  if (!modelsToRun) {
+    console.error(`--model inválido: ${args.model}. Use kimi, qwen3, ou both.`);
+    process.exit(2);
+  }
+
+  const runId = `hac12-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  const timestamp = new Date().toISOString();
+
+  console.error(`H-AC-12 — measure-menu-variance`);
+  console.error(`Mode: ${args.mode} | N=${args.n} | personas: ${personasToRun} | models: ${modelsToRun}`);
+  console.error(`Run ID: ${runId}\n`);
+
+  const cells = [];
+  for (const modelKey of modelsToRun) {
+    let llmCall;
+    let modelLabel;
+    if (modelKey === "kimi") {
+      modelLabel = "Kimi K2.5";
+      llmCall = await loadKimiLlmCall();
+    } else if (modelKey === "qwen3") {
+      modelLabel = "Qwen3-30B Q4";
+      llmCall = makeQwen3LocalLlmCall();
+    } else {
+      console.error(`Modelo desconhecido: ${modelKey}`);
+      process.exit(2);
+    }
+
+    for (const personaKey of personasToRun) {
+      const personaSpec = PERSONAS[personaKey];
+      const cell = await runCell(modelKey, modelLabel, personaSpec, args.n, llmCall);
+      cells.push(cell);
+    }
+  }
+
+  // === Renderiza relatório ===
+  const markdown = variance.renderReport({
+    promptVersion: args.promptVersion,
+    mode: args.mode,
+    timestamp,
+    runId,
+    cells,
+  });
+
+  console.log(markdown);
+
+  if (args.output) {
+    writeFileSync(args.output, markdown, "utf-8");
+    console.error(`\n✓ Saved markdown to ${args.output}`);
+  }
+
+  if (args.commentOn) {
+    postComment(args.commentOn, markdown);
+  }
+
+  // Exit code: PASS=0, FAIL=1
+  let allPass = true;
+  for (const cell of cells) {
+    const kpis = variance.computeKpis(cell.runs);
+    const dist = variance.computeDistAlignment(cell.runs, cell.personaHintBias);
+    const p = variance.passesV0Thresholds(kpis, dist);
+    if (!p.ok) allPass = false;
+  }
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("measure-menu-variance: fatal", err);
+  process.exit(1);
+});

--- a/scripts/weekly-variance.sh
+++ b/scripts/weekly-variance.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# weekly-variance.sh — H-AC-12 manual weekly run wrapper (Opção B)
+#
+# Spec: ascendimacy-ops/docs/specs/H-AC-12-variancia-geracao-v0.md (v1)
+# Decisão Jun 2026-05-13: sem GitHub Action automation (Opção B); Jun
+# dispara este script da WSL semanalmente (ou ad-hoc) pra produzir o
+# feed longitudinal em ops#1058.
+#
+# Pré-requisitos:
+#   - Qwen3 stack up em LLM_LOCAL_ENDPOINT (default WSL→Windows :9000)
+#   - INFOMANIAK_API_KEY + INFOMANIAK_PRODUCT_ID exportados (opcional —
+#     se ausentes, roda só Qwen3 local após confirmação)
+#   - gh CLI autenticado (`gh auth status` deve mostrar ascendimacy/* push)
+#
+# Uso:
+#   bash scripts/weekly-variance.sh             # default: tenta full, fallback Qwen3-only
+#   bash scripts/weekly-variance.sh --qwen3     # força Qwen3-only (skip prompt)
+#   bash scripts/weekly-variance.sh --no-comment # não posta em ops#1058 (sandbox)
+#
+# Output:
+#   - Markdown report no stdout
+#   - Salvo em /tmp/h-ac-12-latest-report.md (override via REPORT_OUT)
+#   - Posted como comment em ops#1058 (a menos que --no-comment)
+
+set -euo pipefail
+
+# ── Args ────────────────────────────────────────────────────────────────
+FORCE_QWEN_ONLY=0
+SKIP_COMMENT=0
+for arg in "$@"; do
+    case "$arg" in
+        --qwen3) FORCE_QWEN_ONLY=1 ;;
+        --no-comment) SKIP_COMMENT=1 ;;
+        --help|-h)
+            sed -n '2,28p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Arg desconhecido: $arg (use --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ── CWD ─────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+REPORT_OUT="${REPORT_OUT:-/tmp/h-ac-12-latest-report.md}"
+
+# ── Sanity: Qwen3 stack up ───────────────────────────────────────────────
+WIN_IP="$(ip route show | awk '/default/ {print $3}' 2>/dev/null || echo "")"
+DEFAULT_ENDPOINT="http://${WIN_IP:-172.28.160.1}:9000"
+ENDPOINT_BASE="${LLM_LOCAL_ENDPOINT:-${DEFAULT_ENDPOINT}/v1/chat/completions}"
+ENDPOINT_PROBE="${ENDPOINT_BASE%/chat/completions}/models"
+
+echo "▶ Checking Qwen3 stack at $ENDPOINT_PROBE…"
+if ! curl -fsS --max-time 5 "$ENDPOINT_PROBE" > /dev/null 2>&1; then
+    echo "  ✗ Qwen3 offline. Start llama.cpp SYCL stack first (llama-qwen3-30b.bat)."
+    exit 1
+fi
+echo "  ✓ Qwen3 up"
+
+# ── Sanity: gh CLI auth (apenas se vai comentar) ────────────────────────
+if [ "$SKIP_COMMENT" = "0" ]; then
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "  ✗ gh CLI não autenticado. Rode: gh auth login" >&2
+        exit 1
+    fi
+    echo "  ✓ gh CLI autenticado"
+fi
+
+# ── Decide mode (full vs qwen3-only) ────────────────────────────────────
+MODE_ARGS=""
+if [ "$FORCE_QWEN_ONLY" = "1" ]; then
+    MODE_ARGS="--manual --model qwen3 --n 30"
+    echo "▶ Modo: Qwen3-only (forçado)"
+elif [ -z "${INFOMANIAK_API_KEY:-}" ] || [ -z "${INFOMANIAK_PRODUCT_ID:-}" ]; then
+    echo "  ⚠ INFOMANIAK_API_KEY/PRODUCT_ID ausentes — Kimi K2.5 indisponível."
+    read -r -p "Continuar com Qwen3 only? [y/N]: " ANS
+    if [ "${ANS:-N}" != "y" ] && [ "${ANS:-N}" != "Y" ]; then
+        echo "Aborted."
+        exit 1
+    fi
+    MODE_ARGS="--manual --model qwen3 --n 30"
+    echo "▶ Modo: Qwen3-only (Infomaniak creds ausentes)"
+else
+    MODE_ARGS="--full"
+    echo "▶ Modo: full (Kimi + Qwen3)"
+fi
+
+# ── Build ────────────────────────────────────────────────────────────────
+echo "▶ Building motor (postbuild copia prompts/)…"
+if ! npm run build > /tmp/h-ac-12-build.log 2>&1; then
+    echo "  ✗ Build falhou. Veja /tmp/h-ac-12-build.log" >&2
+    tail -20 /tmp/h-ac-12-build.log
+    exit 1
+fi
+echo "  ✓ build OK"
+
+# ── Run ──────────────────────────────────────────────────────────────────
+echo "▶ Executando measure-menu-variance.mjs $MODE_ARGS…"
+echo "  (latência esperada: ~5min Kimi por persona, ~7min Qwen3 por persona)"
+echo ""
+
+COMMENT_ARG=""
+if [ "$SKIP_COMMENT" = "0" ]; then
+    COMMENT_ARG="--comment-on ops#1058"
+fi
+
+# Note: script retorna exit code 0 (PASS) ou 1 (FAIL). Não tratamos como
+# erro fatal — relatório fica salvo + postado mesmo se algum KPI reprovou.
+set +e
+node scripts/measure-menu-variance.mjs $MODE_ARGS $COMMENT_ARG --output "$REPORT_OUT"
+EXIT_CODE=$?
+set -e
+
+echo ""
+echo "▶ Done."
+echo "  Report: $REPORT_OUT"
+if [ "$SKIP_COMMENT" = "0" ]; then
+    echo "  Comment posted: https://github.com/ascendimacy/ascendimacy-ops/issues/1058"
+fi
+
+if [ "$EXIT_CODE" = "0" ]; then
+    echo "  Result: PASS — todos os limiares v0 atendidos"
+else
+    echo "  Result: FAIL — algum KPI reprovou (veja sinais acionáveis no report)"
+fi
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
Implementa ops#1058 (H-AC-12) — spec ratificada em ops#1059 (mergeada). Aguarda ops#1059 antes de mergear esta PR (refs cruzados).

## Resumo

CLI + libs pra rodar N execuções de `generateActionMenu` por (modelo × persona), agregar em KPIs longitudinais + dist_alignment KL, e emitir markdown report. Workflows GitHub Action ficam **manual-only v0** (workflow_dispatch); cron + paths-trigger serão ativados em follow-up depois que Jun setar secrets + self-hosted runner.

## Decisões Jun (2026-05-13) baked

| # | Decisão | Onde no código |
|---|---|---|
| 1 | N=30 | script default mode `--full`; tests cover edge cases |
| 2 | Opção B (multi-KPI relaxado v0) | `passesV0Thresholds` + `KPI_THRESHOLDS_V0` |
| 3 | Kimi K2.5 + Qwen3-30B local | 2 LLM adapters no script |
| 4 | Cron seg 03:00 UTC | `h-ac-12-weekly.yml` (comentado, TODO ativar) |
| 5 | dist_alignment KL | `klDivergence` com laplace smoothing |
| 6 | Pré-merge gate fail >10% vs baseline | v0 usa thresholds absolutos; delta-based v0.1 (issue follow-up) |
| 7 | Report = comment (não commit em docs/measurements/) | `gh issue comment` via script; scheduled posta em ops#1058 |

## Arquivos

| Arquivo | Linhas | Tests |
|---|---|---|
| `motor-drota/src/variance/kpis.ts` | 275 | 30 unit (`variance-kpis.unit.test.ts`) |
| `motor-drota/src/variance/report.ts` | 191 | 9 unit (`variance-report.unit.test.ts`) |
| `motor-drota/src/variance/index.ts` | 31 | (barrel) |
| `scripts/measure-menu-variance.mjs` | 402 | smoke node --check |
| `.github/workflows/h-ac-12-pre-merge.yml` | 67 | YAML valid |
| `.github/workflows/h-ac-12-weekly.yml` | 76 | YAML valid |
| **Total** | **1042** | **39 new tests** |

## API do KPIs

```typescript
deriveOutcome(run): "ok" | "ok-retry" | "degraded" | "error"
computeKpis(runs): { passRateFirst, recoveryRate, degradationRate, errorRate }
observedDistribution(runs): PlayedAsDistribution
klDivergence(observedNorm, expectedNorm): number  // com laplace 1e-6
computeDistAlignment(runs, personaHintBias): number  // pipeline e2e
passesV0Thresholds(kpis, distAlignment): {ok} | {ok:false, failures[]}
computeCostStats(runs): { totalUsd, meanUsdPerRun, meanLatencyMs, ... }
```

Limiares v0 (`KPI_THRESHOLDS_V0`):
```
pass_rate_first  ≥ 50%
recovery_rate    ≤ 40%
degradation_rate ≤ 10%
error_rate       ≤ 5%
dist_alignment   ≤ 0.3
```

## Uso manual

```bash
# Build (postbuild copia prompts/ pra dist/)
npm run build

# Pre-merge quick (Kimi only, N=10 por persona)
node scripts/measure-menu-variance.mjs --quick

# Scheduled full (Kimi + Qwen3 local, N=30 por persona)
node scripts/measure-menu-variance.mjs --full --comment-on ops#1058

# Ad-hoc
node scripts/measure-menu-variance.mjs --manual --persona ryo --model qwen3 --n 5
```

Exit code: 0 PASS / 1 FAIL — viável como pre-merge gate em CI.

## Workflows

**v0 status: manual-only (workflow_dispatch).** Cron + paths-trigger ficam comentados. `h-ac-12-weekly.yml` ainda tem `if: false` guard.

**Pre-merge** (`h-ac-12-pre-merge.yml`):
- runs-on: ubuntu-latest (GitHub-hosted)
- timeout 30 min
- inputs: persona, comment_on
- TODO v0.1: descomentar paths-trigger

**Weekly** (`h-ac-12-weekly.yml`):
- runs-on: self-hosted (Windows com Qwen3 stack up)
- timeout 360 min
- sanity check pré-run: curl em LLM_LOCAL_ENDPOINT/v1/models
- TODO v0.1: descomentar cron seg 03:00 UTC + remover `if: false`

## Validação

\`\`\`
shared:        500 / 8 skip   (estável vs main)
planejador:    132            (estável)
motor-drota:   149 / 1 skip   (+39 variance tests)
motor-execucao: 86             (estável)
orchestrator:    2             (estável)
weekly-report:  58             (estável)
llm-gateway:    42             (estável)
Total:         969 / 9 skip   (+39 tests, 0 regressions)
\`\`\`

Build verde 7 workspaces. YAML workflows válidos.

## Follow-up (próxima issue, vou abrir)

\"Ativar automação H-AC-12 v0.1\":
- Jun seta `INFOMANIAK_API_KEY` + `INFOMANIAK_PRODUCT_ID` nos repo secrets
- Jun configura self-hosted Windows runner
- Descomentar `paths-trigger` em pre-merge.yml
- Descomentar `schedule` + remover `if: false` em weekly.yml
- Considerar baseline delta-based pra pre-merge gate v0.1 (decisão 6 spec)

## Não-escopo

- Não ativa workflows automáticos nesta PR (decisão Jun)
- Não implementa baseline parsing (v0 usa absolutos; v0.1 trata)
- Não cria `docs/measurements/` (decisão 7: comment não commit)

## Refs

- ops#1058 (H-AC-12)
- ops#1059 (spec ratificada v1, aguarda merge antes desta)
- motor#90 (mergeado, origem da variância observada)
- ops#1056 D-4-TELO (mergeado, precondição — outcome granular no NDJSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)