### PR TITLE
[fix] menu-generator error paths capturam prompt + response (debug pos-mortem)

### DIFF
--- a/motor-drota/src/menu-generator.ts
+++ b/motor-drota/src/menu-generator.ts
@@ -367,13 +367,9 @@ export async function generateActionMenu(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     warn({ code: "llm_error", message: `LLM call failed (attempt 1): ${msg}` });
-    emitTelemetry({
-      personaId: input.personaId,
-      sessionId: input.sessionId,
-      latencyMs: Date.now() - t0,
-      outcome: "error",
-    });
-    // Retry once on LLM error too.
+    // Retry once on LLM error. Premature `error` emit removido (ops#TBD)
+    // — antes emitia evento error pré-retry que era confuso quando retry
+    // recuperava (criava 2 events num run só). Só emite no final.
     try {
       attempt1 = await llmCall(systemPrompt, userMessage);
     } catch (err2) {
@@ -381,6 +377,14 @@ export async function generateActionMenu(
       warn({
         code: "llm_error",
         message: `LLM call failed (retry): ${msg2}`,
+      });
+      // Captura prompt — não há response (LLM throw 2x consecutivo).
+      emitTelemetry({
+        personaId: input.personaId,
+        sessionId: input.sessionId,
+        latencyMs: Date.now() - t0,
+        outcome: "error",
+        prompt: systemPrompt + "\n---\n" + userMessage,
       });
       return null;
     }
@@ -430,11 +434,16 @@ export async function generateActionMenu(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     warn({ code: "llm_error", message: `LLM call failed (retry): ${msg}` });
+    // Captura prompt do retry + response do attempt1 (que motivou o retry).
+    // Permite debug: "o que LLM emitiu na 1a tentativa que reprovou parse?"
     emitTelemetry({
       personaId: input.personaId,
       sessionId: input.sessionId,
+      result: attempt1,
       latencyMs: Date.now() - t0,
       outcome: "error",
+      prompt: systemPrompt + "\n---\n" + retryUserMessage,
+      response: attempt1.content,
     });
     return null;
   }
@@ -494,13 +503,17 @@ export async function generateActionMenu(
     });
   }
 
-  // Hard failure.
+  // Hard failure. Captura prompt do retry + response do attempt2
+  // (último output do LLM que não parseou + não recuperou via strip).
+  // Crítico pra debug: permite ver o que LLM emitiu que confundiu o parser.
   emitTelemetry({
     personaId: input.personaId,
     sessionId: input.sessionId,
     result: attempt2,
     latencyMs: Date.now() - t0,
     outcome: "error",
+    prompt: systemPrompt + "\n---\n" + retryUserMessage,
+    response: attempt2.content,
   });
   return null;
 }

--- a/motor-drota/tests/menu-generator.unit.test.ts
+++ b/motor-drota/tests/menu-generator.unit.test.ts
@@ -496,4 +496,128 @@ describe("generateActionMenu — telemetria outcome granular", () => {
     const lastEvent = calls[calls.length - 1]![0] as { outcome: string };
     expect(lastEvent.outcome).toBe("error");
   });
+
+  // Fix: error paths capturam prompt + response (motor#95-followup).
+  // Antes: outcome=error emitia evento sem prompt/response → debug pos-mortem cego.
+
+  it("error path (hard failure parse 2x): captura prompt + response do attempt2", async () => {
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: "garbage no JSON aqui",
+        tokens: { in: 100, out: 20, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: "ainda mais garbage final",
+        tokens: { in: 100, out: 10, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    expect(menu).toBeNull();
+
+    const calls = mockLogDebugEvent.mock.calls;
+    const lastEvent = calls[calls.length - 1]![0] as {
+      outcome: string;
+      prompt?: string;
+      response?: string;
+    };
+    expect(lastEvent.outcome).toBe("error");
+    // Prompt + response presentes pra debug pos-mortem
+    expect(lastEvent.prompt).toBeDefined();
+    expect(lastEvent.response).toBe("ainda mais garbage final");
+    // Prompt inclui system prompt + retry user message (com instrução correção)
+    expect(lastEvent.prompt!.toLowerCase()).toContain("retry");
+  });
+
+  it("error path (LLM throw em retry): captura prompt + response do attempt1", async () => {
+    const bad = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    (bad.items[0] as unknown as { played_as: string }).played_as = "scaffold";
+
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad),
+        tokens: { in: 1200, out: 380, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockRejectedValueOnce(new Error("network timeout no retry"));
+
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    expect(menu).toBeNull();
+
+    const calls = mockLogDebugEvent.mock.calls;
+    const lastEvent = calls[calls.length - 1]![0] as {
+      outcome: string;
+      prompt?: string;
+      response?: string;
+    };
+    expect(lastEvent.outcome).toBe("error");
+    // Response do attempt1 (o que motivou o retry) preservado
+    expect(lastEvent.response).toBe(JSON.stringify(bad));
+    expect(lastEvent.prompt).toBeDefined();
+  });
+
+  it("error path (LLM throw 2x consecutivo): captura prompt (sem response, LLM nunca respondeu)", async () => {
+    const llm = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network timeout 1"))
+      .mockRejectedValueOnce(new Error("network timeout 2"));
+
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    expect(menu).toBeNull();
+
+    const calls = mockLogDebugEvent.mock.calls;
+    // Antes do fix: emitia 1 evento error prematuro entre attempt1 throw + retry,
+    // + (sem evento final pq sem captura). Agora: 1 evento error só, no final,
+    // com prompt mas sem response.
+    expect(calls.length).toBe(1);
+    const lastEvent = calls[0]![0] as {
+      outcome: string;
+      prompt?: string;
+      response?: string;
+    };
+    expect(lastEvent.outcome).toBe("error");
+    expect(lastEvent.prompt).toBeDefined();
+    expect(lastEvent.response).toBeUndefined();
+  });
+
+  it("error path (degradação falhou também): captura prompt + response do attempt2", async () => {
+    // Schema invalid não-ISA: persona_id vazio (não strippable)
+    const bad1 = JSON.parse(fullLabeledLlmJson("ryo-ochiai")) as ActionMenu;
+    bad1.persona_id = "";  // structural failure — strip não recupera
+    const bad2 = { ...bad1 };  // 2x mesma falha
+
+    const llm = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad1),
+        tokens: { in: 1200, out: 380, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      })
+      .mockResolvedValueOnce({
+        content: JSON.stringify(bad2),
+        tokens: { in: 1300, out: 400, reasoning: 0 },
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+    const menu = await generateActionMenu(validRyoInput(), { llmCall: llm });
+    expect(menu).toBeNull();
+
+    const calls = mockLogDebugEvent.mock.calls;
+    const lastEvent = calls[calls.length - 1]![0] as {
+      outcome: string;
+      prompt?: string;
+      response?: string;
+    };
+    expect(lastEvent.outcome).toBe("error");
+    // Response do attempt2 (último output do LLM, mesmo que invalido) preservado
+    expect(lastEvent.response).toBe(JSON.stringify(bad2));
+  });
 });


### PR DESCRIPTION
Follow-up de motor#94/#95 (ambos mergeados). Gap detectado durante primeiro full smoke contra Qwen3-30B hoje (2026-05-14).

## Problema observado

Smoke `bash scripts/weekly-variance.sh --qwen3 --no-comment` rodando contra Qwen3-30B-A3B-Instruct-2507. Após 6 runs do persona Ryo:

| # | Outcome | Latency | Tokens out | response_hash |
|---|---|---|---|---|
| 1 | ok | 471s | 2326 | ✅ |
| 2 | ok | 403s | 1518 | ✅ |
| 3 | **error** | 400s | 1763 | ❌ **None** |
| 4 | ok-retry | 357s | 1441 | ✅ |
| 5 | **error** | 447s | 2050 | ❌ **None** |
| 6 | **error** | 404s | 1578 | ❌ **None** |

**50% error rate** observado (3/6) — sinal valioso, exatamente o que H-AC-12 deveria expor. Mas runs com `outcome=error` tinham **response_hash=None** mesmo com tokens.out > 0 (LLM respondeu, debug-logger não capturou).

Investigação pos-mortem impossível: não dá pra ver O QUE o Qwen3 emitiu nos errors.

## Causa raiz

`emitTelemetry` em 3 sites com `outcome: \"error\"` não passava `prompt`/`response`:

- Linha ~370: LLM throw em attempt1 (pré-retry — emit prematuro também era confuso)
- Linha ~433: LLM throw em attempt2 (retry)
- Linha ~498: Hard failure final (após retry parse + strip falharem)

Site `outcome: \"degraded\"` (linha ~476) já capturava — esse path está OK.

## Mudança

3 fixes em `motor-drota/src/menu-generator.ts`:

1. **Hard failure final**: passa `attempt2.content` como response + retryUserMessage como prompt. **Mais importante** pro diagnóstico atual — esse é o path dos 3 errors do smoke.

2. **LLM throw em retry**: passa `attempt1.content` como response. attempt1 deu output que motivou retry; salvar mostra o que confundiu o parser.

3. **LLM throw 2x consecutivo**: passa só prompt (response undefined porque LLM nunca respondeu). Captura ao menos o que foi pedido.

**Bug colateral fixado**: emit prematuro de `error` event entre attempt1 throw + retry foi removido. Antes criava 2 events num run só quando retry recuperava (1 error + 1 ok-retry) — confusing pra agregação KPI.

## Tests

4 cases novos em `motor-drota/tests/menu-generator.unit.test.ts`:

- `error path (hard failure parse 2x)`: response = último content
- `error path (LLM throw em retry)`: response = content do attempt1
- `error path (LLM throw 2x)`: response undefined, prompt presente, **só 1 event emitido** (não 2)
- `error path (degradação não-ISA falhou)`: response = content do attempt2

Suite: motor-drota 153/1skip (era 149/1skip). 0 regressions full motor (973/9skip).

## Próximo

Após merge, próximo smoke run vai capturar o response real dos errors. Aí dá pra diagnosticar:
- JSON truncado por max_tokens=3000? (tokens out 2050 já no limite — provável)
- Prosa pre-JSON longa confundindo extractJson?
- Schema invalid não-ISA não-strippable?

Decisão dependendo do achado:
- Bump `max_tokens` pra 4096 (tweak rápido em config)
- Ajuste de prompt v0.2 (\"NÃO adicione prosa ao redor\")
- Recovery path adicional pra schema invalid não-ISA

## Refs

- ops#1058 (H-AC-12)
- motor#94, motor#95 (base)
- Gap observed 2026-05-14 durante smoke real

🤖 Generated with [Claude Code](https://claude.com/claude-code)