### PR TITLE
[fix] schema action-menu: expires_at no item aceita null (Qwen3 emit pattern)

### DIFF
--- a/planejador/tests/action-menu-schema.unit.test.ts
+++ b/planejador/tests/action-menu-schema.unit.test.ts
@@ -147,6 +147,54 @@ describe("ActionMenuSchema — negative cases", () => {
     const result = ActionMenuSchema.safeParse(menu);
     expect(result.success).toBe(false);
   });
+
+  // Fix 2026-05-14: nullable expires_at (Qwen3-30B emite null em vez de omitir).
+  it("aceita expires_at: null no item (nullable, simétrico ao output LLM)", () => {
+    const menu = baseValidMenu();
+    menu.items[0] = {
+      id: "curio-01",
+      type: "curiosity",
+      content: "item com expires_at null",
+      weight: 0.5,
+      expires_at: null as unknown as undefined,
+    };
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("aceita expires_at: undefined no item (campo ausente)", () => {
+    const menu = baseValidMenu();
+    menu.items[0] = {
+      id: "curio-01",
+      type: "curiosity",
+      content: "item sem expires_at",
+      weight: 0.5,
+    };
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("aceita expires_at: ISO 8601 válida no item (caminho default)", () => {
+    const menu = baseValidMenu();
+    menu.items[0] = {
+      id: "curio-01",
+      type: "curiosity",
+      content: "item com expires_at válido",
+      weight: 0.5,
+      expires_at: "2026-05-15T13:00:00.000Z",
+    };
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("rejeita expires_at não-ISO string (validação ainda ativa quando presente)", () => {
+    const menu = baseValidMenu();
+    menu.items[0] = {
+      id: "curio-01",
+      type: "curiosity",
+      content: "item",
+      weight: 0.5,
+      expires_at: "ontem" as unknown as string,
+    };
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
 });
 
 describe("ActionMenuSchema — ISA pedagogical labels (H-AC-01)", () => {

--- a/shared/src/contracts/action-menu.ts
+++ b/shared/src/contracts/action-menu.ts
@@ -84,8 +84,16 @@ export const ActionMenuItemSchema = z.object({
   content: z.string().min(1),
   /** Peso de relevância normalizado em [0, 1]. */
   weight: z.number().min(0).max(1),
-  /** ISO 8601. Item ignorado pelo lookup quando `now > expires_at`. */
-  expires_at: iso8601String.optional(),
+  /**
+   * ISO 8601. Item ignorado pelo lookup quando `now > expires_at`.
+   *
+   * `.nullable().optional()` (`nullish`) — aceita ausência do campo, `null`
+   * explícito, ou string ISO. Fix simétrico ao comportamento observado em
+   * LLMs (Qwen3-30B emite `"expires_at": null` em vez de omitir o campo).
+   * Ref: ops#TBD diagnose 2026-05-14 — schema_error_first em ~50% dos runs
+   * causado por `expires_at: null` falhando Zod optional check.
+   */
+  expires_at: iso8601String.nullable().optional(),
   /**
    * Rotulagem ISA pedagógica (v0.2, motor#87 H-AC-01). Opcional —
    * legacy menus sem esses campos continuam válidos. População LLM


### PR DESCRIPTION
Fix derivado do diagnóstico H-AC-12 ops#1058 — probe-qwen3.mjs em 2026-05-14 capturou root cause de ~50% error rate observado no full smoke.

## Bug

Qwen3-30B-A3B emite `\"expires_at\": null` nos items em vez de omitir o campo. Zod `iso8601String.optional()` aceita `undefined` mas **rejeita `null`** — schema_error_first virou um dos motivos de error/degraded outcomes.

Evidência (response Qwen3 capturado raw):
\`\`\`json
\"items\": [
  {
    \"id\": \"espelho-gohan-cell\",
    \"type\": \"cultural_diamond\",
    \"weight\": 0.85,
    \"expires_at\": null,   ← rejeitado pelo Zod
    \"played_as\": \"espelho\",
    ...
  }
]
\`\`\`

## Fix

\`iso8601String.optional()\` → \`iso8601String.nullable().optional()\` em \`ActionMenuItemSchema\`.

Aceita 3 formas:
1. **campo ausente** (caminho ideal pré-existente)
2. **`null` explícito** (Qwen3 pattern — novo)
3. **string ISO 8601 válida** (caminho ideal explícito pré-existente)

Validação ISO continua ativa quando valor não é null — \`\"expires_at\": \"ontem\"\` continua falhando.

## Não-escopo

- Não toca \`valid_until\` / \`generated_at\` no menu top-level (Qwen3 sempre emite ISO válido nesses; sem evidência de null observado)
- Não muda \`played_as\` / \`intensity\` / \`is_critical\` (esses já são strippable via graceful degradation se inválidos)
- Não resolve o **outro** bug observado: confusão \`type\` ↔ \`played_as\` enums no Qwen3 (esse fica pra PR sibling: prompt v0.2)

## Validação

\`\`\`
shared:        500 / 8 skip   (estável)
planejador:    136            (era 132 — +4 tests novos)
motor-drota:   149 / 1 skip   (estável)
Total motor:   973 / 9 skip   (+4 tests, 0 regressions)
\`\`\`

Build verde 7 workspaces.

## Refs

- ops#1058 (H-AC-12)
- Probe que diagnosticou: \`/tmp/probe-qwen3.mjs\` (sessão dev, não committed)
- Sibling PR (prompt v0.2): incoming
- motor#96 (error path capture, mergeado — viabilizou esse diagnóstico)

🤖 Generated with [Claude Code](https://claude.com/claude-code)