### PR TITLE
[fix] schema action-menu: nullable simétrico em source.* + valid_until (Qwen3 round 2)

### DIFF
--- a/planejador/tests/action-menu-schema.unit.test.ts
+++ b/planejador/tests/action-menu-schema.unit.test.ts
@@ -195,6 +195,32 @@ describe("ActionMenuSchema — negative cases", () => {
     };
     expect(() => parseActionMenu(menu)).toThrow();
   });
+
+  // Fix 2026-05-14 (segundo round): nullable também em source.profile_hash,
+  // source.eixos_state_hash, valid_until. Qwen3 emite null em todos.
+  it("aceita source.profile_hash: null (Qwen3 emit pattern)", () => {
+    const menu = baseValidMenu();
+    menu.source.profile_hash = null as unknown as undefined;
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("aceita source.eixos_state_hash: null (Qwen3 emit pattern)", () => {
+    const menu = baseValidMenu();
+    menu.source.eixos_state_hash = null as unknown as undefined;
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("aceita valid_until: null no top-level (Qwen3 emit pattern)", () => {
+    const menu = baseValidMenu();
+    menu.valid_until = null as unknown as undefined;
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("rejeita valid_until: 'ontem' (validação ISO ainda ativa quando string)", () => {
+    const menu = baseValidMenu();
+    menu.valid_until = "ontem";
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
 });
 
 describe("ActionMenuSchema — ISA pedagogical labels (H-AC-01)", () => {

--- a/shared/src/contracts/action-menu.ts
+++ b/shared/src/contracts/action-menu.ts
@@ -114,11 +114,16 @@ export type ActionMenuItem = z.infer<typeof ActionMenuItemSchema>;
 /**
  * Procedência do menu — facilita audit (qual hash de profile / eixos)
  * e fallback (se trust_level baixo, lookup pode ser conservador).
+ *
+ * `profile_hash` / `eixos_state_hash`: `.nullable().optional()` — LLMs
+ * (Qwen3-30B observado) emitem `null` em vez de omitir o campo. Mesmo
+ * padrão do fix em `expires_at` (motor#98). Ref: ops#1058 diagnose
+ * 2026-05-14 — schema_error_first por null em campo opt.
  */
 export const ActionMenuSourceSchema = z.object({
   trust_level: z.number().min(0).max(1),
-  profile_hash: z.string().optional(),
-  eixos_state_hash: z.string().optional(),
+  profile_hash: z.string().nullable().optional(),
+  eixos_state_hash: z.string().nullable().optional(),
 });
 export type ActionMenuSource = z.infer<typeof ActionMenuSourceSchema>;
 
@@ -132,8 +137,12 @@ export const ActionMenuSchema = z
     /** Bump quando o shape muda. Consumers checam antes de parse. */
     schema_version: z.string().min(1),
     generated_at: iso8601String,
-    /** Quando `now > valid_until`, o menu inteiro é considerado stale. */
-    valid_until: iso8601String.optional(),
+    /**
+     * Quando `now > valid_until`, o menu inteiro é considerado stale.
+     * `.nullable().optional()` — simétrico aos outros campos optional ISO
+     * (LLMs emitem null em vez de omitir). Ref: motor#98.
+     */
+    valid_until: iso8601String.nullable().optional(),
     source: ActionMenuSourceSchema,
     items: z.array(ActionMenuItemSchema),
   })


### PR DESCRIPTION
Round 2 do diagnose H-AC-12 (ops#1058). motor#98 fixou `expires_at: null` no item; novo probe pós-merge ainda dá schema_error_first com erro **único restante**:

```
source.eixos_state_hash — Invalid input: expected string, received null
```

Aplica fix simétrico nos 3 campos opcionais restantes que LLMs (Qwen3 observado) emitem null em vez de omitir.

## Mudanças

`shared/src/contracts/action-menu.ts`:

| campo | antes | depois |
|---|---|---|
| `source.profile_hash` | `z.string().optional()` | `z.string().nullable().optional()` |
| `source.eixos_state_hash` | `z.string().optional()` | `z.string().nullable().optional()` |
| `valid_until` (top-level) | `iso8601String.optional()` | `iso8601String.nullable().optional()` |

`planejador/tests/action-menu-schema.unit.test.ts`: 4 cases novos cobrindo cada um. Validação ISO em `valid_until` continua ativa quando valor é string ("ontem" rejeitado).

## Evidência empírica (probe 2026-05-14 pós-motor#99)

```
[ATTEMPT 1] ok em 209.4s | tokens in=5611 out=1852 | 5742 chars
[WARN] schema_error_first: Schema invalid on first attempt; retrying with correction

[ATTEMPT 2] ok em 167.0s | tokens in=5810 out=1725 | 5281 chars
RESUMO: Menu OK (12 items)
```

Attempt 1 falha **só** em `eixos_state_hash: null` — 1 erro único. Items todos válidos. Attempt 2 (retry) passa direto, menu vem com **12 items rotulados ISA completos**.

**Comparação dos 3 rounds:**

| Round | Schema | Prompt | Outcome típico | Items labeled |
|---|---|---|---|---|
| 1 (pré-fixes) | optional só | v0.1 | error/degraded (50/50) | 0-10 (stripped) |
| 2 (motor#98 + #99) | nullable expires_at | v0.2 | ok-retry | 10-12 (full) |
| 3 (com este PR) | nullable simétrico | v0.2 | **ok direto** (esperado) | 10-12 (full) |

## Validação

```
shared:        500 / 8 skip   (estável)
planejador:    140            (era 136 — +4 tests novos)
motor-drota:   153 / 1 skip   (estável)
Total:         981 / 9 skip   (+4 tests, 0 regressions)
```

Build verde 7 workspaces.

## Refs

- ops#1058 (H-AC-12)
- motor#98 (round 1 — fix expires_at)
- motor#99 (prompt v0.2 — clarifica enums)

🤖 Generated with [Claude Code](https://claude.com/claude-code)