### PR TITLE
[fix A] schema action-menu: .max(128) em hash fields (Qwen3 degeneration guard)

### DIFF
--- a/planejador/tests/action-menu-schema.unit.test.ts
+++ b/planejador/tests/action-menu-schema.unit.test.ts
@@ -221,6 +221,34 @@ describe("ActionMenuSchema — negative cases", () => {
     menu.valid_until = "ontem";
     expect(() => parseActionMenu(menu)).toThrow();
   });
+
+  // Fix 2026-05-14 round 3: max(128) em hash fields — guard contra
+  // degeneration loops de Qwen3 (observados em 2 errors do baseline N=30).
+  it("rejeita source.profile_hash > 128 chars (degeneration loop guard)", () => {
+    const menu = baseValidMenu();
+    menu.source.profile_hash = "x".repeat(200);
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("rejeita source.eixos_state_hash > 128 chars (degeneration loop guard)", () => {
+    const menu = baseValidMenu();
+    menu.source.eixos_state_hash = "y".repeat(500);
+    expect(() => parseActionMenu(menu)).toThrow();
+  });
+
+  it("aceita hash exatamente em 128 chars (boundary)", () => {
+    const menu = baseValidMenu();
+    menu.source.profile_hash = "a".repeat(128);
+    menu.source.eixos_state_hash = "b".repeat(128);
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
+
+  it("aceita hash sha256 hex normal (64 chars)", () => {
+    const menu = baseValidMenu();
+    menu.source.profile_hash =
+      "e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8";
+    expect(() => parseActionMenu(menu)).not.toThrow();
+  });
 });
 
 describe("ActionMenuSchema — ISA pedagogical labels (H-AC-01)", () => {

--- a/shared/src/contracts/action-menu.ts
+++ b/shared/src/contracts/action-menu.ts
@@ -115,15 +115,21 @@ export type ActionMenuItem = z.infer<typeof ActionMenuItemSchema>;
  * Procedência do menu — facilita audit (qual hash de profile / eixos)
  * e fallback (se trust_level baixo, lookup pode ser conservador).
  *
- * `profile_hash` / `eixos_state_hash`: `.nullable().optional()` — LLMs
- * (Qwen3-30B observado) emitem `null` em vez de omitir o campo. Mesmo
- * padrão do fix em `expires_at` (motor#98). Ref: ops#1058 diagnose
- * 2026-05-14 — schema_error_first por null em campo opt.
+ * `profile_hash` / `eixos_state_hash`:
+ * - `.nullable().optional()` — LLMs (Qwen3-30B observado) emitem `null`
+ *   em vez de omitir o campo. Mesmo padrão do fix em `expires_at` (motor#98).
+ * - `.max(128)` — defensive contra degeneration loops em LLM. Hash real
+ *   (sha256) tem 64 chars hex; 128 dá margem ampla pra schemes alternativos
+ *   (sha512 ou prefixos) mas rejeita "x9k2m4n7p1q3r5..." infinito observado
+ *   em 2 errors do baseline N=30 Qwen3-30B (2026-05-14). Rejeita response
+ *   degenerated na 1ª parse — não desperdiça LLM call de retry inteira.
+ *
+ * Ref: ops#1058 diagnose round 3 — 2026-05-14 baseline full smoke.
  */
 export const ActionMenuSourceSchema = z.object({
   trust_level: z.number().min(0).max(1),
-  profile_hash: z.string().nullable().optional(),
-  eixos_state_hash: z.string().nullable().optional(),
+  profile_hash: z.string().max(128).nullable().optional(),
+  eixos_state_hash: z.string().max(128).nullable().optional(),
 });
 export type ActionMenuSource = z.infer<typeof ActionMenuSourceSchema>;
 


### PR DESCRIPTION
Round 3 do diagnose H-AC-12 — baseline full smoke N=30 (2026-05-14) revelou que **ambos os 2 errors** do Kei foram **degeneration loops** em hash fields:

\`\`\`
"eixos_state_hash": "x9k2m4n7p1q3r5s8t0u2v4w6x8y1z3a5b7c9d2e4f6g8h0i2j4k6l8m1n3o5p7q9..."
                                                                                  ↑ continua infinito até max_tokens=3000
\`\`\`

JSON truncated → parser falha → outcome=error.

## Fix

\`profile_hash\` + \`eixos_state_hash\` ganham \`.max(128)\` em \`ActionMenuSourceSchema\`.

- sha256 hex tem 64 chars (norma)
- 128 dá margem ampla pra schemes alternativos
- Rejeita degeneration na 1ª parse — economiza LLM call de retry

## Validação

Suite: **planejador 144 tests** (era 140 — +4 novos). Build verde 7 workspaces.

## Trade-off vs alternativas

- **Trocar de modelo** (Qwen3-0.6B / DeBERTa híbrido): ~10x mais trabalho, modelos pequenos pioram qualidade na tarefa
- **Lower temperature em retry** (0.3 vez de 0.7): também válido, fica pra v0.1 do retry logic
- **Stop sequences**: requer mudança na llm-call config, fica pra próxima iteração

Esse fix é o mais barato e direto — schema rejeita o pattern observado, sem mudar modelo nem sampling config.

## Refs

- ops#1058 (H-AC-12), baseline report \`/tmp/h-ac-12-baseline-report.md\`
- motor#98 (round 1), motor#100 (round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)