### PR TITLE
[fix B] measure-variance: import PROMPT_TEMPLATE_VERSION canônico (metadata report)

### DIFF
--- a/scripts/measure-menu-variance.mjs
+++ b/scripts/measure-menu-variance.mjs
@@ -35,7 +35,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..");
 
 // Imports do build output do motor-drota (postbuild copia prompts/).
-const { generateActionMenu } = await import(
+const { generateActionMenu, PROMPT_TEMPLATE_VERSION } = await import(
   path.join(REPO_ROOT, "motor-drota", "dist", "menu-generator.js")
 );
 const { RYO_HINT, KEI_HINT } = await import(
@@ -57,7 +57,11 @@ function parseArgs(argv) {
     model: null,
     commentOn: null,
     output: null,
-    promptVersion: "v0.1",
+    // Default: importa PROMPT_TEMPLATE_VERSION canônico do menu-generator
+    // (fonte da verdade). Antes era hardcode "v0.1" que ficou stale após
+    // bump pra v0.2 em motor#99 — report metadata mentia sobre qual prompt
+    // foi usado de fato. Override manual ainda funciona via --prompt-version.
+    promptVersion: PROMPT_TEMPLATE_VERSION,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -112,7 +116,7 @@ Options:
   --model <kimi|qwen3|both> default: --quick=kimi, --full=both, --manual=qwen3
   --comment-on <ref>        posta comment via gh CLI; ex: "ops#1058" ou "motor#42"
   --output <path>           salva markdown em arquivo (além do stdout)
-  --prompt-version <vX.Y>   default: v0.1
+  --prompt-version <vX.Y>   default: PROMPT_TEMPLATE_VERSION do menu-generator (atual: ${PROMPT_TEMPLATE_VERSION})
   -h, --help                este help
 
 Spec: ascendimacy-ops/docs/specs/H-AC-12-variancia-geracao-v0.md


### PR DESCRIPTION
Bug menor observado no baseline 2026-05-14: header do report dizia \`Prompt: \`v0.1\`\` apesar do uso real ser v0.2 (após bump em motor#99).

## Causa

\`scripts/measure-menu-variance.mjs\` tinha default hardcoded:
\`\`\`js
promptVersion: \"v0.1\",
\`\`\`

Após motor#99 bumpar \`PROMPT_TEMPLATE_VERSION\` para v0.2 em menu-generator, o script continuou marcando v0.1 no metadata — report mentia.

## Fix

Import \`PROMPT_TEMPLATE_VERSION\` do build output do motor-drota, usa como default:

\`\`\`js
import { generateActionMenu, PROMPT_TEMPLATE_VERSION } from \"motor-drota/dist/menu-generator.js\";

const args = {
  ...,
  promptVersion: PROMPT_TEMPLATE_VERSION,  // fonte da verdade
};
\`\`\`

Override manual via \`--prompt-version\` ainda funciona (útil pra back-port de relatórios históricos).

## Validação

Sem mudança de comportamento de execução. Próximo baseline vai marcar \`v0.2\` corretamente.

\`node --check\` OK + build verde.

## Refs

- ops#1058 (H-AC-12)
- motor#99 (origem do bump v0.2 que tornou o hardcode stale)
- Baseline report observed mismatch: \`/tmp/h-ac-12-baseline-report.md\` (2026-05-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)