### PR TITLE
[feat] S-T-09-03 — trigger onboarding completion → generateActionMenu (ops#994)

### DIFF
--- a/motor-execucao/src/executor.ts
+++ b/motor-execucao/src/executor.ts
@@ -3,10 +3,25 @@ import type { ExecutePlaybookInput, ExecutePlaybookOutput } from "@ascendimacy/s
 import { getState, updateState, logEvent } from "./state-manager.js";
 import { getPlaybookById } from "./loader.js";
 import type { PlaybookInventory } from "./types.js";
+import {
+  triggerActionMenuGeneration,
+  type OnboardingTriggerDeps,
+} from "./onboarding-trigger.js";
+
+/**
+ * S-T-09-03 (ops#994): hook opcional pra trigger de generateActionMenu
+ * pós conclusão de onboarding. Injetado por server.ts em prod; ausente
+ * em unit tests do executor (testes do trigger em isolated suite).
+ */
+export interface ExecutorOptions {
+  /** Deps pra trigger ActionMenu generation. Quando ausente, hook é no-op. */
+  actionMenuTriggerDeps?: OnboardingTriggerDeps;
+}
 
 export function executePlaybook(
   input: ExecutePlaybookInput,
-  inventory: PlaybookInventory
+  inventory: PlaybookInventory,
+  options: ExecutorOptions = {},
 ): ExecutePlaybookOutput {
   const { sessionId, playbookId, selectedContentId, output, metadata } = input;
   const playbook = getPlaybookById(inventory, playbookId);
@@ -33,6 +48,13 @@ export function executePlaybook(
 
   updateState(sessionId, newState);
   logEvent(sessionId, event);
+
+  // S-T-09-03 (ops#994): trigger fire-and-forget de generateActionMenu
+  // se metadata indica conclusão de onboarding. Caller (server.ts) é
+  // responsável por injetar deps em prod; ausente = no-op (legacy).
+  if (options.actionMenuTriggerDeps && metadata) {
+    triggerActionMenuGeneration(metadata, options.actionMenuTriggerDeps);
+  }
 
   return { success: true, newState, eventLogged: event };
 }

--- a/motor-execucao/src/onboarding-trigger.ts
+++ b/motor-execucao/src/onboarding-trigger.ts
@@ -1,0 +1,165 @@
+/**
+ * Onboarding completion trigger — S-T-09-03 (ops#994).
+ *
+ * Quando `executePlaybook` registra um playbook tagged como conclusão de
+ * onboarding (`metadata.is_final_step === true` + `metadata.playbook_kind
+ * === "onboarding"` + `metadata.personaId` presente), dispara assincronamente
+ * `generateActionMenu` para criar o ActionMenu inicial do persona.
+ *
+ * **Fire-and-forget** — não bloqueia retorno do execute_playbook. Generator
+ * pode levar 5-10 min em Qwen3 local; menu fica disponível eventualmente,
+ * caller decide quando esperar (lookup determinístico de C-T-10 faz
+ * fallback to scoring se menu ausente).
+ *
+ * **Dependency-injected** — pra testabilidade. Produção fornece
+ * generateMenu/loadProfile/saveMenu/resolveHint via dynamic import do
+ * build output de motor-drota (cross-workspace).
+ *
+ * Defaults Jun 2026-05-13:
+ * - trust=cold = 0.1 (post-onboarding com pouco material)
+ * - eixos = [] (array vazio)
+ * - baseDir = fixtures/profiles/ (consistente com motor#85)
+ * - Failure mode: não-bloqueante; warning emitido, executor continua
+ *
+ * Refs: ops#994, ops#989 (capability C-T-09), motor#90 (generator).
+ */
+
+import type { ActionMenu } from "@ascendimacy/shared";
+
+/** Inputs do generator (espelha GenerateActionMenuInput de motor-drota). */
+export interface MenuGeneratorInput {
+  personaId: string;
+  trustLevel: number;
+  profile: unknown;
+  eixosState?: unknown;
+  onboarding?: unknown;
+  personaHint?: unknown;
+  sessionId?: string;
+}
+
+export interface MenuGeneratorWarning {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+/** Dependency surface — injetável pra testes. */
+export interface OnboardingTriggerDeps {
+  /** Generator real ou mock — retorna menu válido ou null em falha. */
+  generateMenu: (
+    input: MenuGeneratorInput,
+    options?: { onWarning?: (w: MenuGeneratorWarning) => void },
+  ) => Promise<ActionMenu | null>;
+
+  /** Lookup do profile do persona. Retorna o JSON do fixture. */
+  loadProfile: (personaId: string) => unknown;
+
+  /** Persiste o menu gerado. Retorna path absoluto. */
+  saveMenu: (menu: ActionMenu, baseDir: string) => Promise<string>;
+
+  /** Lookup do persona hint (RYO/KEI hints). Pode retornar null. */
+  resolveHint: (personaId: string) => unknown;
+
+  /** Diretório base pra persistência. Default produção: fixtures/profiles. */
+  baseDir: string;
+
+  /** Callback opcional pra eventos de log (sucesso/falha do trigger). */
+  onLog?: (event: { code: string; message: string; details?: Record<string, unknown> }) => void;
+}
+
+/**
+ * Detection pura — verifica se metadata indica conclusão de onboarding.
+ * Sem side effects, sem I/O — função de validação isolada testável.
+ */
+export function shouldTriggerActionMenuGeneration(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  if (!metadata) return false;
+  if (metadata["is_final_step"] !== true) return false;
+  if (metadata["playbook_kind"] !== "onboarding") return false;
+  const personaId = metadata["personaId"];
+  if (typeof personaId !== "string" || personaId.length === 0) return false;
+  return true;
+}
+
+/**
+ * Trigger — fire-and-forget. Retorna `void` imediatamente; a promise
+ * interna conclui assincronamente sem bloquear o caller.
+ *
+ * Caller (executePlaybook) chama isso APÓS updateState. Falhas são
+ * silentes pro flow principal — só emitem via `deps.onLog`.
+ *
+ * Nunca throws — todos os errores são capturados e logados.
+ */
+export function triggerActionMenuGeneration(
+  metadata: Record<string, unknown>,
+  deps: OnboardingTriggerDeps,
+): void {
+  // Validate input antes de async work.
+  if (!shouldTriggerActionMenuGeneration(metadata)) {
+    deps.onLog?.({
+      code: "trigger_skipped",
+      message: "Metadata não indica conclusão de onboarding",
+      details: { metadata },
+    });
+    return;
+  }
+
+  const personaId = String(metadata["personaId"]);
+
+  // Fire-and-forget — sem await; .catch silencia qualquer error.
+  void (async () => {
+    try {
+      const profile = deps.loadProfile(personaId);
+      if (profile == null) {
+        deps.onLog?.({
+          code: "profile_not_found",
+          message: `Profile não encontrado para ${personaId}`,
+          details: { personaId },
+        });
+        return;
+      }
+
+      const personaHint = deps.resolveHint(personaId);
+
+      const warnings: MenuGeneratorWarning[] = [];
+      const menu = await deps.generateMenu(
+        {
+          personaId,
+          trustLevel: 0.1, // cold default per spec
+          profile,
+          eixosState: [], // vazio post-onboarding
+          personaHint,
+        },
+        { onWarning: (w) => warnings.push(w) },
+      );
+
+      if (menu == null) {
+        deps.onLog?.({
+          code: "generation_failed",
+          message: "generateActionMenu retornou null (hard failure)",
+          details: { personaId, warnings: warnings.map((w) => w.code) },
+        });
+        return;
+      }
+
+      const savedPath = await deps.saveMenu(menu, deps.baseDir);
+      deps.onLog?.({
+        code: "menu_generated",
+        message: `ActionMenu inicial gerado e persistido`,
+        details: {
+          personaId,
+          path: savedPath,
+          itemsCount: menu.items.length,
+          warningsCount: warnings.length,
+        },
+      });
+    } catch (err) {
+      deps.onLog?.({
+        code: "trigger_error",
+        message: err instanceof Error ? err.message : String(err),
+        details: { personaId, errorClass: (err as { name?: string })?.name ?? "Error" },
+      });
+    }
+  })();
+}

--- a/motor-execucao/tests/onboarding-trigger.unit.test.ts
+++ b/motor-execucao/tests/onboarding-trigger.unit.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests — onboarding-trigger.ts (S-T-09-03 / ops#994).
+ *
+ * Deps injetadas, zero rede, zero LLM real. Cobre:
+ * - shouldTriggerActionMenuGeneration: detection pura
+ * - triggerActionMenuGeneration: fire-and-forget + log events
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { ActionMenu } from "@ascendimacy/shared";
+
+import {
+  shouldTriggerActionMenuGeneration,
+  triggerActionMenuGeneration,
+  type OnboardingTriggerDeps,
+  type MenuGeneratorInput,
+  type MenuGeneratorWarning,
+} from "../src/onboarding-trigger.js";
+
+function fakeValidMenu(personaId: string): ActionMenu {
+  return {
+    persona_id: personaId,
+    schema_version: "v0.2.0",
+    generated_at: "2026-05-14T10:00:00.000Z",
+    source: { trust_level: 0.1 },
+    items: [
+      {
+        id: "esp-01",
+        type: "strategy",
+        content: "mock item",
+        weight: 0.5,
+        played_as: "espelho",
+        intensity: "soft",
+        is_critical: false,
+      },
+    ],
+  };
+}
+
+function makeMockDeps(
+  overrides: Partial<OnboardingTriggerDeps> = {},
+): OnboardingTriggerDeps {
+  return {
+    generateMenu: vi.fn(async (input: MenuGeneratorInput) =>
+      fakeValidMenu(input.personaId),
+    ),
+    loadProfile: vi.fn(() => ({ preferences: { interests: ["tênis"] } })),
+    saveMenu: vi.fn(async () => "/tmp/mock-saved.json"),
+    resolveHint: vi.fn(() => ({
+      persona_id: "ryo-ochiai",
+      archetype: "deflective",
+      bias: [],
+    })),
+    baseDir: "/tmp/test-profiles",
+    ...overrides,
+  };
+}
+
+const onboardingValid = {
+  is_final_step: true,
+  playbook_kind: "onboarding",
+  personaId: "ryo-ochiai",
+};
+
+describe("shouldTriggerActionMenuGeneration", () => {
+  it("retorna true para metadata válido (3 keys presentes)", () => {
+    expect(shouldTriggerActionMenuGeneration(onboardingValid)).toBe(true);
+  });
+
+  it("retorna false quando metadata é undefined", () => {
+    expect(shouldTriggerActionMenuGeneration(undefined)).toBe(false);
+  });
+
+  it("retorna false quando is_final_step !== true", () => {
+    expect(
+      shouldTriggerActionMenuGeneration({
+        ...onboardingValid,
+        is_final_step: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTriggerActionMenuGeneration({
+        ...onboardingValid,
+        is_final_step: "yes",
+      }),
+    ).toBe(false);
+  });
+
+  it("retorna false quando playbook_kind !== 'onboarding'", () => {
+    expect(
+      shouldTriggerActionMenuGeneration({
+        ...onboardingValid,
+        playbook_kind: "session",
+      }),
+    ).toBe(false);
+  });
+
+  it("retorna false quando personaId é vazio ou não-string", () => {
+    expect(
+      shouldTriggerActionMenuGeneration({
+        ...onboardingValid,
+        personaId: "",
+      }),
+    ).toBe(false);
+    expect(
+      shouldTriggerActionMenuGeneration({
+        ...onboardingValid,
+        personaId: 42,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTriggerActionMenuGeneration({
+        ...onboardingValid,
+        personaId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("retorna false quando metadata é objeto vazio", () => {
+    expect(shouldTriggerActionMenuGeneration({})).toBe(false);
+  });
+});
+
+describe("triggerActionMenuGeneration — fire-and-forget", () => {
+  it("happy path: chama generateMenu + saveMenu + emite log success", async () => {
+    const logs: Array<{ code: string; message: string }> = [];
+    const deps = makeMockDeps({
+      onLog: (e) => logs.push({ code: e.code, message: e.message }),
+    });
+
+    triggerActionMenuGeneration(onboardingValid, deps);
+
+    // Fire-and-forget — espera microtasks
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(deps.generateMenu).toHaveBeenCalledTimes(1);
+    expect(deps.loadProfile).toHaveBeenCalledWith("ryo-ochiai");
+    expect(deps.resolveHint).toHaveBeenCalledWith("ryo-ochiai");
+    expect(deps.saveMenu).toHaveBeenCalledTimes(1);
+    expect(logs.find((l) => l.code === "menu_generated")).toBeDefined();
+  });
+
+  it("returns void imediatamente (não bloqueia)", () => {
+    const deps = makeMockDeps();
+    const result = triggerActionMenuGeneration(onboardingValid, deps);
+    expect(result).toBeUndefined();
+  });
+
+  it("skip silently quando metadata não bate detection", async () => {
+    const logs: Array<{ code: string }> = [];
+    const deps = makeMockDeps({
+      onLog: (e) => logs.push({ code: e.code }),
+    });
+
+    triggerActionMenuGeneration({ is_final_step: false } as Record<string, unknown>, deps);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(deps.generateMenu).not.toHaveBeenCalled();
+    expect(logs.find((l) => l.code === "trigger_skipped")).toBeDefined();
+  });
+
+  it("loga profile_not_found se loadProfile retorna null", async () => {
+    const logs: Array<{ code: string }> = [];
+    const deps = makeMockDeps({
+      loadProfile: vi.fn(() => null),
+      onLog: (e) => logs.push({ code: e.code }),
+    });
+
+    triggerActionMenuGeneration(onboardingValid, deps);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(deps.generateMenu).not.toHaveBeenCalled();
+    expect(logs.find((l) => l.code === "profile_not_found")).toBeDefined();
+  });
+
+  it("loga generation_failed se generateMenu retorna null", async () => {
+    const logs: Array<{ code: string; details?: Record<string, unknown> }> = [];
+    const deps = makeMockDeps({
+      generateMenu: vi.fn(async () => null),
+      onLog: (e) => logs.push({ code: e.code, details: e.details }),
+    });
+
+    triggerActionMenuGeneration(onboardingValid, deps);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(deps.saveMenu).not.toHaveBeenCalled();
+    const failLog = logs.find((l) => l.code === "generation_failed");
+    expect(failLog).toBeDefined();
+  });
+
+  it("loga trigger_error e silencia exceptions de generateMenu", async () => {
+    const logs: Array<{ code: string; message: string }> = [];
+    const deps = makeMockDeps({
+      generateMenu: vi.fn(async () => {
+        throw new Error("LLM network blip");
+      }),
+      onLog: (e) => logs.push({ code: e.code, message: e.message }),
+    });
+
+    expect(() => triggerActionMenuGeneration(onboardingValid, deps)).not.toThrow();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const errLog = logs.find((l) => l.code === "trigger_error");
+    expect(errLog).toBeDefined();
+    expect(errLog!.message).toContain("LLM network blip");
+  });
+
+  it("loga trigger_error se saveMenu falha", async () => {
+    const logs: Array<{ code: string; message: string }> = [];
+    const deps = makeMockDeps({
+      saveMenu: vi.fn(async () => {
+        throw new Error("EACCES: read-only filesystem");
+      }),
+      onLog: (e) => logs.push({ code: e.code, message: e.message }),
+    });
+
+    triggerActionMenuGeneration(onboardingValid, deps);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const errLog = logs.find((l) => l.code === "trigger_error");
+    expect(errLog).toBeDefined();
+    expect(errLog!.message).toContain("EACCES");
+  });
+
+  it("propaga warnings de generateMenu pro log de success", async () => {
+    const logs: Array<{ code: string; details?: Record<string, unknown> }> = [];
+    const deps = makeMockDeps({
+      generateMenu: vi.fn(async (input, options) => {
+        options?.onWarning?.({
+          code: "schema_error_first",
+          message: "first attempt invalid",
+        });
+        return fakeValidMenu(input.personaId);
+      }),
+      onLog: (e) => logs.push({ code: e.code, details: e.details }),
+    });
+
+    triggerActionMenuGeneration(onboardingValid, deps);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const okLog = logs.find((l) => l.code === "menu_generated");
+    expect(okLog).toBeDefined();
+    expect(okLog!.details?.warningsCount).toBe(1);
+  });
+
+  it("usa trust=0.1 cold + eixosState=[] + injected hint", async () => {
+    const deps = makeMockDeps();
+    triggerActionMenuGeneration(onboardingValid, deps);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const callArgs = (deps.generateMenu as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![0] as MenuGeneratorInput;
+    expect(callArgs.personaId).toBe("ryo-ochiai");
+    expect(callArgs.trustLevel).toBe(0.1);
+    expect(callArgs.eixosState).toEqual([]);
+    expect(callArgs.profile).toBeDefined();
+    expect(callArgs.personaHint).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes ascendimacy/ascendimacy-ops#994 (S-T-09-03 trigger onboarding completion, Tier 2 semi-autônomo).

## Resumo

Adiciona hook fire-and-forget em \`executePlaybook\` que dispara \`generateActionMenu\` quando metadata indica conclusão de onboarding. Implementação dependency-injected pra preservar testabilidade + isolamento cross-workspace.

## Defaults (Jun 2026-05-13 — propostos no comment de escopo)

Não houve resposta explícita aos 7 pontos do escopo; CC implementa com defaults conservadores. Reversíveis sem effort em PR follow-up se Jun preferir outros valores.

| # | Decisão | Default usado |
|---|---|---|
| 1 | Detection | \`metadata.is_final_step === true\` + \`metadata.playbook_kind === \"onboarding\"\` + \`metadata.personaId\` presente |
| 2 | profile_inicial | Injetado pelo caller (não hardcoded — \`loadProfile(personaId)\` é dep) |
| 3 | trust=cold | \`0.1\` |
| 4 | eixos=[] | array vazio |
| 5 | baseDir | injetado pelo caller (default prod sugerido: \`fixtures/profiles/\`) |
| 6 | Failure mode | não-bloqueante; logs via \`onLog\` callback; executor sempre retorna success |
| 7 | Sync vs async | **fire-and-forget** — executePlaybook retorna imediatamente, menu fica disponível eventualmente |

## API

\`\`\`typescript
// Detection pura (sem side effects, sem I/O)
shouldTriggerActionMenuGeneration(metadata): boolean

// Dispara async (fire-and-forget — nunca throws)
triggerActionMenuGeneration(metadata, deps): void

interface OnboardingTriggerDeps {
  generateMenu: (input, options) => Promise<ActionMenu | null>;
  loadProfile: (personaId) => unknown;
  saveMenu: (menu, baseDir) => Promise<string>;
  resolveHint: (personaId) => unknown;
  baseDir: string;
  onLog?: (event) => void;
}
\`\`\`

## Mudanças

\`motor-execucao/src/onboarding-trigger.ts\` (165 linhas) — função pura + trigger fire-and-forget.

\`motor-execucao/src/executor.ts\` — adiciona \`ExecutorOptions.actionMenuTriggerDeps\` opcional. Quando fornecido, chama trigger após \`updateState\`. Backward compat: callers sem options = no-op.

\`motor-execucao/tests/onboarding-trigger.unit.test.ts\` (259 linhas) — 15 unit tests cobertura completa.

## Não-escopo desta PR

- **Wiring em prod (server.ts injetando deps reais)** — separa cross-workspace boundary pra follow-up. Quem chama \`execute_playbook\` MCP tool pode injetar deps de motor-drota via dynamic import. Sem essa wire, o trigger fica latent (no-op em prod).
- **\`universal.onboarding.playbook.yaml\`** — esse playbook YAML ainda não existe. Caller responsabiliza-se por sinalizar conclusão via metadata até o playbook nascer formalmente.
- **S-T-09-04 trigger profile-compressor (ops#995)** — bloqueado por \`motor#476\` (profile-compressor) que não existe. Comentado na issue separadamente.

## Validação

\`\`\`
motor-execucao:   101 tests (era 86 — +15 novos onboarding-trigger)
Total suite:      1000 / 9 skip   (0 regressions)
\`\`\`

Build verde 7 workspaces.

## Refs

- ops#994 (S-T-09-03)
- ops#989 (capability C-T-09)
- motor#90 (generator base)
- Comment de escopo: ops#994#issuecomment-4447207025 (7 pontos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)