### PR TITLE
[ops#1067] content-usage-repo cross-session — habilita decay + observability

### DIFF
--- a/motor-execucao/src/content-usage-repo.ts
+++ b/motor-execucao/src/content-usage-repo.ts
@@ -1,0 +1,114 @@
+/**
+ * Content usage tracker — cross-session repo (ops#1067).
+ *
+ * Habilita decay temporal real no scorer (shared/scorer.ts:149-160 hoje
+ * tem dead code — `last_used_at` sempre undefined). Plus observability
+ * pra Jun debugar padrões de oferta de items por persona.
+ *
+ * Escopo reduzido pos-reframe Jun 2026-05-14:
+ * - Só observability/decay, NÃO decisão automatizada
+ * - Decisão de repetição é conversacional (ops#1068 — drota pergunta)
+ *
+ * Per-persona granularity (mesmo item pode ter histórico distinto pra
+ * Ryo vs Kei). Chave composta (persona_id, content_id).
+ *
+ * Refs: ops#1067, shared/src/content-item.ts:88-92 (campos declarados),
+ * shared/src/scorer.ts:149-160 (decay logic que vai funcionar).
+ */
+
+import type Database from "better-sqlite3";
+import { getNow } from "./clock.js";
+
+export const CONTENT_USAGE_DDL = `
+CREATE TABLE IF NOT EXISTS content_usage (
+  persona_id TEXT NOT NULL,
+  content_id TEXT NOT NULL,
+  times_used INTEGER NOT NULL DEFAULT 0,
+  last_used_at TEXT NOT NULL,
+  PRIMARY KEY (persona_id, content_id)
+);
+CREATE INDEX IF NOT EXISTS idx_content_usage_persona ON content_usage(persona_id);
+`;
+
+/** Row shape — espelha schema SQL. */
+export interface ContentUsageRow {
+  persona_id: string;
+  content_id: string;
+  times_used: number;
+  last_used_at: string; // ISO 8601
+}
+
+/**
+ * UPSERT — incrementa times_used + atualiza last_used_at.
+ * Idempotente em rolls múltiplos com mesmo input (cada call += 1).
+ *
+ * Aceita `nowIso` override pra testabilidade determinística.
+ */
+export function recordContentUsage(
+  db: Database.Database,
+  args: { personaId: string; contentId: string; nowIso?: string },
+): ContentUsageRow {
+  const { personaId, contentId } = args;
+  const ts = getNow(args.nowIso);
+
+  db.prepare(
+    `INSERT INTO content_usage (persona_id, content_id, times_used, last_used_at)
+     VALUES (?, ?, 1, ?)
+     ON CONFLICT(persona_id, content_id) DO UPDATE SET
+       times_used = times_used + 1,
+       last_used_at = excluded.last_used_at`,
+  ).run(personaId, contentId, ts);
+
+  const row = db
+    .prepare(
+      `SELECT persona_id, content_id, times_used, last_used_at
+       FROM content_usage WHERE persona_id = ? AND content_id = ?`,
+    )
+    .get(personaId, contentId) as ContentUsageRow;
+  return row;
+}
+
+/**
+ * Lê usage de 1 item específico. Retorna null se nunca usado.
+ */
+export function getContentUsage(
+  db: Database.Database,
+  args: { personaId: string; contentId: string },
+): ContentUsageRow | null {
+  const row = db
+    .prepare(
+      `SELECT persona_id, content_id, times_used, last_used_at
+       FROM content_usage WHERE persona_id = ? AND content_id = ?`,
+    )
+    .get(args.personaId, args.contentId);
+  return (row as ContentUsageRow | undefined) ?? null;
+}
+
+/**
+ * Lê todo o histórico de uma persona — pra hidratação do pool no
+ * planejador (futuro). Retorna Map<content_id, ContentUsageRow>.
+ */
+export function getAllContentUsageByPersona(
+  db: Database.Database,
+  personaId: string,
+): Map<string, ContentUsageRow> {
+  const rows = db
+    .prepare(
+      `SELECT persona_id, content_id, times_used, last_used_at
+       FROM content_usage WHERE persona_id = ?`,
+    )
+    .all(personaId) as ContentUsageRow[];
+  const map = new Map<string, ContentUsageRow>();
+  for (const r of rows) map.set(r.content_id, r);
+  return map;
+}
+
+/**
+ * Total usage records — debug/diagnose helper.
+ */
+export function countContentUsage(db: Database.Database): number {
+  const row = db
+    .prepare("SELECT COUNT(*) AS n FROM content_usage")
+    .get() as { n: number };
+  return row.n;
+}

--- a/motor-execucao/src/executor.ts
+++ b/motor-execucao/src/executor.ts
@@ -1,12 +1,13 @@
 import { getNow } from "./clock.js";
 import type { ExecutePlaybookInput, ExecutePlaybookOutput } from "@ascendimacy/shared";
-import { getState, updateState, logEvent } from "./state-manager.js";
+import { getState, updateState, logEvent, getDbInstance } from "./state-manager.js";
 import { getPlaybookById } from "./loader.js";
 import type { PlaybookInventory } from "./types.js";
 import {
   triggerActionMenuGeneration,
   type OnboardingTriggerDeps,
 } from "./onboarding-trigger.js";
+import { recordContentUsage } from "./content-usage-repo.js";
 
 /**
  * S-T-09-03 (ops#994): hook opcional pra trigger de generateActionMenu
@@ -54,6 +55,29 @@ export function executePlaybook(
   // responsável por injetar deps em prod; ausente = no-op (legacy).
   if (options.actionMenuTriggerDeps && metadata) {
     triggerActionMenuGeneration(metadata, options.actionMenuTriggerDeps);
+  }
+
+  // ops#1067: UPSERT content_usage cross-session (per-persona, per-item).
+  // Habilita decay temporal real no scorer (shared/scorer.ts) e
+  // observability longitudinal (H-AC-08 future).
+  //
+  // Requer metadata.personaId presente — caller responsabiliza-se. Sem
+  // personaId OR sem selectedContentId, skip silently (backward compat).
+  const personaId =
+    typeof metadata?.["personaId"] === "string" ? metadata["personaId"] : null;
+  if (personaId && selectedContentId) {
+    try {
+      recordContentUsage(getDbInstance(), {
+        personaId,
+        contentId: selectedContentId,
+      });
+    } catch (err) {
+      // Telemetry-style: não bloqueia execute_playbook se UPSERT falhar.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[executor] content_usage UPSERT falhou: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   return { success: true, newState, eventLogged: event };

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -6,6 +6,7 @@ import { TREE_NODES_DDL, getStatusMatrix } from "./tree-nodes.js";
 import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
 import { PARENT_DECISIONS_DDL } from "./parent-decisions.js";
 import { EMITTED_CARDS_DDL } from "./cards-repo.js";
+import { CONTENT_USAGE_DDL } from "./content-usage-repo.js";
 import { getNow, resolveDbPath } from "./clock.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -38,6 +39,7 @@ function getDb(dbPath?: string): Database.Database {
       ${GARDNER_PROGRAM_DDL}
       ${PARENT_DECISIONS_DDL}
       ${EMITTED_CARDS_DDL}
+      ${CONTENT_USAGE_DDL}
     `);
   }
   return db;

--- a/motor-execucao/tests/content-usage-repo.test.ts
+++ b/motor-execucao/tests/content-usage-repo.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests — content-usage-repo (ops#1067).
+ *
+ * Cobre UPSERT idempotente + leitura individual + leitura batch per-persona.
+ * In-memory SQLite pra isolamento.
+ */
+
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  CONTENT_USAGE_DDL,
+  countContentUsage,
+  getAllContentUsageByPersona,
+  getContentUsage,
+  recordContentUsage,
+} from "../src/content-usage-repo.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(CONTENT_USAGE_DDL);
+});
+
+describe("recordContentUsage — UPSERT idempotent", () => {
+  it("primeira chamada: cria row com times_used=1", () => {
+    const row = recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "ling_inuit_snow",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+
+    expect(row.persona_id).toBe("ryo-ochiai");
+    expect(row.content_id).toBe("ling_inuit_snow");
+    expect(row.times_used).toBe(1);
+    expect(row.last_used_at).toBe("2026-05-14T10:00:00.000Z");
+  });
+
+  it("chamadas múltiplas: incrementa times_used + atualiza last_used_at", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "ling_inuit_snow",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "ling_inuit_snow",
+      nowIso: "2026-05-14T10:15:00.000Z",
+    });
+    const row = recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "ling_inuit_snow",
+      nowIso: "2026-05-14T10:30:00.000Z",
+    });
+
+    expect(row.times_used).toBe(3);
+    expect(row.last_used_at).toBe("2026-05-14T10:30:00.000Z");
+  });
+
+  it("personas separadas: usage independente", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "ling_inuit_snow",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "kei-ochiai",
+      contentId: "ling_inuit_snow",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+
+    expect(getContentUsage(db, { personaId: "ryo-ochiai", contentId: "ling_inuit_snow" })?.times_used).toBe(1);
+    expect(getContentUsage(db, { personaId: "kei-ochiai", contentId: "ling_inuit_snow" })?.times_used).toBe(1);
+    expect(countContentUsage(db)).toBe(2);
+  });
+
+  it("items separados, mesma persona: independente", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-a",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-b",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+
+    expect(getContentUsage(db, { personaId: "ryo-ochiai", contentId: "item-a" })?.times_used).toBe(1);
+    expect(getContentUsage(db, { personaId: "ryo-ochiai", contentId: "item-b" })?.times_used).toBe(1);
+  });
+});
+
+describe("getContentUsage", () => {
+  it("retorna null pra row não existente", () => {
+    expect(
+      getContentUsage(db, { personaId: "ryo-ochiai", contentId: "never-used" }),
+    ).toBeNull();
+  });
+
+  it("retorna row após recordContentUsage", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-x",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    const row = getContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-x",
+    });
+    expect(row).not.toBeNull();
+    expect(row?.times_used).toBe(1);
+  });
+});
+
+describe("getAllContentUsageByPersona", () => {
+  it("retorna Map vazio pra persona sem usage", () => {
+    const map = getAllContentUsageByPersona(db, "ryo-ochiai");
+    expect(map.size).toBe(0);
+  });
+
+  it("retorna Map com todos items da persona", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-a",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-b",
+      nowIso: "2026-05-14T11:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "kei-ochiai", // outra persona — não deve aparecer
+      contentId: "item-c",
+      nowIso: "2026-05-14T12:00:00.000Z",
+    });
+
+    const map = getAllContentUsageByPersona(db, "ryo-ochiai");
+    expect(map.size).toBe(2);
+    expect(map.get("item-a")?.times_used).toBe(1);
+    expect(map.get("item-b")?.times_used).toBe(1);
+    expect(map.has("item-c")).toBe(false);
+  });
+});
+
+describe("countContentUsage — debug helper", () => {
+  it("retorna 0 em db vazio", () => {
+    expect(countContentUsage(db)).toBe(0);
+  });
+
+  it("conta rows após inserts (per persona × content)", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "a",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "b",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    // UPSERT na mesma row não cria nova
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "a",
+      nowIso: "2026-05-14T11:00:00.000Z",
+    });
+
+    expect(countContentUsage(db)).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes ascendimacy/ascendimacy-ops#1067 (tier:2-semi-autonomous, escopo reduzido pos-reframe Jun 2026-05-14).

## Resumo

Repo SQLite \`content_usage\` (per-persona × per-content) com UPSERT em \`executePlaybook\` quando \`metadata.personaId\` + \`selectedContentId\` presentes.

**Habilita:**
- Decay temporal real no scorer (shared/scorer.ts:149-160 hoje tem dead code — \`last_used_at\` sempre undefined; após este PR, executor escreve, hidratação no plan_turn fica pra follow-up)
- Observability longitudinal (H-AC-08 future painel consome esses dados)

**NÃO faz (reframe Jun):**
- Decisão automatizada de repetição → fica pra ops#1068 (drota.repetition_inquiry conversacional)
- Outcome_log rich → escopo original tinha; removido (over-engineering pra observability)
- Hidratação no plan_turn → follow-up explícito quando planejador for tocado (C-T-10-01)

## Mudanças

| Arquivo | Mudança |
|---|---|
| \`motor-execucao/src/content-usage-repo.ts\` (novo) | DDL + 4 funções (recordContentUsage / getContentUsage / getAllContentUsageByPersona / countContentUsage) |
| \`motor-execucao/src/state-manager.ts\` | Adiciona CONTENT_USAGE_DDL ao init SQLite |
| \`motor-execucao/src/executor.ts\` | UPSERT após updateState quando personaId+selectedContentId presentes |
| \`motor-execucao/tests/content-usage-repo.test.ts\` (novo) | 10 unit tests cobrindo UPSERT + leitura + per-persona |

## API

\`\`\`typescript
recordContentUsage(db, { personaId, contentId, nowIso? }): ContentUsageRow
getContentUsage(db, { personaId, contentId }): ContentUsageRow | null
getAllContentUsageByPersona(db, personaId): Map<content_id, ContentUsageRow>
countContentUsage(db): number   // debug
\`\`\`

Schema:
\`\`\`sql
CREATE TABLE content_usage (
  persona_id TEXT NOT NULL,
  content_id TEXT NOT NULL,
  times_used INTEGER NOT NULL DEFAULT 0,
  last_used_at TEXT NOT NULL,
  PRIMARY KEY (persona_id, content_id)
);
\`\`\`

## Backward compat

- Sem \`personaId\` no metadata → UPSERT skipped silently (legacy callers continuam funcionando)
- UPSERT throw → log stderr; executePlaybook continua (telemetry-style)
- Migration: start from zero (nenhum back-fill de event_log histórico — assumimos uso prospectivo)

## Validação

\`\`\`
motor-execucao: 111 tests (era 101 — +10 content-usage-repo)
Total suite:    1010 / 9 skip   (0 regressions)
\`\`\`

Build verde 7 workspaces.

## Próximo passo natural

Hidratação no plan_turn: planejador lê \`content_usage\` antes de scorePool e popula \`item.times_used\` + \`item.last_used_at\` no pool → decay temporal liga. Pode ser parte de C-T-10-01 (ops#999) ou follow-up dedicado.

## Refs

- ops#1067 (capability)
- ops#1066 (signal-extractor approach — superseded)
- ops#1068 (drota.repetition_inquiry conversacional — substitui decisão algorítmica)
- shared/src/scorer.ts:149-160 (decay logic ativável após este repo)
- shared/src/content-item.ts:88-92 (campos times_used/last_used_at declarados há tempos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)