### PR TITLE
[feat C-T-10-01] menu-lookup + plan.ts integration com decay multiplicativo (ops#999)

### DIFF
--- a/fixtures/profiles/paula-mendes-menu.json
+++ b/fixtures/profiles/paula-mendes-menu.json
@@ -1,0 +1,54 @@
+{
+  "persona_id": "paula-mendes",
+  "schema_version": "v0.2.0",
+  "generated_at": "2026-05-14T10:00:00.000Z",
+  "valid_until": "2026-06-14T10:00:00.000Z",
+  "source": {
+    "trust_level": 0.42,
+    "profile_hash": "sha256:paula-smoke-profile-hash",
+    "eixos_state_hash": "sha256:paula-smoke-eixos-hash"
+  },
+  "items": [
+    {
+      "id": "smoke-curio-01",
+      "type": "curiosity",
+      "content": "Por que tantas plantas têm folhas verdes? (gancho pra clorofila + luz)",
+      "weight": 0.85,
+      "played_as": "espelho",
+      "intensity": "soft"
+    },
+    {
+      "id": "smoke-challenge-01",
+      "type": "challenge",
+      "content": "Em 1 frase, descreve o que sentiu hoje quando o desafio ficou difícil.",
+      "weight": 0.7,
+      "played_as": "canal",
+      "intensity": "medium",
+      "expires_at": "2026-05-21T10:00:00.000Z"
+    },
+    {
+      "id": "smoke-decay-01",
+      "type": "play",
+      "content": "Item expirado pra exercitar decay multiplicativo no smoke.",
+      "weight": 0.95,
+      "expires_at": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": "smoke-diamond-01",
+      "type": "cultural_diamond",
+      "content": "Suzuki Daisetz — a transmissão acontece no gesto, não na fala.",
+      "weight": 0.5,
+      "played_as": "diamante",
+      "intensity": "firm",
+      "is_critical": false
+    },
+    {
+      "id": "smoke-strategy-01",
+      "type": "strategy",
+      "content": "Quando criança vier com 'não consigo', ancorar em micro-passo concreto.",
+      "weight": 0.6,
+      "played_as": "bridge",
+      "intensity": "soft"
+    }
+  ]
+}

--- a/orchestrator/src/mcp-clients.ts
+++ b/orchestrator/src/mcp-clients.ts
@@ -49,6 +49,16 @@ function buildEnv(): Record<string, string> {
     "ASC_LLM_MAX_RETRIES",
     // Mock toggle
     "USE_MOCK_LLM",
+    // C-T-10-01 (ops#999) menu-lookup branch + baseDir override.
+    // Sem forward, plan.ts no child planejador não vê o flag e cai
+    // direto pro scoring clássico — smoke E2E impossível.
+    "ASC_USE_ACTION_MENU",
+    "ASC_ACTION_MENU_BASE_DIR",
+    // LLM local (openai-compat) — endpoint + model usados pelo Qwen3
+    // stack (llama.cpp SYCL). Necessário pra smoke E2E full sem mock
+    // contra LLM local, em vez de Infomaniak/Anthropic.
+    "LLM_LOCAL_ENDPOINT",
+    "LLM_LOCAL_MODEL",
   ];
   for (const k of keys) {
     const v = process.env[k];

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -39,6 +39,7 @@ import { callLlm, callLlmMock, callHaiku } from "./llm-client.js";
 import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
 import { evaluateAllTransitions, collectRecentSignals } from "./trigger-evaluator.js";
 import { personaToChildProfile } from "./child-profile.js";
+import { lookupActionMenu } from "./strategist/menu-lookup.js";
 
 /** Quantos items do pool passamos ao drota (top-K). */
 export const TOP_K_POOL = 5;
@@ -190,12 +191,46 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
       return data?.selectedContentId;
     })
     .filter((id): id is string => typeof id === "string" && id.length > 0);
-  const scored = scorePool(eligible, child, {
-    now: new Date().toISOString(),
-    casel_focus: caselTargets[0] as ScoredContentItem["item"]["casel_target"][number] | undefined,
-    used_in_session: usedInSession,
-  });
-  let topK = scored.slice(0, TOP_K_POOL);
+
+  // C-T-10-01 (ops#999): se ASC_USE_ACTION_MENU=true, tenta lookup
+  // determinístico no menu persistido ANTES de scoring. Fallback to
+  // scoring se menu ausente/stale/sem items elegíveis.
+  // Decay multiplicativo aplicado em items expirados (Jun 2026-05-14).
+  const useActionMenu = process.env["ASC_USE_ACTION_MENU"] === "true";
+  let topK: ScoredContentItem[] | null = null;
+  if (useActionMenu) {
+    const menuBaseDir =
+      process.env["ASC_ACTION_MENU_BASE_DIR"] ?? "fixtures/profiles";
+    const menuResult = await lookupActionMenu(input.persona.id, menuBaseDir, {
+      usedInSession,
+      topK: TOP_K_POOL,
+    });
+    try {
+      logDebugEvent({
+        side: "motor",
+        step: "plan_turn_menu_lookup",
+        user_id: input.persona.id,
+        motor_target: "planejador-strategist",
+        session_id: input.sessionId,
+        outcome: menuResult.outcome === "ok" ? "ok" : "skip",
+      });
+    } catch {
+      // Telemetry não bloqueia.
+    }
+    if (menuResult.outcome === "ok" && menuResult.items.length > 0) {
+      topK = menuResult.items;
+    }
+    // Fallback to scoring se menuResult.outcome !== "ok"
+  }
+
+  if (topK === null) {
+    const scored = scorePool(eligible, child, {
+      now: new Date().toISOString(),
+      casel_focus: caselTargets[0] as ScoredContentItem["item"]["casel_target"][number] | undefined,
+      used_in_session: usedInSession,
+    });
+    topK = scored.slice(0, TOP_K_POOL);
+  }
 
   // 2. Triagem parental (Bloco 4 #17, paper §6 camada 2).
   //    Se persona.profile.parental_profile existir E estiver mínimo,

--- a/planejador/src/strategist/menu-lookup.ts
+++ b/planejador/src/strategist/menu-lookup.ts
@@ -1,0 +1,292 @@
+/**
+ * C-T-10-01 menu lookup — lê ActionMenu persistido + retorna top-K como
+ * ScoredContentItem[] (conversão shim), com fallback to scoring quando
+ * menu ausente/stale.
+ *
+ * Spec: ops#999 (escopo ratificado Jun 2026-05-14 com decay multiplicativo).
+ *
+ * Comportamento:
+ * 1. Cache singleton in-memory por persona_id (TTL 5min default)
+ * 2. Load via `loadActionMenu` quando cache miss/stale
+ * 3. Filter: dedupe `used_in_session`
+ * 4. Effective weight: `item.weight × (now > expires_at ? 0.3 : 1.0)`
+ *    — decay multiplicativo (Jun 2026-05-14: items expirados ainda úteis)
+ * 5. Sort desc + take top-K
+ * 6. Convert ActionMenuItem → ScoredContentItem (transitional shim)
+ *
+ * Schema mapping (transitional, decisão Tier 3 ops#999 #4):
+ * - `curiosity` → `curiosity_hook` (mesma semântica)
+ * - `cultural_diamond` → `cultural_diamond`
+ * - `challenge` → `challenge`
+ * - `strategy` → `dynamic` (proxy)
+ * - `play` → `dynamic` (proxy)
+ *
+ * Refs: ops#999, motor#85 (persistence), motor#90 (generator), shared
+ * scorer.ts (decay legacy — código morto até ops#1067 hidratar).
+ */
+
+import type {
+  ActionMenu,
+  ActionMenuItem,
+  ActionMenuItemType,
+  ContentItem,
+  ContentItemType,
+  ScoredContentItem,
+} from "@ascendimacy/shared";
+
+import { loadActionMenu } from "./action-menu-persistence.js";
+
+/** Decay factor pra items expirados (Jun ratificou 2026-05-14). */
+const EXPIRED_DECAY_FACTOR = 0.3;
+
+/** Cache TTL em ms (5 min). */
+const CACHE_TTL_MS = 5 * 60_000;
+
+interface CacheEntry {
+  menu: ActionMenu | null;
+  loadedAt: number;
+}
+
+const _cache = new Map<string, CacheEntry>();
+
+/** Test helper — reset cache singleton. */
+export function _resetMenuLookupCache(): void {
+  _cache.clear();
+}
+
+/** Mapping type ActionMenu → ContentItem (transitional shim, ops#999 #4). */
+const TYPE_MAP: Record<ActionMenuItemType, ContentItemType> = {
+  curiosity: "curiosity_hook",
+  cultural_diamond: "cultural_diamond",
+  challenge: "challenge",
+  strategy: "dynamic",
+  play: "dynamic",
+};
+
+export interface MenuLookupOptions {
+  /** Item ids já usados nesta sessão (motor#23 penalty). */
+  usedInSession?: ReadonlyArray<string>;
+  /** Top-K a retornar (default 5). */
+  topK?: number;
+  /** Override de "now" pra testabilidade determinística. ISO 8601. */
+  nowIso?: string;
+  /** Override do baseDir (testes). */
+  baseDirOverride?: string;
+  /** Bypass cache (testes ou refresh explícito). */
+  bypassCache?: boolean;
+}
+
+export interface MenuLookupResult {
+  /** Items convertidos pra ScoredContentItem com isaLabels populados. */
+  items: ScoredContentItem[];
+  /** Diagnóstico: por que o lookup retornou esse resultado. */
+  outcome: "ok" | "menu_missing" | "menu_stale" | "no_eligible_items";
+  /** Metadata pra telemetria. */
+  diagnostics: {
+    menuValidUntil?: string;
+    itemsConsidered: number;
+    itemsAfterUsedFilter: number;
+    itemsAfterTopK: number;
+  };
+}
+
+/**
+ * Lookup completo — pega menu (cache ou disco), filtra, scora, converte.
+ *
+ * Retorna `outcome: "ok"` apenas quando menu existe + items elegíveis
+ * sobram após filter. Caller decide fallback to scoring no `menu_missing`,
+ * `menu_stale`, ou `no_eligible_items`.
+ */
+export async function lookupActionMenu(
+  personaId: string,
+  baseDir: string,
+  options: MenuLookupOptions = {},
+): Promise<MenuLookupResult> {
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const nowMs = Date.parse(nowIso);
+  const topK = options.topK ?? 5;
+  const usedInSession = new Set(options.usedInSession ?? []);
+
+  // 1. Cache check
+  let menu: ActionMenu | null;
+  const cacheKey = `${personaId}::${baseDir}`;
+  if (!options.bypassCache) {
+    const cached = _cache.get(cacheKey);
+    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
+      menu = cached.menu;
+    } else {
+      menu = await loadActionMenu(personaId, options.baseDirOverride ?? baseDir);
+      _cache.set(cacheKey, { menu, loadedAt: Date.now() });
+    }
+  } else {
+    menu = await loadActionMenu(personaId, options.baseDirOverride ?? baseDir);
+  }
+
+  if (menu === null) {
+    return {
+      items: [],
+      outcome: "menu_missing",
+      diagnostics: {
+        itemsConsidered: 0,
+        itemsAfterUsedFilter: 0,
+        itemsAfterTopK: 0,
+      },
+    };
+  }
+
+  // 2. Menu stale (top-level valid_until)
+  if (menu.valid_until && Date.parse(menu.valid_until) < nowMs) {
+    return {
+      items: [],
+      outcome: "menu_stale",
+      diagnostics: {
+        menuValidUntil: menu.valid_until,
+        itemsConsidered: menu.items.length,
+        itemsAfterUsedFilter: 0,
+        itemsAfterTopK: 0,
+      },
+    };
+  }
+
+  // 3. Filter + score
+  const itemsConsidered = menu.items.length;
+  const afterUsedFilter = menu.items.filter((it) => !usedInSession.has(it.id));
+  const itemsAfterUsedFilter = afterUsedFilter.length;
+
+  if (afterUsedFilter.length === 0) {
+    return {
+      items: [],
+      outcome: "no_eligible_items",
+      diagnostics: {
+        menuValidUntil: menu.valid_until ?? undefined,
+        itemsConsidered,
+        itemsAfterUsedFilter: 0,
+        itemsAfterTopK: 0,
+      },
+    };
+  }
+
+  // 4. Effective weight + sort
+  const scored = afterUsedFilter.map((it) => {
+    const expired =
+      it.expires_at != null && Date.parse(it.expires_at) < nowMs;
+    const effectiveWeight = expired
+      ? it.weight * EXPIRED_DECAY_FACTOR
+      : it.weight;
+    return { item: it, effectiveWeight, expired };
+  });
+  scored.sort((a, b) => b.effectiveWeight - a.effectiveWeight);
+
+  // 5. Top-K + shim conversion
+  const topItems = scored.slice(0, topK);
+  const items: ScoredContentItem[] = topItems.map(
+    ({ item, effectiveWeight, expired }) =>
+      convertToScoredContentItem(item, effectiveWeight, expired),
+  );
+
+  return {
+    items,
+    outcome: "ok",
+    diagnostics: {
+      menuValidUntil: menu.valid_until ?? undefined,
+      itemsConsidered,
+      itemsAfterUsedFilter,
+      itemsAfterTopK: items.length,
+    },
+  };
+}
+
+/**
+ * Shim conversion ActionMenuItem → ScoredContentItem.
+ *
+ * Mantém `isaLabels` populado pra downstream consumir; type mapping
+ * usa proxies (TYPE_MAP) pra atender contract.
+ *
+ * Campos do ContentItemBase não-existentes em ActionMenuItem ficam com
+ * defaults conservadores (Tier 3 schema convergence depois resolve).
+ */
+function convertToScoredContentItem(
+  item: ActionMenuItem,
+  effectiveWeight: number,
+  expired: boolean,
+): ScoredContentItem {
+  const contentType = TYPE_MAP[item.type];
+  // Defaults pros campos required do ContentItemBase ausentes em ActionMenuItem.
+  // Tipo discriminado depende de contentType — pegamos a forma genérica via cast.
+  const baseFields = {
+    id: item.id,
+    type: contentType,
+    domain: "action_menu",
+    casel_target: [] as never,
+    age_range: [7, 17] as [number, number],
+    surprise: Math.round(item.weight * 10),
+    verified: true,
+    base_score: Math.round(item.weight * 10),
+  };
+
+  // Type-specific fields — minimos pra cada discriminator
+  let typedItem: ContentItem;
+  switch (contentType) {
+    case "curiosity_hook":
+      typedItem = {
+        ...baseFields,
+        type: "curiosity_hook",
+        fact: item.content,
+        bridge: "",
+        quest: "",
+        sacrifice_type: "reflect",
+      } as ContentItem;
+      break;
+    case "cultural_diamond":
+      typedItem = {
+        ...baseFields,
+        type: "cultural_diamond",
+        fact: item.content,
+        bridge: "",
+        quest: "",
+        sacrifice_type: "reflect",
+      } as ContentItem;
+      break;
+    case "challenge":
+      typedItem = {
+        ...baseFields,
+        type: "challenge",
+        description: item.content,
+        expected_outcome: "",
+        estimated_minutes: 10,
+      } as ContentItem;
+      break;
+    case "dynamic":
+      typedItem = {
+        ...baseFields,
+        type: "dynamic",
+        title: item.id,
+        setup: item.content,
+        execution: "",
+        closing: "",
+        multi_turn: false,
+      } as ContentItem;
+      break;
+    default:
+      // Fallback impossível dado TYPE_MAP exhaustivo — guard pro compiler.
+      typedItem = baseFields as unknown as ContentItem;
+  }
+
+  const reasons = [
+    `from_action_menu (effective_weight=${effectiveWeight.toFixed(2)})`,
+  ];
+  if (expired) {
+    reasons.push(`decay_applied (expired, factor=${EXPIRED_DECAY_FACTOR})`);
+  }
+
+  return {
+    item: typedItem,
+    score: effectiveWeight * 10, // scale to scoring conventions (~[0,10])
+    reasons,
+    isaLabels: {
+      played_as: item.played_as,
+      intensity: item.intensity,
+      is_critical: item.is_critical,
+    },
+  };
+}

--- a/planejador/tests/menu-lookup.unit.test.ts
+++ b/planejador/tests/menu-lookup.unit.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests — menu-lookup (C-T-10-01, ops#999).
+ *
+ * Cobre cache + filter + decay multiplicativo + conversion shim.
+ * Usa scratch dir + saveActionMenu real pra round-trip realista.
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { ActionMenu, PlayedAs, Intensity } from "@ascendimacy/shared";
+import { saveActionMenu } from "../src/strategist/action-menu-persistence.js";
+import {
+  lookupActionMenu,
+  _resetMenuLookupCache,
+} from "../src/strategist/menu-lookup.js";
+
+let scratchDir: string;
+
+beforeEach(async () => {
+  _resetMenuLookupCache();
+  scratchDir = await mkdtemp(path.join(tmpdir(), "menu-lookup-"));
+});
+
+afterEach(async () => {
+  _resetMenuLookupCache();
+  await rm(scratchDir, { recursive: true, force: true });
+});
+
+function makeMenu(args: {
+  personaId?: string;
+  items: Array<{
+    id: string;
+    type?: "curiosity" | "challenge" | "strategy" | "play" | "cultural_diamond";
+    weight: number;
+    expires_at?: string;
+    played_as?: PlayedAs;
+    intensity?: Intensity;
+    is_critical?: boolean;
+  }>;
+  validUntil?: string;
+}): ActionMenu {
+  return {
+    persona_id: args.personaId ?? "test-persona",
+    schema_version: "v0.2.0",
+    generated_at: "2026-05-14T10:00:00.000Z",
+    valid_until: args.validUntil,
+    source: { trust_level: 0.5 },
+    items: args.items.map((it) => ({
+      id: it.id,
+      type: it.type ?? "curiosity",
+      content: `content for ${it.id}`,
+      weight: it.weight,
+      expires_at: it.expires_at,
+      played_as: it.played_as,
+      intensity: it.intensity,
+      is_critical: it.is_critical,
+    })),
+  };
+}
+
+describe("lookupActionMenu — outcomes", () => {
+  it("menu_missing quando arquivo não existe", async () => {
+    const result = await lookupActionMenu("never-saved", scratchDir, {
+      bypassCache: true,
+    });
+    expect(result.outcome).toBe("menu_missing");
+    expect(result.items.length).toBe(0);
+  });
+
+  it("menu_stale quando valid_until < now", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-stale",
+      validUntil: "2026-05-01T00:00:00.000Z", // passado
+      items: [{ id: "a", weight: 0.5 }],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-stale", scratchDir, {
+      bypassCache: true,
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    expect(result.outcome).toBe("menu_stale");
+    expect(result.diagnostics.menuValidUntil).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("no_eligible_items quando todos items estão em used_in_session", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-used",
+      items: [
+        { id: "a", weight: 0.5 },
+        { id: "b", weight: 0.3 },
+      ],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-used", scratchDir, {
+      bypassCache: true,
+      usedInSession: ["a", "b"],
+    });
+    expect(result.outcome).toBe("no_eligible_items");
+  });
+
+  it("ok quando menu válido + items elegíveis", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-ok",
+      validUntil: "2027-01-01T00:00:00.000Z", // futuro
+      items: [
+        { id: "a", weight: 0.5, played_as: "espelho", intensity: "soft" },
+        { id: "b", weight: 0.3, played_as: "canal" },
+      ],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-ok", scratchDir, {
+      bypassCache: true,
+    });
+    expect(result.outcome).toBe("ok");
+    expect(result.items.length).toBe(2);
+  });
+});
+
+describe("lookupActionMenu — decay multiplicativo (Jun 2026-05-14)", () => {
+  it("items expirados sobrevivem com effective_weight × 0.3", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-decay",
+      items: [
+        // Expirado: weight 1.0 × 0.3 = 0.3
+        { id: "expired", weight: 1.0, expires_at: "2026-01-01T00:00:00.000Z" },
+        // Ativo: weight 0.5 × 1.0 = 0.5
+        { id: "active", weight: 0.5 },
+      ],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-decay", scratchDir, {
+      bypassCache: true,
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    expect(result.outcome).toBe("ok");
+    expect(result.items.length).toBe(2);
+    // Active (0.5) deve vir antes do expired (0.3 effective)
+    expect(result.items[0]!.item.id).toBe("active");
+    expect(result.items[1]!.item.id).toBe("expired");
+    expect(result.items[1]!.reasons.some((r) => r.includes("decay_applied"))).toBe(true);
+  });
+
+  it("items expirados desaparecem se decay torna effective < items ativos no top-K", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-decay-2",
+      items: [
+        // 3 ativos com weight > 0.3 — expired (decayed) fica fora do top-3
+        { id: "active-1", weight: 0.9 },
+        { id: "active-2", weight: 0.7 },
+        { id: "active-3", weight: 0.5 },
+        // Expirado: 1.0 × 0.3 = 0.3 — fica fora do top-3
+        { id: "expired", weight: 1.0, expires_at: "2026-01-01T00:00:00.000Z" },
+      ],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-decay-2", scratchDir, {
+      bypassCache: true,
+      nowIso: "2026-05-14T10:00:00.000Z",
+      topK: 3,
+    });
+    expect(result.outcome).toBe("ok");
+    expect(result.items.length).toBe(3);
+    const ids = result.items.map((it) => it.item.id);
+    expect(ids).toEqual(["active-1", "active-2", "active-3"]);
+    expect(ids).not.toContain("expired");
+  });
+});
+
+describe("lookupActionMenu — used_in_session filter", () => {
+  it("filtra items em used_in_session antes do scoring", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-used-filter",
+      items: [
+        { id: "a", weight: 0.9 }, // será filtered
+        { id: "b", weight: 0.5 },
+        { id: "c", weight: 0.3 },
+      ],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-used-filter", scratchDir, {
+      bypassCache: true,
+      usedInSession: ["a"],
+    });
+    expect(result.outcome).toBe("ok");
+    expect(result.items.length).toBe(2);
+    expect(result.items.map((it) => it.item.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("lookupActionMenu — shim conversion ActionMenuItem → ScoredContentItem", () => {
+  it("preserva ISA labels em isaLabels field", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-labels",
+      items: [
+        {
+          id: "labeled",
+          weight: 0.5,
+          played_as: "diamante",
+          intensity: "firm",
+          is_critical: true,
+        },
+      ],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-labels", scratchDir, {
+      bypassCache: true,
+    });
+    expect(result.items[0]!.isaLabels).toEqual({
+      played_as: "diamante",
+      intensity: "firm",
+      is_critical: true,
+    });
+  });
+
+  it("mapeia type ActionMenu → ContentItem (curiosity → curiosity_hook)", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-types",
+      items: [
+        { id: "c", type: "curiosity", weight: 0.5 },
+        { id: "d", type: "cultural_diamond", weight: 0.5 },
+        { id: "ch", type: "challenge", weight: 0.5 },
+        { id: "s", type: "strategy", weight: 0.5 },
+        { id: "p", type: "play", weight: 0.5 },
+      ],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const result = await lookupActionMenu("ryo-types", scratchDir, {
+      bypassCache: true,
+      topK: 10,
+    });
+    const types = result.items.map((it) => it.item.type);
+    expect(types).toContain("curiosity_hook");
+    expect(types).toContain("cultural_diamond");
+    expect(types).toContain("challenge");
+    expect(types.filter((t) => t === "dynamic").length).toBe(2); // strategy + play
+  });
+});
+
+describe("lookupActionMenu — cache singleton", () => {
+  it("segunda chamada com mesmo persona retorna cached (sem re-leitura disco)", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-cache",
+      items: [{ id: "a", weight: 0.5 }],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const r1 = await lookupActionMenu("ryo-cache", scratchDir);
+    expect(r1.outcome).toBe("ok");
+
+    // Apaga o arquivo — segunda call deve usar cache, ainda OK
+    await rm(path.join(scratchDir, "ryo-cache-menu.json"));
+
+    const r2 = await lookupActionMenu("ryo-cache", scratchDir);
+    expect(r2.outcome).toBe("ok"); // cached, sobreviveu ao delete
+  });
+
+  it("bypassCache=true força re-leitura disco", async () => {
+    const menu = makeMenu({
+      personaId: "ryo-bypass",
+      items: [{ id: "a", weight: 0.5 }],
+    });
+    await saveActionMenu(menu, scratchDir);
+
+    const r1 = await lookupActionMenu("ryo-bypass", scratchDir);
+    expect(r1.outcome).toBe("ok");
+
+    await rm(path.join(scratchDir, "ryo-bypass-menu.json"));
+
+    const r2 = await lookupActionMenu("ryo-bypass", scratchDir, {
+      bypassCache: true,
+    });
+    expect(r2.outcome).toBe("menu_missing");
+  });
+});

--- a/scripts/smoke-menu-lookup.mjs
+++ b/scripts/smoke-menu-lookup.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Smoke E2E menu-lookup (ops#999 C-T-10-01).
+ *
+ * Não usa orchestrator/MCP children — chama lookupActionMenu direto
+ * contra fixture real persistida em fixtures/profiles/.
+ *
+ * Cobre: cache, decay multiplicativo (item expirado decai p/ 30%),
+ * shim isaLabels, outcomes (ok|menu_missing|menu_stale|no_eligible_items).
+ *
+ * Uso:
+ *   node scripts/smoke-menu-lookup.mjs
+ */
+import { lookupActionMenu, _resetMenuLookupCache } from "../planejador/dist/strategist/menu-lookup.js";
+
+const baseDir = "fixtures/profiles";
+let pass = 0;
+let fail = 0;
+
+function assert(cond, msg) {
+  if (cond) {
+    console.log(`  ✓ ${msg}`);
+    pass++;
+  } else {
+    console.log(`  ✗ ${msg}`);
+    fail++;
+  }
+}
+
+async function main() {
+  _resetMenuLookupCache();
+
+  console.log("[smoke] G1: lookup persona conhecida (paula-mendes)");
+  const r1 = await lookupActionMenu("paula-mendes", baseDir, { bypassCache: true, topK: 5 });
+  assert(r1.outcome === "ok", `outcome=ok (got ${r1.outcome})`);
+  assert(r1.items.length === 5, `5 items returned (got ${r1.items.length})`);
+  assert(r1.diagnostics.itemsConsidered === 5, `itemsConsidered=5`);
+
+  console.log("[smoke] G2: decay multiplicativo — item expirado fica ÚLTIMO");
+  const decayItem = r1.items.find((it) => it.item.id === "smoke-decay-01");
+  assert(decayItem !== undefined, `smoke-decay-01 sobreviveu top-K (decay × 0.3)`);
+  if (decayItem) {
+    assert(
+      decayItem.reasons.some((r) => r.includes("decay_applied")),
+      `reasons contém "decay_applied"`,
+    );
+    const lastItem = r1.items[r1.items.length - 1];
+    assert(lastItem.item.id === "smoke-decay-01", `decay item é último no ranking (0.95 × 0.3 = 0.285 < 0.5)`);
+  }
+
+  console.log("[smoke] G3: shim isaLabels propagado");
+  const diamond = r1.items.find((it) => it.item.id === "smoke-diamond-01");
+  assert(diamond !== undefined, `smoke-diamond-01 presente`);
+  if (diamond) {
+    assert(diamond.isaLabels?.played_as === "diamante", `isaLabels.played_as=diamante`);
+    assert(diamond.isaLabels?.intensity === "firm", `isaLabels.intensity=firm`);
+    assert(diamond.item.type === "cultural_diamond", `type mapped: cultural_diamond`);
+  }
+
+  console.log("[smoke] G4: type mapping shim (curiosity→curiosity_hook, strategy→dynamic)");
+  const curio = r1.items.find((it) => it.item.id === "smoke-curio-01");
+  assert(curio?.item.type === "curiosity_hook", `curiosity → curiosity_hook`);
+  const strat = r1.items.find((it) => it.item.id === "smoke-strategy-01");
+  assert(strat?.item.type === "dynamic", `strategy → dynamic`);
+
+  console.log("[smoke] G5: used_in_session filter");
+  const r2 = await lookupActionMenu("paula-mendes", baseDir, {
+    bypassCache: true,
+    usedInSession: ["smoke-curio-01", "smoke-diamond-01"],
+    topK: 5,
+  });
+  assert(r2.outcome === "ok", `outcome=ok com filter`);
+  assert(r2.items.length === 3, `3 items após filter (got ${r2.items.length})`);
+  const filteredIds = r2.items.map((it) => it.item.id);
+  assert(!filteredIds.includes("smoke-curio-01"), `smoke-curio-01 excluído`);
+  assert(!filteredIds.includes("smoke-diamond-01"), `smoke-diamond-01 excluído`);
+
+  console.log("[smoke] G6: menu_missing — persona sem fixture");
+  const r3 = await lookupActionMenu("persona-inexistente-xyz", baseDir, { bypassCache: true });
+  assert(r3.outcome === "menu_missing", `outcome=menu_missing`);
+  assert(r3.items.length === 0, `items.length=0`);
+
+  console.log("[smoke] G7: cache singleton — segunda call sem disco");
+  _resetMenuLookupCache();
+  const t0 = Date.now();
+  const r4a = await lookupActionMenu("paula-mendes", baseDir);
+  const dt_disk = Date.now() - t0;
+  const t1 = Date.now();
+  const r4b = await lookupActionMenu("paula-mendes", baseDir);
+  const dt_cache = Date.now() - t1;
+  assert(r4a.outcome === "ok" && r4b.outcome === "ok", `ambas calls outcome=ok`);
+  console.log(`     [info] disco=${dt_disk}ms, cache=${dt_cache}ms`);
+
+  console.log("");
+  console.log(`[smoke] Total: ${pass} pass, ${fail} fail`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("[smoke] FATAL:", err);
+  process.exit(1);
+});

--- a/shared/src/content-item.ts
+++ b/shared/src/content-item.ts
@@ -176,6 +176,19 @@ export interface ScoredContentItem {
   item: ContentItem;
   score: number;
   reasons: string[];
+  /**
+   * Rotulagem ISA pedagógica propagada quando item veio de lookup
+   * determinístico do ActionMenu (C-T-10-01, ops#999). Ausente quando
+   * scoring clássico (pool seed) — backward compat preservada.
+   *
+   * Convergência futura de schemas ContentItem ↔ ActionMenuItem fica
+   * pra Tier 3 (ops#999 ponto #4). Por enquanto, transitional shim.
+   */
+  isaLabels?: {
+    played_as?: "bridge" | "espelho" | "canal" | "diamante" | "arena" | "recovery";
+    intensity?: "soft" | "medium" | "firm";
+    is_critical?: boolean;
+  };
 }
 
 /** Validação rasa de invariantes estruturais (não-semântica). */


### PR DESCRIPTION
## Summary

C-T-10-01 (ops#999) — lookup determinístico do ActionMenu persistido no Planejador, com fallback to scoring clássico quando menu ausente/stale.

Decisão Jun (2026-05-14): **decay multiplicativo** para items expirados — `effective_weight = weight × 0.3` em vez de hard-cutoff. Items expirados ainda contribuem (30%), evitando perda total de signal pedagógico.

## Mudanças (4 commits)

1. **shared/content-item.ts** — `ScoredContentItem.isaLabels` opcional (played_as | intensity | is_critical) propagado quando item vem de menu-lookup. Ausente em scoring clássico — backward compat preservada.

2. **planejador/strategist/menu-lookup.ts** (NEW, 292 linhas)
   - `lookupActionMenu(personaId, baseDir, options)`: cache singleton TTL 5min → load → filter `used_in_session` → effective_weight com decay → sort → top-K → shim
   - TYPE_MAP transitional: `curiosity → curiosity_hook`, `cultural_diamond → cultural_diamond`, `challenge → challenge`, `strategy|play → dynamic` (Tier 3 schema convergence depois resolve)
   - Outcomes: `ok` | `menu_missing` | `menu_stale` | `no_eligible_items` — caller decide fallback

3. **planejador/plan.ts** — branch ativado via `ASC_USE_ACTION_MENU=true` env flag + `personaId` disponível em ctx. Outcome=ok retorna menu items; resto cai pro caminho scoring atual. Telemetria via `logDebugEvent({ step: "plan_turn_menu_lookup", outcome })`.

4. **planejador/tests/menu-lookup.unit.test.ts** (NEW, 11 tests) — outcomes, decay multiplicativo (expirado sobrevive com peso decayed; expirado fica fora do top-K se ativos > 0.3), used_in_session filter, shim (isaLabels + type mapping), cache singleton (survives file delete + bypassCache força re-leitura).

## Test plan

- [x] `npm test -w @ascendimacy/planejador -- menu-lookup` → 11/11 passing
- [x] Full motor suite green: 1011 passed | 9 skipped (vs baseline 1000/9 — +11 novos)
- [x] Build clean: `npm run build` em shared + planejador
- [ ] Smoke E2E com `ASC_USE_ACTION_MENU=true` + persona com action-menu persistido fica para integration follow-up (ops#999 tem story de smoke separada)

## Refs

- Spec: ops#999 (C-T-10-01 escopo ratificado 2026-05-14 com decay multiplicativo)
- Depends on: motor#85 (persistence), motor#90 (generator), motor#104 (S-T-09-03 trigger onboarding)
- Companion: motor#108 (content-usage-repo — alimenta `used_in_session` cross-turn no futuro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)