### PR TITLE
[feat repetition-inquiry] drota.repetition_inquiry — protocolo conversacional (ops#1068)

### DIFF
--- a/fixtures/profiles/kei-ochiai.pre-phase2.json
+++ b/fixtures/profiles/kei-ochiai.pre-phase2.json
@@ -116,7 +116,8 @@
       "começar com uma ação concreta e clara (ex: ajustar algo no tênis ou em um objeto físico)",
       "evitar mudanças bruscas de tema; manter o foco no que foi iniciado",
       "lembrar de perguntar como foi o treino do Ryo e se ele riu de novo, para conectar com o momento emocional anterior"
-    ]
+    ],
+    "repetition_inquiry": {}
   },
   "last_updated": "2026-05-07T23:32:14.465Z"
 }

--- a/fixtures/profiles/ryo-ochiai.pre-phase2.json
+++ b/fixtures/profiles/ryo-ochiai.pre-phase2.json
@@ -172,7 +172,10 @@
       "Perguntar como foi assistir ao episódio do Gohan no Cell Saga e o que Ryo sentiu sobre a transformação de Gohan.",
       "Explorar mais o que significa ser 'igual' ou 'diferente' em relação ao irmão Kei, com foco em valorização da singularidade.",
       "Sugerir uma atividade criativa: desenhar ou contar uma cena onde Ryo escolhe dividir algo com Kei, como um ato de confiança."
-    ]
+    ],
+    "repetition_inquiry": {
+      "default_on_skip": "b"
+    }
   },
   "last_updated": "2026-05-07T23:39:29.458Z"
 }

--- a/fixtures/profiles/saki-ochiai.pre-phase2.json
+++ b/fixtures/profiles/saki-ochiai.pre-phase2.json
@@ -1,0 +1,35 @@
+{
+  "sessions_seen": [],
+  "profile": {
+    "preferences": {
+      "interests": [
+        "rotinas e repetição (ASD nível 1 — repetir cumpre função sensorial/regulatória)",
+        "personagens recorrentes (familiares por design)",
+        "tarefas com sequência previsível",
+        "ambientes silenciosos"
+      ],
+      "communication_style": "respostas curtas, literais; toleria pouco metacomunicação",
+      "regulation_strategy": "repetição é AUTORREGULAÇÃO, não tédio — protocolo Carvalho-pai exige não interromper o ciclo"
+    },
+    "family_anchors": [
+      "irmão Ryo (referência presente; protetiva)",
+      "irmão Kei (jogo paralelo seguro)",
+      "tia/cuidadora (vínculo de confiança)"
+    ],
+    "recurring_themes": [
+      "atividades sensoriais repetitivas",
+      "fluxo de rotina sem surpresa"
+    ],
+    "open_loops": [],
+    "off_screen_completions": [],
+    "notes_for_next_session": [
+      "NÃO oferecer escolhas em cascata — Saki engaja melhor com 'siga seu fluxo'",
+      "Repetir item já visto NÃO é tédio — drota deve NÃO perguntar (sub-decisão 4, enabled=false)",
+      "Brejo sensorial (ruído, mudança brusca) override imediato"
+    ],
+    "repetition_inquiry": {
+      "enabled": false
+    }
+  },
+  "last_updated": "2026-05-14T12:00:00.000Z"
+}

--- a/motor-drota/src/parse-repetition-answer.ts
+++ b/motor-drota/src/parse-repetition-answer.ts
@@ -1,0 +1,120 @@
+/**
+ * Parse cascata pra resposta da criança ao repetition_inquiry (ops#1068).
+ *
+ * Estratégia em camadas (sub-decisão 7):
+ *  1. Match literal regex case-insensitive
+ *     - Letras: \b(a|b|c)\b
+ *     - Números: \b(1|2|3)\b → 1=a, 2=b, 3=c
+ *     - Linguagem natural:
+ *       - "de novo" / "mesm[oa]" / "aquel[ae]" → a
+ *       - "parecid[oa]" / "outro parecido" / "similar" → b
+ *       - "outro" / "novo" / "diferente" / "mudar" → c
+ *  2. LLM intent classifier via mood-extractor — v0.1 follow-up (não nesta PR)
+ *  3. Skip default — retorna defaultOnSkip configurado per-persona (default "b")
+ *
+ * Ordem importa: matches específicos (multi-palavra) ANTES de single-letter
+ * pra evitar "casca-do-c" ser pego como (c).
+ *
+ * Quem chama: motor-execucao após coletar input da criança no turn seguinte
+ * ao repetition_inquiry_asked. Resultado vai pro contextHints do próximo
+ * planTurn em forma de `last_inquiry_answer: "a"|"b"|"c"`.
+ */
+
+export type InquiryChoice = "a" | "b" | "c";
+
+export interface RepetitionAnswerParseResult {
+  /** Escolha resolvida. Sempre populada (com default em fallback). */
+  choice: InquiryChoice;
+  /** Stage que produziu o match. */
+  stage: "literal" | "llm" | "default";
+  /** Confidence heurística (0-1). Literal=1.0, default=0.0. */
+  confidence: number;
+}
+
+/** Padrões "categoria b" (parecido). Ordem matters — multi-palavra primeiro. */
+const B_PATTERNS = [
+  /outro\s+parecid[oa]/i,
+  /algo\s+parecid[oa]/i,
+  /parecid[oa]/i,
+  /similar/i,
+  /tipo\s+(esse|isso|aquele)/i,
+];
+
+/** Padrões "categoria a" (de novo / tentar mesmo). Ordem matters. */
+const A_PATTERNS = [
+  /de\s+novo/i,
+  /(o|aquel[ae])\s+mesm[oa]/i,
+  /aquel[ae]\b/i,
+  /repetir/i,
+  /tentar\s+(de\s+)?novo/i,
+];
+
+/** Padrões "categoria c" (algo novo / diferente). Ordem matters. */
+const C_PATTERNS = [
+  /algo\s+novo/i,
+  /outr[oa]\s+coisa/i,
+  /diferente/i,
+  /mudar/i,
+  /coisa\s+nova/i,
+  /\bnovo\b/i, // single-word "novo" — depois dos compostos
+  /\boutro\b/i, // single-word "outro" — depois de "outro parecido"
+];
+
+/**
+ * Parse resposta da criança ao repetition_inquiry.
+ *
+ * @param rawText - input cru da criança
+ * @param defaultOnSkip - default quando texto vazio/ambíguo (per-persona)
+ */
+export function parseRepetitionAnswer(
+  rawText: string,
+  defaultOnSkip: InquiryChoice = "b",
+): RepetitionAnswerParseResult {
+  const trimmed = (rawText ?? "").trim();
+
+  // Empty / silence → default
+  if (trimmed.length === 0) {
+    return { choice: defaultOnSkip, stage: "default", confidence: 0 };
+  }
+
+  // ─── Stage 1: literal regex ─────────────────────────────────────────────
+  // Ordem das checagens importa:
+  // 1. Padrões multi-palavra específicos (B > A > C — mais raros vencem)
+  // 2. Single-letter / single-digit como fallback do stage 1
+
+  for (const pat of B_PATTERNS) {
+    if (pat.test(trimmed)) return { choice: "b", stage: "literal", confidence: 1 };
+  }
+  for (const pat of A_PATTERNS) {
+    if (pat.test(trimmed)) return { choice: "a", stage: "literal", confidence: 1 };
+  }
+  for (const pat of C_PATTERNS) {
+    if (pat.test(trimmed)) return { choice: "c", stage: "literal", confidence: 1 };
+  }
+
+  // Single-letter / single-digit como resposta isolada. JS \b é ASCII-only,
+  // então "açúcar" matcharia \ba\b — defesa: exige que letra/dígito seja o
+  // INPUT TODO (com pontuação opcional). Cobre "a", "b)", "c.", "1", "2!"
+  // sem matchar dentro de palavras acentuadas.
+  const STANDALONE_LETTER = /^[\s]*([abc])[\s.,!?:;)\]]*$/i;
+  const STANDALONE_DIGIT = /^[\s]*([123])[\s.,!?:;)\]]*$/;
+  const letterMatch = trimmed.match(STANDALONE_LETTER);
+  if (letterMatch) {
+    const letter = letterMatch[1]!.toLowerCase() as InquiryChoice;
+    return { choice: letter, stage: "literal", confidence: 1 };
+  }
+  const digitMatch = trimmed.match(STANDALONE_DIGIT);
+  if (digitMatch) {
+    const digit = digitMatch[1]!;
+    const mapped: InquiryChoice = digit === "1" ? "a" : digit === "2" ? "b" : "c";
+    return { choice: mapped, stage: "literal", confidence: 1 };
+  }
+
+  // ─── Stage 2: LLM intent classifier (v0.1 follow-up) ────────────────────
+  // Quando ativo, reusa mood-extractor pra classificar intent. Pra v0,
+  // pulamos direto pro default.
+
+  // ─── Stage 3: default ───────────────────────────────────────────────────
+  // "tanto faz" / "sei lá" / texto ambíguo → respeita default per-persona.
+  return { choice: defaultOnSkip, stage: "default", confidence: 0 };
+}

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -119,6 +119,15 @@ function buildDrotaDynamicBody(
   const unilateralBrejo = contextHints?.["joint_unilateral_brejo"] === true;
   const jointPauseReason = contextHints?.["joint_pause_reason"] as string | undefined;
 
+  // ops#1068 — repetition_inquiry. Planejador decide SE perguntar; drota
+  // formula a pergunta. candidate_ids ⊆ contentPool (já elegíveis, não-expirados).
+  const inquiryHint = contextHints?.["repetition_inquiry"] as
+    | { candidate_ids?: string[]; threshold_used?: number; default_on_skip?: "a" | "b" | "c" }
+    | undefined;
+  const inquiryActive = Array.isArray(inquiryHint?.candidate_ids) && inquiryHint!.candidate_ids!.length > 0;
+  const inquiryCandidateIds = inquiryActive ? inquiryHint!.candidate_ids! : [];
+  const inquiryDefaultOnSkip = inquiryHint?.default_on_skip ?? "b";
+
   return `[BLOCO 2 - Dynamic content]
 <persona>
 id: ${persona.id}
@@ -163,9 +172,19 @@ ${instructionAdditionBody}
 6. Língua: "${language}". Gere na MESMA língua que o sujeito.
 7. ${isLimitedProficiency ? `**'pt-br limitado'** descreve o **DESTINATÁRIO** (${persona.name}), NÃO o seu output. SEU output deve ser **pt-br limpo, gramaticalmente correto e simples**: frases curtas, vocabulário básico, zero jargon. **NÃO simule erros de não-nativo no seu output** — o destinatário precisa entender uma fala correta + simples.` : `Gere em ${language} fluente, natural, adequado à idade e contexto.`}
 8. Se <instruction_addition> não está vazio, incorpore-o naturalmente. Exemplos: "day 2 of 5 of chain X" → continuar arco multi-dia; "technique_hint: tribunal" → framear como debate.${
+    inquiryActive
+      ? `
+9. **REPETITION_INQUIRY ATIVO (ops#1068)**: criança ofereceu sinal de repetição (item recente, count ≥ threshold). Em vez de DECIDIR pela criança, **PERGUNTE diretamente** dentro da fala (1 sentença, sem meta-fricção). Itens candidatos a "tentar de novo": ${JSON.stringify(inquiryCandidateIds)}.
+   - **Format**: ofereça 3 opções curtas — "(a) voltar a <item recente>, (b) algo parecido, (c) algo novo?" Adapte linguagem por idade (${persona.age} anos): mais concreta pra <11, mais elaborada pra ≥14.
+   - **Ancore na concretude**: nome do item/atividade, não id técnico. Ex: "aquele desafio do Gohan no Cell" e NÃO "smoke-curio-01".
+   - **Não force**: se criança responder "tanto faz" ou silêncio, o sistema trata como default "${inquiryDefaultOnSkip}" (b=parecido por default) — você não precisa insistir.
+   - **Não pergunte 2x na sessão** (sistema controla cap; este turn é a oportunidade única se condições alinharam).
+   - **Sem meta-tagarela**: "Quer X, Y ou Z?" é o máximo. NÃO explique o porquê de estar perguntando.`
+      : ""
+  }${
     isJoint
       ? `
-9. **MODO JOINT (dyad)**: há dois irmãos nesta sessão. Parceiro: ${partnerName ?? "(nome não fornecido)"}.
+10. **MODO JOINT (dyad)**: há dois irmãos nesta sessão. Parceiro: ${partnerName ?? "(nome não fornecido)"}.
    - **Endereçar ambos por nome explicitamente** na fala — "${persona.name}, ${partnerName ?? "você"}...".
    - **Balancear tempo de fala** — alternar convites, não priorizar um dos dois.
    - **Invariante**: bot nunca > 25% dos turns. Se já foi bot no turn anterior, espere os dois humanos falarem antes de voltar.

--- a/motor-drota/tests/parse-repetition-answer.unit.test.ts
+++ b/motor-drota/tests/parse-repetition-answer.unit.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests — parse-repetition-answer (ops#1068 sub-decisão 7).
+ *
+ * Cobre cascata literal (single-letter, single-digit, linguagem natural)
+ * + default per-persona em ambiguidade/silêncio.
+ *
+ * LLM intent classifier stage (v0.1 follow-up) NÃO coberto aqui.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseRepetitionAnswer } from "../src/parse-repetition-answer.js";
+
+describe("parseRepetitionAnswer — single-letter literal", () => {
+  it("'a' → choice a", () => {
+    const r = parseRepetitionAnswer("a");
+    expect(r.choice).toBe("a");
+    expect(r.stage).toBe("literal");
+    expect(r.confidence).toBe(1);
+  });
+
+  it("'B' (uppercase) → choice b", () => {
+    const r = parseRepetitionAnswer("B");
+    expect(r.choice).toBe("b");
+  });
+
+  it("'c.' (com pontuação) → choice c", () => {
+    const r = parseRepetitionAnswer("c.");
+    expect(r.choice).toBe("c");
+  });
+
+  it("'a)' (estilo opção) → choice a", () => {
+    const r = parseRepetitionAnswer("a)");
+    expect(r.choice).toBe("a");
+  });
+});
+
+describe("parseRepetitionAnswer — single-digit literal", () => {
+  it("'1' → choice a", () => {
+    expect(parseRepetitionAnswer("1").choice).toBe("a");
+  });
+
+  it("'2' → choice b", () => {
+    expect(parseRepetitionAnswer("2").choice).toBe("b");
+  });
+
+  it("'3' → choice c", () => {
+    expect(parseRepetitionAnswer("3").choice).toBe("c");
+  });
+
+  it("'2.' → choice b", () => {
+    expect(parseRepetitionAnswer("2.").choice).toBe("b");
+  });
+});
+
+describe("parseRepetitionAnswer — linguagem natural (a: de novo / mesmo)", () => {
+  it("'de novo' → a", () => {
+    const r = parseRepetitionAnswer("de novo");
+    expect(r.choice).toBe("a");
+    expect(r.stage).toBe("literal");
+  });
+
+  it("'quero aquele mesmo' → a", () => {
+    expect(parseRepetitionAnswer("quero aquele mesmo").choice).toBe("a");
+  });
+
+  it("'aquele do Gohan' → a", () => {
+    expect(parseRepetitionAnswer("aquele do Gohan").choice).toBe("a");
+  });
+
+  it("'tentar de novo' → a", () => {
+    expect(parseRepetitionAnswer("tentar de novo").choice).toBe("a");
+  });
+
+  it("'repetir' → a", () => {
+    expect(parseRepetitionAnswer("repetir").choice).toBe("a");
+  });
+});
+
+describe("parseRepetitionAnswer — linguagem natural (b: parecido)", () => {
+  it("'parecido' → b", () => {
+    expect(parseRepetitionAnswer("parecido").choice).toBe("b");
+  });
+
+  it("'algo parecido' → b", () => {
+    expect(parseRepetitionAnswer("algo parecido").choice).toBe("b");
+  });
+
+  it("'outro parecido' → b (precedência sobre 'outro')", () => {
+    expect(parseRepetitionAnswer("outro parecido").choice).toBe("b");
+  });
+
+  it("'tipo esse' → b", () => {
+    expect(parseRepetitionAnswer("tipo esse").choice).toBe("b");
+  });
+
+  it("'similar' → b", () => {
+    expect(parseRepetitionAnswer("similar").choice).toBe("b");
+  });
+});
+
+describe("parseRepetitionAnswer — linguagem natural (c: novo / diferente)", () => {
+  it("'algo novo' → c", () => {
+    expect(parseRepetitionAnswer("algo novo").choice).toBe("c");
+  });
+
+  it("'outra coisa' → c", () => {
+    expect(parseRepetitionAnswer("outra coisa").choice).toBe("c");
+  });
+
+  it("'diferente' → c", () => {
+    expect(parseRepetitionAnswer("diferente").choice).toBe("c");
+  });
+
+  it("'mudar' → c", () => {
+    expect(parseRepetitionAnswer("mudar").choice).toBe("c");
+  });
+
+  it("'coisa nova' → c", () => {
+    expect(parseRepetitionAnswer("coisa nova").choice).toBe("c");
+  });
+
+  it("'outro' (single-word, sem 'parecido') → c", () => {
+    expect(parseRepetitionAnswer("outro").choice).toBe("c");
+  });
+
+  it("'novo' (single-word) → c", () => {
+    expect(parseRepetitionAnswer("novo").choice).toBe("c");
+  });
+});
+
+describe("parseRepetitionAnswer — default em ambiguidade/silêncio", () => {
+  it("string vazia → default b", () => {
+    const r = parseRepetitionAnswer("");
+    expect(r.choice).toBe("b");
+    expect(r.stage).toBe("default");
+    expect(r.confidence).toBe(0);
+  });
+
+  it("apenas whitespace → default", () => {
+    expect(parseRepetitionAnswer("   ").stage).toBe("default");
+  });
+
+  it("'tanto faz' → default", () => {
+    const r = parseRepetitionAnswer("tanto faz");
+    expect(r.stage).toBe("default");
+    expect(r.choice).toBe("b");
+  });
+
+  it("'sei lá' → default", () => {
+    expect(parseRepetitionAnswer("sei lá").stage).toBe("default");
+  });
+
+  it("respeita defaultOnSkip per-persona quando default disparado", () => {
+    expect(parseRepetitionAnswer("", "a").choice).toBe("a");
+    expect(parseRepetitionAnswer("tanto faz", "c").choice).toBe("c");
+  });
+});
+
+describe("parseRepetitionAnswer — precedência / edge cases", () => {
+  it("multi-palavra B vence single-word C ('outro parecido' não vira c)", () => {
+    expect(parseRepetitionAnswer("outro parecido").choice).toBe("b");
+  });
+
+  it("multi-palavra A vence ('de novo' não vira default)", () => {
+    expect(parseRepetitionAnswer("de novo, por favor").choice).toBe("a");
+  });
+
+  it("não pega 'a' dentro de 'açúcar' (word boundary)", () => {
+    // "açúcar" não contém o pattern \ba\b
+    expect(parseRepetitionAnswer("açúcar").stage).toBe("default");
+  });
+
+  it("frase longa com keyword no meio", () => {
+    expect(parseRepetitionAnswer("mais ou menos, prefiro algo parecido se puder").choice).toBe("b");
+  });
+});

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -19,6 +19,7 @@ import type {
   GardnerProgramState,
   ParentalProfile,
   ContentItem,
+  EventEntry,
 } from "@ascendimacy/shared";
 import {
   scorePool,
@@ -40,6 +41,13 @@ import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
 import { evaluateAllTransitions, collectRecentSignals } from "./trigger-evaluator.js";
 import { personaToChildProfile } from "./child-profile.js";
 import { lookupActionMenu } from "./strategist/menu-lookup.js";
+import {
+  countInquiriesInSession,
+  extractProfileConfig,
+  extractRepetitionCounts,
+  shouldAskRepetitionInquiry,
+  turnsSinceLastInquiry,
+} from "./strategist/repetition-inquiry.js";
 
 /** Quantos items do pool passamos ao drota (top-K). */
 export const TOP_K_POOL = 5;
@@ -358,6 +366,35 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     maxTotalChars: 2000,
     excludeUsedInSession: true,
   });
+
+  // ops#1068 — repetition_inquiry decision (Jun ratificado 2026-05-14).
+  // Conjunção (i)-(vii); drota só pergunta quando todas valem.
+  // Brejo afetivo é override absoluto (sub-decisão 8 §vi).
+  const inquiryEventLog = (input.state.eventLog ?? []) as ReadonlyArray<EventEntry>;
+  const inquiryProfileConfig = extractProfileConfig(
+    input.persona.profile as Record<string, unknown> | undefined,
+  );
+  const inquiryRepetitionCounts = extractRepetitionCounts(inquiryEventLog);
+  const inquiryBrejoActive = shouldPauseProgram(statusMatrix).paused;
+  const inquiryDecision = shouldAskRepetitionInquiry({
+    profileConfig: inquiryProfileConfig,
+    repetitionCounts: inquiryRepetitionCounts,
+    turn: input.state.turn ?? 0,
+    sessionMode,
+    brejoActive: inquiryBrejoActive,
+    inquiriesThisSession: countInquiriesInSession(inquiryEventLog),
+    turnsSinceLastInquiry: turnsSinceLastInquiry(inquiryEventLog),
+    eligiblePoolIds: slimPool.map((s) => s.item.id),
+  });
+  if (inquiryDecision.ask) {
+    contextHints["repetition_inquiry"] = {
+      candidate_ids: inquiryDecision.candidateIds,
+      threshold_used: inquiryDecision.thresholdUsed,
+      default_on_skip: inquiryDecision.defaultOnSkip,
+    };
+  } else if (inquiryDecision.suppressedReason) {
+    contextHints["repetition_inquiry_suppressed"] = inquiryDecision.suppressedReason;
+  }
 
   // motor#25 (handoff #25 B4): Trigger Evaluator — avalia transitions.yaml
   // contra signals capturados nos últimos 5 turns. Read-only — orchestrator

--- a/planejador/src/strategist/repetition-inquiry.ts
+++ b/planejador/src/strategist/repetition-inquiry.ts
@@ -1,0 +1,272 @@
+/**
+ * Repetition inquiry — protocolo conversacional pra decisão de repetição
+ * (ops#1068, Jun ratificado 2026-05-14).
+ *
+ * Origem do reframe: ops#1066 (algorithmic 4-sub-signal classification) →
+ * Jun pergunta "pergunta a opinião da criança?" — pivota pra drota perguntar
+ * diretamente, alinhado a Brota Mestre §2.1 "humanos primeiro".
+ *
+ * Esta layer (planejador) faz APENAS detecção + decisão:
+ * - Conta repetições recentes na window
+ * - Decide SE drota deve perguntar (conjunção (i)-(vii))
+ *
+ * Quem pergunta de fato: motor-drota, ao receber `contextHints.repetition_inquiry`.
+ * Quem parseia resposta: motor-drota/src/parse-repetition-answer.ts.
+ *
+ * Sub-decisões ratificadas (ops#1068 defaults aceitos 2026-05-14):
+ *  1. Cap por sessão: 1 pergunta; cooldown 8 turns; gate ≥4 turns
+ *  2. Skip explícito → default (b) "ir pra outro parecido"
+ *  3. Joint mode → suprime sempre (joint_mode)
+ *  4. Per-persona: profile.repetition_inquiry { enabled, threshold_repetitions, default_on_skip }
+ *  5. Window: 20 turns ∧ 7 dias, o que for menor
+ *  6. Items expirados: fora da opção (a)
+ *  7. Parsing: literal regex (LLM stage v0.1 follow-up)
+ *  8. Heurística trigger: conjunção (i)-(vii); brejo override absoluto
+ */
+
+import type { EventEntry } from "@ascendimacy/shared";
+
+// ─── Defaults ────────────────────────────────────────────────────────────
+
+/** Cap de inquiries por sessão (sub-decisão 1). */
+export const DEFAULT_INQUIRY_CAP_PER_SESSION = 1;
+/** Cooldown em turns desde a última inquiry (sub-decisão 1). */
+export const DEFAULT_INQUIRY_COOLDOWN_TURNS = 8;
+/** Gate: turn mínimo pra começar a perguntar (sub-decisão 1). */
+export const DEFAULT_INQUIRY_TURN_GATE = 4;
+/** Threshold mínimo de repetições no window pra trigger (sub-decisão 5). */
+export const DEFAULT_REPETITION_THRESHOLD = 2;
+/** Window: turns (sub-decisão 5). */
+export const DEFAULT_WINDOW_TURNS = 20;
+/** Window: dias (sub-decisão 5). */
+export const DEFAULT_WINDOW_DAYS = 7;
+/** Default on skip (sub-decisão 2). */
+export const DEFAULT_ON_SKIP = "b" as const;
+
+// ─── Profile schema (runtime, freeform) ──────────────────────────────────
+
+/**
+ * Configuração per-persona do protocolo (sub-decisão 4).
+ *
+ * Vive em `persona.profile.repetition_inquiry` (Record<string, unknown>
+ * freeform — parse defensivo no extractProfileConfig).
+ */
+export interface RepetitionInquiryProfileConfig {
+  /** Master switch. Default true (universal). Saki: false (autorregulação). */
+  enabled?: boolean;
+  /** Repetições mínimas pra disparar. Default 2. Saki: ∞ via enabled=false. */
+  threshold_repetitions?: number;
+  /** Default quando criança skipa ("tanto faz" / silêncio). Default "b". */
+  default_on_skip?: "a" | "b" | "c";
+}
+
+export function extractProfileConfig(
+  profile: Record<string, unknown> | undefined,
+): RepetitionInquiryProfileConfig {
+  const raw = profile?.["repetition_inquiry"];
+  if (!raw || typeof raw !== "object") return {};
+  const r = raw as Record<string, unknown>;
+  const out: RepetitionInquiryProfileConfig = {};
+  if (typeof r["enabled"] === "boolean") out.enabled = r["enabled"];
+  if (typeof r["threshold_repetitions"] === "number") {
+    out.threshold_repetitions = r["threshold_repetitions"];
+  }
+  if (r["default_on_skip"] === "a" || r["default_on_skip"] === "b" || r["default_on_skip"] === "c") {
+    out.default_on_skip = r["default_on_skip"];
+  }
+  return out;
+}
+
+// ─── Window extraction ───────────────────────────────────────────────────
+
+export interface RepetitionWindowOptions {
+  /** Now em ISO 8601. Default: Date.now(). */
+  nowIso?: string;
+  /** Window turns (default 20). */
+  windowTurns?: number;
+  /** Window dias (default 7). */
+  windowDays?: number;
+}
+
+/**
+ * Extrai contagem de repetições por content_id na window (20 turns ∧ 7d).
+ *
+ * Item conta como repetido se aparece como `selectedContentId` em
+ * `playbook_executed` events dentro da janela.
+ *
+ * Window é AND: o que for MAIS RESTRITIVO entre 20 turns e 7 dias vale.
+ * (sub-decisão 5: "20 turns ∧ 7 dias, o que for menor")
+ */
+export function extractRepetitionCounts(
+  eventLog: ReadonlyArray<EventEntry>,
+  options: RepetitionWindowOptions = {},
+): Map<string, number> {
+  const nowMs = options.nowIso ? Date.parse(options.nowIso) : Date.now();
+  const windowDays = options.windowDays ?? DEFAULT_WINDOW_DAYS;
+  const windowTurns = options.windowTurns ?? DEFAULT_WINDOW_TURNS;
+  const cutoffMs = nowMs - windowDays * 24 * 60 * 60 * 1000;
+
+  // 1. Filter to playbook_executed events
+  const executed = eventLog.filter((e) => e.type === "playbook_executed");
+
+  // 2. Bound: last N events (turns proxy) AND timestamp >= cutoff
+  //    "what is more restrictive" — both must hold
+  const lastN = executed.slice(-windowTurns);
+  const inWindow = lastN.filter((e) => {
+    const ts = Date.parse(e.timestamp);
+    return Number.isFinite(ts) && ts >= cutoffMs;
+  });
+
+  const counts = new Map<string, number>();
+  for (const e of inWindow) {
+    const data = e.data as { selectedContentId?: string | null } | undefined;
+    const id = data?.selectedContentId;
+    if (typeof id === "string" && id.length > 0) {
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+// ─── Decision: should drota ask? ─────────────────────────────────────────
+
+export interface RepetitionInquiryDecisionInput {
+  /** Profile config (parsed from persona.profile.repetition_inquiry). */
+  profileConfig: RepetitionInquiryProfileConfig;
+  /** Counts por content_id na window. */
+  repetitionCounts: Map<string, number>;
+  /** Turn atual da sessão. */
+  turn: number;
+  /** sessionMode atual ("solo" | "joint"). */
+  sessionMode: "solo" | "joint";
+  /** Há brejo afetivo ativo no statusMatrix? */
+  brejoActive: boolean;
+  /** Inquiries já feitas nesta sessão (extraído do eventLog). */
+  inquiriesThisSession: number;
+  /** Turns desde a última inquiry. Infinity se nunca. */
+  turnsSinceLastInquiry: number;
+  /** IDs do pool elegível (após filtros). Items expirados NÃO entram aqui. */
+  eligiblePoolIds: ReadonlyArray<string>;
+}
+
+export interface RepetitionInquiryDecision {
+  /** Drota deve perguntar? */
+  ask: boolean;
+  /** IDs candidatos a "opção (a) tentar de novo" — só items elegíveis (não-expirados) com count >= threshold. */
+  candidateIds: string[];
+  /** Threshold efetivo usado. */
+  thresholdUsed: number;
+  /** Default on skip propagado pra drota. */
+  defaultOnSkip: "a" | "b" | "c";
+  /** Reason quando ask=false (auditoria). */
+  suppressedReason?:
+    | "profile_disabled"
+    | "cap_reached"
+    | "cooldown"
+    | "turn_too_early"
+    | "joint_mode"
+    | "brejo_active"
+    | "no_pool_options";
+}
+
+/**
+ * Decide se drota deve perguntar à criança sobre repetição.
+ *
+ * Conjunção (i)-(vii) — TODAS devem valer:
+ *  (i)   profile.enabled !== false
+ *  (ii)  inquiriesThisSession < cap
+ *  (iii) turnsSinceLastInquiry >= cooldown
+ *  (iv)  ∃ item no pool eligível com count >= threshold
+ *  (v)   sessionMode === "solo"
+ *  (vi)  !brejoActive  ← override absoluto
+ *  (vii) turn >= gate
+ *
+ * Brejo (vi) sobrepõe tudo — perguntar em dor aguda é anti-padrão Brota §6.3.
+ */
+export function shouldAskRepetitionInquiry(
+  input: RepetitionInquiryDecisionInput,
+): RepetitionInquiryDecision {
+  const cfg = input.profileConfig;
+  const thresholdUsed = cfg.threshold_repetitions ?? DEFAULT_REPETITION_THRESHOLD;
+  const defaultOnSkip = cfg.default_on_skip ?? DEFAULT_ON_SKIP;
+  const candidateIds: string[] = [];
+
+  // (i) profile_disabled — checa primeiro pra Saki + outros explicitamente off
+  if (cfg.enabled === false) {
+    return { ask: false, candidateIds, thresholdUsed, defaultOnSkip, suppressedReason: "profile_disabled" };
+  }
+
+  // (vi) brejo_active — override absoluto, checa cedo
+  if (input.brejoActive) {
+    return { ask: false, candidateIds, thresholdUsed, defaultOnSkip, suppressedReason: "brejo_active" };
+  }
+
+  // (v) joint_mode
+  if (input.sessionMode === "joint") {
+    return { ask: false, candidateIds, thresholdUsed, defaultOnSkip, suppressedReason: "joint_mode" };
+  }
+
+  // (vii) turn_too_early
+  if (input.turn < DEFAULT_INQUIRY_TURN_GATE) {
+    return { ask: false, candidateIds, thresholdUsed, defaultOnSkip, suppressedReason: "turn_too_early" };
+  }
+
+  // (ii) cap_reached
+  if (input.inquiriesThisSession >= DEFAULT_INQUIRY_CAP_PER_SESSION) {
+    return { ask: false, candidateIds, thresholdUsed, defaultOnSkip, suppressedReason: "cap_reached" };
+  }
+
+  // (iii) cooldown
+  if (input.turnsSinceLastInquiry < DEFAULT_INQUIRY_COOLDOWN_TURNS) {
+    return { ask: false, candidateIds, thresholdUsed, defaultOnSkip, suppressedReason: "cooldown" };
+  }
+
+  // (iv) pool tem item ≥ threshold + ainda elegível (não-expirado)
+  const eligibleSet = new Set(input.eligiblePoolIds);
+  for (const [id, count] of input.repetitionCounts) {
+    if (count >= thresholdUsed && eligibleSet.has(id)) {
+      candidateIds.push(id);
+    }
+  }
+  if (candidateIds.length === 0) {
+    return { ask: false, candidateIds, thresholdUsed, defaultOnSkip, suppressedReason: "no_pool_options" };
+  }
+
+  return { ask: true, candidateIds, thresholdUsed, defaultOnSkip };
+}
+
+// ─── Helpers pra plan.ts consumir eventLog ────────────────────────────────
+
+/**
+ * Conta inquiries já feitas nesta sessão.
+ * Olha eventLog por type === "repetition_inquiry_asked".
+ */
+export function countInquiriesInSession(
+  eventLog: ReadonlyArray<EventEntry>,
+): number {
+  return eventLog.filter((e) => e.type === "repetition_inquiry_asked").length;
+}
+
+/**
+ * Turns desde a última inquiry. Conta playbook_executed events APÓS a
+ * última repetition_inquiry_asked. Infinity se nunca.
+ */
+export function turnsSinceLastInquiry(
+  eventLog: ReadonlyArray<EventEntry>,
+): number {
+  // Encontra index do último asked
+  let lastIdx = -1;
+  for (let i = eventLog.length - 1; i >= 0; i--) {
+    if (eventLog[i]!.type === "repetition_inquiry_asked") {
+      lastIdx = i;
+      break;
+    }
+  }
+  if (lastIdx === -1) return Number.POSITIVE_INFINITY;
+  // Conta playbook_executed depois disso
+  let executed = 0;
+  for (let i = lastIdx + 1; i < eventLog.length; i++) {
+    if (eventLog[i]!.type === "playbook_executed") executed++;
+  }
+  return executed;
+}

--- a/planejador/tests/repetition-inquiry.unit.test.ts
+++ b/planejador/tests/repetition-inquiry.unit.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests — repetition-inquiry (ops#1068).
+ *
+ * Cobre extractRepetitionCounts (window 20 turns ∧ 7d), extractProfileConfig,
+ * countInquiriesInSession, turnsSinceLastInquiry, shouldAskRepetitionInquiry
+ * (conjunção i-vii + brejo override absoluto).
+ */
+
+import { describe, it, expect } from "vitest";
+import type { EventEntry } from "@ascendimacy/shared";
+import {
+  extractRepetitionCounts,
+  extractProfileConfig,
+  countInquiriesInSession,
+  turnsSinceLastInquiry,
+  shouldAskRepetitionInquiry,
+  DEFAULT_INQUIRY_TURN_GATE,
+  DEFAULT_INQUIRY_COOLDOWN_TURNS,
+  DEFAULT_REPETITION_THRESHOLD,
+} from "../src/strategist/repetition-inquiry.js";
+
+function makeExecutedEvent(
+  contentId: string,
+  iso: string,
+): EventEntry {
+  return {
+    timestamp: iso,
+    type: "playbook_executed",
+    data: { selectedContentId: contentId },
+  };
+}
+
+function makeInquiryAskedEvent(iso: string): EventEntry {
+  return {
+    timestamp: iso,
+    type: "repetition_inquiry_asked",
+    data: {},
+  };
+}
+
+describe("extractRepetitionCounts — window 20 turns ∧ 7 dias", () => {
+  it("conta repetições simples dentro da window", () => {
+    const log: EventEntry[] = [
+      makeExecutedEvent("x", "2026-05-14T10:00:00.000Z"),
+      makeExecutedEvent("y", "2026-05-14T10:01:00.000Z"),
+      makeExecutedEvent("x", "2026-05-14T10:02:00.000Z"),
+      makeExecutedEvent("x", "2026-05-14T10:03:00.000Z"),
+    ];
+    const counts = extractRepetitionCounts(log, { nowIso: "2026-05-14T10:05:00.000Z" });
+    expect(counts.get("x")).toBe(3);
+    expect(counts.get("y")).toBe(1);
+  });
+
+  it("ignora events fora da janela temporal de 7 dias", () => {
+    const log: EventEntry[] = [
+      makeExecutedEvent("old", "2026-01-01T00:00:00.000Z"),
+      makeExecutedEvent("recent", "2026-05-14T09:00:00.000Z"),
+    ];
+    const counts = extractRepetitionCounts(log, { nowIso: "2026-05-14T10:00:00.000Z" });
+    expect(counts.get("old")).toBeUndefined();
+    expect(counts.get("recent")).toBe(1);
+  });
+
+  it("aplica bound de turns (window=20) — usa últimos 20 events só", () => {
+    const log: EventEntry[] = [];
+    // 25 events de "old" recentes em timestamp
+    for (let i = 0; i < 25; i++) {
+      log.push(makeExecutedEvent("old", `2026-05-14T09:${String(i).padStart(2, "0")}:00.000Z`));
+    }
+    log.push(makeExecutedEvent("new", "2026-05-14T09:30:00.000Z"));
+    const counts = extractRepetitionCounts(log, { nowIso: "2026-05-14T10:00:00.000Z", windowTurns: 20 });
+    // Últimos 20 = 19 "old" + 1 "new"
+    expect(counts.get("old")).toBe(19);
+    expect(counts.get("new")).toBe(1);
+  });
+
+  it("ignora events sem selectedContentId", () => {
+    const log: EventEntry[] = [
+      makeExecutedEvent("x", "2026-05-14T10:00:00.000Z"),
+      { timestamp: "2026-05-14T10:01:00.000Z", type: "playbook_executed", data: {} },
+      { timestamp: "2026-05-14T10:02:00.000Z", type: "playbook_executed", data: { selectedContentId: null } },
+    ];
+    const counts = extractRepetitionCounts(log, { nowIso: "2026-05-14T10:05:00.000Z" });
+    expect(counts.get("x")).toBe(1);
+    expect(counts.size).toBe(1);
+  });
+
+  it("ignora events de outros types", () => {
+    const log: EventEntry[] = [
+      makeExecutedEvent("x", "2026-05-14T10:00:00.000Z"),
+      { timestamp: "2026-05-14T10:01:00.000Z", type: "transition_evaluated", data: { selectedContentId: "x" } },
+    ];
+    const counts = extractRepetitionCounts(log, { nowIso: "2026-05-14T10:05:00.000Z" });
+    expect(counts.get("x")).toBe(1);
+  });
+});
+
+describe("extractProfileConfig — defensive parse de freeform profile", () => {
+  it("retorna {} quando profile ausente/sem campo", () => {
+    expect(extractProfileConfig(undefined)).toEqual({});
+    expect(extractProfileConfig({})).toEqual({});
+    expect(extractProfileConfig({ other: "field" })).toEqual({});
+  });
+
+  it("retorna {} quando repetition_inquiry não é object", () => {
+    expect(extractProfileConfig({ repetition_inquiry: "string" })).toEqual({});
+    expect(extractProfileConfig({ repetition_inquiry: 42 })).toEqual({});
+    expect(extractProfileConfig({ repetition_inquiry: null })).toEqual({});
+  });
+
+  it("parseia enabled bool", () => {
+    expect(extractProfileConfig({ repetition_inquiry: { enabled: false } })).toEqual({ enabled: false });
+    expect(extractProfileConfig({ repetition_inquiry: { enabled: true } })).toEqual({ enabled: true });
+  });
+
+  it("parseia threshold_repetitions number", () => {
+    expect(extractProfileConfig({ repetition_inquiry: { threshold_repetitions: 5 } }))
+      .toEqual({ threshold_repetitions: 5 });
+  });
+
+  it("parseia default_on_skip apenas valores a/b/c", () => {
+    expect(extractProfileConfig({ repetition_inquiry: { default_on_skip: "b" } }))
+      .toEqual({ default_on_skip: "b" });
+    expect(extractProfileConfig({ repetition_inquiry: { default_on_skip: "invalid" } }))
+      .toEqual({});
+  });
+
+  it("ignora tipos errados sem crashar", () => {
+    expect(extractProfileConfig({
+      repetition_inquiry: {
+        enabled: "yes",
+        threshold_repetitions: "five",
+        default_on_skip: 42,
+      },
+    })).toEqual({});
+  });
+});
+
+describe("countInquiriesInSession + turnsSinceLastInquiry", () => {
+  it("countInquiriesInSession conta repetition_inquiry_asked events", () => {
+    const log: EventEntry[] = [
+      makeExecutedEvent("x", "2026-05-14T10:00:00.000Z"),
+      makeInquiryAskedEvent("2026-05-14T10:01:00.000Z"),
+      makeExecutedEvent("y", "2026-05-14T10:02:00.000Z"),
+      makeInquiryAskedEvent("2026-05-14T10:03:00.000Z"),
+    ];
+    expect(countInquiriesInSession(log)).toBe(2);
+  });
+
+  it("turnsSinceLastInquiry = Infinity quando nunca houve", () => {
+    const log: EventEntry[] = [makeExecutedEvent("x", "2026-05-14T10:00:00.000Z")];
+    expect(turnsSinceLastInquiry(log)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("turnsSinceLastInquiry conta playbook_executed após última asked", () => {
+    const log: EventEntry[] = [
+      makeExecutedEvent("a", "2026-05-14T10:00:00.000Z"),
+      makeInquiryAskedEvent("2026-05-14T10:01:00.000Z"),
+      makeExecutedEvent("b", "2026-05-14T10:02:00.000Z"),
+      makeExecutedEvent("c", "2026-05-14T10:03:00.000Z"),
+      makeExecutedEvent("d", "2026-05-14T10:04:00.000Z"),
+    ];
+    expect(turnsSinceLastInquiry(log)).toBe(3);
+  });
+});
+
+// ─── shouldAskRepetitionInquiry — conjunção i-vii ────────────────────────
+
+function baseDecisionInput(overrides: Partial<Parameters<typeof shouldAskRepetitionInquiry>[0]> = {}) {
+  return {
+    profileConfig: {},
+    repetitionCounts: new Map([["x", 3]]),
+    turn: 6,
+    sessionMode: "solo" as const,
+    brejoActive: false,
+    inquiriesThisSession: 0,
+    turnsSinceLastInquiry: Number.POSITIVE_INFINITY,
+    eligiblePoolIds: ["x", "y"],
+    ...overrides,
+  };
+}
+
+describe("shouldAskRepetitionInquiry — happy path", () => {
+  it("ask=true quando todas as condições i-vii valem", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput());
+    expect(d.ask).toBe(true);
+    expect(d.candidateIds).toEqual(["x"]);
+    expect(d.thresholdUsed).toBe(DEFAULT_REPETITION_THRESHOLD);
+    expect(d.defaultOnSkip).toBe("b");
+    expect(d.suppressedReason).toBeUndefined();
+  });
+
+  it("respeita threshold per-persona override", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      profileConfig: { threshold_repetitions: 5 },
+      repetitionCounts: new Map([["x", 3]]),
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("no_pool_options");
+    expect(d.thresholdUsed).toBe(5);
+  });
+
+  it("propaga default_on_skip per-persona (Ryo)", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      profileConfig: { default_on_skip: "b" },
+    }));
+    expect(d.defaultOnSkip).toBe("b");
+  });
+});
+
+describe("shouldAskRepetitionInquiry — suppressed reasons", () => {
+  it("profile_disabled quando enabled=false (Saki)", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      profileConfig: { enabled: false },
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("profile_disabled");
+  });
+
+  it("brejo_active sobrepõe TUDO (override absoluto)", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      brejoActive: true,
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("brejo_active");
+  });
+
+  it("brejo_active vence até quando profile_disabled também valeria? Sim — checa primeiro disabled", () => {
+    // profile_disabled checked FIRST (intent: respect explicit user config).
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      profileConfig: { enabled: false },
+      brejoActive: true,
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("profile_disabled");
+  });
+
+  it("joint_mode quando sessionMode=joint", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      sessionMode: "joint",
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("joint_mode");
+  });
+
+  it("turn_too_early quando turn < gate (4)", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      turn: DEFAULT_INQUIRY_TURN_GATE - 1,
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("turn_too_early");
+  });
+
+  it("cap_reached quando já houve 1 inquiry na sessão", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      inquiriesThisSession: 1,
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("cap_reached");
+  });
+
+  it("cooldown quando turnsSinceLastInquiry < 8", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      inquiriesThisSession: 0, // cap NÃO atingido (cap=1)
+      turnsSinceLastInquiry: DEFAULT_INQUIRY_COOLDOWN_TURNS - 1,
+    }));
+    // Como cap_reached é checked antes de cooldown e inquiries=0, devemos cair no cooldown
+    // Mas cap=1 e inquiries=0 → passa cap. cooldown deve disparar.
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("cooldown");
+  });
+
+  it("no_pool_options quando nenhum item count ≥ threshold elegível", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      repetitionCounts: new Map([["x", 1]]), // count abaixo do threshold (2)
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("no_pool_options");
+  });
+
+  it("no_pool_options quando item ≥ threshold mas NÃO está no pool elegível (expirado)", () => {
+    const d = shouldAskRepetitionInquiry(baseDecisionInput({
+      repetitionCounts: new Map([["expired", 5]]),
+      eligiblePoolIds: ["other"],
+    }));
+    expect(d.ask).toBe(false);
+    expect(d.suppressedReason).toBe("no_pool_options");
+  });
+});


### PR DESCRIPTION
## Summary

Implementação completa do **drota.repetition_inquiry** (ops#1068) — protocolo conversacional pra decisão de repetição. Reframe pedagógico ratificado por Jun 2026-05-14: em vez de classificar algorithmically 4 sub-motivos (ops#1066, abandonada), drota PERGUNTA à criança. Alinhado a Brota Mestre §2.1 "humanos primeiro".

Todos os 8 defaults da spec foram ratificados em [ops#1068 comment 4464994937](https://github.com/ascendimacy/ascendimacy-ops/issues/1068#issuecomment-4464994937). Stories internas documentadas em [ops#1068 comment 4465000774](https://github.com/ascendimacy/ascendimacy-ops/issues/1068#issuecomment-4465000774) para rastreabilidade post-merge.

## Mudanças (9 commits, ordem dependency-aware)

### Planejador (camada decisão)
1. **`planejador/src/strategist/repetition-inquiry.ts`** (NEW, 272 linhas) — `extractRepetitionCounts` (window 20 turns ∧ 7d), `extractProfileConfig` (parse defensivo), `shouldAskRepetitionInquiry` (conjunção i-vii com brejo override absoluto), `countInquiriesInSession`, `turnsSinceLastInquiry`.
2. **`planejador/src/plan.ts`** — após slimPool definitivo, avalia decisão + injeta `contextHints.repetition_inquiry` (ask=true) ou `contextHints.repetition_inquiry_suppressed` (ask=false). Suppressed isolado pra auditoria sem poluir o key que drota consome.
3. **`planejador/tests/repetition-inquiry.unit.test.ts`** (NEW, 26 tests) — window, conjunção, defaults, edge cases.

### Motor-drota (camada execução)
4. **`motor-drota/src/parse-repetition-answer.ts`** (NEW, 120 linhas) — cascata 3 stages. v0 implementa stage 1 (literal regex) + stage 3 (default per-persona); stage 2 (LLM intent classifier) v0.1 follow-up. Padrões natural language ordem-sensível (B > A > C, multi-palavra vence single-word). Defesa contra JS `\b` ASCII-only com regex STANDALONE.
5. **`motor-drota/src/server.ts`** — instrução 9 nova quando `inquiry_active`; joint mode bumped pra 10. Formato \"(a)/(b)/(c)\", ancorar concretude, adapta idade, não força.
6. **`motor-drota/tests/parse-repetition-answer.unit.test.ts`** (NEW, 34 tests) — single-letter/digit/natural/default + precedência + word-boundary (\"açúcar\" NÃO vira \"a\").

### Fixtures (sub-decisão 4 calibration)
7. **`fixtures/profiles/saki-ochiai.pre-phase2.json`** (NEW) — `enabled: false`. ASD nível 1, repetição cumpre função sensorial/regulatória.
8. **`fixtures/profiles/ryo-ochiai.pre-phase2.json`** — `default_on_skip: \"b\"`. Deflective, silêncio = \"continuar sem decidir\".
9. **`fixtures/profiles/kei-ochiai.pre-phase2.json`** — `{}`. Marker explícito de \"checado, usa defaults universais\".

## Sub-decisões implementadas

| # | Default | Implementação |
|---|---------|----------------|
| 1 | 1 inquiry/sessão; cooldown 8 turns; gate ≥4 turns | `DEFAULT_INQUIRY_*` constants em strategist |
| 2 | Skip → (b) parecido + log | `defaultOnSkip` propagado pro contextHints |
| 3 | Joint NÃO dispara | `sessionMode === \"joint\"` → `suppressed_reason=joint_mode` |
| 4 | profile.repetition_inquiry per-persona | `extractProfileConfig` + fixtures Saki/Ryo/Kei |
| 5 | Window 20 turns ∧ 7d, threshold ≥ 2 | `extractRepetitionCounts` aplica AND |
| 6 | Expirados fora de (a); pool vazio suprime | `eligiblePoolIds` recebe slimPool pós-filtros |
| 7 | Cascata literal regex → default (LLM v0.1) | `parse-repetition-answer.ts` |
| 8 | Conjunção (i)-(vii); brejo override absoluto | `shouldAskRepetitionInquiry` checa brejo cedo |

## Sub-decisão 6 (event types) — implementação parcial

EventEntry.type é freeform string no `shared/src/types.ts`, então não há enum pra adicionar. Os 4 tipos de evento (`repetition_inquiry_asked` / `_answered` / `_skipped` / `_suppressed`) são string literals — `countInquiriesInSession` já lê `\"repetition_inquiry_asked\"`. O log de fato dos eventos pelo motor-execucao fica em PR separado (precisa de consumer downstream do parse — atualmente parse-repetition-answer existe mas ninguém chama; integração end-to-end é v0.1).

## Test plan

- [x] `npm test -w @ascendimacy/planejador -- repetition-inquiry` → 26/26 passing
- [x] `npm test -w @ascendimacy/motor-drota -- parse-repetition-answer` → 34/34 passing
- [x] Full motor suite: 1086 passed | 9 skipped (vs prev baseline 1011 — +60 novos + outros tests existentes)
- [x] Build clean: `npm run build` em todos os workspaces
- [ ] Smoke E2E com Qwen3 local (pré-req: stack up + integração motor-execucao consumindo parser) — fica v0.1 follow-up

## Não inclui (v0.1 follow-up explícitos)

1. **LLM intent classifier stage 2** — mood-extractor reuse pra parsear respostas ambíguas em vez de cair direto pro default
2. **Motor-execucao integração end-to-end** — ler resposta da criança no turn seguinte, chamar `parseRepetitionAnswer`, propagar `last_inquiry_answer` pro próximo planTurn
3. **Cross-session window via content-usage-repo (motor#108 mergeado)** — v0 usa só eventLog per-session
4. **Smoke E2E** — depende dos itens acima

## Refs

- Spec: ops#1068
- Ratificação defaults: https://github.com/ascendimacy/ascendimacy-ops/issues/1068#issuecomment-4464994937
- Story breakdown rastreabilidade: https://github.com/ascendimacy/ascendimacy-ops/issues/1068#issuecomment-4465000774
- Superseded: ops#1066 (approach algorithmic — abandonada pelo reframe)
- Sibling: ops#1067 / motor#108 (content-usage-repo) — habilitará cross-session window em v0.1

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)