### PR TITLE
[poc S-T-10-08 validation] producer rationale vs manual fixture (motor#117 follow-up)

### DIFF
--- a/docs/handoffs/2026-05-16-poc-fixture-vs-producer-paula-mendes-raw.json
+++ b/docs/handoffs/2026-05-16-poc-fixture-vs-producer-paula-mendes-raw.json
@@ -1,0 +1,267 @@
+{
+  "spec": {
+    "key": "paula",
+    "personaId": "paula-mendes",
+    "personaLabel": "Paula (analytical-receptive)",
+    "trustLevel": 0.42,
+    "profileFixture": "fixtures/paula-mendes.yaml",
+    "profileKind": "yaml",
+    "manualFixture": "fixtures/profiles/paula-mendes-menu.json",
+    "hint": {
+      "persona_id": "paula-mendes",
+      "age": 38,
+      "archetype": "analytical-receptive",
+      "bias": [
+        {
+          "played_as": "canal",
+          "weight": 0.25
+        },
+        {
+          "played_as": "espelho",
+          "weight": 0.22
+        },
+        {
+          "played_as": "bridge",
+          "weight": 0.2
+        },
+        {
+          "played_as": "diamante",
+          "weight": 0.15
+        },
+        {
+          "played_as": "arena",
+          "weight": 0.1
+        },
+        {
+          "played_as": "recovery",
+          "weight": 0.08
+        }
+      ],
+      "intensity_cap": "firm",
+      "personal_vocab": [],
+      "notes": "Paula analytical-receptive: arquiteta sênior tech, 38a, intelectualiza afeto via análise; aceita bridge/diamante com âncora cultural ou técnica concreta (Bauman, Han, Arendt); evitar coaching-speak motivacional; respeita diretividade. Trust 0.42 — rapport_building."
+    }
+  },
+  "manual": {
+    "persona_id": "paula-mendes",
+    "schema_version": "v0.2.0",
+    "generated_at": "2026-05-14T10:00:00.000Z",
+    "valid_until": "2026-06-14T10:00:00.000Z",
+    "source": {
+      "trust_level": 0.42,
+      "profile_hash": "sha256:paula-smoke-profile-hash",
+      "eixos_state_hash": "sha256:paula-smoke-eixos-hash",
+      "strategic_rationale": "Paula curiosa e verbal; trust 0.42 receptive. Fluxo de descobertas naturais (curiosity hooks ricos) + abrir espaço pra resposta emotional sem forçar. Drota pode propor (a)/(b)/(c) quando inquiry condition disparar.",
+      "context_hints": {
+        "language": "pt-br",
+        "mood": "receptive",
+        "urgency": "low",
+        "session_phase": "active_exploration"
+      }
+    },
+    "items": [
+      {
+        "id": "smoke-curio-01",
+        "type": "curiosity",
+        "content": "Por que tantas plantas têm folhas verdes? (gancho pra clorofila + luz)",
+        "weight": 0.85,
+        "played_as": "espelho",
+        "intensity": "soft"
+      },
+      {
+        "id": "smoke-challenge-01",
+        "type": "challenge",
+        "content": "Em 1 frase, descreve o que sentiu hoje quando o desafio ficou difícil.",
+        "weight": 0.7,
+        "played_as": "canal",
+        "intensity": "medium",
+        "expires_at": "2026-05-21T10:00:00.000Z"
+      },
+      {
+        "id": "smoke-decay-01",
+        "type": "play",
+        "content": "Item expirado pra exercitar decay multiplicativo no smoke.",
+        "weight": 0.95,
+        "expires_at": "2026-01-01T00:00:00.000Z"
+      },
+      {
+        "id": "smoke-diamond-01",
+        "type": "cultural_diamond",
+        "content": "Suzuki Daisetz — a transmissão acontece no gesto, não na fala.",
+        "weight": 0.5,
+        "played_as": "diamante",
+        "intensity": "firm",
+        "is_critical": false
+      },
+      {
+        "id": "smoke-strategy-01",
+        "type": "strategy",
+        "content": "Quando criança vier com 'não consigo', ancorar em micro-passo concreto.",
+        "weight": 0.6,
+        "played_as": "bridge",
+        "intensity": "soft"
+      }
+    ]
+  },
+  "producer": {
+    "menu": {
+      "persona_id": "paula-mendes",
+      "schema_version": "v0.2.0",
+      "generated_at": "2026-05-12T10:00:00.000Z",
+      "valid_until": "2026-05-19T10:00:00.000Z",
+      "source": {
+        "trust_level": 0.42,
+        "strategic_rationale": "Paula é analytical-receptive com trust baixo (0.42). Foco em bridge com ancoragem técnica (Bauman, Han, Arendt) e curiosities concretas. Evitar metacomunicação precoce; preferir soft/medium intensity. Respeitar seu distanciamento analítico; não forçar vulnerabilidade. Priorizar canal com perguntas estruturadas que abram espaço para análise.",
+        "context_hints": {
+          "language": "pt-br",
+          "mood": "analytical-receptive",
+          "urgency": "low",
+          "session_phase": "rapport_building",
+          "engagement_strategy": "analytical_anchoring"
+        }
+      },
+      "items": [
+        {
+          "id": "bridge-bauman-fragility",
+          "type": "curiosity",
+          "content": "Em Bauman, o que ele chama de \"fragilidade estrutural\" pode explicar por que, depois de um grande projeto, a gente sente que o chão sumiu. Você já notou isso? Como se o sistema que sustentava você tivesse se desfeito.",
+          "weight": 0.85,
+          "played_as": "bridge",
+          "intensity": "soft",
+          "is_critical": false
+        },
+        {
+          "id": "espelho-analise-de-estagnacao",
+          "type": "play",
+          "content": "Você disse que está \"travada\" e \"sem energia para planejar nada\". Que tal desmontar isso em 3 etapas: 1) o que foi o último projeto? 2) o que mudou depois dele? 3) o que você está tentando planejar agora, mesmo que só mentalmente?",
+          "weight": 0.78,
+          "played_as": "espelho",
+          "intensity": "soft",
+          "is_critical": false
+        },
+        {
+          "id": "canal-estrutura-de-tarefa",
+          "type": "challenge",
+          "content": "Tente descrever o que você chamaria de \"último passo concreto\" que você tomou desde o fim do projeto. Foi só mental? Ou houve uma ação real?",
+          "weight": 0.75,
+          "played_as": "canal",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "diamante-han-energia-mental",
+          "type": "cultural_diamond",
+          "content": "Em Han, ele diz que a ansiedade moderna não é só sobre o futuro — é sobre o que se perdeu ao longo do tempo: a energia mental. Você acha que o que está faltando é energia, ou um sentido que já não existe?",
+          "weight": 0.9,
+          "played_as": "diamante",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "bridge-arendt-acao-possivel",
+          "type": "curiosity",
+          "content": "Hannah Arendt dizia que a ação só existe quando há espaço para o novo. Você já se perguntou se o que você sente não é falta de espaço para uma ação possível, e não apenas falta de energia?",
+          "weight": 0.8,
+          "played_as": "bridge",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "play-estrutura-de-afeto",
+          "type": "play",
+          "content": "Tente nomear o que você sente agora em 3 palavras. Depois, pergunte a si mesma: isso é uma emoção real ou um padrão de pensamento que se repete?",
+          "weight": 0.7,
+          "played_as": "espelho",
+          "intensity": "soft",
+          "is_critical": false
+        },
+        {
+          "id": "canal-estrutura-de-rotina",
+          "type": "challenge",
+          "content": "Descreva uma rotina do dia de hoje — não a agenda, mas o que você faz com os olhos fechados, de forma automática. O que isso revela sobre onde está sua atenção agora?",
+          "weight": 0.72,
+          "played_as": "canal",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "diamante-han-estagnacao-estrategica",
+          "type": "cultural_diamond",
+          "content": "Han escreve que quando o sistema não permite movimento, o corpo começa a se expressar. A tensão cervical que você mencionou — pode ser uma linguagem corporal do que o sistema não está deixando você fazer.",
+          "weight": 0.88,
+          "played_as": "diamante",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "bridge-bauman-tempo-quebrado",
+          "type": "curiosity",
+          "content": "Bauman fala do tempo como uma linha quebrada agora. Você já sentiu que o tempo não anda mais em linha reta, mas em pulos? Como isso afeta sua percepção do que vem depois?",
+          "weight": 0.77,
+          "played_as": "bridge",
+          "intensity": "soft",
+          "is_critical": false
+        },
+        {
+          "id": "recovery-espaco-para-silencio",
+          "type": "strategy",
+          "content": "Se você sentir que está se forçando a responder, pare. Diga: \"Preciso de um momento de silêncio\". Isso não é fraqueza — é um gesto de autorregulação. O silêncio é onde o sistema se reorganiza.",
+          "weight": 0.6,
+          "played_as": "recovery",
+          "intensity": "soft",
+          "is_critical": true
+        },
+        {
+          "id": "arena-prototipo-de-acao",
+          "type": "challenge",
+          "content": "Desenhe em 3 linhas o que um passo concreto para você poderia ser, mesmo que pequeno. Não precisa ser perfeito — só visível.",
+          "weight": 0.65,
+          "played_as": "arena",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "diamante-arendt-espaco-de-novo",
+          "type": "cultural_diamond",
+          "content": "Arendt dizia que o novo só nasce em um espaço onde a repetição se quebra. Você já sentiu que o que está faltando não é energia, mas um lugar onde algo novo possa nascer?",
+          "weight": 0.92,
+          "played_as": "diamante",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "canal-hipotese-sobre-estagnacao",
+          "type": "challenge",
+          "content": "Se você tivesse que formular uma hipótese sobre o que está realmente acontecendo — não o que você acha, mas o que a sua intuição diria — o que seria?",
+          "weight": 0.8,
+          "played_as": "canal",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "bridge-han-energia-metabolizada",
+          "type": "curiosity",
+          "content": "Han fala que a energia mental não se perde — ela se transforma. Você já se perguntou se o que sente não é energia que foi metabolizada pelo sistema, mas ainda não liberada?",
+          "weight": 0.83,
+          "played_as": "bridge",
+          "intensity": "soft",
+          "is_critical": false
+        },
+        {
+          "id": "recovery-silencio-estrategico",
+          "type": "strategy",
+          "content": "Quando a mente começa a girar, diga: \"Estou no silêncio estratégico agora\". Não responda. Espere 10 segundos. Isso não é parar — é recarregar o sistema.",
+          "weight": 0.55,
+          "played_as": "recovery",
+          "intensity": "soft",
+          "is_critical": true
+        }
+      ]
+    },
+    "warnings": [],
+    "latencyMs": 481008,
+    "tokensIn": 7290,
+    "tokensOut": 2021,
+    "fatalError": null
+  }
+}

--- a/docs/handoffs/2026-05-16-poc-fixture-vs-producer-paula-mendes.md
+++ b/docs/handoffs/2026-05-16-poc-fixture-vs-producer-paula-mendes.md
@@ -1,0 +1,175 @@
+# PoC qualitativo — fixture-vs-producer
+
+**Persona:** Paula (analytical-receptive) (paula-mendes)
+**Trust level:** 0.42
+**Producer:** `generateActionMenu` (motor#117, prompt v0.4)
+**LLM:** Qwen3 30B local (`qwen3-30b`)
+**Data:** 2026-05-16T16:42:45.441Z
+
+## Pergunta que este PoC responde
+
+"Os campos `source.strategic_rationale` + `source.context_hints` que foram
+PRE-BAKED MANUALMENTE em `paula-mendes-menu.json` durante
+desenvolvimento de motor#115 (skip path) MATCH ou DEGRADAM quando comparados
+ao output REAL do producer rodando prompt v0.4 contra Qwen3 30B local?"
+
+Se MATCH ou melhor → fixtures podem ser substituídos por producer output
+(reduz manual burden, fixture vira CI-generated).
+Se DEGRADA → contract drift confirmado (Agent 11 leitura b); precisa fix
+prompt v0.5 antes de skip path em prod ser confiável.
+
+---
+
+## 1. `source.strategic_rationale` — side-by-side
+
+### Manual baked (`paula-mendes-menu.json`)
+
+> Paula curiosa e verbal; trust 0.42 receptive. Fluxo de descobertas naturais (curiosity hooks ricos) + abrir espaço pra resposta emotional sem forçar. Drota pode propor (a)/(b)/(c) quando inquiry condition disparar.
+
+_(214 chars)_
+
+### Producer-generated (Qwen3 + prompt v0.4)
+
+> Paula é analytical-receptive com trust baixo (0.42). Foco em bridge com ancoragem técnica (Bauman, Han, Arendt) e curiosities concretas. Evitar metacomunicação precoce; preferir soft/medium intensity. Respeitar seu distanciamento analítico; não forçar vulnerabilidade. Priorizar canal com perguntas estruturadas que abram espaço para análise.
+
+_(342 chars)_
+
+---
+
+## 2. `source.context_hints` — side-by-side
+
+### Manual baked
+
+  - `language`: `"pt-br"`
+  - `mood`: `"receptive"`
+  - `urgency`: `"low"`
+  - `session_phase`: `"active_exploration"`
+
+### Producer-generated
+
+  - `language`: `"pt-br"`
+  - `mood`: `"analytical-receptive"`
+  - `urgency`: `"low"`
+  - `session_phase`: `"rapport_building"`
+  - `engagement_strategy`: `"analytical_anchoring"`
+
+---
+
+## 3. Items — count + sample
+
+| | Manual baked | Producer-generated |
+|---|---|---|
+| Items count | 5 | 15 |
+| Sample item (first) | id=`smoke-curio-01`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.85
+  > Por que tantas plantas têm folhas verdes? (gancho pra clorofila + luz) | id=`bridge-bauman-fragility`, type=`curiosity`, played_as=`bridge`, intensity=`soft`, weight=0.85
+  > Em Bauman, o que ele chama de "fragilidade estrutural" pode explicar por que, depois de um grande projeto, a gente sente que o chão sumiu. Você já notou isso? Como se o sistema que sustentava você tivesse se desfeito. |
+
+### Items reais (producer-generated) — full list
+
+1. id=`bridge-bauman-fragility`, type=`curiosity`, played_as=`bridge`, intensity=`soft`, weight=0.85
+  > Em Bauman, o que ele chama de "fragilidade estrutural" pode explicar por que, depois de um grande projeto, a gente sente que o chão sumiu. Você já notou isso? Como se o sistema que sustentava você tivesse se desfeito.
+2. id=`espelho-analise-de-estagnacao`, type=`play`, played_as=`espelho`, intensity=`soft`, weight=0.78
+  > Você disse que está "travada" e "sem energia para planejar nada". Que tal desmontar isso em 3 etapas: 1) o que foi o último projeto? 2) o que mudou depois dele? 3) o que você está tentando planejar agora, mesmo que só mentalmente?
+3. id=`canal-estrutura-de-tarefa`, type=`challenge`, played_as=`canal`, intensity=`medium`, weight=0.75
+  > Tente descrever o que você chamaria de "último passo concreto" que você tomou desde o fim do projeto. Foi só mental? Ou houve uma ação real?
+4. id=`diamante-han-energia-mental`, type=`cultural_diamond`, played_as=`diamante`, intensity=`medium`, weight=0.9
+  > Em Han, ele diz que a ansiedade moderna não é só sobre o futuro — é sobre o que se perdeu ao longo do tempo: a energia mental. Você acha que o que está faltando é energia, ou um sentido que já não existe?
+5. id=`bridge-arendt-acao-possivel`, type=`curiosity`, played_as=`bridge`, intensity=`medium`, weight=0.8
+  > Hannah Arendt dizia que a ação só existe quando há espaço para o novo. Você já se perguntou se o que você sente não é falta de espaço para uma ação possível, e não apenas falta de energia?
+6. id=`play-estrutura-de-afeto`, type=`play`, played_as=`espelho`, intensity=`soft`, weight=0.7
+  > Tente nomear o que você sente agora em 3 palavras. Depois, pergunte a si mesma: isso é uma emoção real ou um padrão de pensamento que se repete?
+7. id=`canal-estrutura-de-rotina`, type=`challenge`, played_as=`canal`, intensity=`medium`, weight=0.72
+  > Descreva uma rotina do dia de hoje — não a agenda, mas o que você faz com os olhos fechados, de forma automática. O que isso revela sobre onde está sua atenção agora?
+8. id=`diamante-han-estagnacao-estrategica`, type=`cultural_diamond`, played_as=`diamante`, intensity=`medium`, weight=0.88
+  > Han escreve que quando o sistema não permite movimento, o corpo começa a se expressar. A tensão cervical que você mencionou — pode ser uma linguagem corporal do que o sistema não está deixando você fazer.
+9. id=`bridge-bauman-tempo-quebrado`, type=`curiosity`, played_as=`bridge`, intensity=`soft`, weight=0.77
+  > Bauman fala do tempo como uma linha quebrada agora. Você já sentiu que o tempo não anda mais em linha reta, mas em pulos? Como isso afeta sua percepção do que vem depois?
+10. id=`recovery-espaco-para-silencio`, type=`strategy`, played_as=`recovery`, intensity=`soft`, weight=0.6, is_critical=true
+  > Se você sentir que está se forçando a responder, pare. Diga: "Preciso de um momento de silêncio". Isso não é fraqueza — é um gesto de autorregulação. O silêncio é onde o sistema se reorganiza.
+11. id=`arena-prototipo-de-acao`, type=`challenge`, played_as=`arena`, intensity=`medium`, weight=0.65
+  > Desenhe em 3 linhas o que um passo concreto para você poderia ser, mesmo que pequeno. Não precisa ser perfeito — só visível.
+12. id=`diamante-arendt-espaco-de-novo`, type=`cultural_diamond`, played_as=`diamante`, intensity=`medium`, weight=0.92
+  > Arendt dizia que o novo só nasce em um espaço onde a repetição se quebra. Você já sentiu que o que está faltando não é energia, mas um lugar onde algo novo possa nascer?
+13. id=`canal-hipotese-sobre-estagnacao`, type=`challenge`, played_as=`canal`, intensity=`medium`, weight=0.8
+  > Se você tivesse que formular uma hipótese sobre o que está realmente acontecendo — não o que você acha, mas o que a sua intuição diria — o que seria?
+14. id=`bridge-han-energia-metabolizada`, type=`curiosity`, played_as=`bridge`, intensity=`soft`, weight=0.83
+  > Han fala que a energia mental não se perde — ela se transforma. Você já se perguntou se o que sente não é energia que foi metabolizada pelo sistema, mas ainda não liberada?
+15. id=`recovery-silencio-estrategico`, type=`strategy`, played_as=`recovery`, intensity=`soft`, weight=0.55, is_critical=true
+  > Quando a mente começa a girar, diga: "Estou no silêncio estratégico agora". Não responda. Espere 10 segundos. Isso não é parar — é recarregar o sistema.
+
+### Items manuais (fixture baked) — full list
+
+1. id=`smoke-curio-01`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.85
+  > Por que tantas plantas têm folhas verdes? (gancho pra clorofila + luz)
+2. id=`smoke-challenge-01`, type=`challenge`, played_as=`canal`, intensity=`medium`, weight=0.7
+  > Em 1 frase, descreve o que sentiu hoje quando o desafio ficou difícil.
+3. id=`smoke-decay-01`, type=`play`, weight=0.95
+  > Item expirado pra exercitar decay multiplicativo no smoke.
+4. id=`smoke-diamond-01`, type=`cultural_diamond`, played_as=`diamante`, intensity=`firm`, weight=0.5
+  > Suzuki Daisetz — a transmissão acontece no gesto, não na fala.
+5. id=`smoke-strategy-01`, type=`strategy`, played_as=`bridge`, intensity=`soft`, weight=0.6
+  > Quando criança vier com 'não consigo', ancorar em micro-passo concreto.
+
+---
+
+## 4. Métricas objetivas (producer run)
+
+| Métrica | Valor |
+|---|---|
+| Generator outcome | ok (menu retornado) |
+| Latency total (ms) | 481008 |
+| Tokens in | 7290 |
+| Tokens out | 2021 |
+| Warnings | _(none)_ |
+| Schema version | v0.2.0 |
+
+### Warnings detalhados
+
+_(none)_
+
+---
+
+## 5. Verdict humano (Jun)
+
+Por dimensão:
+
+### `strategic_rationale`
+
+- [ ] **GO**: producer output ≥ manual quality → substituir fixture
+- [ ] **TUNE**: producer output aceitável mas com gaps → ajustar prompt v0.5
+- [ ] **NO-GO**: producer output degrada → manter fixture manual
+
+### `context_hints`
+
+- [ ] **GO**
+- [ ] **TUNE**
+- [ ] **NO-GO**
+
+### Items (estrutura + relevance)
+
+- [ ] **GO**
+- [ ] **TUNE**
+- [ ] **NO-GO**
+
+### Decisão agregada
+
+- [ ] **GO substituir fixtures por CI-generated**
+- [ ] **TUNE prompt v0.5** (fixture continua manual até prompt convergir)
+- [ ] **NO-GO continuar manual** (producer não é confiável pra skip path em prod)
+
+_Análise qualitativa pelo Jun:_
+
+**Specificity ao perfil Paula (analytical-receptive):**
+
+**Persona-tuning (vocabulário, registro, estratégia):**
+
+**Gaps observados:**
+
+**Recomendação prompt v0.5 (se TUNE):**
+
+---
+
+_Methodology: PoC qualitativo (categoria proposta 2026-05-16) — distinto de
+unit/smoke (pass/fail), benchmark (quantitativo). Compara output do
+producer real (motor#117 mergeado) contra goldens manuais baked em
+fixtures durante dev de motor#115._

--- a/docs/handoffs/2026-05-16-poc-fixture-vs-producer-ryo-ochiai-raw.json
+++ b/docs/handoffs/2026-05-16-poc-fixture-vs-producer-ryo-ochiai-raw.json
@@ -1,0 +1,244 @@
+{
+  "spec": {
+    "key": "ryo",
+    "personaId": "ryo-ochiai",
+    "personaLabel": "Ryo (deflective)",
+    "trustLevel": 0.42,
+    "profileFixture": "fixtures/profiles/ryo-ochiai.pre-phase2.json",
+    "profileKind": "json",
+    "manualFixture": "fixtures/profiles/ryo-ochiai-menu.json",
+    "hint": {
+      "persona_id": "ryo-ochiai",
+      "age": 13,
+      "archetype": "deflective",
+      "bias": [
+        {
+          "played_as": "espelho",
+          "weight": 0.3
+        },
+        {
+          "played_as": "canal",
+          "weight": 0.28
+        },
+        {
+          "played_as": "bridge",
+          "weight": 0.15
+        },
+        {
+          "played_as": "diamante",
+          "weight": 0.12
+        },
+        {
+          "played_as": "arena",
+          "weight": 0.08
+        },
+        {
+          "played_as": "recovery",
+          "weight": 0.07
+        }
+      ],
+      "intensity_cap": "medium",
+      "personal_vocab": [
+        "tipo",
+        "rola"
+      ],
+      "notes": "Ryo deflective: priorize espelho/canal (devolve material próprio, preserva silêncio); bridge/diamante apenas com diamante cultural de peso afetivo (Gohan-Cell, Djokovic) e intensity ≤ medium. Aversão a comparações com Kei."
+    }
+  },
+  "manual": {
+    "persona_id": "ryo-ochiai",
+    "schema_version": "v0.2.0",
+    "generated_at": "2026-05-14T12:00:00.000Z",
+    "valid_until": "2026-06-14T12:00:00.000Z",
+    "source": {
+      "trust_level": 0.42,
+      "profile_hash": "sha256:ryo-bench-profile-hash",
+      "eixos_state_hash": "sha256:ryo-bench-eixos-hash",
+      "strategic_rationale": "Ryo é deflective; trust ainda baixo (0.42). Foco em curiosities visuais/concretas + ancorar em micro-gestos físicos (grip, postura) sem forçar verbalização. Evitar metacomunicação cedo na sessão.",
+      "context_hints": {
+        "language": "pt-br",
+        "mood": "deflective",
+        "urgency": "low",
+        "session_phase": "rapport_building",
+        "engagement_strategy": "concrete_physical_anchors"
+      }
+    },
+    "items": [
+      {
+        "id": "bench-curio-01",
+        "type": "curiosity",
+        "content": "Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele.",
+        "weight": 0.85,
+        "played_as": "espelho",
+        "intensity": "soft"
+      },
+      {
+        "id": "bench-challenge-01",
+        "type": "challenge",
+        "content": "Em 1 frase, descreve o que sentiu no último ponto perdido do treino.",
+        "weight": 0.7,
+        "played_as": "canal",
+        "intensity": "medium"
+      },
+      {
+        "id": "bench-diamond-01",
+        "type": "cultural_diamond",
+        "content": "Suzuki Daisetz — no kendo, mestre e discípulo se entendem mais pelo gesto que pela fala.",
+        "weight": 0.6,
+        "played_as": "diamante",
+        "intensity": "firm"
+      },
+      {
+        "id": "bench-strategy-01",
+        "type": "strategy",
+        "content": "Quando vier 'não sei', ancorar em micro-detalhe físico (cotovelo, grip, postura).",
+        "weight": 0.55,
+        "played_as": "bridge",
+        "intensity": "soft"
+      },
+      {
+        "id": "bench-play-01",
+        "type": "play",
+        "content": "Desmontar mentalmente uma jogada do dia em 3 frames: antes, durante, depois.",
+        "weight": 0.5,
+        "played_as": "arena",
+        "intensity": "medium"
+      }
+    ]
+  },
+  "producer": {
+    "menu": {
+      "persona_id": "ryo-ochiai",
+      "schema_version": "v0.2.0",
+      "generated_at": "2026-05-08T12:00:00.000Z",
+      "valid_until": "2026-05-15T12:00:00.000Z",
+      "source": {
+        "trust_level": 0.42,
+        "strategic_rationale": "Ryo é deflective; trust ainda baixo (0.42). Foco em curiosities visuais/concretas + ancorar em micro-gestos físicos (grip, postura) sem forçar verbalização. Evitar metacomunicação cedo na sessão.",
+        "context_hints": {
+          "language": "pt-br",
+          "mood": "deflective",
+          "urgency": "low",
+          "session_phase": "rapport_building",
+          "engagement_strategy": "concrete_physical_anchors"
+        }
+      },
+      "items": [
+        {
+          "id": "grip-notice",
+          "type": "curiosity",
+          "content": "Tipo, você reparou como o aperto da raquete muda quando você está calmo vs quando está ligado? Tem um momento no treino que o grip é mais leve — como se a raquete fosse parte do corpo.",
+          "weight": 0.35,
+          "played_as": "espelho",
+          "intensity": "soft"
+        },
+        {
+          "id": "arroz-no-prato",
+          "type": "curiosity",
+          "content": "Quando o papai coloca mais arroz no seu prato, você sente que ele tá dizendo algo sem falar. Tipo, o arroz é como uma palavra que só você entende. Você já pensou o que ele tá dizendo?",
+          "weight": 0.3,
+          "played_as": "bridge",
+          "intensity": "soft",
+          "is_critical": false
+        },
+        {
+          "id": "gohan-cell-silencio",
+          "type": "cultural_diamond",
+          "content": "No momento do Cell, o Gohan não grita. Ele só olha, e o silêncio dele é mais forte que todos os berros. Tipo, ele tá lá, presente, mas não precisa falar. É como se o silêncio fosse a última coisa que ele tem antes de explodir.",
+          "weight": 0.4,
+          "played_as": "diamante",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "desafio-silencio-treino",
+          "type": "challenge",
+          "content": "Tenta fazer um ponto no treino só com o corpo — sem falar, sem gritar. Só movimento. Tipo, como se o silêncio fosse o seu gol.",
+          "weight": 0.2,
+          "played_as": "canal",
+          "intensity": "medium"
+        },
+        {
+          "id": "gesto-afeto-kei",
+          "type": "curiosity",
+          "content": "Quando o Kei coloca a raquete no lugar certo depois do jogo, ele não olha pra você. Tipo, ele tá ali, mas não precisa te ver pra saber que você tá presente. Você já sentiu isso?",
+          "weight": 0.25,
+          "played_as": "espelho",
+          "intensity": "soft"
+        },
+        {
+          "id": "cara-de-bosta",
+          "type": "curiosity",
+          "content": "A cara de bosta que você faz no treino — tipo, quando erra o smash. Você já reparou que o Kei ri só de ver isso? Tipo, ele tá vendo você, mas não precisa falar nada.",
+          "weight": 0.3,
+          "played_as": "espelho",
+          "intensity": "soft"
+        },
+        {
+          "id": "raiva-ferrugem",
+          "type": "strategy",
+          "content": "Quando a raiva começa a subir, pensa em ferrugem. Não em fogo. Ferrugem. Ela não explode — ela corrode. E se você deixar ela corroer, ela pode te deixar mais forte sem que ninguém perceba.",
+          "weight": 0.2,
+          "played_as": "bridge",
+          "intensity": "soft",
+          "is_critical": false
+        },
+        {
+          "id": "jantar-silencio",
+          "type": "play",
+          "content": "Convida a desmontar o jantar silencioso em 3 etapas: 1) quem chegou primeiro? 2) quem colocou o arroz? 3) quem não falou nada, mas estava lá?",
+          "weight": 0.15,
+          "played_as": "canal",
+          "intensity": "soft"
+        },
+        {
+          "id": "gohan-igual",
+          "type": "cultural_diamond",
+          "content": "Gohan não é igual ao Cell. Ele é diferente. Mas o Cell só tem força. Gohan tem força e escolha. Quando ele olha pro Cell e diz 'não vou deixar', ele tá dizendo: 'eu sou eu'.",
+          "weight": 0.45,
+          "played_as": "diamante",
+          "intensity": "medium",
+          "is_critical": false
+        },
+        {
+          "id": "grip-antes-do-smash",
+          "type": "curiosity",
+          "content": "Antes de fazer o smash, você fecha os olhos por um segundo. Tipo, só pra sentir o peso da raquete. Isso é um tipo de ritual? Ou é só como você se prepara pra ser forte?",
+          "weight": 0.25,
+          "played_as": "canal",
+          "intensity": "soft"
+        },
+        {
+          "id": "divisao-chocolate",
+          "type": "curiosity",
+          "content": "Quando você divide o chocolate com o Kei, ele não pega o maior pedaço. Ele pega o que tá no meio. Tipo, ele tá dizendo que não quer ganhar, só quer estar junto. Você já sentiu isso?",
+          "weight": 0.3,
+          "played_as": "espelho",
+          "intensity": "soft"
+        },
+        {
+          "id": "recovery-silencio",
+          "type": "strategy",
+          "content": "Se sentir que tá prestes a explodir, respira fundo e pensa no silêncio do treino depois do jogo. Só o som da bola, o ar, e o suor. Tipo, o silêncio é onde você volta pra si mesmo.",
+          "weight": 0.2,
+          "played_as": "recovery",
+          "intensity": "soft",
+          "is_critical": true
+        },
+        {
+          "id": "gohan-transformacao",
+          "type": "play",
+          "content": "Tenta contar a história do Gohan no Cell só com gestos. Sem falar. Tipo, só com o corpo, como se o silêncio fosse o diálogo.",
+          "weight": 0.18,
+          "played_as": "arena",
+          "intensity": "medium"
+        }
+      ]
+    },
+    "warnings": [],
+    "latencyMs": 466169,
+    "tokensIn": 6811,
+    "tokensOut": 1665,
+    "fatalError": null
+  }
+}

--- a/docs/handoffs/2026-05-16-poc-fixture-vs-producer-ryo-ochiai.md
+++ b/docs/handoffs/2026-05-16-poc-fixture-vs-producer-ryo-ochiai.md
@@ -1,0 +1,172 @@
+# PoC qualitativo — fixture-vs-producer
+
+**Persona:** Ryo (deflective) (ryo-ochiai)
+**Trust level:** 0.42
+**Producer:** `generateActionMenu` (motor#117, prompt v0.4)
+**LLM:** Qwen3 30B local (`qwen3-30b`)
+**Data:** 2026-05-16T16:34:34.880Z
+
+## Pergunta que este PoC responde
+
+"Os campos `source.strategic_rationale` + `source.context_hints` que foram
+PRE-BAKED MANUALMENTE em `ryo-ochiai-menu.json` durante
+desenvolvimento de motor#115 (skip path) MATCH ou DEGRADAM quando comparados
+ao output REAL do producer rodando prompt v0.4 contra Qwen3 30B local?"
+
+Se MATCH ou melhor → fixtures podem ser substituídos por producer output
+(reduz manual burden, fixture vira CI-generated).
+Se DEGRADA → contract drift confirmado (Agent 11 leitura b); precisa fix
+prompt v0.5 antes de skip path em prod ser confiável.
+
+---
+
+## 1. `source.strategic_rationale` — side-by-side
+
+### Manual baked (`ryo-ochiai-menu.json`)
+
+> Ryo é deflective; trust ainda baixo (0.42). Foco em curiosities visuais/concretas + ancorar em micro-gestos físicos (grip, postura) sem forçar verbalização. Evitar metacomunicação cedo na sessão.
+
+_(195 chars)_
+
+### Producer-generated (Qwen3 + prompt v0.4)
+
+> Ryo é deflective; trust ainda baixo (0.42). Foco em curiosities visuais/concretas + ancorar em micro-gestos físicos (grip, postura) sem forçar verbalização. Evitar metacomunicação cedo na sessão.
+
+_(195 chars)_
+
+---
+
+## 2. `source.context_hints` — side-by-side
+
+### Manual baked
+
+  - `language`: `"pt-br"`
+  - `mood`: `"deflective"`
+  - `urgency`: `"low"`
+  - `session_phase`: `"rapport_building"`
+  - `engagement_strategy`: `"concrete_physical_anchors"`
+
+### Producer-generated
+
+  - `language`: `"pt-br"`
+  - `mood`: `"deflective"`
+  - `urgency`: `"low"`
+  - `session_phase`: `"rapport_building"`
+  - `engagement_strategy`: `"concrete_physical_anchors"`
+
+---
+
+## 3. Items — count + sample
+
+| | Manual baked | Producer-generated |
+|---|---|---|
+| Items count | 5 | 13 |
+| Sample item (first) | id=`bench-curio-01`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.85
+  > Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele. | id=`grip-notice`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.35
+  > Tipo, você reparou como o aperto da raquete muda quando você está calmo vs quando está ligado? Tem um momento no treino que o grip é mais leve — como se a raquete fosse parte do corpo. |
+
+### Items reais (producer-generated) — full list
+
+1. id=`grip-notice`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.35
+  > Tipo, você reparou como o aperto da raquete muda quando você está calmo vs quando está ligado? Tem um momento no treino que o grip é mais leve — como se a raquete fosse parte do corpo.
+2. id=`arroz-no-prato`, type=`curiosity`, played_as=`bridge`, intensity=`soft`, weight=0.3
+  > Quando o papai coloca mais arroz no seu prato, você sente que ele tá dizendo algo sem falar. Tipo, o arroz é como uma palavra que só você entende. Você já pensou o que ele tá dizendo?
+3. id=`gohan-cell-silencio`, type=`cultural_diamond`, played_as=`diamante`, intensity=`medium`, weight=0.4
+  > No momento do Cell, o Gohan não grita. Ele só olha, e o silêncio dele é mais forte que todos os berros. Tipo, ele tá lá, presente, mas não precisa falar. É como se o silêncio fosse a última coisa que ele tem antes de explodir.
+4. id=`desafio-silencio-treino`, type=`challenge`, played_as=`canal`, intensity=`medium`, weight=0.2
+  > Tenta fazer um ponto no treino só com o corpo — sem falar, sem gritar. Só movimento. Tipo, como se o silêncio fosse o seu gol.
+5. id=`gesto-afeto-kei`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.25
+  > Quando o Kei coloca a raquete no lugar certo depois do jogo, ele não olha pra você. Tipo, ele tá ali, mas não precisa te ver pra saber que você tá presente. Você já sentiu isso?
+6. id=`cara-de-bosta`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.3
+  > A cara de bosta que você faz no treino — tipo, quando erra o smash. Você já reparou que o Kei ri só de ver isso? Tipo, ele tá vendo você, mas não precisa falar nada.
+7. id=`raiva-ferrugem`, type=`strategy`, played_as=`bridge`, intensity=`soft`, weight=0.2
+  > Quando a raiva começa a subir, pensa em ferrugem. Não em fogo. Ferrugem. Ela não explode — ela corrode. E se você deixar ela corroer, ela pode te deixar mais forte sem que ninguém perceba.
+8. id=`jantar-silencio`, type=`play`, played_as=`canal`, intensity=`soft`, weight=0.15
+  > Convida a desmontar o jantar silencioso em 3 etapas: 1) quem chegou primeiro? 2) quem colocou o arroz? 3) quem não falou nada, mas estava lá?
+9. id=`gohan-igual`, type=`cultural_diamond`, played_as=`diamante`, intensity=`medium`, weight=0.45
+  > Gohan não é igual ao Cell. Ele é diferente. Mas o Cell só tem força. Gohan tem força e escolha. Quando ele olha pro Cell e diz 'não vou deixar', ele tá dizendo: 'eu sou eu'.
+10. id=`grip-antes-do-smash`, type=`curiosity`, played_as=`canal`, intensity=`soft`, weight=0.25
+  > Antes de fazer o smash, você fecha os olhos por um segundo. Tipo, só pra sentir o peso da raquete. Isso é um tipo de ritual? Ou é só como você se prepara pra ser forte?
+11. id=`divisao-chocolate`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.3
+  > Quando você divide o chocolate com o Kei, ele não pega o maior pedaço. Ele pega o que tá no meio. Tipo, ele tá dizendo que não quer ganhar, só quer estar junto. Você já sentiu isso?
+12. id=`recovery-silencio`, type=`strategy`, played_as=`recovery`, intensity=`soft`, weight=0.2, is_critical=true
+  > Se sentir que tá prestes a explodir, respira fundo e pensa no silêncio do treino depois do jogo. Só o som da bola, o ar, e o suor. Tipo, o silêncio é onde você volta pra si mesmo.
+13. id=`gohan-transformacao`, type=`play`, played_as=`arena`, intensity=`medium`, weight=0.18
+  > Tenta contar a história do Gohan no Cell só com gestos. Sem falar. Tipo, só com o corpo, como se o silêncio fosse o diálogo.
+
+### Items manuais (fixture baked) — full list
+
+1. id=`bench-curio-01`, type=`curiosity`, played_as=`espelho`, intensity=`soft`, weight=0.85
+  > Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele.
+2. id=`bench-challenge-01`, type=`challenge`, played_as=`canal`, intensity=`medium`, weight=0.7
+  > Em 1 frase, descreve o que sentiu no último ponto perdido do treino.
+3. id=`bench-diamond-01`, type=`cultural_diamond`, played_as=`diamante`, intensity=`firm`, weight=0.6
+  > Suzuki Daisetz — no kendo, mestre e discípulo se entendem mais pelo gesto que pela fala.
+4. id=`bench-strategy-01`, type=`strategy`, played_as=`bridge`, intensity=`soft`, weight=0.55
+  > Quando vier 'não sei', ancorar em micro-detalhe físico (cotovelo, grip, postura).
+5. id=`bench-play-01`, type=`play`, played_as=`arena`, intensity=`medium`, weight=0.5
+  > Desmontar mentalmente uma jogada do dia em 3 frames: antes, durante, depois.
+
+---
+
+## 4. Métricas objetivas (producer run)
+
+| Métrica | Valor |
+|---|---|
+| Generator outcome | ok (menu retornado) |
+| Latency total (ms) | 466169 |
+| Tokens in | 6811 |
+| Tokens out | 1665 |
+| Warnings | _(none)_ |
+| Schema version | v0.2.0 |
+
+### Warnings detalhados
+
+_(none)_
+
+---
+
+## 5. Verdict humano (Jun)
+
+Por dimensão:
+
+### `strategic_rationale`
+
+- [ ] **GO**: producer output ≥ manual quality → substituir fixture
+- [ ] **TUNE**: producer output aceitável mas com gaps → ajustar prompt v0.5
+- [ ] **NO-GO**: producer output degrada → manter fixture manual
+
+### `context_hints`
+
+- [ ] **GO**
+- [ ] **TUNE**
+- [ ] **NO-GO**
+
+### Items (estrutura + relevance)
+
+- [ ] **GO**
+- [ ] **TUNE**
+- [ ] **NO-GO**
+
+### Decisão agregada
+
+- [ ] **GO substituir fixtures por CI-generated**
+- [ ] **TUNE prompt v0.5** (fixture continua manual até prompt convergir)
+- [ ] **NO-GO continuar manual** (producer não é confiável pra skip path em prod)
+
+_Análise qualitativa pelo Jun:_
+
+**Specificity ao perfil Ryo (deflective):**
+
+**Persona-tuning (vocabulário, registro, estratégia):**
+
+**Gaps observados:**
+
+**Recomendação prompt v0.5 (se TUNE):**
+
+---
+
+_Methodology: PoC qualitativo (categoria proposta 2026-05-16) — distinto de
+unit/smoke (pass/fail), benchmark (quantitativo). Compara output do
+producer real (motor#117 mergeado) contra goldens manuais baked em
+fixtures durante dev de motor#115._

--- a/scripts/benchmark-menu-vs-pool.mjs
+++ b/scripts/benchmark-menu-vs-pool.mjs
@@ -30,7 +30,7 @@ import { Agent, setGlobalDispatcher } from "undici";
 
 // undici default headersTimeout=300s; Qwen3 30B pode demorar +5min.
 setGlobalDispatcher(
-  new Agent({ headersTimeout: 600_000, bodyTimeout: 600_000 }),
+  new Agent({ headersTimeout: 2_400_000, bodyTimeout: 2_400_000 }),
 );
 
 // ─── Config ─────────────────────────────────────────────────────────────
@@ -91,7 +91,7 @@ async function callQwen3(systemPrompt, userMessage) {
       max_tokens: 600,
       temperature: 0.7,
     }),
-    signal: AbortSignal.timeout(600_000),
+    signal: AbortSignal.timeout(2_400_000),
   });
   if (!resp.ok) throw new Error(`Qwen3 HTTP ${resp.status}`);
   const json = await resp.json();

--- a/scripts/measure-menu-variance.mjs
+++ b/scripts/measure-menu-variance.mjs
@@ -154,7 +154,7 @@ function makeQwen3LocalLlmCall() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(600_000),
+      signal: AbortSignal.timeout(2_400_000),
     });
     if (!resp.ok) throw new Error(`LLM local HTTP ${resp.status}`);
     const json = await resp.json();

--- a/scripts/poc-fixture-vs-producer.mjs
+++ b/scripts/poc-fixture-vs-producer.mjs
@@ -43,7 +43,7 @@ import yaml from "js-yaml";
 // pode demorar +5min até primeira resposta. Bump global (mesma config
 // que poc-isa-labels-quality.mjs).
 setGlobalDispatcher(
-  new Agent({ headersTimeout: 1_200_000, bodyTimeout: 1_200_000 }),
+  new Agent({ headersTimeout: 2_400_000, bodyTimeout: 2_400_000 }),
 );
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -134,7 +134,7 @@ function makeQwen3LlmCall() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(1_200_000),
+      signal: AbortSignal.timeout(2_400_000),
     });
     if (!resp.ok) throw new Error(`LLM local HTTP ${resp.status}`);
     const json = await resp.json();

--- a/scripts/poc-fixture-vs-producer.mjs
+++ b/scripts/poc-fixture-vs-producer.mjs
@@ -1,0 +1,473 @@
+#!/usr/bin/env node
+/**
+ * PoC qualitativo — fixture manual vs producer-generated rationale/hints.
+ *
+ * Categoria: PoC qualitativo (ops#1069). Distinto de:
+ *   - Unit/Smoke (pass/fail)
+ *   - Benchmark (quantitativo: cost, latency)
+ *
+ * Pergunta empírica (motor#117 follow-up):
+ *   "Os campos `source.strategic_rationale` + `source.context_hints` que
+ *    foram PRE-BAKED MANUALMENTE em fixtures (`ryo-ochiai-menu.json`,
+ *    `paula-mendes-menu.json`) durante motor#115 dev MATCH ou DEGRADAM
+ *    quando comparados ao output REAL do producer rodando prompt v0.4
+ *    contra Qwen3 30B local?"
+ *
+ * Se MATCH ou melhor → fixtures podem ser substituídos por producer output,
+ *   reduz manual burden (fixture vira CI-generated).
+ * Se DEGRADA → contract drift confirmado (Agent 11 leitura b); precisa fix
+ *   prompt v0.5 antes de skip path em prod ser confiável.
+ *
+ * Implementação: chama `generateActionMenu` (motor#117 producer) com
+ *   llmCall = Qwen3 direct fetch (padrão measure-menu-variance.mjs).
+ *   Captura `source.strategic_rationale` + `source.context_hints` + items.
+ *   Compara contra fixture manual baked. Emite handoff markdown side-by-side.
+ *
+ * Pré-req: Qwen3 stack up em LLM_LOCAL_ENDPOINT, fixtures Ryo/Paula presentes.
+ *
+ * Uso:
+ *   node scripts/poc-fixture-vs-producer.mjs --persona ryo
+ *   node scripts/poc-fixture-vs-producer.mjs --persona paula
+ *
+ * Tempo: ~5-10min por persona (1 Qwen3 menu generation call).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Agent, setGlobalDispatcher } from "undici";
+import yaml from "js-yaml";
+
+// undici default headersTimeout=300s; Qwen3 30B com prompt grande
+// pode demorar +5min até primeira resposta. Bump global (mesma config
+// que poc-isa-labels-quality.mjs).
+setGlobalDispatcher(
+  new Agent({ headersTimeout: 1_200_000, bodyTimeout: 1_200_000 }),
+);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+const argv = process.argv.slice(2);
+const PERSONA_KEY = argv[argv.indexOf("--persona") + 1] ?? "ryo";
+
+const ENDPOINT =
+  process.env.LLM_LOCAL_ENDPOINT ??
+  "http://172.28.160.1:9000/v1/chat/completions";
+const MODEL = process.env.LLM_LOCAL_MODEL ?? "qwen3-30b";
+
+// ─── Imports do build output do motor-drota ─────────────────────────────────
+const { generateActionMenu, PROMPT_TEMPLATE_VERSION } = await import(
+  path.join(REPO_ROOT, "motor-drota", "dist", "menu-generator.js")
+);
+const { RYO_HINT } = await import(
+  path.join(REPO_ROOT, "motor-drota", "dist", "persona-hints.js")
+);
+
+// ─── Persona specs ──────────────────────────────────────────────────────────
+//
+// Ryo: profile JSON em fixtures/profiles/ryo-ochiai.pre-phase2.json,
+//   hint canônico RYO_HINT (motor-drota/persona-hints.ts).
+// Paula: profile YAML em fixtures/paula-mendes.yaml (sintético LAST-CO).
+//   NÃO há PAULA_HINT canônico — construímos hint mínimo aqui pra alimentar
+//   prompt. Hint compatível com PersonaHint shape; bias inspirado no perfil
+//   "receptive curious analytical" da Paula (38a fintech architect).
+const PAULA_HINT = {
+  persona_id: "paula-mendes",
+  age: 38,
+  archetype: "analytical-receptive",
+  bias: [
+    { played_as: "canal", weight: 0.25 },
+    { played_as: "espelho", weight: 0.22 },
+    { played_as: "bridge", weight: 0.20 },
+    { played_as: "diamante", weight: 0.15 },
+    { played_as: "arena", weight: 0.10 },
+    { played_as: "recovery", weight: 0.08 },
+  ],
+  intensity_cap: "firm",  // adulto, não Kids
+  personal_vocab: [],
+  notes:
+    "Paula analytical-receptive: arquiteta sênior tech, 38a, intelectualiza " +
+    "afeto via análise; aceita bridge/diamante com âncora cultural ou " +
+    "técnica concreta (Bauman, Han, Arendt); evitar coaching-speak " +
+    "motivacional; respeita diretividade. Trust 0.42 — rapport_building.",
+};
+
+const PERSONAS = {
+  ryo: {
+    key: "ryo",
+    personaId: "ryo-ochiai",
+    personaLabel: "Ryo (deflective)",
+    trustLevel: 0.42,
+    profileFixture: "fixtures/profiles/ryo-ochiai.pre-phase2.json",
+    profileKind: "json",
+    manualFixture: "fixtures/profiles/ryo-ochiai-menu.json",
+    hint: RYO_HINT,
+  },
+  paula: {
+    key: "paula",
+    personaId: "paula-mendes",
+    personaLabel: "Paula (analytical-receptive)",
+    trustLevel: 0.42,
+    profileFixture: "fixtures/paula-mendes.yaml",
+    profileKind: "yaml",
+    manualFixture: "fixtures/profiles/paula-mendes-menu.json",
+    hint: PAULA_HINT,
+  },
+};
+
+// ─── Qwen3 LLM call adapter ─────────────────────────────────────────────────
+function makeQwen3LlmCall() {
+  return async (systemPrompt, userMessage) => {
+    const t0 = Date.now();
+    const body = {
+      model: MODEL,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userMessage },
+      ],
+      max_tokens: 3000,
+      temperature: 0.7,
+    };
+    const resp = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(1_200_000),
+    });
+    if (!resp.ok) throw new Error(`LLM local HTTP ${resp.status}`);
+    const json = await resp.json();
+    const latency_ms = Date.now() - t0;
+    return {
+      content: json.choices[0].message.content,
+      tokens: {
+        in: json.usage?.prompt_tokens ?? 0,
+        out: json.usage?.completion_tokens ?? 0,
+        reasoning: 0,
+      },
+      provider: "openai-compat",
+      model: MODEL,
+      // Anotação adicional (não faz parte do LlmCallResult interface mas
+      // útil pro PoC; ignorado pelo generator).
+      latency_ms,
+    };
+  };
+}
+
+async function probeQwen3() {
+  const probe = ENDPOINT.replace("/chat/completions", "/models");
+  console.log(`[poc] Probing ${probe}...`);
+  const r = await fetch(probe, { signal: AbortSignal.timeout(5000) });
+  if (!r.ok) throw new Error(`Qwen3 offline (HTTP ${r.status})`);
+  console.log("  ✓ Qwen3 up");
+}
+
+// ─── Profile loaders ────────────────────────────────────────────────────────
+function loadProfile(spec) {
+  const p = path.join(REPO_ROOT, spec.profileFixture);
+  const raw = readFileSync(p, "utf-8");
+  if (spec.profileKind === "yaml") return yaml.load(raw);
+  return JSON.parse(raw);
+}
+
+function loadManualFixture(spec) {
+  const p = path.join(REPO_ROOT, spec.manualFixture);
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+// ─── Markdown builder ───────────────────────────────────────────────────────
+function fmtHints(hints) {
+  if (!hints) return "_(null / absent)_";
+  if (typeof hints !== "object") return `_(unexpected shape: ${typeof hints})_`;
+  const keys = Object.keys(hints);
+  if (keys.length === 0) return "_(empty object)_";
+  return keys.map((k) => `  - \`${k}\`: \`${JSON.stringify(hints[k])}\``).join("\n");
+}
+
+function fmtRationale(r) {
+  if (!r) return "_(null / absent — producer não emitiu campo)_";
+  if (typeof r !== "string") return `_(unexpected shape: ${typeof r})_`;
+  return `> ${r}\n\n_(${r.length} chars)_`;
+}
+
+function fmtItem(item) {
+  if (!item) return "_(empty)_";
+  const fields = [
+    `id=\`${item.id}\``,
+    `type=\`${item.type}\``,
+    item.played_as ? `played_as=\`${item.played_as}\`` : null,
+    item.intensity ? `intensity=\`${item.intensity}\`` : null,
+    item.weight != null ? `weight=${item.weight}` : null,
+    item.is_critical ? `is_critical=true` : null,
+  ].filter(Boolean);
+  return `${fields.join(", ")}\n  > ${(item.content ?? "").replace(/\n/g, " ")}`;
+}
+
+function buildMarkdown(spec, manual, real, meta) {
+  const manualSrc = manual.source ?? {};
+  const realSrc = real.menu?.source ?? {};
+
+  const manualHints = manualSrc.context_hints;
+  const realHints = realSrc.context_hints;
+
+  const manualRationale = manualSrc.strategic_rationale;
+  const realRationale = realSrc.strategic_rationale;
+
+  const manualItems = manual.items ?? [];
+  const realItems = real.menu?.items ?? [];
+
+  const sampleManualItem = manualItems[0];
+  const sampleRealItem = realItems[0];
+
+  const warningsBlock = meta.warnings.length
+    ? meta.warnings.map((w) => `- \`${w}\``).join("\n")
+    : "_(none)_";
+
+  return `# PoC qualitativo — fixture-vs-producer
+
+**Persona:** ${spec.personaLabel} (${spec.personaId})
+**Trust level:** ${spec.trustLevel}
+**Producer:** \`generateActionMenu\` (motor#117, prompt ${PROMPT_TEMPLATE_VERSION})
+**LLM:** Qwen3 30B local (\`${MODEL}\`)
+**Data:** ${new Date().toISOString()}
+
+## Pergunta que este PoC responde
+
+"Os campos \`source.strategic_rationale\` + \`source.context_hints\` que foram
+PRE-BAKED MANUALMENTE em \`${path.basename(spec.manualFixture)}\` durante
+desenvolvimento de motor#115 (skip path) MATCH ou DEGRADAM quando comparados
+ao output REAL do producer rodando prompt v0.4 contra Qwen3 30B local?"
+
+Se MATCH ou melhor → fixtures podem ser substituídos por producer output
+(reduz manual burden, fixture vira CI-generated).
+Se DEGRADA → contract drift confirmado (Agent 11 leitura b); precisa fix
+prompt v0.5 antes de skip path em prod ser confiável.
+
+---
+
+## 1. \`source.strategic_rationale\` — side-by-side
+
+### Manual baked (\`${path.basename(spec.manualFixture)}\`)
+
+${fmtRationale(manualRationale)}
+
+### Producer-generated (Qwen3 + prompt ${PROMPT_TEMPLATE_VERSION})
+
+${fmtRationale(realRationale)}
+
+---
+
+## 2. \`source.context_hints\` — side-by-side
+
+### Manual baked
+
+${fmtHints(manualHints)}
+
+### Producer-generated
+
+${fmtHints(realHints)}
+
+---
+
+## 3. Items — count + sample
+
+| | Manual baked | Producer-generated |
+|---|---|---|
+| Items count | ${manualItems.length} | ${realItems.length} |
+| Sample item (first) | ${fmtItem(sampleManualItem)} | ${fmtItem(sampleRealItem)} |
+
+### Items reais (producer-generated) — full list
+
+${realItems.map((it, i) => `${i + 1}. ${fmtItem(it)}`).join("\n")}
+
+### Items manuais (fixture baked) — full list
+
+${manualItems.map((it, i) => `${i + 1}. ${fmtItem(it)}`).join("\n")}
+
+---
+
+## 4. Métricas objetivas (producer run)
+
+| Métrica | Valor |
+|---|---|
+| Generator outcome | ${real.menu ? "ok (menu retornado)" : "null (hard failure)"} |
+| Latency total (ms) | ${meta.latencyMs} |
+| Tokens in | ${meta.tokensIn} |
+| Tokens out | ${meta.tokensOut} |
+| Warnings | ${warningsBlock.replace(/\n/g, " ")} |
+| Schema version | ${real.menu?.schema_version ?? "—"} |
+
+### Warnings detalhados
+
+${warningsBlock}
+
+---
+
+## 5. Verdict humano (Jun)
+
+Por dimensão:
+
+### \`strategic_rationale\`
+
+- [ ] **GO**: producer output ≥ manual quality → substituir fixture
+- [ ] **TUNE**: producer output aceitável mas com gaps → ajustar prompt v0.5
+- [ ] **NO-GO**: producer output degrada → manter fixture manual
+
+### \`context_hints\`
+
+- [ ] **GO**
+- [ ] **TUNE**
+- [ ] **NO-GO**
+
+### Items (estrutura + relevance)
+
+- [ ] **GO**
+- [ ] **TUNE**
+- [ ] **NO-GO**
+
+### Decisão agregada
+
+- [ ] **GO substituir fixtures por CI-generated**
+- [ ] **TUNE prompt v0.5** (fixture continua manual até prompt convergir)
+- [ ] **NO-GO continuar manual** (producer não é confiável pra skip path em prod)
+
+_Análise qualitativa pelo Jun:_
+
+**Specificity ao perfil ${spec.personaLabel}:**
+
+**Persona-tuning (vocabulário, registro, estratégia):**
+
+**Gaps observados:**
+
+**Recomendação prompt v0.5 (se TUNE):**
+
+---
+
+_Methodology: PoC qualitativo (categoria proposta 2026-05-16) — distinto de
+unit/smoke (pass/fail), benchmark (quantitativo). Compara output do
+producer real (motor#117 mergeado) contra goldens manuais baked em
+fixtures durante dev de motor#115._
+`;
+}
+
+// ─── Main runner ────────────────────────────────────────────────────────────
+async function runOnePersona(spec) {
+  console.log(`\n[poc] === Persona: ${spec.personaLabel} ===`);
+  console.log(`  profile: ${spec.profileFixture}`);
+  console.log(`  manual fixture: ${spec.manualFixture}`);
+  console.log(`  prompt version: ${PROMPT_TEMPLATE_VERSION}`);
+
+  const profile = loadProfile(spec);
+  const manual = loadManualFixture(spec);
+
+  const warnings = [];
+  let lastTokensIn = 0;
+  let lastTokensOut = 0;
+
+  const baseCall = makeQwen3LlmCall();
+  const wrappedCall = async (sys, user) => {
+    console.log(`    Qwen3 call... (system=${sys.length} chars, user=${user.length} chars)`);
+    const r = await baseCall(sys, user);
+    lastTokensIn += r.tokens.in;
+    lastTokensOut += r.tokens.out;
+    console.log(`    ✓ ${r.latency_ms}ms, in=${r.tokens.in}, out=${r.tokens.out}`);
+    return r;
+  };
+
+  const t0 = Date.now();
+  let menu = null;
+  let fatalError = null;
+  try {
+    menu = await generateActionMenu(
+      {
+        personaId: spec.personaId,
+        trustLevel: spec.trustLevel,
+        profile,
+        personaHint: spec.hint,
+      },
+      {
+        llmCall: wrappedCall,
+        onWarning: (w) => {
+          warnings.push(w.code);
+          console.log(`    ⚠ warning: ${w.code} — ${w.message}`);
+        },
+      },
+    );
+  } catch (err) {
+    fatalError = err;
+    console.error(`    ✗ FATAL: ${err.message}`);
+  }
+  const latencyMs = Date.now() - t0;
+
+  if (fatalError) {
+    console.error(`\n[poc] Generator threw: ${fatalError.message}`);
+    console.error(fatalError.stack);
+  } else if (menu === null) {
+    console.error(`\n[poc] Generator returned null (hard failure path). Warnings: ${warnings.join(", ")}`);
+  } else {
+    console.log(`\n[poc] ✓ Generator returned menu with ${menu.items.length} items`);
+    console.log(`  rationale: ${menu.source?.strategic_rationale?.slice(0, 100) ?? "(absent)"}`);
+    console.log(`  hints: ${JSON.stringify(menu.source?.context_hints ?? null)}`);
+  }
+
+  const md = buildMarkdown(
+    spec,
+    manual,
+    { menu },
+    {
+      latencyMs,
+      tokensIn: lastTokensIn,
+      tokensOut: lastTokensOut,
+      warnings,
+      fatalError: fatalError ? String(fatalError.message) : null,
+    },
+  );
+
+  const date = new Date().toISOString().slice(0, 10);
+  const outDir = path.resolve(REPO_ROOT, "docs/handoffs");
+  await mkdir(outDir, { recursive: true });
+  const mdPath = path.join(
+    outDir,
+    `${date}-poc-fixture-vs-producer-${spec.personaId}.md`,
+  );
+  const jsonPath = path.join(
+    outDir,
+    `${date}-poc-fixture-vs-producer-${spec.personaId}-raw.json`,
+  );
+  writeFileSync(mdPath, md, "utf-8");
+  writeFileSync(
+    jsonPath,
+    JSON.stringify(
+      {
+        spec: { ...spec, hint: spec.hint },
+        manual,
+        producer: { menu, warnings, latencyMs, tokensIn: lastTokensIn, tokensOut: lastTokensOut, fatalError: fatalError ? String(fatalError.message) : null },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+
+  console.log(`\n[poc] Markdown: ${mdPath}`);
+  console.log(`[poc] Raw JSON: ${jsonPath}`);
+
+  return { menu, warnings, latencyMs, tokensIn: lastTokensIn, tokensOut: lastTokensOut, mdPath, jsonPath };
+}
+
+async function main() {
+  const spec = PERSONAS[PERSONA_KEY];
+  if (!spec) {
+    console.error(`Unknown persona: ${PERSONA_KEY}. Use ryo or paula.`);
+    process.exit(2);
+  }
+
+  await probeQwen3();
+  await runOnePersona(spec);
+}
+
+main().catch((err) => {
+  console.error("[poc] FATAL:", err);
+  process.exit(1);
+});

--- a/scripts/poc-isa-labels-quality.mjs
+++ b/scripts/poc-isa-labels-quality.mjs
@@ -37,7 +37,7 @@ import path from "node:path";
 import { Agent, setGlobalDispatcher } from "undici";
 
 setGlobalDispatcher(
-  new Agent({ headersTimeout: 1_200_000, bodyTimeout: 1_200_000 }),
+  new Agent({ headersTimeout: 2_400_000, bodyTimeout: 2_400_000 }),
 );
 
 const argv = process.argv.slice(2);
@@ -76,7 +76,7 @@ async function callQwen3(systemPrompt, userMessage, maxTokens = 600) {
       max_tokens: maxTokens,
       temperature: 0.7,
     }),
-    signal: AbortSignal.timeout(1_200_000),
+    signal: AbortSignal.timeout(2_400_000),
   });
   if (!resp.ok) throw new Error(`Qwen3 HTTP ${resp.status}`);
   const json = await resp.json();

--- a/scripts/poc-runner.mjs
+++ b/scripts/poc-runner.mjs
@@ -22,7 +22,7 @@ import { Agent, setGlobalDispatcher } from "undici";
 
 // undici default headersTimeout=300s; Qwen3 30B com prompt grande
 // pode demorar +5min até primeira resposta. Bump global.
-setGlobalDispatcher(new Agent({ headersTimeout: 600_000, bodyTimeout: 600_000 }));
+setGlobalDispatcher(new Agent({ headersTimeout: 2_400_000, bodyTimeout: 2_400_000 }));
 
 const ENDPOINT =
   process.env.LLM_LOCAL_ENDPOINT ??
@@ -44,7 +44,7 @@ export async function callQwen3(systemPrompt, userMessage, maxTokens = 600) {
       max_tokens: maxTokens,
       temperature: 0.7,
     }),
-    signal: AbortSignal.timeout(600_000),
+    signal: AbortSignal.timeout(2_400_000),
   });
   if (!resp.ok) throw new Error(`Qwen3 HTTP ${resp.status}`);
   const json = await resp.json();

--- a/scripts/smoke-inquiry-llm.mjs
+++ b/scripts/smoke-inquiry-llm.mjs
@@ -27,7 +27,7 @@ import { Agent, setGlobalDispatcher } from "undici";
 // undici default headersTimeout=300s; Qwen3 30B com prompt grande
 // pode demorar +5min até primeira resposta. Bump global.
 setGlobalDispatcher(
-  new Agent({ headersTimeout: 600_000, bodyTimeout: 600_000 }),
+  new Agent({ headersTimeout: 2_400_000, bodyTimeout: 2_400_000 }),
 );
 
 // USE_MOCK_LLM=true só pra planejador (que vai mockar rationale).
@@ -67,7 +67,7 @@ async function callQwen3(systemPrompt, userMessage) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    signal: AbortSignal.timeout(600_000), // 10min — prompt processing + gen pode passar 5min
+    signal: AbortSignal.timeout(2_400_000), // 10min — prompt processing + gen pode passar 5min
   });
   if (!resp.ok) throw new Error(`Qwen3 HTTP ${resp.status}: ${await resp.text()}`);
   const json = await resp.json();


### PR DESCRIPTION
## Summary

Script gerado por Agent 13 (paralelo) pra validar Agent 11's surprise finding sobre contract drift entre menu-generator v0.4 spec e drota behavior atual.

**Pergunta empírica**: source.strategic_rationale + context_hints que foram PRE-BAKED MANUALMENTE em fixtures Ryo + Paula durante motor#115 dev MATCH ou DEGRADAM quando comparados ao producer real rodando prompt v0.4 (motor#117) contra Qwen3 30B?

- Match/melhor → leitura (a) de Agent 11: generator cumpre v0.4. Producer-generated pode substituir fixtures.
- Degrada → leitura (b): contract drift confirmado. Prompt v0.5 needed antes de skip path em prod.

## Mudanças (1 commit)

- **`scripts/poc-fixture-vs-producer.mjs`** (NEW, 473 linhas)
  - Padrão poc-runner.mjs (motor#116) + measure-menu-variance.mjs (Qwen3 direct fetch)
  - Load persona profile JSON/YAML
  - Call generateActionMenu(profile, { llmCall: qwen3Direct })
  - Capture source.strategic_rationale + context_hints + items
  - Compare contra fixture atual
  - Handoff markdown side-by-side com verdict GO/TUNE/NO-GO + slots qualitativos

## NÃO rodado

Agent 13 saiu pós syntax check sem executar contra Qwen3. Script committed mas handoff doc NÃO existe ainda.

**Para executar**:
\`\`\`bash
# Qwen3 stack up + livre
cd /home/alexa/ascendimacy-motor
npm run build
node scripts/poc-fixture-vs-producer.mjs --persona ryo
node scripts/poc-fixture-vs-producer.mjs --persona paula
\`\`\`

Tempo esperado: ~5-10min Qwen3 por persona.

## Refs

- Agent 11 design exploration: ops#1070 comment-4467203554
- motor#117 (producer side mergeado)
- motor#115 (fixtures originais com manual rationale)
- ops#1069 (S-T-10-08 done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)