### PR TITLE
[feat ops#371] SACRIFICE_TYPES adiciona 'expose' + validation (Option A ratified)

### DIFF
--- a/shared/src/content-item.ts
+++ b/shared/src/content-item.ts
@@ -36,12 +36,34 @@ export const GARDNER_CHANNELS = [
 ] as const;
 export type GardnerChannel = (typeof GARDNER_CHANNELS)[number];
 
+/**
+ * Sacrifice type — categoria pedagógica do que o item pede da criança.
+ *
+ * Distinção semântica (ratificada Jun 2026-05-16 via ops#371 audit dos 3 hooks
+ * "expose": `bio_dolphin_names`, `bio_caterpillar_dissolve`, `myth_kintsugi_philosophy`):
+ *
+ *  - `reflect` — pensar/processar internamente. Sacrifice cognitivo.
+ *  - `create` — produzir algo novo (texto, desenho, ação criativa). Sacrifice produtivo.
+ *  - `act` — executar uma ação física/comportamental. Sacrifice de movimento.
+ *  - `share` — oferecer algo (conhecimento, recurso, opinião) ao outro. Sacrifice social-leve.
+ *  - `observe` — prestar atenção sem agir. Sacrifice perceptual.
+ *  - `expose` — revelar vulnerabilidade pessoal (luto, ferida, dissolução interior).
+ *                Sacrifice profundo / auto-exposição emocional.
+ *
+ *  `expose` ≠ `share`: share é generoso (oferece algo positivo); expose é
+ *  vulnerável (revela ferida). Items `expose` típicos têm `sacrifice_amount`
+ *  alto (12-16 vs 5-10 default) por refletir profundidade.
+ *
+ *  Ratificação: ops#371 E-080 audit + Jun 2026-05-16 escolha Option A
+ *  (expand enum vs substitute, optando por preservar signal pedagógico).
+ */
 export const SACRIFICE_TYPES = [
   "reflect",
   "create",
   "act",
   "share",
   "observe",
+  "expose",
 ] as const;
 export type SacrificeType = (typeof SACRIFICE_TYPES)[number];
 
@@ -213,5 +235,10 @@ export function isContentItem(value: unknown): value is ContentItem {
   if (typeof v.surprise !== "number") return false;
   if (typeof v.verified !== "boolean") return false;
   if (typeof v.base_score !== "number") return false;
+  // ops#371: validate sacrifice_type enum strict quando presente.
+  // Previne regressão futura (e.g., re-introdução de "expose" pre-ratification).
+  if (v.sacrifice_type !== undefined) {
+    if (!SACRIFICE_TYPES.includes(v.sacrifice_type as SacrificeType)) return false;
+  }
   return true;
 }


### PR DESCRIPTION
## Summary

ops#371 E-080 audit fix. Jun ratified 2026-05-16 Option A (expand enum) vs Option B (substitute → \"share\"), porque inspection dos 3 hooks revelou intent pedagógico diferenciado.

## Mudanças

- **shared/src/content-item.ts** — adiciona \`\"expose\"\` ao enum SACRIFICE_TYPES (5 → 6 valores)
- Inline doc define semantic distinction:
  - \`share\`: oferecer algo (knowledge/opinion/recurso) — social-leve
  - \`expose\`: revelar vulnerabilidade pessoal (luto/ferida/dissolução) — profundo
- \`isContentItem()\` add validation enum strict — previne regressão

## 3 hooks \"expose\" preservados (zero content changes)

| Hook | Quest | sacrifice_amount |
|------|-------|------------------|
| bio_dolphin_names | \"Pensa em algo que perdeu... 'assobiar o nome' dele\" | 16 |
| bio_caterpillar_dissolve | \"Pensa numa fase de 'casulo' — confuso, perdido?\" | null |
| myth_kintsugi_philosophy | \"Pensa numa 'rachadura' tua — algo que te machucou\" | 12 |

Padrão: items \`expose\` típicos têm sacrifice_amount alto (12-16 vs 5-10 default) refletindo profundidade emocional.

## Test plan

- [x] Build clean: \`npm run build -w @ascendimacy/shared\`
- [x] Full motor suite: 534 passed | 8 skipped (no regressions)
- [x] No schema migration needed (enum-add backward compatible)

## Refs

- ops#371 E-080 audit (closes when this merges)
- A27 investigation found 3 violations atual em seed.json
- Jun decision 2026-05-16 SWOT analysis Option A

🤖 Generated with [Claude Code](https://claude.com/claude-code)