### PR TITLE
[G-05] Double Helix cycle engine — port para motor TS canônico

### DIFF
--- a/motor-execucao/src/kids-helix-state.ts
+++ b/motor-execucao/src/kids-helix-state.ts
@@ -1,0 +1,216 @@
+/**
+ * kids_helix_state — persistência SQLite do Double Helix cycle engine
+ * (G-05, ops#1091). Sibling pattern de `kids_gardner_program`.
+ *
+ * Schema: 1 row por persona_id (UNIQUE). State machine puro vive em
+ * `planejador/src/strategist/helix-engine.ts`; este arquivo é só repo +
+ * DDL + bootstrap.
+ *
+ * Spec: ops#1091 sub-decisão 1 ratified Jun 2026-05-16.
+ */
+
+import type Database from "better-sqlite3";
+import type {
+  CaselDimension,
+  CaselDimensionPair,
+  KidsHelixMode,
+  KidsHelixState,
+  KidsHelixVacationTrigger,
+} from "@ascendimacy/shared";
+import {
+  defaultKidsHelixState,
+  KIDS_HELIX_MODES,
+  KIDS_HELIX_VACATION_TRIGGERS,
+} from "@ascendimacy/shared";
+import { getNow } from "./clock.js";
+
+export const KIDS_HELIX_STATE_DDL = `
+CREATE TABLE IF NOT EXISTS kids_helix_state (
+  persona_id TEXT PRIMARY KEY,
+  active_pair_0 TEXT NOT NULL,
+  active_pair_1 TEXT NOT NULL,
+  cycle_started_at TEXT NOT NULL,
+  current_day INTEGER NOT NULL DEFAULT 0,
+  mode TEXT NOT NULL DEFAULT 'active',
+  previous_pair_0 TEXT,
+  previous_pair_1 TEXT,
+  cycles_completed INTEGER NOT NULL DEFAULT 0,
+  queue_csv TEXT NOT NULL DEFAULT '',
+  completed_csv TEXT NOT NULL DEFAULT '',
+  deferred_csv TEXT NOT NULL DEFAULT '',
+  vacation_trigger TEXT,
+  vacation_started_at TEXT,
+  updated_at TEXT NOT NULL
+);
+`;
+
+interface KidsHelixRow {
+  persona_id: string;
+  active_pair_0: string;
+  active_pair_1: string;
+  cycle_started_at: string;
+  current_day: number;
+  mode: string;
+  previous_pair_0: string | null;
+  previous_pair_1: string | null;
+  cycles_completed: number;
+  queue_csv: string;
+  completed_csv: string;
+  deferred_csv: string;
+  vacation_trigger: string | null;
+  vacation_started_at: string | null;
+  updated_at: string;
+}
+
+function csvToDims(csv: string): CaselDimension[] {
+  if (!csv) return [];
+  return csv
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is CaselDimension =>
+      s === "SA" || s === "SM" || s === "SOC" || s === "REL" || s === "DM",
+    );
+}
+
+function dimsToCsv(dims: CaselDimension[]): string {
+  return dims.join(",");
+}
+
+function isMode(value: string): value is KidsHelixMode {
+  return (KIDS_HELIX_MODES as readonly string[]).includes(value);
+}
+
+function isVacationTrigger(value: string): value is KidsHelixVacationTrigger {
+  return (KIDS_HELIX_VACATION_TRIGGERS as readonly string[]).includes(value);
+}
+
+function rowToState(row: KidsHelixRow): KidsHelixState {
+  const pair: CaselDimensionPair = [
+    row.active_pair_0 as CaselDimension,
+    row.active_pair_1 as CaselDimension,
+  ];
+  const prev: CaselDimensionPair | null =
+    row.previous_pair_0 && row.previous_pair_1
+      ? [
+          row.previous_pair_0 as CaselDimension,
+          row.previous_pair_1 as CaselDimension,
+        ]
+      : null;
+  return {
+    persona_id: row.persona_id,
+    active_pair: pair,
+    cycle_started_at: row.cycle_started_at,
+    current_day: row.current_day,
+    mode: isMode(row.mode) ? row.mode : "active",
+    previous_pair: prev,
+    cycles_completed: row.cycles_completed,
+    queue: csvToDims(row.queue_csv),
+    completed: csvToDims(row.completed_csv),
+    deferred: csvToDims(row.deferred_csv),
+    vacation_trigger:
+      row.vacation_trigger && isVacationTrigger(row.vacation_trigger)
+        ? row.vacation_trigger
+        : null,
+    vacation_started_at: row.vacation_started_at,
+    updated_at: row.updated_at,
+  };
+}
+
+/**
+ * Lê estado atual do helix pra uma persona. Se ausente, retorna null —
+ * caller decide se bootstrap (via `bootstrapKidsHelixStateRow`) ou erro.
+ */
+export function getKidsHelixState(
+  db: Database.Database,
+  personaId: string,
+): KidsHelixState | null {
+  const row = db
+    .prepare("SELECT * FROM kids_helix_state WHERE persona_id = ?")
+    .get(personaId) as KidsHelixRow | undefined;
+  if (!row) return null;
+  return rowToState(row);
+}
+
+/**
+ * Persist (upsert) state — sobrescreve por persona_id.
+ *
+ * Caller (orchestrator) chama após qualquer state transition do helix-engine
+ * (cycleStart, dayAdvance, completeCycle, defer/resume, enter/exit vacation).
+ */
+export function updateKidsHelixState(
+  db: Database.Database,
+  state: KidsHelixState,
+  nowIso?: string,
+): KidsHelixState {
+  const ts = getNow(nowIso);
+  const updated = { ...state, updated_at: ts };
+  db.prepare(
+    `INSERT INTO kids_helix_state
+      (persona_id, active_pair_0, active_pair_1, cycle_started_at, current_day,
+       mode, previous_pair_0, previous_pair_1, cycles_completed, queue_csv,
+       completed_csv, deferred_csv, vacation_trigger, vacation_started_at,
+       updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(persona_id) DO UPDATE SET
+       active_pair_0 = excluded.active_pair_0,
+       active_pair_1 = excluded.active_pair_1,
+       cycle_started_at = excluded.cycle_started_at,
+       current_day = excluded.current_day,
+       mode = excluded.mode,
+       previous_pair_0 = excluded.previous_pair_0,
+       previous_pair_1 = excluded.previous_pair_1,
+       cycles_completed = excluded.cycles_completed,
+       queue_csv = excluded.queue_csv,
+       completed_csv = excluded.completed_csv,
+       deferred_csv = excluded.deferred_csv,
+       vacation_trigger = excluded.vacation_trigger,
+       vacation_started_at = excluded.vacation_started_at,
+       updated_at = excluded.updated_at`,
+  ).run(
+    updated.persona_id,
+    updated.active_pair[0],
+    updated.active_pair[1],
+    updated.cycle_started_at,
+    updated.current_day,
+    updated.mode,
+    updated.previous_pair?.[0] ?? null,
+    updated.previous_pair?.[1] ?? null,
+    updated.cycles_completed,
+    dimsToCsv(updated.queue),
+    dimsToCsv(updated.completed),
+    dimsToCsv(updated.deferred),
+    updated.vacation_trigger ?? null,
+    updated.vacation_started_at ?? null,
+    updated.updated_at,
+  );
+  return updated;
+}
+
+/**
+ * Bootstrap row pra persona nova. Wrapper de `defaultKidsHelixState` que
+ * persiste + retorna state criado.
+ *
+ * Idempotente: se row já existe, retorna existing (não sobrescreve).
+ *
+ * Sub-decisão 2: caller passa `firstPair` opcional resolvido externamente
+ * (via `computeInitialPair` do helix-engine ou hardcoded pra testes).
+ * Fallback SA+SOC já implícito em `defaultKidsHelixState`.
+ */
+export function bootstrapKidsHelixStateRow(
+  db: Database.Database,
+  args: {
+    personaId: string;
+    firstPair?: CaselDimensionPair;
+    nowIso?: string;
+  },
+): KidsHelixState {
+  const existing = getKidsHelixState(db, args.personaId);
+  if (existing) return existing;
+  const ts = getNow(args.nowIso);
+  const fresh = defaultKidsHelixState({
+    personaId: args.personaId,
+    nowIso: ts,
+    firstPair: args.firstPair,
+  });
+  return updateKidsHelixState(db, fresh, ts);
+}

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -7,6 +7,7 @@ import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
 import { PARENT_DECISIONS_DDL } from "./parent-decisions.js";
 import { EMITTED_CARDS_DDL } from "./cards-repo.js";
 import { CONTENT_USAGE_DDL } from "./content-usage-repo.js";
+import { KIDS_HELIX_STATE_DDL } from "./kids-helix-state.js";
 import { getNow, resolveDbPath } from "./clock.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -40,6 +41,7 @@ function getDb(dbPath?: string): Database.Database {
       ${PARENT_DECISIONS_DDL}
       ${EMITTED_CARDS_DDL}
       ${CONTENT_USAGE_DDL}
+      ${KIDS_HELIX_STATE_DDL}
     `);
   }
   return db;

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -7,7 +7,10 @@ import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
 import { PARENT_DECISIONS_DDL } from "./parent-decisions.js";
 import { EMITTED_CARDS_DDL } from "./cards-repo.js";
 import { CONTENT_USAGE_DDL } from "./content-usage-repo.js";
-import { KIDS_HELIX_STATE_DDL } from "./kids-helix-state.js";
+import {
+  KIDS_HELIX_STATE_DDL,
+  getKidsHelixState,
+} from "./kids-helix-state.js";
 import { getNow, resolveDbPath } from "./clock.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -47,7 +50,18 @@ function getDb(dbPath?: string): Database.Database {
   return db;
 }
 
-export function getState(sessionId: string, now?: string): SessionState {
+/**
+ * Hidrata SessionState a partir do SQLite. Inclui statusMatrix, gardnerProgram,
+ * eventLog. Aceita personaId opcional pra hidratar kidsHelixState (G-05).
+ *
+ * Backward compat: chamada antiga `getState(sessionId)` continua funcionando;
+ * kidsHelixState fica undefined. Caller que precisar do helix passa personaId.
+ */
+export function getState(
+  sessionId: string,
+  now?: string,
+  personaId?: string,
+): SessionState {
   const database = getDb();
   let row = database
     .prepare("SELECT * FROM sessions WHERE session_id = ?")
@@ -66,6 +80,9 @@ export function getState(sessionId: string, now?: string): SessionState {
     .all(sessionId) as Record<string, unknown>[];
   const statusMatrix = getStatusMatrix(database, sessionId);
   const gardnerProgram = getProgramState(database, sessionId);
+  const kidsHelixState = personaId
+    ? getKidsHelixState(database, personaId) ?? undefined
+    : undefined;
   return {
     sessionId,
     trustLevel: Number(row["trust_level"]),
@@ -73,6 +90,7 @@ export function getState(sessionId: string, now?: string): SessionState {
     turn: Number(row["turn"]),
     statusMatrix,
     gardnerProgram,
+    ...(kidsHelixState ? { kidsHelixState } : {}),
     eventLog: events.map((e) => ({
       timestamp: String(e["timestamp"]),
       type: String(e["type"]),

--- a/motor-execucao/tests/kids-helix-state.unit.test.ts
+++ b/motor-execucao/tests/kids-helix-state.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests pra kids_helix_state SQLite repo (G-05, ops#1091).
+ *
+ * Cobre: DDL, getKidsHelixState, updateKidsHelixState, bootstrapKidsHelixStateRow.
+ * Round-trip serialization (CSVs, previous_pair null handling, vacation_trigger).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  KIDS_HELIX_STATE_DDL,
+  bootstrapKidsHelixStateRow,
+  getKidsHelixState,
+  updateKidsHelixState,
+} from "../src/kids-helix-state.js";
+import { defaultKidsHelixState } from "@ascendimacy/shared";
+
+const NOW = "2026-05-16T12:00:00.000Z";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(KIDS_HELIX_STATE_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("kids_helix_state DDL", () => {
+  it("getKidsHelixState retorna null pra persona ausente", () => {
+    expect(getKidsHelixState(db, "ghost")).toBeNull();
+  });
+
+  it("bootstrap cria row + retorna state default", () => {
+    const state = bootstrapKidsHelixStateRow(db, {
+      personaId: "ryo",
+      nowIso: NOW,
+    });
+    expect(state.persona_id).toBe("ryo");
+    expect(state.active_pair).toEqual(["SA", "SOC"]);
+    expect(state.queue).toEqual(["SM", "REL", "DM"]);
+    expect(state.mode).toBe("active");
+    expect(state.cycles_completed).toBe(0);
+    expect(state.previous_pair).toBeNull();
+  });
+
+  it("bootstrap é idempotente (não sobrescreve existing)", () => {
+    const first = bootstrapKidsHelixStateRow(db, {
+      personaId: "ryo",
+      nowIso: NOW,
+    });
+    // Modify and persist
+    const modified = updateKidsHelixState(
+      db,
+      { ...first, cycles_completed: 5, current_day: 7 },
+      "2026-05-17T00:00:00.000Z",
+    );
+    expect(modified.cycles_completed).toBe(5);
+
+    // Bootstrap again — should return existing, NOT reset.
+    const second = bootstrapKidsHelixStateRow(db, {
+      personaId: "ryo",
+      nowIso: "2026-05-18T00:00:00.000Z",
+    });
+    expect(second.cycles_completed).toBe(5);
+    expect(second.current_day).toBe(7);
+  });
+
+  it("update + get round-trip preserva todos campos", () => {
+    const fresh = defaultKidsHelixState({
+      personaId: "kei",
+      nowIso: NOW,
+      firstPair: ["REL", "DM"],
+    });
+    const persisted = updateKidsHelixState(
+      db,
+      {
+        ...fresh,
+        previous_pair: ["SA", "SOC"],
+        cycles_completed: 3,
+        current_day: 8,
+        mode: "buffer",
+        completed: ["SA", "SOC"],
+        deferred: ["SM"],
+        vacation_trigger: "parental_request",
+        vacation_started_at: "2026-05-10T00:00:00.000Z",
+      },
+      NOW,
+    );
+    const loaded = getKidsHelixState(db, "kei");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.active_pair).toEqual(["REL", "DM"]);
+    expect(loaded!.previous_pair).toEqual(["SA", "SOC"]);
+    expect(loaded!.cycles_completed).toBe(3);
+    expect(loaded!.current_day).toBe(8);
+    expect(loaded!.mode).toBe("buffer");
+    expect(loaded!.completed).toEqual(["SA", "SOC"]);
+    expect(loaded!.deferred).toEqual(["SM"]);
+    expect(loaded!.vacation_trigger).toBe("parental_request");
+    expect(loaded!.vacation_started_at).toBe("2026-05-10T00:00:00.000Z");
+    void persisted;
+  });
+
+  it("CSV vazio (queue/completed/deferred) round-trips como array vazio", () => {
+    bootstrapKidsHelixStateRow(db, {
+      personaId: "p1",
+      firstPair: ["SA", "SM"],
+      nowIso: NOW,
+    });
+    const state = getKidsHelixState(db, "p1");
+    expect(state).not.toBeNull();
+    // Bootstrap deixa queue=[SOC, REL, DM], completed=[], deferred=[]
+    expect(state!.completed).toEqual([]);
+    expect(state!.deferred).toEqual([]);
+  });
+
+  it("previous_pair null round-trips (sem coluna NULL leak)", () => {
+    bootstrapKidsHelixStateRow(db, {
+      personaId: "p1",
+      nowIso: NOW,
+    });
+    const state = getKidsHelixState(db, "p1");
+    expect(state!.previous_pair).toBeNull();
+  });
+
+  it("update sobrescreve previous_pair de não-null pra null", () => {
+    const base = bootstrapKidsHelixStateRow(db, {
+      personaId: "p1",
+      nowIso: NOW,
+    });
+    updateKidsHelixState(db, { ...base, previous_pair: ["SA", "SOC"] }, NOW);
+    expect(getKidsHelixState(db, "p1")!.previous_pair).toEqual(["SA", "SOC"]);
+    updateKidsHelixState(db, { ...base, previous_pair: null }, NOW);
+    expect(getKidsHelixState(db, "p1")!.previous_pair).toBeNull();
+  });
+
+  it("update preserva persona_id (no spillover entre personas)", () => {
+    bootstrapKidsHelixStateRow(db, { personaId: "ryo", nowIso: NOW });
+    bootstrapKidsHelixStateRow(db, { personaId: "kei", nowIso: NOW });
+    expect(getKidsHelixState(db, "ryo")!.persona_id).toBe("ryo");
+    expect(getKidsHelixState(db, "kei")!.persona_id).toBe("kei");
+  });
+});

--- a/motor-execucao/tests/state-manager-helix.unit.test.ts
+++ b/motor-execucao/tests/state-manager-helix.unit.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Migration bootstrap: getState() com personaId hidrata kidsHelixState
+ * quando row presente, e backward-compat sem personaId.
+ *
+ * G-05, ops#1091 Step 4 — "Migration: bootstrap state quando persona nova".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getState, closeDb, getDbInstance } from "../src/state-manager.js";
+import { bootstrapKidsHelixStateRow } from "../src/kids-helix-state.js";
+import { rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  closeDb();
+  tmpDir = mkdtempSync(join(tmpdir(), "motor-helix-test-"));
+  process.env["MOTOR_STATE_DIR"] = tmpDir;
+});
+
+afterEach(() => {
+  closeDb();
+  delete process.env["MOTOR_STATE_DIR"];
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("getState × kids_helix_state hydration (G-05)", () => {
+  it("backward compat: getState(sessionId) sem personaId → kidsHelixState undefined", () => {
+    const state = getState("sess-1");
+    expect(state.kidsHelixState).toBeUndefined();
+  });
+
+  it("getState(sessionId, undefined, personaId) sem bootstrap → kidsHelixState undefined", () => {
+    const state = getState("sess-1", undefined, "ryo-no-row");
+    expect(state.kidsHelixState).toBeUndefined();
+  });
+
+  it("após bootstrap, getState hidrata kidsHelixState com active_pair fallback", () => {
+    // Cria DB primeiro (getState bootstrap)
+    getState("sess-1");
+    // Bootstrap helix row via repo
+    bootstrapKidsHelixStateRow(getDbInstance(), {
+      personaId: "ryo",
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    const state = getState("sess-1", undefined, "ryo");
+    expect(state.kidsHelixState).toBeDefined();
+    expect(state.kidsHelixState!.active_pair).toEqual(["SA", "SOC"]);
+    expect(state.kidsHelixState!.mode).toBe("active");
+    expect(state.kidsHelixState!.current_day).toBe(0);
+  });
+
+  it("personas distintas: hydration isolada por personaId", () => {
+    getState("sess-1");
+    bootstrapKidsHelixStateRow(getDbInstance(), {
+      personaId: "ryo",
+      firstPair: ["DM", "REL"],
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    bootstrapKidsHelixStateRow(getDbInstance(), {
+      personaId: "kei",
+      firstPair: ["SM", "SA"],
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    const ryoState = getState("sess-1", undefined, "ryo");
+    const keiState = getState("sess-1", undefined, "kei");
+    expect(ryoState.kidsHelixState!.active_pair).toEqual(["DM", "REL"]);
+    expect(keiState.kidsHelixState!.active_pair).toEqual(["SM", "SA"]);
+  });
+});

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -46,6 +46,7 @@ import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
 import { evaluateAllTransitions, collectRecentSignals } from "./trigger-evaluator.js";
 import { personaToChildProfile } from "./child-profile.js";
 import { lookupActionMenu } from "./strategist/menu-lookup.js";
+import { cycleProgress } from "./strategist/helix-engine.js";
 import {
   countInquiriesInSession,
   extractProfileConfig,
@@ -401,6 +402,33 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
       contextHints["gardner_pause_reason"] = gardnerInstruction.pauseReason;
     }
   }
+
+  // G-05 (ops#1091) — Double Helix cycle context.
+  // Injeta active_pair + cycle_progress + previous_pair pro drota
+  // entender em qual par de dims CASEL ancorar. Também serve ops#1020 G-07
+  // downstream (50%/100% triggers consomem cycle_progress).
+  //
+  // Hidratação é responsabilidade de motor-execucao (kids_helix_state repo).
+  // Se persona não tem state ainda (bootstrap pendente), helix block ausente
+  // — drota usa fallback CASEL via casel_focus_dimension (gate antigo).
+  const helixState = input.state.kidsHelixState;
+  if (helixState) {
+    contextHints["helix_active_pair"] = [...helixState.active_pair];
+    contextHints["helix_cycle_progress"] = cycleProgress(helixState);
+    contextHints["helix_cycle_day"] = helixState.current_day;
+    contextHints["helix_mode"] = helixState.mode;
+    contextHints["helix_cycles_completed"] = helixState.cycles_completed;
+    if (helixState.previous_pair) {
+      contextHints["helix_previous_pair"] = [...helixState.previous_pair];
+    }
+    if (helixState.mode === "vacation" && helixState.vacation_trigger) {
+      contextHints["helix_vacation_trigger"] = helixState.vacation_trigger;
+    }
+    if (helixState.deferred.length > 0) {
+      contextHints["helix_deferred_dims"] = [...helixState.deferred];
+    }
+  }
+
   if (triageMode !== "skipped") {
     contextHints["parental_triage_mode"] = triageMode;
     if (triageRejectedIds.length > 0) {

--- a/planejador/src/strategist/helix-engine.ts
+++ b/planejador/src/strategist/helix-engine.ts
@@ -1,0 +1,526 @@
+/**
+ * Helix Engine — Double Helix cycle state machine (G-05, ops#1091).
+ *
+ * Funções puras (sem side-effects, sem db). Caller (motor-execucao
+ * state-manager) é responsável por persistência.
+ *
+ * Sub-decisões ratified Jun 2026-05-16 (ops#1091 comment 4468127426):
+ *  1. Schema KidsHelixState — em `shared/src/contracts/kids-helix-state.ts`.
+ *  2. 50% overlap rotation algorithm + initial pair fallback SA+SOC.
+ *  3. State transitions canônicas (active→deferred via brejo/vacation/parental).
+ *  4. Modo férias trigger compound (parental + brejo>5d + sacrifice 3+ + family).
+ *
+ * **Quem chama o quê**:
+ *  - `cycleStart` — orchestrator on persona new OR on completeCycle when not vacation.
+ *  - `dayAdvance` — orchestrator at end of session (1x por dia ativo).
+ *  - `completeCycle` — orchestrator quando current_day chega ao TOTAL_DAYS-1.
+ *  - `deferDimension` — orchestrator quando detecta brejo>3d/vacation/parental.
+ *  - `resumeDimension` — orchestrator quando recovery confirmed.
+ *  - `enterVacation` / `exitVacation` — orchestrator on modo-férias triggers.
+ *  - `checkVacationTrigger` — orchestrator pre-cycle-start (sub-decisão 4).
+ *  - `computeNextPair` — interno; usado por `completeCycle`.
+ *
+ * Refs: ops#1091 spec, ops#1020 G-07 (downstream blocker — consome
+ * cycle_progress), ops#1033 G-22 (sacrifice exhaustion signal source).
+ */
+
+import type {
+  CaselDimension,
+} from "@ascendimacy/shared";
+import {
+  KIDS_HELIX_ACTIVE_DAYS,
+  KIDS_HELIX_BREJO_DEFER_DAYS,
+  KIDS_HELIX_BREJO_VACATION_DAYS,
+  KIDS_HELIX_DEFAULT_FALLBACK_PAIR,
+  KIDS_HELIX_SACRIFICE_EXHAUSTION_SESSIONS,
+  KIDS_HELIX_TOTAL_DAYS,
+  defaultKidsHelixState,
+  type CaselDimensionPair,
+  type KidsHelixDeferReason,
+  type KidsHelixResumeReason,
+  type KidsHelixState,
+  type KidsHelixVacationTrigger,
+} from "@ascendimacy/shared";
+
+/** Todas as 5 dims CASEL canônicas. */
+const ALL_CASEL_DIMS: CaselDimension[] = ["SA", "SM", "SOC", "REL", "DM"];
+
+/**
+ * Computa par inicial pra persona nova.
+ *
+ * Sub-decisão 2 ratified:
+ *  - Highest-need (lowest statusMatrix value) + complementary-engagement
+ *    (highest signal dim from G-02 baseline).
+ *  - Fallback SA+SOC se nenhum baseline disponível (Brota Mestre foundational).
+ *
+ * Caller passa `statusMatrix` (lowest = highest-need) + opcional `engagementSignals`
+ * (G-02 baseline). G-02 ainda não ratified em prod; fallback é caminho dominante hoje.
+ *
+ * @returns par de 2 dims distintas. Garantido never throw.
+ */
+export function computeInitialPair(args: {
+  statusMatrix?: Record<string, string>;
+  engagementSignals?: Partial<Record<CaselDimension, number>>;
+}): CaselDimensionPair {
+  // Highest-need: dim com pior status (brejo > baia > pasto).
+  // Pontuação inversa: brejo=3, baia=2, pasto=1, ausente=2 (default).
+  const statusScore = (val: string | undefined): number => {
+    if (val === "brejo") return 3;
+    if (val === "baia") return 2;
+    if (val === "pasto") return 1;
+    return 2;
+  };
+  const matrix = args.statusMatrix ?? {};
+  const needRanked = [...ALL_CASEL_DIMS].sort((a, b) => {
+    const diff = statusScore(matrix[b]) - statusScore(matrix[a]);
+    if (diff !== 0) return diff;
+    // Tie-break determinístico: ordem canônica SA, SM, SOC, REL, DM.
+    return ALL_CASEL_DIMS.indexOf(a) - ALL_CASEL_DIMS.indexOf(b);
+  });
+  const highestNeed = needRanked[0]!;
+
+  // Complementary: highest engagement (G-02). Fallback SOC se ausente / mesma dim.
+  const signals = args.engagementSignals ?? {};
+  const candidates = ALL_CASEL_DIMS.filter((d) => d !== highestNeed);
+  const hasSignals = candidates.some((d) => typeof signals[d] === "number");
+  if (!hasSignals) {
+    // G-02 baseline ausente — usa fallback SA+SOC se highest-need é SA, caso
+    // contrário pareia com SOC. Se highest-need já é SOC, pareia com SA.
+    const fallbackPartner: CaselDimension = highestNeed === "SOC" ? "SA" : "SOC";
+    if (highestNeed === fallbackPartner) {
+      // Edge: não pode acontecer (sempre distintos por construção).
+      return KIDS_HELIX_DEFAULT_FALLBACK_PAIR;
+    }
+    return [highestNeed, fallbackPartner];
+  }
+  const engagementRanked = [...candidates].sort((a, b) => {
+    const diff = (signals[b] ?? 0) - (signals[a] ?? 0);
+    if (diff !== 0) return diff;
+    return ALL_CASEL_DIMS.indexOf(a) - ALL_CASEL_DIMS.indexOf(b);
+  });
+  return [highestNeed, engagementRanked[0]!];
+}
+
+/**
+ * Cria estado inicial pra persona nova. Wrapper de `defaultKidsHelixState`
+ * que resolve par via `computeInitialPair`.
+ *
+ * Idempotente em sentido funcional — sempre retorna mesmo state pra mesmo input.
+ */
+export function bootstrapKidsHelixState(args: {
+  personaId: string;
+  nowIso: string;
+  statusMatrix?: Record<string, string>;
+  engagementSignals?: Partial<Record<CaselDimension, number>>;
+}): KidsHelixState {
+  const firstPair = computeInitialPair({
+    statusMatrix: args.statusMatrix,
+    engagementSignals: args.engagementSignals,
+  });
+  return defaultKidsHelixState({
+    personaId: args.personaId,
+    nowIso: args.nowIso,
+    firstPair,
+  });
+}
+
+/**
+ * Computa próximo par com 50% overlap (sub-decisão 2).
+ *
+ * Cycle N pair = [X, Y] → Cycle N+1 pair = [Y, Z] onde Z é primeiro da queue.
+ * Reshuffle quando `completed.length === 5`: todos voltam pra queue, novo
+ * par anchored em highest-engagement (caller passa signals via `engagementSignals`).
+ *
+ * @returns `{ pair, queue, completed }` — novo par + queues atualizadas.
+ *          Edge: queue vazia E completed < 5 → mantém Y, repete (caller deve
+ *          tratar como anomalia — só ocorre se defer drenar tudo).
+ */
+export function computeNextPair(args: {
+  currentPair: CaselDimensionPair;
+  queue: CaselDimension[];
+  completed: CaselDimension[];
+  engagementSignals?: Partial<Record<CaselDimension, number>>;
+}): { pair: CaselDimensionPair; queue: CaselDimension[]; completed: CaselDimension[] } {
+  const [, carry] = args.currentPair; // Y carry-over
+  const previousCompletedPlusCurrent = uniqueAppend(args.completed, args.currentPair[0]);
+
+  // Reshuffle: quando todas 5 dims foram "visitadas" (passaram pelo par ativo
+  // pelo menos uma vez). Como Y carrega pra próximo ciclo só após X ir pra
+  // completed, contamos: completed + X + Y. Se = 5 (todas), reshuffle.
+  //
+  // Spec lit "completed.length === 5": completed tracks X transitions only.
+  // Após cycle 4 ([REL,DM]), completed=[SA,SOC,SM]+REL = 4; DM ainda em pair[1].
+  // Cycle 5: X=DM → completed=[SA,SOC,SM,REL,DM]=5 → reshuffle.
+  // Ou seja: reshuffle quando queue vazia E todos cooperaram pelo menos 1x.
+  const wouldVisit = uniqueAppend(previousCompletedPlusCurrent, carry);
+  const allVisited = wouldVisit.length >= ALL_CASEL_DIMS.length;
+
+  if (allVisited && args.queue.length === 0) {
+    // Re-shuffle: nova rotação a partir de zero, anchored em engagement.
+    const signals = args.engagementSignals ?? {};
+    const ranked = [...ALL_CASEL_DIMS].sort((a, b) => {
+      const diff = (signals[b] ?? 0) - (signals[a] ?? 0);
+      if (diff !== 0) return diff;
+      return ALL_CASEL_DIMS.indexOf(a) - ALL_CASEL_DIMS.indexOf(b);
+    });
+    const newPair: CaselDimensionPair = [ranked[0]!, ranked[1]!];
+    const newQueue = ranked.slice(2);
+    return { pair: newPair, queue: newQueue, completed: [] };
+  }
+
+  // Normal 50% overlap. Z = primeiro elemento da queue não-presente em current_pair.
+  const candidates = args.queue.filter(
+    (d) => d !== args.currentPair[0] && d !== args.currentPair[1],
+  );
+  if (candidates.length === 0) {
+    // Queue drenada (defer extremo OU pré-reshuffle inválido). Mantém Y +
+    // procura qualquer dim restante non-carry, non-completed, non-queue.
+    // Se nada disponível, expande pra qualquer non-carry (fallback brando).
+    const strictFallback = ALL_CASEL_DIMS.find(
+      (d) =>
+        d !== carry &&
+        !previousCompletedPlusCurrent.includes(d) &&
+        !args.queue.includes(d),
+    );
+    const softFallback = strictFallback ?? ALL_CASEL_DIMS.find((d) => d !== carry);
+    const next: CaselDimensionPair = softFallback
+      ? [carry, softFallback]
+      : [carry, carry];
+    return {
+      pair: next,
+      queue: args.queue,
+      completed: previousCompletedPlusCurrent,
+    };
+  }
+  const next = candidates[0]!;
+  const remainingQueue = args.queue.filter((d) => d !== next);
+  return {
+    pair: [carry, next],
+    queue: remainingQueue,
+    completed: previousCompletedPlusCurrent,
+  };
+}
+
+/**
+ * Inicia novo ciclo. Para persona nova (state ausente), use
+ * `bootstrapKidsHelixState`. Para próximo ciclo após completar, use `completeCycle`.
+ *
+ * Sub-decisão 3: queue → active transition.
+ */
+export function cycleStart(args: {
+  state: KidsHelixState;
+  nowIso: string;
+}): KidsHelixState {
+  // No-op se já em modo active e current_day=0 (cycleStart idempotente).
+  if (args.state.mode === "active" && args.state.current_day === 0) {
+    return args.state;
+  }
+  return {
+    ...args.state,
+    cycle_started_at: args.nowIso,
+    current_day: 0,
+    mode: "active",
+    updated_at: args.nowIso,
+  };
+}
+
+/**
+ * Avança 1 dia no ciclo. Caller chama 1x por sessão completada.
+ *
+ * Mode transitions:
+ *  - active (0..13) → active (next day) | buffer (day 14)
+ *  - buffer (14..16) → buffer (next day) | ready-to-complete (day 17)
+ *  - vacation → no-op (sub-decisão 4: cycle paused)
+ *
+ * @returns novo state. Caller deve verificar `current_day >= TOTAL_DAYS-1`
+ *          pra disparar `completeCycle` no próximo turn.
+ */
+export function dayAdvance(args: {
+  state: KidsHelixState;
+  nowIso: string;
+}): KidsHelixState {
+  if (args.state.mode === "vacation") return args.state;
+  const nextDay = args.state.current_day + 1;
+  if (nextDay >= KIDS_HELIX_TOTAL_DAYS) {
+    // Cap at TOTAL_DAYS-1 (17). Caller decide se chama completeCycle.
+    return {
+      ...args.state,
+      current_day: KIDS_HELIX_TOTAL_DAYS - 1,
+      mode: "buffer",
+      updated_at: args.nowIso,
+    };
+  }
+  const newMode = nextDay >= KIDS_HELIX_ACTIVE_DAYS ? "buffer" : "active";
+  return {
+    ...args.state,
+    current_day: nextDay,
+    mode: newMode,
+    updated_at: args.nowIso,
+  };
+}
+
+/**
+ * Completa ciclo: move X (active_pair[0]) pra completed, Y (active_pair[1])
+ * carrega pra próximo ciclo, Z (próximo da queue) entra como nova segunda dim.
+ * Reset day/mode. Sub-decisões 2 + 3.
+ *
+ * Caller chama quando `current_day === TOTAL_DAYS - 1` (day 17).
+ *
+ * Edge: se em vacation, no-op (cycle não progride durante férias).
+ *
+ * Spec: "Cycle N pair = [X, Y] → Cycle N+1 pair = [Y, Z]" — Y carries over
+ * como retrieval source. X vira completed.
+ *
+ * Reshuffle (completed.length === 5 post-X): retorna tudo pra queue,
+ * novo par anchored em highest-engagement signals.
+ */
+export function completeCycle(args: {
+  state: KidsHelixState;
+  nowIso: string;
+  engagementSignals?: Partial<Record<CaselDimension, number>>;
+}): KidsHelixState {
+  if (args.state.mode === "vacation") return args.state;
+
+  const result = computeNextPair({
+    currentPair: args.state.active_pair,
+    queue: args.state.queue,
+    completed: args.state.completed,
+    engagementSignals: args.engagementSignals,
+  });
+
+  return {
+    ...args.state,
+    previous_pair: args.state.active_pair,
+    active_pair: result.pair,
+    queue: result.queue,
+    completed: result.completed,
+    cycle_started_at: args.nowIso,
+    current_day: 0,
+    mode: "active",
+    cycles_completed: args.state.cycles_completed + 1,
+    updated_at: args.nowIso,
+  };
+}
+
+/**
+ * Defere uma dimensão: move de active_pair pra deferred. Sub-decisão 3.
+ *
+ * Casos:
+ *  - active → deferred: extended_brejo / vacation_triggered / parental_pause.
+ *
+ * Quando uma dim do par é deferida, a outra continua no ciclo (par fica
+ * incompleto). Caller decide se quer também deferir a outra ou substituir
+ * por dim da queue. Por simplicidade, esta função só move 1 dim; caller
+ * orquestra substituição se necessário.
+ *
+ * Edge: dim já em deferred → no-op idempotente.
+ *
+ * @param substitute opcional — dim da queue pra substituir a deferida no par.
+ *                    Se ausente, par fica com a deferida marcada (caller deve
+ *                    tratar como "single-dim cycle" interim).
+ */
+export function deferDimension(args: {
+  state: KidsHelixState;
+  dim: CaselDimension;
+  reason: KidsHelixDeferReason;
+  nowIso: string;
+  substitute?: CaselDimension;
+}): KidsHelixState {
+  if (args.state.deferred.includes(args.dim)) return args.state;
+  // Só pode deferir dim que está no active_pair.
+  if (
+    args.state.active_pair[0] !== args.dim &&
+    args.state.active_pair[1] !== args.dim
+  ) {
+    return args.state;
+  }
+
+  const newDeferred = [...args.state.deferred, args.dim];
+  let newPair: CaselDimensionPair = args.state.active_pair;
+  let newQueue = args.state.queue;
+
+  if (args.substitute && args.state.queue.includes(args.substitute)) {
+    // Substitui dim deferida pelo substitute.
+    newPair =
+      args.state.active_pair[0] === args.dim
+        ? [args.substitute, args.state.active_pair[1]]
+        : [args.state.active_pair[0], args.substitute];
+    newQueue = args.state.queue.filter((d) => d !== args.substitute);
+  }
+
+  void args.reason; // razão é semântica (telemetria); state não armazena
+  // (caller deve emitir evento `helix.dim.deferred` com reason).
+  return {
+    ...args.state,
+    active_pair: newPair,
+    queue: newQueue,
+    deferred: newDeferred,
+    updated_at: args.nowIso,
+  };
+}
+
+/**
+ * Resume uma dimensão deferida → volta pra queue. Sub-decisão 3.
+ *
+ * Casos: recovery_confirmed / parental_resume / vacation_end.
+ *
+ * Edge: dim não em deferred → no-op.
+ */
+export function resumeDimension(args: {
+  state: KidsHelixState;
+  dim: CaselDimension;
+  reason: KidsHelixResumeReason;
+  nowIso: string;
+}): KidsHelixState {
+  if (!args.state.deferred.includes(args.dim)) return args.state;
+  void args.reason; // razão é semântica (telemetria).
+  return {
+    ...args.state,
+    deferred: args.state.deferred.filter((d) => d !== args.dim),
+    queue: uniqueAppend(args.state.queue, args.dim),
+    updated_at: args.nowIso,
+  };
+}
+
+/**
+ * Entra em modo férias. Sub-decisão 4.
+ *
+ * Pausa cycle progression (dayAdvance no-op em vacation). Cycle continua
+ * existindo (active_pair preservado) — só "congela" current_day.
+ */
+export function enterVacation(args: {
+  state: KidsHelixState;
+  trigger: KidsHelixVacationTrigger;
+  nowIso: string;
+}): KidsHelixState {
+  if (args.state.mode === "vacation") return args.state;
+  return {
+    ...args.state,
+    mode: "vacation",
+    vacation_trigger: args.trigger,
+    vacation_started_at: args.nowIso,
+    updated_at: args.nowIso,
+  };
+}
+
+/**
+ * Sai de modo férias. Sub-decisão 4 resume conditions.
+ *
+ * Restaura mode baseado em current_day (active se <14, buffer se ≥14).
+ */
+export function exitVacation(args: {
+  state: KidsHelixState;
+  nowIso: string;
+}): KidsHelixState {
+  if (args.state.mode !== "vacation") return args.state;
+  const restoredMode =
+    args.state.current_day >= KIDS_HELIX_ACTIVE_DAYS ? "buffer" : "active";
+  return {
+    ...args.state,
+    mode: restoredMode,
+    vacation_trigger: null,
+    vacation_started_at: null,
+    updated_at: args.nowIso,
+  };
+}
+
+/**
+ * Avalia se condições pra entrar em vacation estão satisfeitas. Sub-decisão 4.
+ *
+ * Trigger conditions (any single sufficient):
+ *  - parental_request — explicit `parent_decisions.vacation_start`
+ *  - brejo_emotional_persistent — statusMatrix.emotional === "brejo" por > BREJO_VACATION_DAYS
+ *  - sacrifice_exhaustion — N sessões consecutivas com `budget_exhausted`
+ *  - family_vacation_signal — event_log `family_vacation_start` recente
+ *
+ * NOTA SOBRE FONTES DE SINAL (honest gap):
+ *  Em F0 atual, alguns sinais não estão wired-up:
+ *   - `parent_decisions.vacation_start` — schema parent-decisions só tem
+ *     status approved/rejected/pinned (motor-execucao). Estende em followup.
+ *   - `family_vacation_start` event — não existe no event_log canônico hoje.
+ *   - sacrifice_exhaustion conta — caller passa via `consecutiveExhaustedSessions`.
+ *
+ *  Por enquanto, função aceita TODOS sinais via args (caller decide quais já
+ *  observa). Wire-up real fica pra G-05 follow-up + G-22 integration.
+ */
+export function checkVacationTrigger(args: {
+  state: KidsHelixState;
+  parentalVacationStart?: boolean;
+  consecutiveBrejoDaysEmotional?: number;
+  consecutiveExhaustedSessions?: number;
+  familyVacationSignal?: boolean;
+}): {
+  shouldEnterVacation: boolean;
+  trigger: KidsHelixVacationTrigger | null;
+  reasons: KidsHelixVacationTrigger[];
+} {
+  // No-op se já em vacation.
+  if (args.state.mode === "vacation") {
+    return { shouldEnterVacation: false, trigger: null, reasons: [] };
+  }
+  const reasons: KidsHelixVacationTrigger[] = [];
+  if (args.parentalVacationStart) reasons.push("parental_request");
+  if (
+    (args.consecutiveBrejoDaysEmotional ?? 0) > KIDS_HELIX_BREJO_VACATION_DAYS
+  ) {
+    reasons.push("brejo_emotional_persistent");
+  }
+  if (
+    (args.consecutiveExhaustedSessions ?? 0) >=
+    KIDS_HELIX_SACRIFICE_EXHAUSTION_SESSIONS
+  ) {
+    reasons.push("sacrifice_exhaustion");
+  }
+  if (args.familyVacationSignal) reasons.push("family_vacation_signal");
+
+  if (reasons.length === 0) {
+    return { shouldEnterVacation: false, trigger: null, reasons: [] };
+  }
+  // Trigger priority: parental > family > brejo > sacrifice (mais explícitos primeiro).
+  const priority: KidsHelixVacationTrigger[] = [
+    "parental_request",
+    "family_vacation_signal",
+    "brejo_emotional_persistent",
+    "sacrifice_exhaustion",
+  ];
+  const trigger = priority.find((p) => reasons.includes(p)) ?? reasons[0]!;
+  return { shouldEnterVacation: true, trigger, reasons };
+}
+
+/**
+ * Avalia se uma dim do par ativo deveria ser deferida por brejo prolongado.
+ * Sub-decisão 3 (active→deferred via extended_brejo).
+ *
+ * Caller passa contagem de dias consecutivos da dim em brejo. Threshold = 3.
+ */
+export function checkDeferTrigger(args: {
+  state: KidsHelixState;
+  dim: CaselDimension;
+  consecutiveBrejoDays: number;
+}): boolean {
+  if (
+    args.state.active_pair[0] !== args.dim &&
+    args.state.active_pair[1] !== args.dim
+  ) {
+    return false;
+  }
+  return args.consecutiveBrejoDays > KIDS_HELIX_BREJO_DEFER_DAYS;
+}
+
+/**
+ * Cycle progress 0.0..1.0 — usado por ops#1020 G-07 cadência 18d
+ * (50%/100% triggers).
+ */
+export function cycleProgress(state: KidsHelixState): number {
+  if (state.mode === "vacation") {
+    // Vacation = freeze. Progress reportado é current_day/TOTAL_DAYS.
+    return state.current_day / KIDS_HELIX_TOTAL_DAYS;
+  }
+  return Math.min(1, state.current_day / KIDS_HELIX_TOTAL_DAYS);
+}
+
+// -- Internal helpers --
+
+function uniqueAppend<T>(arr: T[], item: T): T[] {
+  return arr.includes(item) ? arr : [...arr, item];
+}

--- a/planejador/tests/helix-engine.unit.test.ts
+++ b/planejador/tests/helix-engine.unit.test.ts
@@ -1,0 +1,564 @@
+/**
+ * Unit tests pra helix-engine (G-05, ops#1091).
+ *
+ * Cobre 4 sub-decisões ratified Jun 2026-05-16:
+ *   1. Schema KidsHelixState — testado indiretamente via bootstrap/transitions.
+ *   2. 50% overlap rotation + initial pair fallback SA+SOC.
+ *   3. Queue/completed/deferred state transitions.
+ *   4. Modo férias trigger compound + behavior.
+ *
+ * Edge cases:
+ *   - All-dims-completed reshuffle
+ *   - Initial pair fallback (no G-02 baseline)
+ *   - 50% overlap continuity (cycle N→N+1→N+2)
+ *   - Vacation pauses dayAdvance
+ *   - Defer + substitute path
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  KIDS_HELIX_ACTIVE_DAYS,
+  KIDS_HELIX_DEFAULT_FALLBACK_PAIR,
+  KIDS_HELIX_TOTAL_DAYS,
+  type CaselDimension,
+  type KidsHelixState,
+} from "@ascendimacy/shared";
+import {
+  bootstrapKidsHelixState,
+  checkDeferTrigger,
+  checkVacationTrigger,
+  completeCycle,
+  computeInitialPair,
+  computeNextPair,
+  cycleProgress,
+  cycleStart,
+  dayAdvance,
+  deferDimension,
+  enterVacation,
+  exitVacation,
+  resumeDimension,
+} from "../src/strategist/helix-engine.js";
+
+const NOW = "2026-05-16T12:00:00.000Z";
+const LATER = "2026-05-17T12:00:00.000Z";
+
+describe("computeInitialPair (sub-decisão 2 — initial pair selection)", () => {
+  it("retorna fallback SA+SOC quando matrix vazia e signals ausentes", () => {
+    // Sem matrix nem signals, default 2 (baia) pra todas; tie-break canônico
+    // → SA primeiro. Sem signals → fallback partner SOC.
+    const pair = computeInitialPair({});
+    expect(pair[0]).toBe("SA");
+    expect(pair[1]).toBe("SOC");
+  });
+
+  it("highest-need vence (dim em brejo prioriza)", () => {
+    const pair = computeInitialPair({
+      statusMatrix: { SM: "brejo", SA: "pasto", SOC: "baia" },
+    });
+    expect(pair[0]).toBe("SM"); // único brejo
+    // Sem signals, partner é SOC (fallback porque SM != SOC).
+    expect(pair[1]).toBe("SOC");
+  });
+
+  it("complementary via engagement signals (G-02 baseline)", () => {
+    const pair = computeInitialPair({
+      statusMatrix: { SM: "brejo" },
+      engagementSignals: { REL: 0.9, DM: 0.4, SA: 0.7 },
+    });
+    expect(pair[0]).toBe("SM"); // highest need
+    expect(pair[1]).toBe("REL"); // highest engagement entre não-SM
+  });
+
+  it("se highest-need é SOC, fallback partner vira SA", () => {
+    const pair = computeInitialPair({
+      statusMatrix: { SOC: "brejo" },
+    });
+    expect(pair[0]).toBe("SOC");
+    expect(pair[1]).toBe("SA");
+  });
+
+  it("tie-break determinístico (ordem canônica SA, SM, SOC, REL, DM)", () => {
+    // Todas baia → tie em score 2. Sort estável devolve SA primeiro.
+    const pair = computeInitialPair({
+      statusMatrix: { SA: "baia", SM: "baia", SOC: "baia", REL: "baia", DM: "baia" },
+    });
+    expect(pair[0]).toBe("SA");
+  });
+});
+
+describe("bootstrapKidsHelixState (sub-decisão 1+2)", () => {
+  it("cria state pra persona nova com par computado", () => {
+    const state = bootstrapKidsHelixState({
+      personaId: "ryo",
+      nowIso: NOW,
+    });
+    expect(state.persona_id).toBe("ryo");
+    expect(state.active_pair).toEqual(KIDS_HELIX_DEFAULT_FALLBACK_PAIR);
+    expect(state.cycle_started_at).toBe(NOW);
+    expect(state.current_day).toBe(0);
+    expect(state.mode).toBe("active");
+    expect(state.previous_pair).toBeNull();
+    expect(state.cycles_completed).toBe(0);
+    expect(state.queue).toEqual(["SM", "REL", "DM"]); // restantes
+    expect(state.completed).toEqual([]);
+    expect(state.deferred).toEqual([]);
+    expect(state.vacation_trigger).toBeNull();
+  });
+
+  it("statusMatrix com brejo + signals → par computado correto", () => {
+    const state = bootstrapKidsHelixState({
+      personaId: "kei",
+      nowIso: NOW,
+      statusMatrix: { REL: "brejo" },
+      engagementSignals: { SM: 0.95 },
+    });
+    expect(state.active_pair).toEqual(["REL", "SM"]);
+    expect(state.queue).toEqual(["SA", "SOC", "DM"]);
+  });
+});
+
+describe("cycleStart (sub-decisão 3)", () => {
+  it("idempotente quando já em active + day=0", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const after = cycleStart({ state, nowIso: LATER });
+    expect(after).toEqual(state);
+  });
+
+  it("força reset day/mode quando state em buffer", () => {
+    const base = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const inBuffer: KidsHelixState = { ...base, mode: "buffer", current_day: 15 };
+    const after = cycleStart({ state: inBuffer, nowIso: LATER });
+    expect(after.mode).toBe("active");
+    expect(after.current_day).toBe(0);
+    expect(after.cycle_started_at).toBe(LATER);
+  });
+});
+
+describe("dayAdvance (sub-decisão 3)", () => {
+  it("avança de active 0→1 mantendo active", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const next = dayAdvance({ state, nowIso: LATER });
+    expect(next.current_day).toBe(1);
+    expect(next.mode).toBe("active");
+  });
+
+  it("transiciona pra buffer no dia 14", () => {
+    const base = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const day13: KidsHelixState = { ...base, current_day: 13, mode: "active" };
+    const next = dayAdvance({ state: day13, nowIso: LATER });
+    expect(next.current_day).toBe(KIDS_HELIX_ACTIVE_DAYS);
+    expect(next.mode).toBe("buffer");
+  });
+
+  it("cap no TOTAL_DAYS-1 (dia 17)", () => {
+    const base = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const day17: KidsHelixState = { ...base, current_day: 17, mode: "buffer" };
+    const next = dayAdvance({ state: day17, nowIso: LATER });
+    expect(next.current_day).toBe(KIDS_HELIX_TOTAL_DAYS - 1);
+    expect(next.mode).toBe("buffer");
+  });
+
+  it("vacation pausa advance (sub-decisão 4 behavior)", () => {
+    const base = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const onVacation = enterVacation({
+      state: base,
+      trigger: "parental_request",
+      nowIso: LATER,
+    });
+    const after = dayAdvance({ state: onVacation, nowIso: LATER });
+    expect(after.current_day).toBe(0); // unchanged
+    expect(after.mode).toBe("vacation");
+  });
+});
+
+describe("computeNextPair (sub-decisão 2 — 50% overlap rotation)", () => {
+  it("Y carry-over: [X,Y] → [Y,Z] onde Z é primeiro da queue", () => {
+    const result = computeNextPair({
+      currentPair: ["SA", "SOC"],
+      queue: ["SM", "REL", "DM"],
+      completed: [],
+    });
+    expect(result.pair).toEqual(["SOC", "SM"]);
+    expect(result.queue).toEqual(["REL", "DM"]);
+    expect(result.completed).toEqual(["SA"]);
+  });
+
+  it("preserva ordem queue (FIFO da queue)", () => {
+    const result = computeNextPair({
+      currentPair: ["SOC", "SM"],
+      queue: ["REL", "DM"],
+      completed: ["SA"],
+    });
+    expect(result.pair).toEqual(["SM", "REL"]);
+    expect(result.queue).toEqual(["DM"]);
+    expect(result.completed).toEqual(["SA", "SOC"]);
+  });
+
+  it("reshuffle quando completed atinge 5 dims", () => {
+    // [DM, SA] completing → completed=[SM,SOC,REL,DM,SA]=5 → reshuffle.
+    const result = computeNextPair({
+      currentPair: ["DM", "SA"],
+      queue: [],
+      completed: ["SM", "SOC", "REL"],
+      engagementSignals: { REL: 1.0, SM: 0.5 },
+    });
+    expect(result.completed).toEqual([]); // reset
+    // New pair anchored em highest engagement: REL (1.0), SM (0.5).
+    expect(result.pair).toEqual(["REL", "SM"]);
+    expect(result.queue).toContain("SA");
+    expect(result.queue).toContain("SOC");
+    expect(result.queue).toContain("DM");
+    expect(result.queue).toHaveLength(3);
+  });
+
+  it("reshuffle sem signals: ordem canônica tie-break", () => {
+    const result = computeNextPair({
+      currentPair: ["DM", "SA"],
+      queue: [],
+      completed: ["SM", "SOC", "REL"],
+    });
+    expect(result.pair).toEqual(["SA", "SM"]); // canonical SA,SM first
+  });
+
+  it("queue drenada (edge) usa fallback dim restante", () => {
+    // Cenário extremo: queue vazia mas só 2 completed.
+    const result = computeNextPair({
+      currentPair: ["SA", "SOC"],
+      queue: [],
+      completed: ["SM"], // só 1 prior
+    });
+    // wouldComplete = [SM, SA] = 2 (< 5). Candidates da queue = []. Fallback
+    // procura dim non-current, non-completed, non-queue → REL ou DM.
+    // SOC carries; partner é primeiro fallback. Cand: SM (no completed), REL, DM.
+    expect(result.pair[0]).toBe("SOC"); // Y carries
+    expect(["REL", "DM"]).toContain(result.pair[1]);
+  });
+});
+
+describe("completeCycle (sub-decisão 2+3 integration)", () => {
+  it("incrementa cycles_completed + previous_pair = old active_pair", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const after = completeCycle({ state, nowIso: LATER });
+    expect(after.cycles_completed).toBe(1);
+    expect(after.previous_pair).toEqual(state.active_pair);
+    expect(after.active_pair).toEqual(["SOC", "SM"]);
+    expect(after.current_day).toBe(0);
+    expect(after.mode).toBe("active");
+    expect(after.cycle_started_at).toBe(LATER);
+  });
+
+  it("vacation: completeCycle é no-op (cycle congelado)", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const onVacation = enterVacation({
+      state,
+      trigger: "family_vacation_signal",
+      nowIso: LATER,
+    });
+    const after = completeCycle({ state: onVacation, nowIso: LATER });
+    expect(after).toEqual(onVacation);
+  });
+
+  it("50% overlap continuity: 3 ciclos consecutivos preservam carry-over", () => {
+    let state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    // Cycle 1: [SA, SOC]
+    expect(state.active_pair).toEqual(["SA", "SOC"]);
+    state = completeCycle({ state, nowIso: NOW });
+    // Cycle 2: [SOC, SM] — SOC carries
+    expect(state.active_pair).toEqual(["SOC", "SM"]);
+    state = completeCycle({ state, nowIso: NOW });
+    // Cycle 3: [SM, REL] — SM carries
+    expect(state.active_pair).toEqual(["SM", "REL"]);
+    state = completeCycle({ state, nowIso: NOW });
+    // Cycle 4: [REL, DM]
+    expect(state.active_pair).toEqual(["REL", "DM"]);
+    // Cycle 5: completing → all 5 hit → reshuffle.
+    state = completeCycle({ state, nowIso: NOW });
+    expect(state.completed).toEqual([]);
+    expect(state.cycles_completed).toBe(4);
+  });
+});
+
+describe("deferDimension (sub-decisão 3 — active→deferred)", () => {
+  it("move dim do par pra deferred", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const after = deferDimension({
+      state,
+      dim: "SA",
+      reason: "extended_brejo",
+      nowIso: LATER,
+    });
+    expect(after.deferred).toContain("SA");
+    expect(after.active_pair).toEqual(state.active_pair); // sem substitute, par inalterado
+  });
+
+  it("com substitute, troca dim do par", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const after = deferDimension({
+      state,
+      dim: "SA",
+      reason: "vacation_triggered",
+      nowIso: LATER,
+      substitute: "REL",
+    });
+    expect(after.deferred).toContain("SA");
+    expect(after.active_pair).toEqual(["REL", "SOC"]);
+    expect(after.queue).not.toContain("REL");
+  });
+
+  it("no-op se dim não está no par ativo", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const after = deferDimension({
+      state,
+      dim: "DM", // não está no par (SA,SOC)
+      reason: "parental_pause",
+      nowIso: LATER,
+    });
+    expect(after).toEqual(state);
+  });
+
+  it("idempotente: dim já deferida não duplica", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const once = deferDimension({
+      state,
+      dim: "SA",
+      reason: "extended_brejo",
+      nowIso: LATER,
+    });
+    const twice = deferDimension({
+      state: once,
+      dim: "SA",
+      reason: "extended_brejo",
+      nowIso: LATER,
+    });
+    expect(twice.deferred).toEqual(["SA"]);
+  });
+});
+
+describe("resumeDimension (sub-decisão 3 — deferred→queue)", () => {
+  it("move dim de deferred pra queue", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const deferred = deferDimension({
+      state,
+      dim: "SA",
+      reason: "extended_brejo",
+      nowIso: LATER,
+    });
+    const resumed = resumeDimension({
+      state: deferred,
+      dim: "SA",
+      reason: "recovery_confirmed",
+      nowIso: LATER,
+    });
+    expect(resumed.deferred).not.toContain("SA");
+    expect(resumed.queue).toContain("SA");
+  });
+
+  it("no-op se dim não está em deferred", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const after = resumeDimension({
+      state,
+      dim: "DM",
+      reason: "parental_resume",
+      nowIso: LATER,
+    });
+    expect(after).toEqual(state);
+  });
+});
+
+describe("enterVacation / exitVacation (sub-decisão 4)", () => {
+  it("enterVacation marca trigger + timestamp", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const after = enterVacation({
+      state,
+      trigger: "brejo_emotional_persistent",
+      nowIso: LATER,
+    });
+    expect(after.mode).toBe("vacation");
+    expect(after.vacation_trigger).toBe("brejo_emotional_persistent");
+    expect(after.vacation_started_at).toBe(LATER);
+  });
+
+  it("exitVacation restaura mode active (current_day < 14)", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const onVacation = enterVacation({
+      state,
+      trigger: "parental_request",
+      nowIso: LATER,
+    });
+    const after = exitVacation({ state: onVacation, nowIso: LATER });
+    expect(after.mode).toBe("active");
+    expect(after.vacation_trigger).toBeNull();
+    expect(after.vacation_started_at).toBeNull();
+  });
+
+  it("exitVacation restaura buffer se current_day >= 14", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const buffered: KidsHelixState = { ...state, current_day: 16, mode: "active" };
+    const onVacation = enterVacation({
+      state: buffered,
+      trigger: "parental_request",
+      nowIso: LATER,
+    });
+    const after = exitVacation({ state: onVacation, nowIso: LATER });
+    expect(after.mode).toBe("buffer");
+  });
+
+  it("enterVacation idempotente", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const first = enterVacation({
+      state,
+      trigger: "parental_request",
+      nowIso: LATER,
+    });
+    const second = enterVacation({
+      state: first,
+      trigger: "family_vacation_signal", // different trigger
+      nowIso: LATER,
+    });
+    expect(second).toEqual(first); // first trigger wins
+  });
+});
+
+describe("checkVacationTrigger (sub-decisão 4 — compound trigger)", () => {
+  const baseState = (overrides?: Partial<KidsHelixState>): KidsHelixState => ({
+    ...bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW }),
+    ...overrides,
+  });
+
+  it("parental_request triggers (single condition sufficient)", () => {
+    const result = checkVacationTrigger({
+      state: baseState(),
+      parentalVacationStart: true,
+    });
+    expect(result.shouldEnterVacation).toBe(true);
+    expect(result.trigger).toBe("parental_request");
+  });
+
+  it("brejo>5 dias triggers brejo_emotional_persistent", () => {
+    const result = checkVacationTrigger({
+      state: baseState(),
+      consecutiveBrejoDaysEmotional: 6,
+    });
+    expect(result.shouldEnterVacation).toBe(true);
+    expect(result.trigger).toBe("brejo_emotional_persistent");
+  });
+
+  it("brejo=5 não dispara (strict >)", () => {
+    const result = checkVacationTrigger({
+      state: baseState(),
+      consecutiveBrejoDaysEmotional: 5,
+    });
+    expect(result.shouldEnterVacation).toBe(false);
+  });
+
+  it("sacrifice_exhaustion 3+ triggers", () => {
+    const result = checkVacationTrigger({
+      state: baseState(),
+      consecutiveExhaustedSessions: 3,
+    });
+    expect(result.shouldEnterVacation).toBe(true);
+    expect(result.trigger).toBe("sacrifice_exhaustion");
+  });
+
+  it("sacrifice 2 não dispara (precisa 3+)", () => {
+    const result = checkVacationTrigger({
+      state: baseState(),
+      consecutiveExhaustedSessions: 2,
+    });
+    expect(result.shouldEnterVacation).toBe(false);
+  });
+
+  it("family_vacation_signal triggers", () => {
+    const result = checkVacationTrigger({
+      state: baseState(),
+      familyVacationSignal: true,
+    });
+    expect(result.shouldEnterVacation).toBe(true);
+    expect(result.trigger).toBe("family_vacation_signal");
+  });
+
+  it("priority: parental > family > brejo > sacrifice (multiple)", () => {
+    const result = checkVacationTrigger({
+      state: baseState(),
+      parentalVacationStart: true,
+      consecutiveBrejoDaysEmotional: 10,
+      consecutiveExhaustedSessions: 5,
+      familyVacationSignal: true,
+    });
+    expect(result.trigger).toBe("parental_request");
+    expect(result.reasons).toHaveLength(4);
+  });
+
+  it("no-op se já em vacation", () => {
+    const onVacation = enterVacation({
+      state: baseState(),
+      trigger: "parental_request",
+      nowIso: LATER,
+    });
+    const result = checkVacationTrigger({
+      state: onVacation,
+      parentalVacationStart: true,
+    });
+    expect(result.shouldEnterVacation).toBe(false);
+  });
+
+  it("nenhuma condição → não dispara", () => {
+    const result = checkVacationTrigger({ state: baseState() });
+    expect(result.shouldEnterVacation).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+});
+
+describe("checkDeferTrigger (sub-decisão 3 — brejo>3d defer)", () => {
+  it("brejo=4 (dim no par) → defer", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    expect(
+      checkDeferTrigger({
+        state,
+        dim: "SA",
+        consecutiveBrejoDays: 4,
+      }),
+    ).toBe(true);
+  });
+
+  it("brejo=3 → não defer (strict >)", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    expect(
+      checkDeferTrigger({
+        state,
+        dim: "SA",
+        consecutiveBrejoDays: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("dim fora do par ativo → não defer", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    expect(
+      checkDeferTrigger({
+        state,
+        dim: "DM" satisfies CaselDimension,
+        consecutiveBrejoDays: 10,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("cycleProgress (G-07 downstream consumption)", () => {
+  it("dia 0 → 0.0", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    expect(cycleProgress(state)).toBeCloseTo(0);
+  });
+
+  it("dia 9 → ~0.5 (G-07 50% trigger zone)", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const day9: KidsHelixState = { ...state, current_day: 9 };
+    expect(cycleProgress(day9)).toBeCloseTo(9 / 18);
+  });
+
+  it("dia 17 (last) ≈ 1.0", () => {
+    const state = bootstrapKidsHelixState({ personaId: "p1", nowIso: NOW });
+    const day17: KidsHelixState = { ...state, current_day: 17, mode: "buffer" };
+    expect(cycleProgress(day17)).toBeCloseTo(17 / 18);
+  });
+});

--- a/planejador/tests/plan-helix-integration.unit.test.ts
+++ b/planejador/tests/plan-helix-integration.unit.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration: planTurn injeta contextHints helix quando kidsHelixState
+ * presente em SessionState (G-05, ops#1091).
+ */
+
+import { describe, it, expect } from "vitest";
+import { planTurn } from "../src/plan.js";
+import { bootstrapKidsHelixState } from "../src/strategist/helix-engine.js";
+
+process.env["USE_MOCK_LLM"] = "true";
+
+const mockPersona = {
+  id: "ryo",
+  name: "Ryo",
+  age: 13,
+  profile: { interests: ["dragon_ball"] },
+};
+
+const mockAdquirente = {
+  id: "jun",
+  name: "Jun Ochiai",
+  defaults: { style: "direto", language: "pt-br" },
+};
+
+const mockInventory = [
+  {
+    id: "kids.helix.session",
+    title: "Helix session",
+    category: "kids",
+    estimatedSacrifice: 1,
+    estimatedConfidenceGain: 4,
+  },
+];
+
+const baseState = {
+  sessionId: "test-helix",
+  trustLevel: 0.3,
+  budgetRemaining: 100,
+  turn: 0,
+  eventLog: [],
+};
+
+describe("planTurn × KidsHelixState (G-05 integration)", () => {
+  it("sem helix state → contextHints sem helix_* keys (backward compat)", async () => {
+    const output = await planTurn({
+      sessionId: "test-helix",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: baseState,
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["helix_active_pair"]).toBeUndefined();
+    expect(output.contextHints["helix_cycle_progress"]).toBeUndefined();
+  });
+
+  it("com helix state ativo → injeta active_pair + cycle_progress + cycle_day + mode", async () => {
+    const helixState = bootstrapKidsHelixState({
+      personaId: "ryo",
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    const output = await planTurn({
+      sessionId: "test-helix",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: { ...baseState, kidsHelixState: helixState },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["helix_active_pair"]).toEqual(["SA", "SOC"]);
+    expect(output.contextHints["helix_cycle_progress"]).toBe(0);
+    expect(output.contextHints["helix_cycle_day"]).toBe(0);
+    expect(output.contextHints["helix_mode"]).toBe("active");
+    expect(output.contextHints["helix_cycles_completed"]).toBe(0);
+    expect(output.contextHints["helix_previous_pair"]).toBeUndefined();
+  });
+
+  it("com previous_pair populado → contextHints helix_previous_pair", async () => {
+    const helixState = bootstrapKidsHelixState({
+      personaId: "ryo",
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    const output = await planTurn({
+      sessionId: "test-helix",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: {
+        ...baseState,
+        kidsHelixState: {
+          ...helixState,
+          previous_pair: ["DM", "REL"],
+          cycles_completed: 3,
+          current_day: 9,
+        },
+      },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["helix_previous_pair"]).toEqual(["DM", "REL"]);
+    expect(output.contextHints["helix_cycles_completed"]).toBe(3);
+    expect(output.contextHints["helix_cycle_day"]).toBe(9);
+    // Day 9 / 18 = 0.5 → G-07 50% trigger zone.
+    expect(output.contextHints["helix_cycle_progress"]).toBeCloseTo(9 / 18);
+  });
+
+  it("vacation mode → injeta helix_vacation_trigger", async () => {
+    const helixState = bootstrapKidsHelixState({
+      personaId: "ryo",
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    const output = await planTurn({
+      sessionId: "test-helix",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: {
+        ...baseState,
+        kidsHelixState: {
+          ...helixState,
+          mode: "vacation",
+          vacation_trigger: "parental_request",
+          vacation_started_at: "2026-05-15T00:00:00.000Z",
+        },
+      },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["helix_mode"]).toBe("vacation");
+    expect(output.contextHints["helix_vacation_trigger"]).toBe("parental_request");
+  });
+
+  it("deferred dims populados → contextHints helix_deferred_dims", async () => {
+    const helixState = bootstrapKidsHelixState({
+      personaId: "ryo",
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    const output = await planTurn({
+      sessionId: "test-helix",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: {
+        ...baseState,
+        kidsHelixState: { ...helixState, deferred: ["DM"] },
+      },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["helix_deferred_dims"]).toEqual(["DM"]);
+  });
+
+  it("vacation sem trigger → vacation_trigger ausente do contextHints", async () => {
+    const helixState = bootstrapKidsHelixState({
+      personaId: "ryo",
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    const output = await planTurn({
+      sessionId: "test-helix",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: {
+        ...baseState,
+        kidsHelixState: { ...helixState, mode: "vacation" },
+      },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["helix_vacation_trigger"]).toBeUndefined();
+    expect(output.contextHints["helix_mode"]).toBe("vacation");
+  });
+});

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -49,3 +49,23 @@ export {
   type Intensity,
   type PlayedAs,
 } from "./action-menu.js";
+
+export {
+  KIDS_HELIX_MODES,
+  KIDS_HELIX_DEFER_REASONS,
+  KIDS_HELIX_RESUME_REASONS,
+  KIDS_HELIX_VACATION_TRIGGERS,
+  KIDS_HELIX_ACTIVE_DAYS,
+  KIDS_HELIX_TOTAL_DAYS,
+  KIDS_HELIX_BREJO_VACATION_DAYS,
+  KIDS_HELIX_BREJO_DEFER_DAYS,
+  KIDS_HELIX_SACRIFICE_EXHAUSTION_SESSIONS,
+  KIDS_HELIX_DEFAULT_FALLBACK_PAIR,
+  defaultKidsHelixState,
+  type KidsHelixState,
+  type KidsHelixMode,
+  type KidsHelixDeferReason,
+  type KidsHelixResumeReason,
+  type KidsHelixVacationTrigger,
+  type CaselDimensionPair,
+} from "./kids-helix-state.js";

--- a/shared/src/contracts/kids-helix-state.ts
+++ b/shared/src/contracts/kids-helix-state.ts
@@ -1,0 +1,169 @@
+/**
+ * KidsHelixState — Double Helix cycle engine (G-05, ops#1091).
+ *
+ * Pair-based CASEL rotation: cada ciclo de ~18d tem um PAR de dimensões ativas
+ * (vs. helix-state.ts legacy que era single-dim). 50% overlap entre ciclos
+ * consecutivos preserva retrieval link pedagógico.
+ *
+ * **Distinção importante** vs. `shared/src/helix-state.ts` (HelixState):
+ * - HelixState (legacy) = single `activeDimension` + retrieval da anterior.
+ *   Origem: ebrota CLAUDE_6 §5 + helix-planner H1-H8. Persistido via
+ *   helix-repo-memory (in-mem) ou postgres `helix_state` table (F1).
+ * - KidsHelixState (este) = `active_pair` de 2 dims simultâneas + rotação
+ *   50% overlap. Origem: ops#1091 spec ratified 2026-05-16 (CC defaults).
+ *   Persistido via SQLite `kids_helix_state` table (motor-execucao).
+ *
+ * Ambos coexistem; HelixState não foi migrado para preservar callers
+ * existentes (helix-planner.test.ts, helix-events.ts). G-05 introduz o
+ * shape pair-based como vocabulário canônico do motor TS pós-ops#369
+ * 4-layer architecture; futura convergência fica pra Tier 3.
+ *
+ * Spec: ascendimacy-ops/issues/1091 (4 sub-decisões ratified Jun 2026-05-16).
+ * Capability parent: ops#990 C-T-10 + ops#989 C-T-09.
+ * Downstream: ops#1020 G-07 cadência 18d (consome cycle_progress).
+ */
+
+import type { CaselDimension } from "../content-item.js";
+
+/** Modo do ciclo helix — tri-state. */
+export const KIDS_HELIX_MODES = ["active", "buffer", "vacation"] as const;
+export type KidsHelixMode = (typeof KIDS_HELIX_MODES)[number];
+
+/** Razões canônicas pra defer (move dim de `active` pra `deferred`). */
+export const KIDS_HELIX_DEFER_REASONS = [
+  "extended_brejo",
+  "vacation_triggered",
+  "parental_pause",
+] as const;
+export type KidsHelixDeferReason = (typeof KIDS_HELIX_DEFER_REASONS)[number];
+
+/** Razões canônicas pra resume (move dim de `deferred` pra `queue`). */
+export const KIDS_HELIX_RESUME_REASONS = [
+  "recovery_confirmed",
+  "parental_resume",
+  "vacation_end",
+] as const;
+export type KidsHelixResumeReason = (typeof KIDS_HELIX_RESUME_REASONS)[number];
+
+/** Razões canônicas pra entrada/saída de modo férias. */
+export const KIDS_HELIX_VACATION_TRIGGERS = [
+  "parental_request",
+  "brejo_emotional_persistent",
+  "sacrifice_exhaustion",
+  "family_vacation_signal",
+] as const;
+export type KidsHelixVacationTrigger =
+  (typeof KIDS_HELIX_VACATION_TRIGGERS)[number];
+
+/** Par de dimensões CASEL — sempre 2 distintas. */
+export type CaselDimensionPair = readonly [CaselDimension, CaselDimension];
+
+/**
+ * Estado completo do KidsHelix por persona (1 row por persona_id).
+ *
+ * Sub-decisão 1 ratified Jun 2026-05-16 (ops#1091 comment).
+ */
+export interface KidsHelixState {
+  /** Persona id (chave). */
+  persona_id: string;
+
+  // -- Current cycle context --
+
+  /** Par de 2 dims focadas neste ciclo. */
+  active_pair: CaselDimensionPair;
+
+  /** ISO timestamp — início do ciclo atual. */
+  cycle_started_at: string;
+
+  /** Dia corrente no ciclo, 0..17 (0-13 active, 14-17 buffer). */
+  current_day: number;
+
+  /** Fase do ciclo. */
+  mode: KidsHelixMode;
+
+  // -- History (G-07 50% trigger) --
+
+  /** Par anterior — null no ciclo 1; populado após primeira rotação. */
+  previous_pair: CaselDimensionPair | null;
+
+  /** Total de ciclos fechados (completed → next). */
+  cycles_completed: number;
+
+  // -- Rotation queues --
+
+  /** Dims aguardando próximo ciclo (ordem indica prioridade). */
+  queue: CaselDimension[];
+
+  /** Dims já cicladas (re-entram na queue ao completar todas 5). */
+  completed: CaselDimension[];
+
+  /** Dims pausadas (brejo, vacation, parental_pause). */
+  deferred: CaselDimension[];
+
+  // -- Modo férias --
+
+  /**
+   * Razão atual de vacation (quando `mode === "vacation"`). Permite caller
+   * decidir condição de resume automática (ex: vacation_end signal só sai
+   * se entrou por family_vacation_signal).
+   */
+  vacation_trigger: KidsHelixVacationTrigger | null;
+
+  /** ISO timestamp — quando entrou em vacation (null se nunca). */
+  vacation_started_at: string | null;
+
+  /** Audit. */
+  updated_at: string;
+}
+
+/** Duração ativa default do ciclo (dias 0..13). */
+export const KIDS_HELIX_ACTIVE_DAYS = 14;
+
+/** Duração total (ativos + buffer). */
+export const KIDS_HELIX_TOTAL_DAYS = 18;
+
+/** Threshold de brejo emocional consecutivo pra trigger vacation. */
+export const KIDS_HELIX_BREJO_VACATION_DAYS = 5;
+
+/** Threshold de brejo simples pra defer dim (sub-decisão 3). */
+export const KIDS_HELIX_BREJO_DEFER_DAYS = 3;
+
+/** Threshold de sacrifice exhaustion consecutiva pra trigger vacation. */
+export const KIDS_HELIX_SACRIFICE_EXHAUSTION_SESSIONS = 3;
+
+/** Default fallback pair quando G-02 baseline ausente (Brota Mestre foundational). */
+export const KIDS_HELIX_DEFAULT_FALLBACK_PAIR: CaselDimensionPair = ["SA", "SOC"];
+
+/**
+ * Bootstrap state pra persona nova. Caller (state-manager) usa quando
+ * `kids_helix_state` row ainda não existe.
+ *
+ * Sub-decisão 2: initial pair = highest-need + complementary-engagement.
+ * Caller passa `firstPair` opcional resolvido a partir de G-02/status_matrix;
+ * se ausente, usa fallback SA+SOC.
+ */
+export function defaultKidsHelixState(args: {
+  personaId: string;
+  nowIso: string;
+  firstPair?: CaselDimensionPair;
+}): KidsHelixState {
+  const pair = args.firstPair ?? KIDS_HELIX_DEFAULT_FALLBACK_PAIR;
+  // Queue = dims restantes na ordem canônica que não estão no par inicial.
+  const allDims: CaselDimension[] = ["SA", "SM", "SOC", "REL", "DM"];
+  const queue = allDims.filter((d) => d !== pair[0] && d !== pair[1]);
+  return {
+    persona_id: args.personaId,
+    active_pair: pair,
+    cycle_started_at: args.nowIso,
+    current_day: 0,
+    mode: "active",
+    previous_pair: null,
+    cycles_completed: 0,
+    queue,
+    completed: [],
+    deferred: [],
+    vacation_trigger: null,
+    vacation_started_at: null,
+    updated_at: args.nowIso,
+  };
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,6 +1,7 @@
 import type { StatusMatrix } from "./status-matrix.js";
 import type { GardnerProgramState } from "./mixins/with-gardner-program.js";
 import type { MoodScore, MoodWindow } from "./mood.js";
+import type { KidsHelixState } from "./contracts/kids-helix-state.js";
 
 export interface PersonaDef {
   id: string;
@@ -36,6 +37,14 @@ export interface SessionState {
   statusMatrix?: StatusMatrix;
   /** Estado do programa Gardner 5 semanas (Bloco 2b). */
   gardnerProgram?: GardnerProgramState;
+
+  /**
+   * Estado do Double Helix cycle engine (G-05, ops#1091).
+   * Hidratado por motor-execucao a partir de `kids_helix_state` (per persona_id).
+   * Planejador lê pra injetar `contextHints.active_pair` + `cycle_progress`.
+   * Ausente quando persona ainda não bootstrapped (caller decide).
+   */
+  kidsHelixState?: KidsHelixState;
 
   // ─── F1 mood (motor#35) ──────────────────────────────────────────────
 


### PR DESCRIPTION
Refs ascendimacy/ascendimacy-ops#1091 (cross-repo `Closes` não auto-fecha; Jun fecha manual após merge — ver memory `reference_cross_repo_close_limitation`).

## Summary

Porta Double Helix cycle engine (ops#365 ebrota legacy closed) para o motor TS canônico, implementando as 4 sub-decisões ratificadas por Jun em 2026-05-16 (ops#1091 comment 4468127426).

Engine pair-based vive ao lado do `helix-state.ts` legacy (single-dim). Convive sem colidir — convergência fica pra Tier 3.

## Sub-decisões implementadas (4/4 ratificadas)

### Sub-decisão 1 — Schema `kids_helix_state`
- **Tipo**: `shared/src/contracts/kids-helix-state.ts:67-119` (`KidsHelixState` interface com `active_pair`, `mode` tri-state, `previous_pair`, queues, vacation tracking)
- **DDL**: `motor-execucao/src/kids-helix-state.ts:30-46` (SQLite, sibling pattern de `kids_gardner_program`)
- **Repo**: `getKidsHelixState`/`updateKidsHelixState`/`bootstrapKidsHelixStateRow` em mesmo arquivo
- Serialização CSV pra arrays curtos (queue/completed/deferred), NULL handling pra previous_pair

### Sub-decisão 2 — 50% overlap rotation + initial pair fallback
- **Initial pair**: `planejador/src/strategist/helix-engine.ts:62-102` (`computeInitialPair`) — highest-need (status_matrix) + complementary-engagement (G-02 signals), fallback SA+SOC quando baseline ausente
- **Rotation**: `helix-engine.ts:138-201` (`computeNextPair`) — Y carry-over [X,Y]→[Y,Z], reshuffle quando todas 5 dims visitadas E queue vazia (mais robusto que literal `completed===5` porque Y só vai pra completed quando vira X)
- 3-cycle continuity test confirma carry-over (SA,SOC → SOC,SM → SM,REL → REL,DM → reshuffle)

### Sub-decisão 3 — Queue/completed/deferred state transitions
- `helix-engine.ts:cycleStart` (queue→active)
- `helix-engine.ts:completeCycle` (active→completed via computeNextPair)
- `helix-engine.ts:deferDimension` (active→deferred com substitute opcional)
- `helix-engine.ts:resumeDimension` (deferred→queue)
- `helix-engine.ts:checkDeferTrigger` (brejo>3d threshold, strict)

### Sub-decisão 4 — Modo férias trigger compound
- `helix-engine.ts:enterVacation`/`exitVacation` (mode tri-state, vacation_trigger + vacation_started_at)
- `helix-engine.ts:checkVacationTrigger` (4 conditions: parental_request, brejo_emotional>5d strict, sacrifice_exhaustion≥3, family_vacation_signal — qualquer um sufficient, prioridade parental>family>brejo>sacrifice)
- `dayAdvance` é no-op em vacation (cycle congela)

## Integration

- `shared/src/types.ts:38-44` — `SessionState.kidsHelixState?` opcional (hidratado por motor-execucao)
- `planejador/src/plan.ts:412-438` — bloco de `contextHints.helix_*` (active_pair, cycle_progress, cycle_day, mode, cycles_completed, previous_pair, vacation_trigger, deferred_dims). Backward compat: ausência preserva comportamento anterior
- `motor-execucao/src/state-manager.ts:51-87` — `getState(sessionId, now, personaId)` aceita personaId opcional pra hidratar kidsHelixState

## Test coverage (64 novos tests, 100% green)

- `planejador/tests/helix-engine.unit.test.ts` — **46 unit tests** (state machine, todas sub-decisões, edge cases: reshuffle, defer+substitute, vacation pausa dayAdvance, 3-cycle continuity, brejo strict thresholds)
- `motor-execucao/tests/kids-helix-state.unit.test.ts` — **8 unit tests** (DDL round-trip, idempotência, null handling, isolamento per persona)
- `motor-execucao/tests/state-manager-helix.unit.test.ts` — **4 unit tests** (backward compat sem personaId, hidratação após bootstrap, isolamento)
- `planejador/tests/plan-helix-integration.unit.test.ts` — **6 unit tests** (sem-state backward compat, com-state básico, previous_pair, vacation mode, deferred dims, vacation sem trigger)

Full monorepo test sweep: **35+17+16+16+2+7+5 = 98 test files passing** após mudanças (zero regressão; todas as fixtures de gardner/joint/triage/etc preservadas).

## Migration / Bootstrap path

- Orchestrator chama `bootstrapKidsHelixStateRow(db, { personaId, firstPair? })` quando persona nova
- Chamadas subsequentes: `getState(sessionId, undefined, personaId)` hidrata automaticamente
- Sem migration SQL standalone — DDL roda via `CREATE TABLE IF NOT EXISTS` no `state-manager:getDb()` (sibling pattern de gardner_program/parent_decisions/cards/etc)

## Gaps / Honest limitations

### Wire-up incompleto pra `checkVacationTrigger`
A função aceita sinais via args (`parentalVacationStart`, `consecutiveBrejoDaysEmotional`, `consecutiveExhaustedSessions`, `familyVacationSignal`). Em F0 atual:
- `parent_decisions.vacation_start` — schema parent-decisions só tem `approved/rejected/pinned` hoje (motor-execucao). Estender em follow-up dedicado (não-blocker pra G-05 spec — função aceita arg).
- `family_vacation_start` event — não existe no event_log canônico. Caller passa hardcoded por ora.
- `sacrifice_exhaustion` count — não wired; integração com G-22 (ops#1033) é follow-up. Por enquanto orchestrator passa 0.

**Justificativa**: spec ratified diz "Defaults Jun ratify bloco — 4 sub-decisões aceitas as proposed". A 4 cobre algoritmo + behavior. Source-of-signal wiring é trabalho subjacente (e cross-issue: G-22 sacrifice + parent_decisions extension) que não cabe em G-05.

### Orchestrator não chamado nesta PR
Esta PR entrega `helix-engine.ts` (pure state machine) + `kids-helix-state.ts` (repo) + `plan.ts` integration. Wire-up do orchestrator (chamar `dayAdvance`/`completeCycle` no fim de cada sessão) é trabalho de **G-06 sessões 2/dia** (downstream da spec). Quando G-06 implementar, vai chamar os helpers daqui.

### `helix-state.ts` legacy preservado
Coexiste em `shared/src/helix-state.ts` + `shared/src/helix-planner.ts` (single-dim model). Callers existentes (helix-planner.test.ts, helix-events.ts, helix-repo-memory.ts) seguem funcionando. Convergência futura é Tier 3.

## Não modifiquei fixtures existentes
Nenhuma fixture tocada — todas as 98 test files pre-existentes seguem com mesmo comportamento.

## Cadência de commits

5 commits por logical scope (memory `feedback_pr_cadence`):
1. `3c89855` schema + types
2. `c61fc35` state machine + 46 tests
3. `bf56df6` SQLite DDL + repo + 8 tests
4. `49754d1` plan.ts integration + 6 tests
5. `78f2bdb` migration bootstrap + 4 tests

## Test plan

- [x] `npm test` em todos workspaces — 100% green
- [x] Subset focado em helix: `npm run test -w @ascendimacy/planejador -- helix` + `-w motor-execucao -- helix` → 64 new passing
- [x] Backward compat: `planTurn` sem `kidsHelixState` no SessionState → contextHints helix_* ausentes (test explícito)
- [x] Cross-cycle continuity: 5 ciclos consecutivos preservam Y carry-over + reshuffle correto
- [x] Vacation behavior: dayAdvance é no-op + cycleProgress reporta congelado

Do NOT merge. Wait for Jun.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>