### PR TITLE
[feat ops#1084] inaugural turn 0 templates JP/BR/recorrente — salvage motor#59

### DIFF
--- a/motor-drota/src/inaugural.ts
+++ b/motor-drota/src/inaugural.ts
@@ -1,0 +1,117 @@
+/**
+ * Inaugural turn — apresentação de primeira sessão (turn 0).
+ *
+ * Salvage de motor#59 (PR closed PHANTOM-MERGEABLE associated com motor#58).
+ * Ported para main pós motor#125 (post-processor F3+F5) — escopo independente,
+ * additive only. Spec ops#1084.
+ *
+ * Differentiation: em vez de passar pelo pipeline scorePool/LLM normal, turn 0
+ * retorna mensagem construída por template determinístico, com cláusulas
+ * obrigatórias de não-avaliação + direito de saída (primeira sessão), ou
+ * resumo conversacional de retorno (sessões subsequentes).
+ *
+ * Sub-decisões CC defaults (per ops#1084):
+ * 1. Trigger turn 0 = `state.turn === 0`. Distinção primeira-vs-recorrente via
+ *    `eventLog.some(e => e.type === 'playbook_executed')` (sessão recorrente
+ *    quando há histórico prévio de execução).
+ * 2. Language detection: `contextHints.profile_id` (string) com fallback
+ *    `persona.id`. Patterns JP: contém `-jp`, `_jp`, ou `nagareyama`.
+ * 3. Recorrente semantics: `sessionNumber > 1` triggera template
+ *    `inaugural_recorrente`. Sem cláusulas (já estabelecidas na primeira).
+ *
+ * Refs:
+ * - ops#1084 (spec)
+ * - motor#59 (source, closed)
+ * - motor#125 (sibling salvage pattern — post-processor F3+F5)
+ * - motor#110 (repetition_inquiry — NOT touched, this code lives before rankPool)
+ */
+
+export interface InauguralContext {
+  personaName: string;
+  personaAge: number;
+  profileId: string;
+  culturalDefaults?: object;
+  sessionNumber: number;
+  isJoint: boolean;
+  jointPartnerName?: string;
+}
+
+export interface InauguralOutput {
+  text: string;
+  template_used: string;
+  non_evaluation_clause_present: boolean;
+  exit_right_present: boolean;
+}
+
+function isJpProfile(profileId: string): boolean {
+  return profileId.includes("-jp") || profileId.includes("_jp") || profileId.includes("nagareyama");
+}
+
+function buildSoloJp(ctx: InauguralContext): InauguralOutput {
+  const addressee = ctx.isJoint && ctx.jointPartnerName
+    ? `${ctx.personaName} e ${ctx.jointPartnerName}`
+    : ctx.personaName;
+
+  const text = [
+    `${addressee}, bom te ver por aqui.`,
+    ``,
+    `Não estou aqui pra te avaliar — sem provas, sem notas, sem julgamentos. O que você compartilhar aqui fica entre nós.`,
+    ``,
+    `Se em algum momento quiser parar, é só falar — sem explicação necessária.`,
+    ``,
+    `${ctx.personaName}, tem algo que move você bastante ultimamente? Pode ser um interesse, algo que você pratica, ou uma ideia que fica voltando mesmo quando você não quer.`,
+  ].join("\n");
+
+  return {
+    text,
+    template_used: "inaugural_solo_jp",
+    non_evaluation_clause_present: true,
+    exit_right_present: true,
+  };
+}
+
+function buildSoloBr(ctx: InauguralContext): InauguralOutput {
+  const addressee = ctx.isJoint && ctx.jointPartnerName
+    ? `${ctx.personaName} e ${ctx.jointPartnerName}`
+    : ctx.personaName;
+
+  const text = [
+    `${addressee}, bom te conhecer.`,
+    ``,
+    `Quero deixar claro logo de cara: não estou aqui pra te avaliar. Sem provas, sem julgamentos — o que você trouxer aqui, fica aqui.`,
+    ``,
+    `Se quiser parar em qualquer momento, é só me falar. Sem problema nenhum.`,
+    ``,
+    `Tem alguma coisa que te interesse muito ultimamente, ${ctx.personaName}? Pode ser qualquer coisa — algo que você faz, aprende, ou que fica na sua cabeça mesmo sem querer.`,
+  ].join("\n");
+
+  return {
+    text,
+    template_used: "inaugural_solo_br",
+    non_evaluation_clause_present: true,
+    exit_right_present: true,
+  };
+}
+
+function buildRecorrente(ctx: InauguralContext): InauguralOutput {
+  const text = ctx.isJoint && ctx.jointPartnerName
+    ? `${ctx.personaName}, ${ctx.jointPartnerName} — bom ter vocês dois de volta. Da última vez vocês trouxeram coisas que ficaram martelando. Alguma delas ainda está na cabeça de vocês?`
+    : `${ctx.personaName}, bom ter você de volta. Da última vez você trouxe coisas interessantes — alguma delas ficou martelando na sua cabeça desde então?`;
+
+  return {
+    text,
+    template_used: "inaugural_recorrente",
+    non_evaluation_clause_present: false,
+    exit_right_present: false,
+  };
+}
+
+export async function buildInaugural(ctx: InauguralContext): Promise<InauguralOutput> {
+  if (ctx.sessionNumber > 1) {
+    return buildRecorrente(ctx);
+  }
+  if (isJpProfile(ctx.profileId)) {
+    return buildSoloJp(ctx);
+  }
+  return buildSoloBr(ctx);
+}

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -13,6 +13,7 @@ import { callLlm, callLlmMock } from "./llm-client.js";
 import { parseDrotaOutput } from "./parse-output.js";
 import { extractSignals } from "./signal-extractor.js";
 import { applyPostProcessors } from "./post-processor.js";
+import { buildInaugural } from "./inaugural.js";
 import { logDebugEvent, getProviderForStep } from "@ascendimacy/shared";
 
 const server = new McpServer({
@@ -247,6 +248,51 @@ server.registerTool(
     } as any,
   },
   async (input: EvaluateAndSelectInput) => {
+    // ops#1084 (A-02 salvage): inaugural turn — early-return ANTES de rankPool.
+    // Turn 0 não passa pelo pipeline scorePool/LLM normal; entrega template
+    // determinístico com cláusulas obrigatórias (primeira sessão) ou resumo
+    // de retorno (recorrente). NÃO conflita com menu_hit (planejador roda upstream)
+    // nem com repetition_inquiry (buildDrotaDynamicBody intacto).
+    const isFirstTurn = input.state.turn === 0;
+    const isFirstSession = !(input.state.eventLog ?? []).some(
+      (e) => (e as { type?: string }).type === "playbook_executed",
+    );
+    if (isFirstTurn) {
+      const inauguralOutput = await buildInaugural({
+        personaName: input.persona.name,
+        personaAge: input.persona.age,
+        profileId: String(input.contextHints?.["profile_id"] ?? input.persona.id ?? ""),
+        sessionNumber: isFirstSession ? 1 : 2,
+        isJoint: input.state.sessionMode === "joint",
+        jointPartnerName: input.state.jointPartnerName,
+      });
+      const inauguralResult: EvaluateAndSelectOutput = {
+        selectedContent: {
+          item: {
+            id: "__inaugural__",
+            type: "curiosity_hook",
+            domain: "social_emotional",
+            casel_target: ["relationship_skills"],
+            age_range: [10, 18],
+            surprise: 5,
+            verified: true,
+            base_score: 10,
+            fact: "",
+            bridge: "",
+            quest: "",
+            sacrifice_type: "reflect",
+          } as unknown as ContentItem,
+          score: 10,
+          reasons: [`inaugural:${inauguralOutput.template_used}`],
+        },
+        selectionRationale: `inaugural:${inauguralOutput.template_used}`,
+        linguisticMaterialization: inauguralOutput.text,
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(inauguralResult) }],
+      };
+    }
+
     const ranked = rankPool(input.contentPool);
     if (ranked.length === 0) {
       // Pool vazio: fallback conversacional (v2 §4.2 do plano).

--- a/motor-drota/tests/inaugural.unit.test.ts
+++ b/motor-drota/tests/inaugural.unit.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { buildInaugural } from "../src/inaugural.js";
+import type { InauguralContext } from "../src/inaugural.js";
+
+const baseCtxJp: InauguralContext = {
+  personaName: "Ryo",
+  personaAge: 13,
+  profileId: "kids-jp",
+  sessionNumber: 1,
+  isJoint: false,
+};
+
+const baseCtxBr: InauguralContext = {
+  personaName: "Paula",
+  personaAge: 13,
+  profileId: "kids-br",
+  sessionNumber: 1,
+  isJoint: false,
+};
+
+describe("buildInaugural — primeira sessão (turn 0 + isFirstSession)", () => {
+  it("JP profile: non_evaluation_clause present", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.non_evaluation_clause_present).toBe(true);
+    expect(result.text).toMatch(/não.*avaliar|sem.*julgamento/i);
+  });
+
+  it("JP profile: exit_right present", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.exit_right_present).toBe(true);
+    expect(result.text).toMatch(/parar|sair/i);
+  });
+
+  it("JP profile: uses inaugural_solo_jp template", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.template_used).toBe("inaugural_solo_jp");
+  });
+
+  it("BR profile: uses inaugural_solo_br template", async () => {
+    const result = await buildInaugural(baseCtxBr);
+    expect(result.template_used).toBe("inaugural_solo_br");
+    expect(result.non_evaluation_clause_present).toBe(true);
+    expect(result.exit_right_present).toBe(true);
+  });
+
+  it("nagareyama profileId routes to JP template", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, profileId: "nagareyama-ryo-001" });
+    expect(result.template_used).toBe("inaugural_solo_jp");
+  });
+
+  it("addresses persona by name", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.text).toContain("Ryo");
+  });
+
+  it("NUNCA 'Como posso te ajudar'", async () => {
+    const jp = await buildInaugural(baseCtxJp);
+    const br = await buildInaugural(baseCtxBr);
+    expect(jp.text).not.toMatch(/como posso te?\s+ajudar/i);
+    expect(br.text).not.toMatch(/como posso te?\s+ajudar/i);
+  });
+
+  it("NUNCA identificadores técnicos (dot-notation, UUIDs)", async () => {
+    const result = await buildInaugural(baseCtxJp);
+    expect(result.text).not.toMatch(/kids-jp|nagareyama-ryo|[a-f0-9-]{36}/i);
+    expect(result.text).not.toMatch(/profileId|personaAge|sessionNumber/i);
+  });
+
+  it("NUNCA 'Como IA' ou tom de assistente genérico", async () => {
+    const jp = await buildInaugural(baseCtxJp);
+    const br = await buildInaugural(baseCtxBr);
+    expect(jp.text).not.toMatch(/como ia/i);
+    expect(br.text).not.toMatch(/como ia/i);
+    expect(jp.text).not.toMatch(/estou aqui para te ajudar/i);
+    expect(br.text).not.toMatch(/estou aqui para te ajudar/i);
+  });
+});
+
+describe("buildInaugural — segunda sessão (turn 0 + !isFirstSession)", () => {
+  it("uses inaugural_recorrente template", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, sessionNumber: 2 });
+    expect(result.template_used).toBe("inaugural_recorrente");
+  });
+
+  it("recorrente does NOT require non_evaluation_clause (já estabelecido)", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, sessionNumber: 2 });
+    expect(result.non_evaluation_clause_present).toBe(false);
+  });
+
+  it("recorrente references previous session", async () => {
+    const result = await buildInaugural({ ...baseCtxJp, sessionNumber: 2 });
+    expect(result.text).toMatch(/últim|de volta|voltou/i);
+  });
+});
+
+describe("buildInaugural — modo joint", () => {
+  it("addresses both names in joint JP session", async () => {
+    const result = await buildInaugural({
+      ...baseCtxJp,
+      isJoint: true,
+      jointPartnerName: "Kei",
+    });
+    expect(result.text).toMatch(/Ryo/);
+    expect(result.text).toMatch(/Kei/);
+    expect(result.non_evaluation_clause_present).toBe(true);
+  });
+
+  it("joint recorrente also addresses both", async () => {
+    const result = await buildInaugural({
+      ...baseCtxJp,
+      sessionNumber: 2,
+      isJoint: true,
+      jointPartnerName: "Kei",
+    });
+    expect(result.text).toMatch(/Ryo/);
+    expect(result.text).toMatch(/Kei/);
+  });
+});


### PR DESCRIPTION
## Summary

Salvages inaugural turn 0 templates from motor#59 (closed PHANTOM-MERGEABLE) and integrates ADDITIVELY against current main. Turn 0 now bypasses the scorePool/LLM pipeline and returns a purpose-built first-contact message with non_evaluation_clause + exit_right (first session) or a conversational re-opener (recurrent session).

Pre-piloto requirement: Yuji/Yuko/Ryo need a proper inaugural message before the first session.

## Salvage scope

**Ported from motor#59 `feat/inaugural-turn-0-a02`:**
- `motor-drota/src/inaugural.ts` — `InauguralContext`, `InauguralOutput`, `buildInaugural` (verbatim, header refreshed with ops#1084 + sibling refs)
- 14 unit tests in `motor-drota/tests/inaugural.unit.test.ts` (renamed `.test.ts` → `.unit.test.ts` per current naming convention, matching motor#125 pattern)
- server.ts integration: early-return ANTES de `rankPool` in `evaluate_and_select` handler

**NOT ported (none destructive identified in motor#59):**
- motor#59 was additive-only; its closure was associated with motor#58's PHANTOM-MERGEABLE concerns rather than its own regressions. Pattern preserved: additive code, no rewrites of buildDrotaDynamicBody/buildDrotaPrompt/sanitize.

## Sub-decisões (CC defaults per ops#1084)

1. **Trigger condition**: `state.turn === 0`. Primeira sessão derivada de `eventLog` sem `playbook_executed` prévio.
2. **Language detection**: `contextHints.profile_id` (preferred) com fallback `persona.id`. Patterns JP: `-jp`, `_jp`, `nagareyama`.
3. **Recorrente semantics**: `sessionNumber > 1` (current encoding: first vs subsequent). `inaugural_recorrente` sem cláusulas (já estabelecidas na primeira).

If Jun prefers different defaults, indicate in review and I'll re-spec.

## Server integration (additive)

```ts
async (input: EvaluateAndSelectInput) => {
  const isFirstTurn = input.state.turn === 0;
  const isFirstSession = !(input.state.eventLog ?? []).some(
    (e) => (e as { type?: string }).type === "playbook_executed",
  );
  if (isFirstTurn) {
    const inauguralOutput = await buildInaugural({ ... });
    return { content: [{ type: "text", text: JSON.stringify(inauguralResult) }] };
  }
  const ranked = rankPool(input.contentPool); // path normal continua intacto
  ...
}
```

## Compatibility verificada (no silent regression)

| Path | Impact | Verificação |
|---|---|---|
| menu_hit (motor#115) | none | Planejador roda upstream do motor-drota; contextHints chega mas turn=0 short-circuita antes |
| repetition_inquiry (motor#110) | none | `buildDrotaDynamicBody` intacto; turn 0 nunca entra nele |
| post-processor F3+F5 (motor#125) | none | Aplicado APÓS sanitize do LLM output; turn 0 não chega lá |
| empty-pool fallback (linha 251) | none | Lógica preservada para turn > 0 |

**Grep workspace**: 0 occurrences de `turn: 0` / `turn === 0` em `motor-drota/tests/` antes do meu PR — nenhum teste existente assertando comportamento turn=0 → rankPool. Tests `planejador/tests/plan.test.ts`, `parental-triage-integration.test.ts`, `plan-helix-integration.unit.test.ts` usam turn=0 mas testam planejador isolado, não chamam `evaluate_and_select`.

## Test delta

| Suite | Before | After | Delta |
|---|---|---|---|
| `motor-drota` | 180 passed / 1 skipped | 194 passed / 1 skipped | +14 |
| Full monorepo | 1254 passed / 9 skipped / 0 fail | 1269 passed / 9 skipped / 0 fail | +14 + new file |

Test coverage cobre: cláusulas obrigatórias presence, exit_right presence, template routing (JP/BR/recorrente/nagareyama), endereçamento por nome, regras NUNCA (assistente genérico, "como posso ajudar", IDs técnicos, "Como IA"), modo joint endereçando ambos.

## DTs preserved from motor#59

- **DT-A02-01**: `sessionNumber` é binário (1 vs 2+) — futura customização turn-0 para sessão 3+ exigiria full eventLog ou context mais rico.
- **DT-A02-02**: Template selection usa `contextHints.profile_id` com fallback `persona.id`. Orchestrator deve passar `profile_id` em contextHints para routing correto.
- **DT-A02-03**: `inaugural_recorrente` tem `non_evaluation_clause_present=false` e `exit_right_present=false` (sessão context já estabelecido). Intencional para v0.

## Honest gaps

- Não há teste E2E (server → tool) cobrindo inaugural path; apenas unit. E2E coverage exigiria mock MCP transport + scenario harness — fora do escopo desta salvage. Recomendo follow-up issue se Jun quer cobertura.
- Template strings são hardcoded; futuro refactor poderia mover pra arquivos `.txt` em `src/prompts/` (estilo do `menu-generator.txt`) pra facilitar A/B testing pedagógico — fora do escopo desta salvage.

## Refs

- Spec: ascendimacy/ascendimacy-ops#1084
- Salvage source: ascendimacy/ascendimacy-motor#59 (closed PHANTOM-MERGEABLE)
- Sibling pattern: ascendimacy/ascendimacy-motor#125 (post-processor F3+F5)
- Phantom-mergeable memory: `feedback_phantom_mergeable_stale_prs`
- Cross-repo: `Closes` not used (per `reference_cross_repo_close_limitation`); use Refs and close ops#1084 manually post-merge

lane:review actor:jun scope:ascendimacy-motor

---
Generated by Claude Code (A42 parallel agent pool)