### PR TITLE
[feat ops#1033] G-22 sacrifice fórmula complete — gaps 5+6+7+10 + recentUsageCount hydration

### DIFF
--- a/motor-execucao/src/content-usage-repo.ts
+++ b/motor-execucao/src/content-usage-repo.ts
@@ -112,3 +112,44 @@ export function countContentUsage(db: Database.Database): number {
     .get() as { n: number };
   return row.n;
 }
+
+/**
+ * G-22 Gap 2 hydration helper (ops#1033) — projeta usage per-persona em
+ * Record<content_id, times_used>, filtrando por janela temporal (14 dias canon).
+ *
+ * Usado por state-manager.getState pra hidratar SessionState.recentContentUsage.
+ * Planejador então consome em `computeChallengeCost.recentUsageCount` por item.
+ *
+ * Filtra rows com `last_used_at` dentro de [now - windowDays, now].
+ * Sem usage → record vazio (não null), pra simplificar callers.
+ *
+ * @param windowDays — janela em dias; default 14 (canon G-22).
+ * @param nowIso     — override pra testabilidade determinística.
+ */
+export function getRecentContentUsageRecord(
+  db: Database.Database,
+  personaId: string,
+  windowDays = 14,
+  nowIso?: string,
+): Record<string, number> {
+  const now = getNow(nowIso);
+  const nowMs = Date.parse(now);
+  if (Number.isNaN(nowMs)) {
+    // Defensive — se nowIso malformado, retorna vazio sem throw
+    return {};
+  }
+  const windowStartMs = nowMs - windowDays * 24 * 60 * 60 * 1000;
+  const windowStartIso = new Date(windowStartMs).toISOString();
+
+  const rows = db
+    .prepare(
+      `SELECT content_id, times_used
+       FROM content_usage
+       WHERE persona_id = ? AND last_used_at >= ?`,
+    )
+    .all(personaId, windowStartIso) as Array<{ content_id: string; times_used: number }>;
+
+  const record: Record<string, number> = {};
+  for (const r of rows) record[r.content_id] = r.times_used;
+  return record;
+}

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -6,7 +6,7 @@ import { TREE_NODES_DDL, getStatusMatrix } from "./tree-nodes.js";
 import { GARDNER_PROGRAM_DDL, getProgramState } from "./gardner-program.js";
 import { PARENT_DECISIONS_DDL } from "./parent-decisions.js";
 import { EMITTED_CARDS_DDL } from "./cards-repo.js";
-import { CONTENT_USAGE_DDL } from "./content-usage-repo.js";
+import { CONTENT_USAGE_DDL, getRecentContentUsageRecord } from "./content-usage-repo.js";
 import {
   KIDS_HELIX_STATE_DDL,
   getKidsHelixState,
@@ -83,6 +83,13 @@ export function getState(
   const kidsHelixState = personaId
     ? getKidsHelixState(database, personaId) ?? undefined
     : undefined;
+  // G-22 Gap 2 hydration (ops#1033) — quando personaId presente, projeta
+  // content_usage da janela 14d em SessionState.recentContentUsage. Planejador
+  // consome em computeChallengeCost. Sem personaId, fica undefined (backward
+  // compat com callers legacy/testes sem persona).
+  const recentContentUsage = personaId
+    ? getRecentContentUsageRecord(database, personaId, 14, now)
+    : undefined;
   return {
     sessionId,
     trustLevel: Number(row["trust_level"]),
@@ -91,6 +98,7 @@ export function getState(
     statusMatrix,
     gardnerProgram,
     ...(kidsHelixState ? { kidsHelixState } : {}),
+    ...(recentContentUsage ? { recentContentUsage } : {}),
     eventLog: events.map((e) => ({
       timestamp: String(e["timestamp"]),
       type: String(e["type"]),

--- a/motor-execucao/tests/content-usage-repo.test.ts
+++ b/motor-execucao/tests/content-usage-repo.test.ts
@@ -13,6 +13,7 @@ import {
   countContentUsage,
   getAllContentUsageByPersona,
   getContentUsage,
+  getRecentContentUsageRecord,
   recordContentUsage,
 } from "../src/content-usage-repo.js";
 
@@ -142,6 +143,120 @@ describe("getAllContentUsageByPersona", () => {
     expect(map.get("item-a")?.times_used).toBe(1);
     expect(map.get("item-b")?.times_used).toBe(1);
     expect(map.has("item-c")).toBe(false);
+  });
+});
+
+describe("getRecentContentUsageRecord — G-22 Gap 2 hydration (ops#1033)", () => {
+  it("retorna {} para persona sem usage", () => {
+    expect(getRecentContentUsageRecord(db, "ryo-ochiai", 14, "2026-05-14T10:00:00.000Z"))
+      .toEqual({});
+  });
+
+  it("projeta {content_id: times_used} para usage dentro da janela", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-a",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-a",
+      nowIso: "2026-05-14T11:00:00.000Z", // times_used=2
+    });
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-b",
+      nowIso: "2026-05-14T11:00:00.000Z",
+    });
+
+    const record = getRecentContentUsageRecord(
+      db,
+      "ryo-ochiai",
+      14,
+      "2026-05-14T12:00:00.000Z",
+    );
+    expect(record).toEqual({ "item-a": 2, "item-b": 1 });
+  });
+
+  it("filtra rows fora da janela (14d default)", () => {
+    // Usage muito antigo — 30 dias atrás
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "old-item",
+      nowIso: "2026-04-14T10:00:00.000Z",
+    });
+    // Usage recente — 5 dias atrás
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "recent-item",
+      nowIso: "2026-05-09T10:00:00.000Z",
+    });
+
+    const record = getRecentContentUsageRecord(
+      db,
+      "ryo-ochiai",
+      14,
+      "2026-05-14T10:00:00.000Z",
+    );
+    expect(record).toEqual({ "recent-item": 1 });
+    expect(record).not.toHaveProperty("old-item");
+  });
+
+  it("janela customizada respeitada (e.g., 7 dias)", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "day-10-old",
+      nowIso: "2026-05-04T10:00:00.000Z", // 10 dias atrás
+    });
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "day-3-old",
+      nowIso: "2026-05-11T10:00:00.000Z", // 3 dias atrás
+    });
+
+    const recent7 = getRecentContentUsageRecord(
+      db,
+      "ryo-ochiai",
+      7,
+      "2026-05-14T10:00:00.000Z",
+    );
+    expect(recent7).toEqual({ "day-3-old": 1 });
+
+    const recent14 = getRecentContentUsageRecord(
+      db,
+      "ryo-ochiai",
+      14,
+      "2026-05-14T10:00:00.000Z",
+    );
+    expect(recent14).toEqual({ "day-10-old": 1, "day-3-old": 1 });
+  });
+
+  it("isola personas (cross-persona não vaza)", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-x",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(db, {
+      personaId: "kei-ochiai",
+      contentId: "item-y",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+
+    expect(getRecentContentUsageRecord(db, "ryo-ochiai", 14, "2026-05-14T11:00:00.000Z"))
+      .toEqual({ "item-x": 1 });
+    expect(getRecentContentUsageRecord(db, "kei-ochiai", 14, "2026-05-14T11:00:00.000Z"))
+      .toEqual({ "item-y": 1 });
+  });
+
+  it("retorna {} defensivo se nowIso malformado", () => {
+    recordContentUsage(db, {
+      personaId: "ryo-ochiai",
+      contentId: "item-z",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    expect(getRecentContentUsageRecord(db, "ryo-ochiai", 14, "not-a-date"))
+      .toEqual({});
   });
 });
 

--- a/motor-execucao/tests/state-manager-content-usage.unit.test.ts
+++ b/motor-execucao/tests/state-manager-content-usage.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * G-22 Gap 2 hydration (ops#1033) — getState() com personaId hidrata
+ * recentContentUsage a partir de content_usage table (janela 14d).
+ *
+ * Backward compat: sem personaId, recentContentUsage fica undefined.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getState, closeDb, getDbInstance } from "../src/state-manager.js";
+import { recordContentUsage } from "../src/content-usage-repo.js";
+import { rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  closeDb();
+  tmpDir = mkdtempSync(join(tmpdir(), "motor-content-usage-test-"));
+  process.env["MOTOR_STATE_DIR"] = tmpDir;
+});
+
+afterEach(() => {
+  closeDb();
+  delete process.env["MOTOR_STATE_DIR"];
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("getState × content_usage hydration (G-22 Gap 2)", () => {
+  it("backward compat: getState(sessionId) sem personaId → recentContentUsage undefined", () => {
+    const state = getState("sess-1");
+    expect(state.recentContentUsage).toBeUndefined();
+  });
+
+  it("getState com personaId sem usage prévio → recentContentUsage = {}", () => {
+    const state = getState("sess-1", "2026-05-14T10:00:00.000Z", "ryo-no-usage");
+    expect(state.recentContentUsage).toEqual({});
+  });
+
+  it("hidrata record {content_id: times_used} dentro da janela 14d", () => {
+    // Bootstrap DB
+    getState("sess-1");
+    recordContentUsage(getDbInstance(), {
+      personaId: "ryo",
+      contentId: "item-a",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(getDbInstance(), {
+      personaId: "ryo",
+      contentId: "item-a",
+      nowIso: "2026-05-14T11:00:00.000Z", // → times_used=2
+    });
+    recordContentUsage(getDbInstance(), {
+      personaId: "ryo",
+      contentId: "item-b",
+      nowIso: "2026-05-14T11:30:00.000Z",
+    });
+
+    const state = getState("sess-1", "2026-05-14T12:00:00.000Z", "ryo");
+    expect(state.recentContentUsage).toEqual({ "item-a": 2, "item-b": 1 });
+  });
+
+  it("isola por personaId (cross-persona não vaza)", () => {
+    getState("sess-1");
+    recordContentUsage(getDbInstance(), {
+      personaId: "ryo",
+      contentId: "item-x",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+    recordContentUsage(getDbInstance(), {
+      personaId: "kei",
+      contentId: "item-y",
+      nowIso: "2026-05-14T10:00:00.000Z",
+    });
+
+    const ryo = getState("sess-1", "2026-05-14T12:00:00.000Z", "ryo");
+    const kei = getState("sess-1", "2026-05-14T12:00:00.000Z", "kei");
+    expect(ryo.recentContentUsage).toEqual({ "item-x": 1 });
+    expect(kei.recentContentUsage).toEqual({ "item-y": 1 });
+  });
+
+  it("filtra rows fora da janela 14d", () => {
+    getState("sess-1");
+    // Usage 30 dias antes do now — fora da janela 14d
+    recordContentUsage(getDbInstance(), {
+      personaId: "ryo",
+      contentId: "old",
+      nowIso: "2026-04-14T10:00:00.000Z",
+    });
+    // Usage 5 dias antes do now — dentro
+    recordContentUsage(getDbInstance(), {
+      personaId: "ryo",
+      contentId: "recent",
+      nowIso: "2026-05-09T10:00:00.000Z",
+    });
+
+    const state = getState("sess-1", "2026-05-14T10:00:00.000Z", "ryo");
+    expect(state.recentContentUsage).toEqual({ "recent": 1 });
+    expect(state.recentContentUsage).not.toHaveProperty("old");
+  });
+
+  it("preserva hidratação de kidsHelixState junto (sem regressão G-05)", async () => {
+    // Garante que adição do recentContentUsage não quebra outras hydrations
+    const { bootstrapKidsHelixStateRow } = await import("../src/kids-helix-state.js");
+    getState("sess-1");
+    bootstrapKidsHelixStateRow(getDbInstance(), {
+      personaId: "ryo",
+      nowIso: "2026-05-16T12:00:00.000Z",
+    });
+    recordContentUsage(getDbInstance(), {
+      personaId: "ryo",
+      contentId: "co-existing-item",
+      nowIso: "2026-05-16T13:00:00.000Z",
+    });
+
+    const state = getState("sess-1", "2026-05-16T14:00:00.000Z", "ryo");
+    expect(state.kidsHelixState).toBeDefined();
+    expect(state.recentContentUsage).toEqual({ "co-existing-item": 1 });
+  });
+});

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -37,6 +37,7 @@ import {
   getProviderForStep,
   computeChallengeCost,
   computeTrustRatio,
+  deriveOutcomeSignal,
   isItemAllowedUnderBudgetExhaustion,
   extractPersonaSensitivity,
   isExhausted,
@@ -455,17 +456,20 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     }
   }
 
-  // G-22 (ops#1033, Jun ratify B 2026-05-16) — sacrifice fórmula PARCIAL.
-  // Gaps cobertos: 1+2+3+4+8+9. Deferred: 5 (outcome), 6/7 (onda), 10 (boss).
+  // G-22 (ops#1033) — sacrifice fórmula COMPLETA pós Jun ratify B + remaining
+  // gaps (5+6+7+10). CC defaults inline aguardando ratify.
   //
-  // - Gap 8 budget exhaustion: se isExhausted(state), flag contextHints +
-  //   compute soft-degrade allowed_item_ids para drota saber quais filtrar.
-  // - Gap 9 trust ratio: computeTrustRatio(state.trustLevel) → drota interpreta.
-  // - Gaps 1+2+3+4 breakdown: top-K items × cost (observability/debug).
+  // - Gap 1+2+3+4 (motor#124): base × consumption × sensitivity × challenge
+  // - Gap 5 (este PR): outcome_mult derivado de eventLog (feedback_signal)
+  // - Gap 6 (este PR): weekly_mult via Date.getDay() canon onda semanal
+  // - Gap 7 (este PR): cycle_mult via kidsHelixState.current_day canon onda ciclo
+  // - Gap 8 (motor#124): budget exhaustion soft degrade
+  // - Gap 9 (motor#124): trust ratio prazer/sacrifice
+  // - Gap 10 (este PR): clamp [MIN_SINGLE_ITEM_COST, MAX_SINGLE_ITEM_COST]
   //
-  // recentUsageCount não disponível aqui (content_usage_repo é motor-execucao;
-  // planejador roda sem db handle direto). Default 0 → consumption_mult=1.0;
-  // future hydration via pool-builder com db handle resolverá.
+  // recentUsageCount: hidratado via state.recentContentUsage (motor#108 →
+  // state-manager getRecentContentUsageRecord). Por-item via map lookup;
+  // ausência → 0 (consumption_mult=1.0, sem decay — backward compat).
   const personaSensitivity = extractPersonaSensitivity(
     input.persona.profile as Record<string, unknown> | undefined,
   );
@@ -505,12 +509,26 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     contextHints["budget_state"] = "ok";
   }
 
-  // G-22 breakdown — top-K cost preview (observability; não modifica scoring).
+  // Gap 5+6+7 hydration — derivados antes do breakdown loop.
+  //   - outcomeSignal: derived once por turn (último feedback_signal event)
+  //   - weekday: JS Date.getDay() em UTC (orchestrator pode override via env futura)
+  //   - cycleDay: from kidsHelixState (G-05); undefined quando persona não bootstrapped
+  //   - recentUsageMap: hidratado por motor-execucao em state.recentContentUsage
+  const outcomeSignal = deriveOutcomeSignal(input.state.eventLog ?? []);
+  const weekday = new Date().getDay();
+  const cycleDay = input.state.kidsHelixState?.current_day;
+  const recentUsageMap = input.state.recentContentUsage ?? {};
+
+  // G-22 breakdown completo — top-K cost preview (observability; não modifica scoring).
   const sacrificeBreakdown = topK.slice(0, 5).map((s) => {
     const cost = computeChallengeCost({
       item: s.item,
       personaSensitivity,
       intensity: s.isaLabels?.intensity,
+      recentUsageCount: recentUsageMap[s.item.id] ?? 0,
+      outcomeSignal,
+      weekday,
+      cycleDay,
     });
     return {
       id: s.item.id,
@@ -518,11 +536,22 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
       consumption_mult: Number(cost.consumptionMult.toFixed(4)),
       sensitivity_mult: cost.sensitivityMult,
       challenge_mult: cost.challengeMult,
+      outcome_mult: cost.outcomeMult,
+      weekly_mult: cost.weeklyMult,
+      cycle_mult: cost.cycleMult,
+      raw_total: Number(cost.rawTotal.toFixed(4)),
       total: Number(cost.total.toFixed(4)),
+      bounded: cost.bounded,
     };
   });
   contextHints["sacrifice_breakdown"] = sacrificeBreakdown;
   contextHints["persona_sensitivity"] = personaSensitivity;
+  contextHints["sacrifice_context"] = {
+    outcome_signal: outcomeSignal,
+    weekday,
+    cycle_day: cycleDay ?? null,
+    recent_usage_keys: Object.keys(recentUsageMap).length,
+  };
 
   // motor#25 (handoff #24 Tarefa 1): slim pool antes do drota.
   // Filtra used_in_session (score≤0) + char budget 2000.

--- a/planejador/src/server.ts
+++ b/planejador/src/server.ts
@@ -49,6 +49,11 @@ server.registerTool(
         jointPartnerChildId: z.string().optional(),
         jointPartnerName: z.string().optional(),
         partnerStatusMatrix: z.record(z.string(), z.string()).optional(),
+        // G-22 Gap 2 hydration (ops#1033) — content_usage per item id
+        // (janela 14d). Map {content_id: times_used}. Plain Record pra JSON.
+        recentContentUsage: z.record(z.string(), z.number()).optional(),
+        // G-22 Gap 7 hydration — kids helix state (cycle_day extraído).
+        kidsHelixState: z.record(z.string(), z.unknown()).optional(),
       }),
       incomingMessage: z.string(),
     } as any,

--- a/planejador/tests/plan.test.ts
+++ b/planejador/tests/plan.test.ts
@@ -100,3 +100,137 @@ describe("planTurn — Bloco 2a (contentPool)", () => {
     expect(output.contextHints["casel_focus_dimension"]).toBe("emotional");
   });
 });
+
+describe("planTurn — G-22 remaining gaps integration (ops#1033)", () => {
+  it("sacrifice_breakdown agora inclui outcome/weekly/cycle/raw_total/bounded", async () => {
+    const output = await planTurn({
+      sessionId: "test-g22",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    const breakdown = output.contextHints["sacrifice_breakdown"] as Array<
+      Record<string, unknown>
+    >;
+    expect(Array.isArray(breakdown)).toBe(true);
+    expect(breakdown.length).toBeGreaterThan(0);
+    const first = breakdown[0]!;
+    // motor#124 fields preserved
+    expect(first).toHaveProperty("base_effort");
+    expect(first).toHaveProperty("consumption_mult");
+    expect(first).toHaveProperty("sensitivity_mult");
+    expect(first).toHaveProperty("challenge_mult");
+    expect(first).toHaveProperty("total");
+    // novos fields gaps 5+6+7+10
+    expect(first).toHaveProperty("outcome_mult");
+    expect(first).toHaveProperty("weekly_mult");
+    expect(first).toHaveProperty("cycle_mult");
+    expect(first).toHaveProperty("raw_total");
+    expect(first).toHaveProperty("bounded");
+  });
+
+  it("emite sacrifice_context com outcome_signal + weekday + cycle_day + recent_usage_keys", async () => {
+    const output = await planTurn({
+      sessionId: "test-g22-ctx",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    const ctx = output.contextHints["sacrifice_context"] as Record<string, unknown>;
+    expect(ctx).toBeDefined();
+    expect(ctx).toHaveProperty("outcome_signal");
+    expect(ctx).toHaveProperty("weekday");
+    expect(ctx).toHaveProperty("cycle_day");
+    expect(ctx).toHaveProperty("recent_usage_keys");
+    // Default sem state.recentContentUsage → recent_usage_keys=0
+    expect(ctx["recent_usage_keys"]).toBe(0);
+    // Sem kidsHelixState → cycle_day=null
+    expect(ctx["cycle_day"]).toBeNull();
+    // Sem feedback_signal events → outcome_signal="unknown"
+    expect(ctx["outcome_signal"]).toBe("unknown");
+  });
+
+  it("recentContentUsage hidratado propaga em recent_usage_keys (proxy)", async () => {
+    const stateWithUsage = {
+      ...mockState,
+      recentContentUsage: { "item-a": 3, "item-b": 1 },
+    };
+    const output = await planTurn({
+      sessionId: "test-g22-usage",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: stateWithUsage,
+      incomingMessage: "oi",
+    });
+    const ctx = output.contextHints["sacrifice_context"] as Record<string, unknown>;
+    expect(ctx["recent_usage_keys"]).toBe(2);
+  });
+
+  it("kidsHelixState.current_day populado → cycle_day reflete", async () => {
+    const stateWithHelix = {
+      ...mockState,
+      kidsHelixState: {
+        persona_id: "ryo",
+        active_pair: ["SA", "SOC"] as const,
+        cycle_started_at: "2026-05-01T00:00:00.000Z",
+        current_day: 8,
+        mode: "active" as const,
+        previous_pair: null,
+        cycles_completed: 0,
+        queue: [],
+        completed: [],
+        deferred: [],
+        triggers_fired_this_cycle: {},
+      },
+    };
+    const output = await planTurn({
+      sessionId: "test-g22-cycle",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      state: stateWithHelix as any,
+      incomingMessage: "oi",
+    });
+    const ctx = output.contextHints["sacrifice_context"] as Record<string, unknown>;
+    expect(ctx["cycle_day"]).toBe(8);
+    // breakdown[*].cycle_mult ≈ 1.3 (PICO day 7-9)
+    const breakdown = output.contextHints["sacrifice_breakdown"] as Array<
+      Record<string, unknown>
+    >;
+    expect(breakdown[0]!["cycle_mult"]).toBe(1.3);
+  });
+
+  it("eventLog com feedback_signal recente → outcome_signal derivado", async () => {
+    const stateWithFeedback = {
+      ...mockState,
+      eventLog: [
+        {
+          timestamp: "2026-05-14T10:00:00.000Z",
+          type: "feedback_signal",
+          data: { signal_type: "positive_engagement" },
+        },
+      ],
+    };
+    const output = await planTurn({
+      sessionId: "test-g22-feedback",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: stateWithFeedback,
+      incomingMessage: "oi",
+    });
+    const ctx = output.contextHints["sacrifice_context"] as Record<string, unknown>;
+    expect(ctx["outcome_signal"]).toBe("positive_engagement");
+    // breakdown[*].outcome_mult deve refletir 1.1
+    const breakdown = output.contextHints["sacrifice_breakdown"] as Array<
+      Record<string, unknown>
+    >;
+    expect(breakdown[0]!["outcome_mult"]).toBe(1.1);
+  });
+});

--- a/shared/src/sacrifice-budget.ts
+++ b/shared/src/sacrifice-budget.ts
@@ -121,19 +121,27 @@ export function canAfford(
 }
 
 // =============================================================================
-// G-22 Sacrifice fórmula PARCIAL — Jun ratify B 2026-05-16 (ops#1033).
+// G-22 Sacrifice fórmula — Jun ratify B 2026-05-16 + remaining gaps (ops#1033).
 //
-// Gaps cobertos: 1 (base_effort), 2 (consumption_mult), 3 (sensitivity_mult),
-// 4 (challenge_mult), 8 (budget_exhausted soft degrade), 9 (trust ratio).
+// Gaps cobertos (motor#124, base): 1 (base_effort), 2 (consumption_mult),
+//   3 (sensitivity_mult), 4 (challenge_mult), 8 (budget_exhausted soft degrade),
+//   9 (trust ratio).
 //
-// Deferred (NÃO implementado nesta tier):
-//   - Gap 5 outcome_mult (precisa canonization signal — v2 separate)
-//   - Gap 6 onda semanal enforcement (depends G-05/G-07)
-//   - Gap 7 onda ciclo enforcement (depends G-05/G-07)
-//   - Gap 10 boss fight override (depends G-07 ratify)
+// Gaps cobertos (este PR, CC defaults inline aguardando ratify):
+//   - Gap 5 outcome_mult — last feedback_signal event → multiplier
+//   - Gap 6 onda semanal enforcement — day-of-week multiplier
+//     (canon Mon leve → Wed pico1 → Thu recov → Fri pico2)
+//   - Gap 7 onda ciclo enforcement — cycle-day multiplier
+//     (canon d1-3 min → d4-7 cresc → d8-10 PICO → d11-14 plateau → buffer recov)
+//   - Gap 10 cap/floor enforcement — MAX/MIN sobre total cost
+//     (cycle-reservoir multi-session pendente; per-item bounds shipped)
 //
-// Formula: base_effort × consumption_mult × sensitivity_mult × challenge_mult
-// (outcome_mult slot reservado, returns 1.0 enquanto deferred)
+// Formula completa:
+//   raw_total = base × consumption × sensitivity × challenge × outcome × weekly × cycle
+//   total = clamp(raw_total, MIN_SINGLE_ITEM_COST, MAX_SINGLE_ITEM_COST)
+//
+// Backward-compat: todos novos params são opcionais; default = 1.0 (não-enforcement)
+// pra manter assinatura motor#124 verde.
 // =============================================================================
 
 /** G-22 ratified Jun 2026-05-16 — sensitivity multiplier values (Gap 3). */
@@ -177,6 +185,113 @@ export const TRUST_RATIO_SLOPE = 0.6;
 export const CHALLENGE_AMOUNT_FIRM_THRESHOLD = 15;
 export const CHALLENGE_AMOUNT_SOFT_THRESHOLD = 7;
 
+// -----------------------------------------------------------------------------
+// G-22 Gap 5 outcome_mult (CC default Jun 2026-05-16, aguardando ratify).
+// -----------------------------------------------------------------------------
+//
+// Canon CLAUDE_6 §D24 "Recovery: ação bem recebida +2 | mal recebida -3 |
+// silêncio: congela" — esses números são deltas DE BUDGET (já cobertos por
+// `recoverBudget`). Para outcome_mult sobre CUSTO da próxima oferta, CC
+// extrapola: outcome positivo → multiplier maior (crianca engajada, suporta
+// mais); negativo → menor (precisa softer); silêncio → reduzido (cautela);
+// missing → neutro.
+//
+// CC defaults aguardando ratify Jun (alternativas:
+//   (A) ZERO impacto sem signal explícito (1.0 always)
+//   (B) Mapping abaixo (CC default)
+//   (C) Inverter (positivo=0.9 pra dar break, negativo=1.1 pra forçar)
+// CC escolheu (B) pq alinha com dose-response pedagógico standard.
+export const OUTCOME_MULTIPLIERS = {
+  positive_engagement: 1.1,
+  negative_engagement: 0.7,
+  silence: 0.9,
+  unknown: 1.0,
+} as const;
+
+export type OutcomeSignal = keyof typeof OUTCOME_MULTIPLIERS;
+
+/** Tipos canônicos de events que carregam outcome signal. */
+export const OUTCOME_FEEDBACK_EVENT_TYPES = ["feedback_signal"] as const;
+
+/** Janela máxima (em turns/events) pra considerar último outcome relevante. */
+export const OUTCOME_LOOKBACK_TURNS = 5;
+
+// -----------------------------------------------------------------------------
+// G-22 Gap 6 onda semanal (CC default Jun 2026-05-16, aguardando ratify).
+// -----------------------------------------------------------------------------
+//
+// Canon CLAUDE_6 §D24: "Onda semanal seg(leve)→qua(pico 1)→qui(recov)→sex(pico 2)".
+// CC interpola valores conservadores (0.8..1.2) — mantém variação ≤±20%:
+//   Mon (1) = 0.8 (leve)        — semana começa, easing
+//   Tue (2) = 0.9               — crescendo
+//   Wed (3) = 1.2 (pico 1)      — pico mid-week
+//   Thu (4) = 0.85 (recovery)   — pós-pico cool-down
+//   Fri (5) = 1.15 (pico 2)     — pico final pré-weekend
+//   Sat (6) = 0.95              — weekend default
+//   Sun (0) = 0.9               — pre-week prep
+//
+// JavaScript Date.getDay(): 0=Sun, 1=Mon, ..., 6=Sat.
+export const WEEKLY_WAVE_MULTIPLIERS: Record<number, number> = {
+  0: 0.9,  // Sunday
+  1: 0.8,  // Monday (leve)
+  2: 0.9,  // Tuesday
+  3: 1.2,  // Wednesday (pico 1)
+  4: 0.85, // Thursday (recovery)
+  5: 1.15, // Friday (pico 2)
+  6: 0.95, // Saturday
+};
+
+// -----------------------------------------------------------------------------
+// G-22 Gap 7 onda ciclo 18d (CC default Jun 2026-05-16, aguardando ratify).
+// -----------------------------------------------------------------------------
+//
+// Canon CLAUDE_6 §D24: "Onda ciclo (18d): 1-3 mínimo → 4-7 crescente →
+// 8-10 PICO → 11-14 plateau". KidsHelixState.current_day é 0-indexed (0..17,
+// 0-13 active phase, 14-17 buffer). Canon usa 1-indexed (1-14 active, 15-18
+// buffer). Mapeamento 0-indexed: d0-2=mínimo, d3-6=crescente, d7-9=PICO,
+// d10-13=plateau, d14-17=buffer.
+//
+// CC values mantém variação ≤±30% pra evitar surpresas drásticas:
+//   d0-2  (mínimo)   = 0.7
+//   d3-6  (crescente) = 0.85  — single average; mais granular seria 0.8..0.9 ramp
+//   d7-9  (PICO)     = 1.3
+//   d10-13 (plateau) = 1.0
+//   d14-17 (buffer)  = 0.6   — recovery / consolidação
+//
+// CC defaults aguardando ratify Jun (alternativas:
+//   (A) Single ramp via current_day/14 fórmula contínua (smoothing)
+//   (B) Discrete tiers como acima (CC default — espelha canon literal)
+//   (C) Ignorar cycle wave (1.0 always) até spec quantitativo
+// CC escolheu (B) pq canon usa nomes discretos (mínimo/crescente/PICO/plateau).
+export function getCycleWaveMultiplier(cycleDayZeroIndexed: number): number {
+  if (cycleDayZeroIndexed < 0) return 1.0;
+  if (cycleDayZeroIndexed <= 2) return 0.7;   // d1-3 mínimo
+  if (cycleDayZeroIndexed <= 6) return 0.85;  // d4-7 crescente
+  if (cycleDayZeroIndexed <= 9) return 1.3;   // d8-10 PICO
+  if (cycleDayZeroIndexed <= 13) return 1.0;  // d11-14 plateau
+  if (cycleDayZeroIndexed <= 17) return 0.6;  // d15-18 buffer
+  return 1.0; // fora do range esperado — defensive
+}
+
+// -----------------------------------------------------------------------------
+// G-22 Gap 10 cap/floor enforcement (CC default Jun 2026-05-16, aguardando ratify).
+// -----------------------------------------------------------------------------
+//
+// Canon menciona "cap/floor" sem números concretos. CC default:
+//   MAX_SINGLE_ITEM_COST = 50  — evita item degenerar pra cost absurdo quando
+//                                multipliers se compõem (e.g., Saki sensory
+//                                1.5 × firm 1.3 × peak 1.3 × pico-sem 1.2 ≈
+//                                3× base; com base=20 → 60 sem cap)
+//   MIN_SINGLE_ITEM_COST = 1   — evita zero/negativo quando multipliers de
+//                                supressão se compõem (e.g., buffer 0.6 ×
+//                                soft 0.8 × low-sens 0.7 ≈ 0.34 sem floor)
+//
+// **Cycle reservoir multi-session NÃO shipped** (gap honest). Spec menciona
+// "cumulative budget per cycle" mas não fornece formula concreta — CC opted
+// por per-item bounds only, deferred reservoir pra v3 quando spec maturar.
+export const MAX_SINGLE_ITEM_COST = 50;
+export const MIN_SINGLE_ITEM_COST = 1;
+
 /**
  * G-22 input ao cômputo de custo per-challenge.
  *
@@ -185,6 +300,10 @@ export const CHALLENGE_AMOUNT_SOFT_THRESHOLD = 7;
  * @field intensity          — Gap 4 fonte primária; ISA label se disponível.
  * @field recentUsageCount   — Gap 2; vem do content_usage_repo (motor#108) na janela 14d.
  * @field cycleTargetSessions — Gap 2 denominador; default 28.
+ * @field outcomeSignal      — Gap 5; resolved via deriveOutcomeSignal(eventLog).
+ * @field weekday            — Gap 6; 0=Sun..6=Sat (JS Date.getDay()). Undefined→1.0.
+ * @field cycleDay           — Gap 7; 0..17 (KidsHelixState.current_day). Undefined→1.0.
+ * @field enforceBounds      — Gap 10; quando true (default), clamp [MIN, MAX]. Tests podem disable.
  */
 export interface ChallengeCostInput {
   item: { sacrifice_amount?: number };
@@ -192,6 +311,10 @@ export interface ChallengeCostInput {
   intensity?: ChallengeIntensity;
   recentUsageCount?: number;
   cycleTargetSessions?: number;
+  outcomeSignal?: OutcomeSignal;
+  weekday?: number;
+  cycleDay?: number;
+  enforceBounds?: boolean;
 }
 
 /** G-22 breakdown — útil pra observability (contextHints + telemetry). */
@@ -200,7 +323,13 @@ export interface ChallengeCostBreakdown {
   consumptionMult: number;
   sensitivityMult: number;
   challengeMult: number;
+  outcomeMult: number;
+  weeklyMult: number;
+  cycleMult: number;
+  rawTotal: number;
   total: number;
+  /** True se Gap 10 clamp aplicou (MAX ou MIN bound triggered). */
+  bounded: boolean;
 }
 
 /**
@@ -253,8 +382,92 @@ export function computeChallengeCost(input: ChallengeCostInput): ChallengeCostBr
     challengeMult = INTENSITY_MULTIPLIERS.medium;
   }
 
-  const total = baseEffort * consumptionMult * sensitivityMult * challengeMult;
-  return { baseEffort, consumptionMult, sensitivityMult, challengeMult, total };
+  // Gap 5: outcome_mult (default 1.0 quando ausente)
+  const outcomeMult = input.outcomeSignal
+    ? OUTCOME_MULTIPLIERS[input.outcomeSignal]
+    : 1.0;
+
+  // Gap 6: weekly_mult (default 1.0 quando weekday undefined)
+  const weeklyMult =
+    typeof input.weekday === "number" && WEEKLY_WAVE_MULTIPLIERS[input.weekday] !== undefined
+      ? WEEKLY_WAVE_MULTIPLIERS[input.weekday]!
+      : 1.0;
+
+  // Gap 7: cycle_mult (default 1.0 quando cycleDay undefined)
+  const cycleMult =
+    typeof input.cycleDay === "number" ? getCycleWaveMultiplier(input.cycleDay) : 1.0;
+
+  const rawTotal =
+    baseEffort *
+    consumptionMult *
+    sensitivityMult *
+    challengeMult *
+    outcomeMult *
+    weeklyMult *
+    cycleMult;
+
+  // Gap 10: cap/floor enforcement (default enabled)
+  const enforceBounds = input.enforceBounds !== false; // default true
+  let total = rawTotal;
+  let bounded = false;
+  if (enforceBounds) {
+    if (rawTotal > MAX_SINGLE_ITEM_COST) {
+      total = MAX_SINGLE_ITEM_COST;
+      bounded = true;
+    } else if (rawTotal < MIN_SINGLE_ITEM_COST) {
+      total = MIN_SINGLE_ITEM_COST;
+      bounded = true;
+    }
+  }
+
+  return {
+    baseEffort,
+    consumptionMult,
+    sensitivityMult,
+    challengeMult,
+    outcomeMult,
+    weeklyMult,
+    cycleMult,
+    rawTotal,
+    total,
+    bounded,
+  };
+}
+
+/**
+ * Gap 5 helper — extrai outcome signal mais recente do eventLog.
+ *
+ * Procura events de tipo em OUTCOME_FEEDBACK_EVENT_TYPES (canon: "feedback_signal")
+ * nos últimos OUTCOME_LOOKBACK_TURNS (5) events. Retorna o `signal_type` do mais
+ * recente, ou "unknown" quando nenhum encontrado.
+ *
+ * `signal_type` esperado: "positive_engagement" | "negative_engagement" | "silence".
+ * Valores fora do enum → "unknown" (defensive).
+ *
+ * Caller passa eventLog cronológico (mais antigo primeiro, padrão SessionState).
+ */
+export function deriveOutcomeSignal(
+  eventLog: ReadonlyArray<{ type: string; data: Record<string, unknown> }>,
+): OutcomeSignal {
+  if (!eventLog || eventLog.length === 0) return "unknown";
+  const feedbackTypes = OUTCOME_FEEDBACK_EVENT_TYPES as readonly string[];
+  // Itera do mais recente pro mais antigo, max OUTCOME_LOOKBACK_TURNS
+  const start = Math.max(0, eventLog.length - OUTCOME_LOOKBACK_TURNS);
+  for (let i = eventLog.length - 1; i >= start; i--) {
+    const ev = eventLog[i]!;
+    if (feedbackTypes.includes(ev.type)) {
+      const raw = ev.data?.["signal_type"];
+      if (
+        raw === "positive_engagement" ||
+        raw === "negative_engagement" ||
+        raw === "silence"
+      ) {
+        return raw;
+      }
+      return "unknown"; // event existe mas signal_type inválido
+    }
+  }
+  return "unknown";
 }
 
 /**

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -46,6 +46,18 @@ export interface SessionState {
    */
   kidsHelixState?: KidsHelixState;
 
+  /**
+   * G-22 Gap 2 hydration (ops#1033) — content_usage records per item id,
+   * filtrados pela janela canon (14 dias). Map content_id → times_used.
+   * Hidratado por motor-execucao a partir de `content_usage` (motor#108)
+   * quando personaId é passado pra getState. Planejador consome em
+   * computeChallengeCost.recentUsageCount per item.
+   *
+   * Plain Record (não Map) pra survivir serialização MCP JSON.
+   * Ausente quando personaId não passado (e.g., callers legacy/tests).
+   */
+  recentContentUsage?: Record<string, number>;
+
   // ─── F1 mood (motor#35) ──────────────────────────────────────────────
 
   /**

--- a/shared/tests/sacrifice-budget.test.ts
+++ b/shared/tests/sacrifice-budget.test.ts
@@ -19,6 +19,8 @@ import {
   computeTrustRatio,
   isItemAllowedUnderBudgetExhaustion,
   extractPersonaSensitivity,
+  deriveOutcomeSignal,
+  getCycleWaveMultiplier,
   SENSITIVITY_MULTIPLIERS,
   INTENSITY_MULTIPLIERS,
   CONSUMPTION_MIN,
@@ -26,6 +28,10 @@ import {
   BASE_EFFORT_DEFAULT,
   BUDGET_EXHAUSTED_MAX_SACRIFICE,
   DEFAULT_CYCLE_TARGET_SESSIONS,
+  OUTCOME_MULTIPLIERS,
+  WEEKLY_WAVE_MULTIPLIERS,
+  MAX_SINGLE_ITEM_COST,
+  MIN_SINGLE_ITEM_COST,
 } from "../src/sacrifice-budget.js";
 import type { SessionState } from "../src/types.js";
 
@@ -405,5 +411,336 @@ describe("extractPersonaSensitivity", () => {
   it("default 'medium' quando valor inválido", () => {
     expect(extractPersonaSensitivity({ sensitivity: "extreme" })).toBe("medium");
     expect(extractPersonaSensitivity({ sensitivity: 42 })).toBe("medium");
+  });
+});
+
+// =============================================================================
+// G-22 Sacrifice fórmula — remaining gaps (5+6+7+10).
+// CC defaults Jun 2026-05-16 (ops#1033) aguardando ratify.
+// =============================================================================
+
+describe("computeChallengeCost — Gap 5 outcome_mult", () => {
+  it("default 1.0 quando outcomeSignal undefined (backward-compat motor#124)", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 } });
+    expect(out.outcomeMult).toBe(1.0);
+  });
+
+  it("positive_engagement → 1.1 (boost)", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      outcomeSignal: "positive_engagement",
+    });
+    expect(out.outcomeMult).toBe(OUTCOME_MULTIPLIERS.positive_engagement);
+    expect(out.outcomeMult).toBe(1.1);
+  });
+
+  it("negative_engagement → 0.7 (soften)", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      outcomeSignal: "negative_engagement",
+    });
+    expect(out.outcomeMult).toBe(0.7);
+  });
+
+  it("silence → 0.9 (cautela)", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      outcomeSignal: "silence",
+    });
+    expect(out.outcomeMult).toBe(0.9);
+  });
+
+  it("unknown → 1.0 (neutro)", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      outcomeSignal: "unknown",
+    });
+    expect(out.outcomeMult).toBe(1.0);
+  });
+
+  it("propaga no total: base=10 × positive=1.1 → ~11", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      outcomeSignal: "positive_engagement",
+    });
+    expect(out.total).toBeCloseTo(11.0, 5);
+  });
+});
+
+describe("deriveOutcomeSignal — Gap 5 helper", () => {
+  it("retorna 'unknown' em eventLog vazio", () => {
+    expect(deriveOutcomeSignal([])).toBe("unknown");
+  });
+
+  it("retorna signal_type do último feedback_signal event", () => {
+    const log = [
+      { type: "playbook_executed", data: { id: "x" } },
+      { type: "feedback_signal", data: { signal_type: "positive_engagement" } },
+    ];
+    expect(deriveOutcomeSignal(log)).toBe("positive_engagement");
+  });
+
+  it("respeita ordem (mais recente vence)", () => {
+    const log = [
+      { type: "feedback_signal", data: { signal_type: "negative_engagement" } },
+      { type: "feedback_signal", data: { signal_type: "positive_engagement" } },
+    ];
+    expect(deriveOutcomeSignal(log)).toBe("positive_engagement");
+  });
+
+  it("ignora events fora dos últimos OUTCOME_LOOKBACK_TURNS (5)", () => {
+    // feedback_signal antigo + 5 events vazios depois → ignorado
+    const log = [
+      { type: "feedback_signal", data: { signal_type: "positive_engagement" } },
+      { type: "playbook_executed", data: {} },
+      { type: "playbook_executed", data: {} },
+      { type: "playbook_executed", data: {} },
+      { type: "playbook_executed", data: {} },
+      { type: "playbook_executed", data: {} },
+    ];
+    expect(deriveOutcomeSignal(log)).toBe("unknown");
+  });
+
+  it("retorna 'unknown' para signal_type inválido", () => {
+    const log = [
+      { type: "feedback_signal", data: { signal_type: "random_other" } },
+    ];
+    expect(deriveOutcomeSignal(log)).toBe("unknown");
+  });
+
+  it("retorna 'unknown' quando data.signal_type ausente", () => {
+    const log = [{ type: "feedback_signal", data: {} }];
+    expect(deriveOutcomeSignal(log)).toBe("unknown");
+  });
+});
+
+describe("computeChallengeCost — Gap 6 weekly_mult (onda semanal)", () => {
+  it("default 1.0 quando weekday undefined (backward-compat)", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 } });
+    expect(out.weeklyMult).toBe(1.0);
+  });
+
+  it("Mon (1) leve → 0.8", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 }, weekday: 1 });
+    expect(out.weeklyMult).toBe(WEEKLY_WAVE_MULTIPLIERS[1]);
+    expect(out.weeklyMult).toBe(0.8);
+  });
+
+  it("Wed (3) pico 1 → 1.2", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 }, weekday: 3 });
+    expect(out.weeklyMult).toBe(1.2);
+  });
+
+  it("Thu (4) recovery → 0.85", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 }, weekday: 4 });
+    expect(out.weeklyMult).toBe(0.85);
+  });
+
+  it("Fri (5) pico 2 → 1.15", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 }, weekday: 5 });
+    expect(out.weeklyMult).toBe(1.15);
+  });
+
+  it("Sun (0) e Sat (6) — defaults conservadores", () => {
+    const sun = computeChallengeCost({ item: { sacrifice_amount: 10 }, weekday: 0 });
+    const sat = computeChallengeCost({ item: { sacrifice_amount: 10 }, weekday: 6 });
+    expect(sun.weeklyMult).toBe(0.9);
+    expect(sat.weeklyMult).toBe(0.95);
+  });
+
+  it("weekday inválido (7+) → fallback 1.0", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 }, weekday: 7 });
+    expect(out.weeklyMult).toBe(1.0);
+  });
+
+  it("propaga no total: base=10 × Wed pico=1.2 → ~12", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      weekday: 3,
+    });
+    expect(out.total).toBeCloseTo(12.0, 5);
+  });
+});
+
+describe("getCycleWaveMultiplier — Gap 7", () => {
+  it("d0-2 mínimo → 0.7", () => {
+    expect(getCycleWaveMultiplier(0)).toBe(0.7);
+    expect(getCycleWaveMultiplier(1)).toBe(0.7);
+    expect(getCycleWaveMultiplier(2)).toBe(0.7);
+  });
+
+  it("d3-6 crescente → 0.85", () => {
+    expect(getCycleWaveMultiplier(3)).toBe(0.85);
+    expect(getCycleWaveMultiplier(6)).toBe(0.85);
+  });
+
+  it("d7-9 PICO → 1.3", () => {
+    expect(getCycleWaveMultiplier(7)).toBe(1.3);
+    expect(getCycleWaveMultiplier(8)).toBe(1.3);
+    expect(getCycleWaveMultiplier(9)).toBe(1.3);
+  });
+
+  it("d10-13 plateau → 1.0", () => {
+    expect(getCycleWaveMultiplier(10)).toBe(1.0);
+    expect(getCycleWaveMultiplier(13)).toBe(1.0);
+  });
+
+  it("d14-17 buffer → 0.6", () => {
+    expect(getCycleWaveMultiplier(14)).toBe(0.6);
+    expect(getCycleWaveMultiplier(17)).toBe(0.6);
+  });
+
+  it("cycleDay negativo → 1.0 defensive", () => {
+    expect(getCycleWaveMultiplier(-1)).toBe(1.0);
+  });
+
+  it("cycleDay fora do range (>17) → 1.0 defensive", () => {
+    expect(getCycleWaveMultiplier(18)).toBe(1.0);
+    expect(getCycleWaveMultiplier(99)).toBe(1.0);
+  });
+});
+
+describe("computeChallengeCost — Gap 7 cycle_mult via input.cycleDay", () => {
+  it("default 1.0 quando cycleDay undefined (backward-compat)", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 } });
+    expect(out.cycleMult).toBe(1.0);
+  });
+
+  it("cycleDay=8 (PICO) → 1.3", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 }, cycleDay: 8 });
+    expect(out.cycleMult).toBe(1.3);
+  });
+
+  it("cycleDay=0 (mínimo) → 0.7", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 }, cycleDay: 0 });
+    expect(out.cycleMult).toBe(0.7);
+  });
+
+  it("propaga no total: base=10 × PICO=1.3 → 13.0", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      cycleDay: 8,
+    });
+    expect(out.total).toBeCloseTo(13.0, 5);
+  });
+});
+
+describe("computeChallengeCost — Gap 10 cap/floor enforcement", () => {
+  it("clamp em MAX (50) quando raw_total excede", () => {
+    // Saki sensory (1.5) × firm (1.3) × PICO (1.3) × Fri (1.15) × positive (1.1)
+    // = 1.5 × 1.3 × 1.3 × 1.15 × 1.1 ≈ 3.21 multiplier
+    // base=20 → ~64 sem cap
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 20 },
+      personaSensitivity: "sensory",
+      intensity: "firm",
+      cycleDay: 8,
+      weekday: 5,
+      outcomeSignal: "positive_engagement",
+    });
+    expect(out.rawTotal).toBeGreaterThan(MAX_SINGLE_ITEM_COST);
+    expect(out.total).toBe(MAX_SINGLE_ITEM_COST);
+    expect(out.bounded).toBe(true);
+  });
+
+  it("clamp em MIN (1) quando raw_total fica próximo de zero", () => {
+    // base=5 × low (0.7) × soft (0.8) × buffer (0.6) × neg (0.7) × Mon (0.8)
+    // = 5 × 0.7 × 0.8 × 0.6 × 0.7 × 0.8 ≈ 0.94 — fica abaixo do floor
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 5 },
+      personaSensitivity: "low",
+      intensity: "soft",
+      cycleDay: 14,
+      weekday: 1,
+      outcomeSignal: "negative_engagement",
+    });
+    expect(out.rawTotal).toBeLessThan(MIN_SINGLE_ITEM_COST);
+    expect(out.total).toBe(MIN_SINGLE_ITEM_COST);
+    expect(out.bounded).toBe(true);
+  });
+
+  it("não clampa em range normal (bounded=false)", () => {
+    const out = computeChallengeCost({ item: { sacrifice_amount: 10 } });
+    expect(out.bounded).toBe(false);
+    expect(out.total).toBe(out.rawTotal);
+  });
+
+  it("enforceBounds: false desliga clamp", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 20 },
+      personaSensitivity: "sensory",
+      intensity: "firm",
+      cycleDay: 8,
+      weekday: 5,
+      outcomeSignal: "positive_engagement",
+      enforceBounds: false,
+    });
+    expect(out.total).toBe(out.rawTotal);
+    expect(out.total).toBeGreaterThan(MAX_SINGLE_ITEM_COST);
+    expect(out.bounded).toBe(false);
+  });
+
+  it("rawTotal preservado mesmo com clamp ativo", () => {
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 30 },
+      personaSensitivity: "sensory",
+      intensity: "firm",
+    });
+    // base=30 × 1 × 1.5 × 1.3 = 58.5 — excede MAX
+    expect(out.rawTotal).toBeCloseTo(58.5, 5);
+    expect(out.total).toBe(MAX_SINGLE_ITEM_COST);
+    expect(out.bounded).toBe(true);
+  });
+});
+
+describe("computeChallengeCost — integrated remaining gaps composition", () => {
+  it("Saki sensory + Wed PICO + Fri pico2 + positive — clamped", () => {
+    // base=15 × sensory(1.5) × firm(1.3) × PICO d8(1.3) × Fri(1.15) × positive(1.1)
+    // = 15 × 1.5 × 1.3 × 1.3 × 1.15 × 1.1 ≈ 48.13 → não clampa (< 50)
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 15 },
+      personaSensitivity: "sensory",
+      intensity: "firm",
+      cycleDay: 8,
+      weekday: 5,
+      outcomeSignal: "positive_engagement",
+    });
+    const expected = 15 * 1.5 * 1.3 * 1.3 * 1.15 * 1.1;
+    expect(out.rawTotal).toBeCloseTo(expected, 4);
+    expect(out.bounded).toBe(false);
+    expect(out.total).toBeCloseTo(expected, 4);
+  });
+
+  it("Ryo medium + Mon leve + buffer + negative — gentle", () => {
+    // base=10 × medium(1.0) × medium(1.0) × Mon(0.8) × buffer d14(0.6) × neg(0.7)
+    // = 10 × 1 × 1 × 0.8 × 0.6 × 0.7 = 3.36
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 10 },
+      personaSensitivity: "medium",
+      intensity: "medium",
+      cycleDay: 14,
+      weekday: 1,
+      outcomeSignal: "negative_engagement",
+    });
+    expect(out.rawTotal).toBeCloseTo(3.36, 5);
+    expect(out.bounded).toBe(false);
+  });
+
+  it("backward-compat motor#124 — sem nenhum dos novos params, total inalterado", () => {
+    // Reproduz exatamente o teste existente "composição realista Saki"
+    const out = computeChallengeCost({
+      item: { sacrifice_amount: 15 },
+      personaSensitivity: "sensory",
+      intensity: "firm",
+      recentUsageCount: 14,
+      cycleTargetSessions: 28,
+    });
+    // base=15 × consumption=0.85 × sensory=1.5 × firm=1.3 = 24.86
+    // outcome=1, weekly=1, cycle=1 (defaults)
+    expect(out.total).toBeCloseTo(15 * 0.85 * 1.5 * 1.3, 5);
+    expect(out.outcomeMult).toBe(1.0);
+    expect(out.weeklyMult).toBe(1.0);
+    expect(out.cycleMult).toBe(1.0);
+    expect(out.bounded).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes os 4 gaps remanescentes de G-22 deixados OPEN após motor#124 (Jun GO B partial) + resolve honest gap de hydration. **Todas as adições têm CC defaults inline aguardando ratify Jun em ops#1033.**

Formula completa agora:
```
raw_total = base × consumption × sensitivity × challenge × outcome × weekly × cycle
total = clamp(raw_total, MIN_SINGLE_ITEM_COST=1, MAX_SINGLE_ITEM_COST=50)
```

## Gaps fechados (4)

### Gap 5 — outcome_mult
- `OUTCOME_MULTIPLIERS`: positive_engagement=1.1 | negative_engagement=0.7 | silence=0.9 | unknown=1.0
- Helper `deriveOutcomeSignal(eventLog)` lookback 5 turns para `feedback_signal` events
- **CC default (B)** aguardando ratify: alternativas (A) zero-impact-sem-signal e (C) inverter (positivo=0.9 pra dar break) documentadas no source. CC escolheu B alinhado com dose-response pedagógico standard.

### Gap 6 — weekly_mult (onda semanal)
- `WEEKLY_WAVE_MULTIPLIERS[Date.getDay()]`: Sun 0.9 | Mon 0.8 (leve) | Tue 0.9 | Wed 1.2 (pico 1) | Thu 0.85 (recov) | Fri 1.15 (pico 2) | Sat 0.95
- Variação contida em ±20% pra evitar surpresa drástica entre dias

### Gap 7 — cycle_mult (onda ciclo 18d)
- `getCycleWaveMultiplier(cycleDayZeroIndexed)`: d0-2 mínimo(0.7) | d3-6 cresc(0.85) | d7-9 PICO(1.3) | d10-13 plat(1.0) | d14-17 buffer(0.6)
- Mapeia 0-indexed `kidsHelixState.current_day` ao vocabulário canon CLAUDE_6 §D24 (1-indexed)
- **CC default (B)** discrete tiers; alternativas (A) ramp contínuo e (C) ignorar até spec quantitativa documentadas

### Gap 10 — cap/floor enforcement
- `MAX_SINGLE_ITEM_COST = 50` — protege contra compounding (Saki sensory × firm × PICO × Fri × positive ≈ 64 sem cap)
- `MIN_SINGLE_ITEM_COST = 1` — protege contra colapso (low × soft × buffer × neg × Mon ≈ 0.34 sem floor)
- `enforceBounds: false` flag pra unit tests precisarem do raw
- **HONEST GAP REMAINING**: cycle reservoir multi-session NÃO shipped. Spec menciona \"cumulative budget per cycle\" sem números concretos — CC limitou-se a per-item bounds, deferred reservoir pra v3 quando spec maturar. Documentado no source.

## recentUsageCount hydration (resolve honest gap motor#124)

Antes: `consumption_mult` sempre 1.0 porque planejador não tinha db handle.
Agora: hidratação ponta-a-ponta:

```
content_usage table 
  → state-manager.getState(personaId) [shared/types.ts SessionState.recentContentUsage]
  → SessionState
  → planejador computeChallengeCost(recentUsageCount: state.recentContentUsage[item.id])
```

Mudanças:
- `shared/src/types.ts:42` — `SessionState.recentContentUsage?: Record<string, number>` (plain Record pra MCP JSON survivibility)
- `motor-execucao/src/content-usage-repo.ts:108` — novo `getRecentContentUsageRecord(db, personaId, windowDays=14, nowIso?)`
- `motor-execucao/src/state-manager.ts:86` — hidratação dentro de `getState` quando `personaId` presente
- `planejador/src/server.ts:53` — zod schema extends `recentContentUsage` + `kidsHelixState` (ambos opcionais)
- `planejador/src/plan.ts:472` — wired via `recentUsageMap[item.id] ?? 0`

## Files touched (7)

| File | Change | LOC |
|------|--------|-----|
| `shared/src/sacrifice-budget.ts` | +4 gaps + helper | +150 |
| `shared/tests/sacrifice-budget.test.ts` | +39 leaf tests | +273 |
| `shared/src/types.ts` | SessionState.recentContentUsage | +12 |
| `motor-execucao/src/content-usage-repo.ts` | getRecentContentUsageRecord | +43 |
| `motor-execucao/src/state-manager.ts` | getState hidratação | +9 |
| `motor-execucao/tests/content-usage-repo.test.ts` | +6 leaf tests | +94 |
| `motor-execucao/tests/state-manager-content-usage.unit.test.ts` | novo arquivo | +109 |
| `planejador/src/server.ts` | zod schema extension | +5 |
| `planejador/src/plan.ts` | wire 4 gaps + hydration | +27/-9 |
| `planejador/tests/plan.test.ts` | +5 integration tests | +109 |

## Test delta

| Suite | Before | After | Delta |
|-------|--------|-------|-------|
| `shared/tests/sacrifice-budget.test.ts` | 52 | 91 | +39 |
| `motor-execucao/tests/content-usage-repo.test.ts` | 10 | 16 | +6 |
| `motor-execucao/tests/state-manager-content-usage.unit.test.ts` | 0 | 6 | +6 |
| `planejador/tests/plan.test.ts` | 5 | 10 | +5 |
| **Total** | — | — | **+56 new** |

Full workspace: `1310 passing | 9 skipped | 0 failures`.

## Backwards compatibility

- Todos novos params em `computeChallengeCost` são opcionais → defaults = 1.0 → backward compat motor#124
- `motor#124` test \"composição realista Saki sensory + firm\" preserva exato 24.86 (verificado via test integrated #3)
- `recentContentUsage` ausente em SessionState → `recent_usage_keys=0`, `consumption_mult=1.0` (mesmo comportamento que motor#124)
- `kidsHelixState` ausente → `cycle_mult=1.0` (sem enforcement)
- `eventLog` sem `feedback_signal` → `outcome_signal=unknown` → `outcome_mult=1.0`

## PoC numerics changed?

**NÃO.** PoC handoff `docs/handoffs/2026-05-16-poc-g22-g05-g07-e2e.md` (branch `cc/poc-g22-g05-g07-e2e`) usa `recentUsageCount=0`, sem intensity/weekday/cycleDay/outcomeSignal — fica em backward-compat path → totals Ryo high=26.00 / Saki high=39.00 preservados.

## CC defaults inline aguardando ratify Jun

1. **Gap 5 outcome mapping** (B): positive=1.1 / negative=0.7 / silence=0.9 / unknown=1.0
2. **Gap 6 weekly multipliers**: Sun 0.9 / Mon 0.8 / Tue 0.9 / Wed 1.2 / Thu 0.85 / Fri 1.15 / Sat 0.95
3. **Gap 7 cycle tiers**: 0-2=0.7 / 3-6=0.85 / 7-9=1.3 / 10-13=1.0 / 14-17=0.6
4. **Gap 10 bounds**: MAX=50 / MIN=1
5. **OUTCOME_LOOKBACK_TURNS**: 5 events de janela

Jun: ratify em bloco ou contra-propõe específico (alternativas A/C documentadas inline no source).

## Honest gap remaining

- **Gap 10 cycle reservoir multi-session** NÃO shipped — spec menciona \"cumulative budget per cycle\" sem números concretos. Per-item bounds shipped; reservoir aguarda spec quantitativa.

Refs: ops#1033 (G-22 doctrine), motor#124 (parcial precedente gaps 1+2+3+4+8+9), motor#108 (content-usage-repo).