### PR TITLE
[feat ops#1092] Trio runtime engine → orchestrator wire-up

### DIFF
--- a/orchestrator/src/brejo-composer.ts
+++ b/orchestrator/src/brejo-composer.ts
@@ -1,0 +1,132 @@
+/**
+ * BrejoSignal composer — caller-side helper (ops#1092, follow-up motor#129).
+ *
+ * Compõe `BrejoSignal[]` pra alimentar `decideBrejoPause` / `decideNextSpeaker`
+ * a partir de:
+ *   - `statusMatrix` per persona (dimension → "brejo"|"baia"|"pasto")
+ *   - `participant.regulation_strategy` (declarado no persona profile)
+ *
+ * Regra (CC default ratify Jun ops#1092):
+ *   1. `statusMatrix.emotional === "brejo"` → emite `{ type: "emotional" }`.
+ *      Override §11.4 doctrine: qualquer participant em brejo emocional → full pause.
+ *
+ *   2. participant com `regulation_strategy === "sensory"` E **alguma** dimensão
+ *      sensorial-leaning em brejo → emite `{ type: "sensory" }`. v1 trata
+ *      `social_with_sibling === "brejo"` como sensory-proxy (Saki ASD-1: conflito
+ *      sensorial frequentemente surge como ruído social-irmão). Doctrine §11.4
+ *      Saki entry — partial pause path.
+ *
+ *   3. Sem brejo em nenhum dim → sem signal.
+ *
+ * Pure function — sem IO, sem persistência. Caller mantém o map per-persona.
+ *
+ * Doctrine cross-ref:
+ *   ascendimacy-ops/docs/fundamentos/ebrota-kids-dinamicas-grupo.md §11.4
+ *   ascendimacy-ops/docs/playbooks/kids.group.playbook.yaml (brejo_pause_policy_trio)
+ */
+
+import type { BrejoSignal, TrioParticipant } from "@ascendimacy/shared";
+import type { StatusMatrix } from "@ascendimacy/shared";
+
+/**
+ * Dimensões consideradas "sensory-leaning" no contexto trio Saki entry v1.
+ * Lista conservadora — outras dimensões cognitivas/linguísticas NÃO entram
+ * porque brejo cognitivo em Saki não exige partial pause (apenas emotional/sensory).
+ *
+ * Pode ser estendida via override `extraSensoryDimensions` em
+ * `composeBrejoSignals` se um caller tiver matrix com chaves customizadas.
+ */
+export const DEFAULT_SENSORY_DIMENSIONS: readonly string[] = [
+  "social_with_sibling",
+  "sensory",
+];
+
+export interface ComposeBrejoSignalsInput {
+  /** Participants da sessão (mesmos passados pra TrioState). */
+  participants: TrioParticipant[];
+  /**
+   * Map persona_id → statusMatrix. Caller monta tipicamente lendo o
+   * statusMatrix de cada participant (motor-execucao get_state per child).
+   * Participants sem matrix são ignorados (graceful).
+   */
+  statusMatrixByPersona: Record<string, StatusMatrix | undefined>;
+  /**
+   * Override opcional pra adicionar dimensões além de DEFAULT_SENSORY_DIMENSIONS.
+   * Não substitui — extends.
+   */
+  extraSensoryDimensions?: readonly string[];
+}
+
+/**
+ * Compõe BrejoSignal[] a partir do statusMatrix per persona + perfis.
+ *
+ * Cada participant pode contribuir com 0, 1 ou 2 signals (max 1 emotional + 1 sensory).
+ * Order de signals é: emotional first (per persona), depois sensory (per persona).
+ * Caller é livre pra deduplicar ou agregar se a doctrine evoluir.
+ */
+export function composeBrejoSignals(
+  input: ComposeBrejoSignalsInput,
+): BrejoSignal[] {
+  const { participants, statusMatrixByPersona, extraSensoryDimensions } = input;
+  const sensoryDims = new Set([
+    ...DEFAULT_SENSORY_DIMENSIONS,
+    ...(extraSensoryDimensions ?? []),
+  ]);
+  const signals: BrejoSignal[] = [];
+
+  for (const participant of participants) {
+    const matrix = statusMatrixByPersona[participant.personaId];
+    if (!matrix) continue;
+
+    // (1) Emotional brejo — emite pra qualquer participant (não depende de strategy).
+    if (matrix["emotional"] === "brejo") {
+      signals.push({ personaId: participant.personaId, type: "emotional" });
+    }
+
+    // (2) Sensory brejo — só pra participants com regulation_strategy="sensory".
+    //     Doctrine §11.4 partial-pause path é desenhado pra Saki especificamente.
+    //     Sem strategy match, brejo sensorial sobe pra "full pause" por precaução
+    //     já dentro de decideBrejoPause — aqui só emitimos quando o sinal qualifica
+    //     pra partial.
+    if (participant.regulation_strategy === "sensory") {
+      const hasSensoryBrejo = Object.entries(matrix).some(
+        ([dim, val]) => val === "brejo" && sensoryDims.has(dim),
+      );
+      if (hasSensoryBrejo) {
+        signals.push({ personaId: participant.personaId, type: "sensory" });
+      }
+    }
+  }
+
+  return signals;
+}
+
+/**
+ * Helper conveniente: extrai `regulation_strategy` e `silence_tolerance_rounds`
+ * de um `PersonaDef.profile` no shape canonical (ver Saki fixture).
+ *
+ * Retorna um `TrioParticipant` pronto pra uso em TrioState.
+ *
+ * `profile` é `Record<string, unknown>` por PersonaDef — fields opcionais com
+ * type-narrowing defensivo.
+ */
+export function trioParticipantFromPersona(
+  personaId: string,
+  name: string,
+  profile: Record<string, unknown> | undefined,
+): TrioParticipant {
+  const participant: TrioParticipant = { personaId, name };
+  const strategy = profile?.["regulation_strategy"];
+  if (
+    strategy === "sensory" ||
+    strategy === "emotional" ||
+    strategy === "cognitive"
+  ) {
+    participant.regulation_strategy = strategy;
+  }
+  const tolerance = profile?.["silence_tolerance_rounds"];
+  if (typeof tolerance === "number" && Number.isFinite(tolerance) && tolerance > 0) {
+    participant.silence_tolerance_rounds = tolerance;
+  }
+  return participant;
+}

--- a/orchestrator/src/trio-orchestrator.ts
+++ b/orchestrator/src/trio-orchestrator.ts
@@ -1,0 +1,268 @@
+/**
+ * Trio orchestrator wire-up — integração runtime engine → session loop
+ * (ops#1092, follow-up motor#129).
+ *
+ * Responsabilidades:
+ *   - Carregar TrioRuntimeConfig de `kids.group.playbook.yaml` (ou outro path).
+ *   - Inicializar TrioState a partir de participants.
+ *   - Per-turn hook que chama `decideNextSpeaker` e devolve target.
+ *   - Append de TurnHistoryEntry pós-turn.
+ *   - Emit de warnings via callback (caller plugga sink — tipicamente
+ *     `motor-execucao.log_event`).
+ *
+ * Design choices (CC defaults ratify Jun ops#1092):
+ *   - **Pure module**: sem IO direto pra MCP; recebe state mutável + warnings
+ *     callback. Caller (cli ou group-session.ts) wireia tudo.
+ *   - **No-modify runTurn**: integração é wrapper, não invade `orchestrator.ts`.
+ *     Dyad solo paths (existing) ficam intactos.
+ *   - **In-memory state**: TrioState passado por referência; caller persiste
+ *     se quiser (v1 não persiste cross-session).
+ *
+ * Doctrine cross-ref:
+ *   ascendimacy-ops/docs/fundamentos/ebrota-kids-dinamicas-grupo.md §10 + §11
+ *   ascendimacy-ops/docs/playbooks/kids.group.playbook.yaml
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+import {
+  DEFAULT_TRIO_RUNTIME_CONFIG,
+  type BrejoSignal,
+  type GroupMode,
+  type TrioDecision,
+  type TrioParticipant,
+  type TrioRuntimeConfig,
+  type TrioState,
+  type TrioWarning,
+  type TurnHistoryEntry,
+  type TurnSpeakerType,
+} from "@ascendimacy/shared";
+import {
+  buildTrioConfigFromPlaybook,
+  decideNextSpeaker,
+  modeFromParticipantCount,
+} from "./trio-runtime.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolve path canônico do playbook YAML de grupo.
+ *
+ * Order de resolução:
+ *   1. `overridePath` se fornecido.
+ *   2. `<motor>/playbooks/kids.group.playbook.yaml` (canon local).
+ *   3. Undefined → caller cai em DEFAULT_TRIO_RUNTIME_CONFIG.
+ *
+ * Spec note: a fonte canônica vive em ascendimacy-ops/docs/playbooks/
+ * mas o motor monorepo recebe uma cópia em `playbooks/` (sync manual ou via
+ * symlink — fora do scope desta story).
+ */
+export function resolveGroupPlaybookPath(overridePath?: string): string | undefined {
+  if (overridePath) {
+    return existsSync(overridePath) ? overridePath : undefined;
+  }
+  const canonLocal = join(__dirname, "../../playbooks/kids.group.playbook.yaml");
+  return existsSync(canonLocal) ? canonLocal : undefined;
+}
+
+/**
+ * Carrega TrioRuntimeConfig a partir de um YAML file.
+ *
+ * Falha-soft: file inexistente → DEFAULT_TRIO_RUNTIME_CONFIG.
+ * Parse error → propaga (yaml.load throws YAMLException).
+ *
+ * `personaIdAliases.saki` mapeia o id canonical da fixture pra `saki`
+ * (chave usada pelo schema YAML `absence_threshold_rounds_saki`).
+ */
+export function loadTrioConfigFromPlaybook(
+  playbookPath?: string,
+  personaIdAliases: { saki?: string } = {},
+): TrioRuntimeConfig {
+  const resolved = resolveGroupPlaybookPath(playbookPath);
+  if (!resolved) return { ...DEFAULT_TRIO_RUNTIME_CONFIG };
+  const raw = yaml.load(readFileSync(resolved, "utf-8"));
+  return buildTrioConfigFromPlaybook(raw, personaIdAliases);
+}
+
+/**
+ * Inicializa TrioState pra uma nova sessão.
+ *
+ * - Determina `mode` automaticamente do count (dyad=2, trio=3+) se não
+ *   passado explicitamente.
+ * - turnHistory inicia vazio.
+ * - brejoSignals inicia vazio (caller injeta per-turn via prepareTurn).
+ *
+ * Errors quando participants vazio (session sem participants é caso patológico).
+ */
+export function initTrioState(
+  participants: TrioParticipant[],
+  mode?: GroupMode,
+): TrioState {
+  if (participants.length === 0) {
+    throw new Error("initTrioState: participants vazio");
+  }
+  return {
+    mode: mode ?? modeFromParticipantCount(participants.length),
+    participants: [...participants],
+    turnHistory: [],
+    brejoSignals: [],
+  };
+}
+
+/**
+ * Próximo round number a usar em TurnHistoryEntry.
+ *
+ * Round 1 = primeiro round (bot prompt + child responses). Round 0 reservado
+ * pra inaugural turn (motor#127) se relevante.
+ *
+ * Strategy: 1 + max(round) no histórico; vazio → 1.
+ */
+export function nextRoundNumber(state: TrioState): number {
+  if (state.turnHistory.length === 0) return 1;
+  return 1 + Math.max(...state.turnHistory.map((e) => e.round));
+}
+
+/**
+ * Resultado do per-turn hook. Caller usa `decision.target` pra rotear:
+ *   - "bot" → drota gera prompt, endereça participants exceto excludedParticipants
+ *   - "child" → drota direciona prompt a `decision.nextSpeakerHint`
+ *   - "pause_full" → não chama drota; espera signal externo (timer, parent)
+ *   - "pause_partial" → semelhante mas mantém alguns participants engajáveis
+ *
+ * `roundNumber` é o round que o caller vai usar quando registrar a turn entry.
+ */
+export interface PrepareTurnResult {
+  decision: TrioDecision;
+  roundNumber: number;
+}
+
+/**
+ * Per-turn hook: chama decideNextSpeaker e devolve roundNumber pré-computado.
+ *
+ * Mutates `state.brejoSignals` pra refletir o snapshot passado (caller-side
+ * convention: brejo signals são per-turn, não acumulativos cross-turn).
+ *
+ * Warnings vêm dentro de `decision.warnings`. Caller decide se emite ao
+ * event_log via `emitWarnings` callback abaixo.
+ */
+export function prepareTurn(
+  state: TrioState,
+  config: TrioRuntimeConfig,
+  brejoSignals: BrejoSignal[] = [],
+): PrepareTurnResult {
+  state.brejoSignals = [...brejoSignals];
+  const decision = decideNextSpeaker(state, config);
+  return { decision, roundNumber: nextRoundNumber(state) };
+}
+
+/**
+ * Append da turn entry no histórico — pos-execução, side-effect controlado.
+ *
+ * Não muta brejoSignals (caller já gerencia).
+ *
+ * Retorna o entry appended pra trace/log convenience.
+ */
+export function appendTurnHistory(
+  state: TrioState,
+  entry: {
+    round: number;
+    speakerType: TurnSpeakerType;
+    personaId?: string;
+    timestamp?: string;
+  },
+): TurnHistoryEntry {
+  const fullEntry: TurnHistoryEntry = {
+    round: entry.round,
+    speakerType: entry.speakerType,
+    personaId: entry.personaId,
+    timestamp: entry.timestamp ?? new Date().toISOString(),
+  };
+  state.turnHistory.push(fullEntry);
+  return fullEntry;
+}
+
+/**
+ * Severity mapping pros TrioWarning kinds — useful pra event_log sink.
+ *
+ * CC default ratify Jun ops#1092:
+ *   - dominance_detected, absence_detected → "info" (observability)
+ *   - bot_ratio_exceeded, consecutive_bot_turns_exceeded → "warn"
+ *     (action implícita: bot perdeu turn)
+ */
+export const TRIO_WARNING_SEVERITY = {
+  bot_ratio_exceeded: "warn",
+  consecutive_bot_turns_exceeded: "warn",
+  dominance_detected: "info",
+  absence_detected: "info",
+} as const;
+
+export type TrioWarningSeverity =
+  (typeof TRIO_WARNING_SEVERITY)[keyof typeof TRIO_WARNING_SEVERITY];
+
+export interface EmittableWarning {
+  kind: TrioWarning["kind"];
+  severity: TrioWarningSeverity;
+  personaId?: string;
+  reason: string;
+  value?: number;
+}
+
+/**
+ * Converte TrioWarning[] em formato amigável pra event_log sink.
+ * Pure function (sem IO).
+ */
+export function annotateWarnings(warnings: TrioWarning[]): EmittableWarning[] {
+  return warnings.map((w) => ({
+    kind: w.kind,
+    severity: TRIO_WARNING_SEVERITY[w.kind],
+    personaId: w.personaId,
+    reason: w.reason,
+    value: w.value,
+  }));
+}
+
+/**
+ * Sink callback type — caller plugga sua implementação (typically
+ * wrap around motor-execucao.log_event com type="trio_warning").
+ *
+ * Async para suportar IO. NÃO deve throw — sink errors são swallowed
+ * pelo caller pra preservar session.
+ */
+export type WarningSink = (
+  warnings: EmittableWarning[],
+  context: {
+    sessionId: string;
+    roundNumber: number;
+    decisionTarget: TrioDecision["target"];
+  },
+) => Promise<void>;
+
+/**
+ * Helper: dispatch warnings via sink, fail-soft.
+ *
+ * Loga sink errors em console.warn (não throw). Mantém session viva mesmo
+ * com event_log offline.
+ */
+export async function emitWarnings(
+  decision: TrioDecision,
+  context: { sessionId: string; roundNumber: number },
+  sink?: WarningSink,
+): Promise<void> {
+  if (!sink || decision.warnings.length === 0) return;
+  const annotated = annotateWarnings(decision.warnings);
+  try {
+    await sink(annotated, {
+      sessionId: context.sessionId,
+      roundNumber: context.roundNumber,
+      decisionTarget: decision.target,
+    });
+  } catch (err) {
+    // Fail-soft: warnings nunca quebram session.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[trio-orchestrator] WarningSink falhou (swallowed): ${String(err).slice(0, 120)}`,
+    );
+  }
+}

--- a/orchestrator/tests/trio-orchestrator.unit.test.ts
+++ b/orchestrator/tests/trio-orchestrator.unit.test.ts
@@ -1,0 +1,554 @@
+/**
+ * Unit tests — trio orchestrator wire-up (ops#1092, follow-up motor#129).
+ *
+ * Cobre:
+ *   - loadTrioConfigFromPlaybook (canon YAML + missing file fallback)
+ *   - initTrioState (dyad + trio modes)
+ *   - nextRoundNumber
+ *   - prepareTurn (per-turn hook integration)
+ *   - appendTurnHistory
+ *   - annotateWarnings + emitWarnings (fail-soft sink)
+ *   - composeBrejoSignals (emotional + sensory paths)
+ *   - trioParticipantFromPersona (profile shape extraction)
+ *
+ * Doctrine cross-ref: ebrota-kids-dinamicas-grupo.md §10 + §11.
+ */
+
+import { describe, it, expect } from "vitest";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  loadTrioConfigFromPlaybook,
+  resolveGroupPlaybookPath,
+  initTrioState,
+  nextRoundNumber,
+  prepareTurn,
+  appendTurnHistory,
+  annotateWarnings,
+  emitWarnings,
+  TRIO_WARNING_SEVERITY,
+  type WarningSink,
+} from "../src/trio-orchestrator.js";
+import {
+  composeBrejoSignals,
+  trioParticipantFromPersona,
+  DEFAULT_SENSORY_DIMENSIONS,
+} from "../src/brejo-composer.js";
+import {
+  DEFAULT_TRIO_RUNTIME_CONFIG,
+  type BrejoSignal,
+  type StatusMatrix,
+  type TrioParticipant,
+  type TrioState,
+} from "@ascendimacy/shared";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────
+
+function ryo(): TrioParticipant {
+  return { personaId: "ryo", name: "Ryo" };
+}
+function kei(): TrioParticipant {
+  return { personaId: "kei", name: "Kei" };
+}
+function saki(): TrioParticipant {
+  return {
+    personaId: "saki",
+    name: "Saki",
+    regulation_strategy: "sensory",
+    silence_tolerance_rounds: 5,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// loadTrioConfigFromPlaybook
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("loadTrioConfigFromPlaybook", () => {
+  it("returns DEFAULT config when playbook path doesn't resolve", () => {
+    const config = loadTrioConfigFromPlaybook(
+      "/nonexistent/path/playbook.yaml",
+    );
+    expect(config).toEqual(DEFAULT_TRIO_RUNTIME_CONFIG);
+  });
+
+  it("loads canon kids.group.playbook.yaml from motor playbooks dir", () => {
+    // Canon foi copiado em ops#1092 wire-up.
+    const canonPath = join(
+      __dirname,
+      "../../playbooks/kids.group.playbook.yaml",
+    );
+    if (!existsSync(canonPath)) {
+      // Skip se ambiente não tem canon (CI sem sync).
+      return;
+    }
+    const config = loadTrioConfigFromPlaybook(canonPath, { saki: "saki" });
+    // Valores canonicalizados em ops#1086 (Jun GO 2026-05-16).
+    expect(config.bot_turn_ratio_trio).toBe(0.2);
+    expect(config.bot_turn_ratio_dyad).toBe(0.25);
+    expect(config.dominance_threshold_trio).toBe(0.5);
+    expect(config.dominance_threshold_dyad).toBe(0.6);
+    expect(config.absence_threshold_rounds_default).toBe(3);
+    expect(config.absence_threshold_rounds_overrides["saki"]).toBe(5);
+    expect(config.brejo_pause_policy_trio.sensory_saki).toBe("partial");
+    expect(config.brejo_pause_policy_trio.emotional_any).toBe("full");
+    expect(config.max_consecutive_bot_turns).toBe(2);
+  });
+
+  it("loads from temp YAML w/ partial moderation_rules (fallback to defaults)", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "trio-cfg-"));
+    try {
+      const path = join(tmpDir, "partial.yaml");
+      writeFileSync(
+        path,
+        `
+base_mixins:
+  - name: withCrossing
+    config:
+      max_group_size: 3
+      moderation_rules:
+        bot_turn_ratio_trio: 0.18
+`,
+      );
+      const config = loadTrioConfigFromPlaybook(path);
+      expect(config.max_group_size).toBe(3);
+      expect(config.bot_turn_ratio_trio).toBe(0.18);
+      // Resto cai em defaults.
+      expect(config.dominance_threshold_trio).toBe(0.5);
+      expect(config.absence_threshold_rounds_default).toBe(3);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveGroupPlaybookPath", () => {
+  it("returns undefined for nonexistent override", () => {
+    expect(resolveGroupPlaybookPath("/nope.yaml")).toBeUndefined();
+  });
+
+  it("returns override path when exists", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "trio-resolve-"));
+    try {
+      const path = join(tmpDir, "p.yaml");
+      writeFileSync(path, "{}");
+      expect(resolveGroupPlaybookPath(path)).toBe(path);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// initTrioState + nextRoundNumber
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("initTrioState", () => {
+  it("infers dyad mode from 2 participants", () => {
+    const state = initTrioState([ryo(), kei()]);
+    expect(state.mode).toBe("dyad");
+    expect(state.participants).toHaveLength(2);
+    expect(state.turnHistory).toEqual([]);
+    expect(state.brejoSignals).toEqual([]);
+  });
+
+  it("infers trio mode from 3 participants", () => {
+    const state = initTrioState([ryo(), kei(), saki()]);
+    expect(state.mode).toBe("trio");
+    expect(state.participants).toHaveLength(3);
+  });
+
+  it("respects explicit mode override", () => {
+    const state = initTrioState([ryo(), kei(), saki()], "dyad");
+    expect(state.mode).toBe("dyad");
+  });
+
+  it("throws on empty participants", () => {
+    expect(() => initTrioState([])).toThrow(/participants vazio/);
+  });
+});
+
+describe("nextRoundNumber", () => {
+  it("returns 1 for empty history", () => {
+    const state = initTrioState([ryo(), kei()]);
+    expect(nextRoundNumber(state)).toBe(1);
+  });
+
+  it("returns max(round)+1 for non-empty history", () => {
+    const state = initTrioState([ryo(), kei()]);
+    state.turnHistory.push(
+      { round: 1, speakerType: "bot" },
+      { round: 1, speakerType: "child", personaId: "ryo" },
+      { round: 2, speakerType: "bot" },
+    );
+    expect(nextRoundNumber(state)).toBe(3);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// prepareTurn (per-turn hook)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("prepareTurn", () => {
+  it("returns bot target on empty history (round 1 opening)", () => {
+    const state = initTrioState([ryo(), kei(), saki()]);
+    const { decision, roundNumber } = prepareTurn(
+      state,
+      DEFAULT_TRIO_RUNTIME_CONFIG,
+    );
+    expect(decision.target).toBe("bot");
+    expect(roundNumber).toBe(1);
+  });
+
+  it("returns child target after bot opens", () => {
+    const state = initTrioState([ryo(), kei(), saki()]);
+    state.turnHistory.push({ round: 1, speakerType: "bot" });
+    // bot ratio = 1.0 → cap exceeded; runtime force child target.
+    const { decision } = prepareTurn(state, DEFAULT_TRIO_RUNTIME_CONFIG);
+    expect(decision.target).toBe("child");
+    expect(decision.nextSpeakerHint).toBeDefined();
+  });
+
+  it("returns pause_full when emotional brejo signal injected", () => {
+    const state = initTrioState([ryo(), kei(), saki()]);
+    state.turnHistory.push({ round: 1, speakerType: "bot" });
+    const brejoSignals: BrejoSignal[] = [
+      { personaId: "kei", type: "emotional" },
+    ];
+    const { decision } = prepareTurn(
+      state,
+      DEFAULT_TRIO_RUNTIME_CONFIG,
+      brejoSignals,
+    );
+    expect(decision.target).toBe("pause_full");
+    // Estado também guarda brejoSignals pra próxima call ler.
+    expect(state.brejoSignals).toEqual(brejoSignals);
+  });
+
+  it("trio: returns child target w/ Saki excluded on sensory partial-pause", () => {
+    const state = initTrioState([ryo(), kei(), saki()]);
+    // Histórico equilibrado pra evitar dominance warning.
+    state.turnHistory.push(
+      { round: 1, speakerType: "bot" },
+      { round: 1, speakerType: "child", personaId: "ryo" },
+      { round: 1, speakerType: "child", personaId: "kei" },
+      { round: 1, speakerType: "child", personaId: "saki" },
+      { round: 2, speakerType: "bot" },
+    );
+    const brejoSignals: BrejoSignal[] = [
+      { personaId: "saki", type: "sensory" },
+    ];
+    const { decision } = prepareTurn(
+      state,
+      DEFAULT_TRIO_RUNTIME_CONFIG,
+      brejoSignals,
+    );
+    // Saki excluded; Ryo ou Kei deve ser sugerido (bot ratio já alto → child).
+    expect(decision.excludedParticipants).toContain("saki");
+    if (decision.target === "child") {
+      expect(decision.nextSpeakerHint).not.toBe("saki");
+    }
+  });
+
+  it("dyad: emotional brejo signal still triggers full pause (§10 invariant)", () => {
+    const state = initTrioState([ryo(), kei()], "dyad");
+    state.turnHistory.push({ round: 1, speakerType: "bot" });
+    const brejoSignals: BrejoSignal[] = [
+      { personaId: "ryo", type: "emotional" },
+    ];
+    const { decision } = prepareTurn(
+      state,
+      DEFAULT_TRIO_RUNTIME_CONFIG,
+      brejoSignals,
+    );
+    expect(decision.target).toBe("pause_full");
+  });
+
+  it("dyad: sensory brejo also full pause (no partial path in dyad)", () => {
+    const state = initTrioState([ryo(), kei()], "dyad");
+    state.turnHistory.push({ round: 1, speakerType: "bot" });
+    const brejoSignals: BrejoSignal[] = [
+      { personaId: "kei", type: "sensory" },
+    ];
+    const { decision } = prepareTurn(
+      state,
+      DEFAULT_TRIO_RUNTIME_CONFIG,
+      brejoSignals,
+    );
+    expect(decision.target).toBe("pause_full");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// appendTurnHistory
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("appendTurnHistory", () => {
+  it("appends entry with default timestamp", () => {
+    const state = initTrioState([ryo(), kei()]);
+    const entry = appendTurnHistory(state, {
+      round: 1,
+      speakerType: "child",
+      personaId: "ryo",
+    });
+    expect(state.turnHistory).toHaveLength(1);
+    expect(entry.timestamp).toBeDefined();
+    expect(entry.round).toBe(1);
+    expect(entry.personaId).toBe("ryo");
+  });
+
+  it("preserves explicit timestamp", () => {
+    const state = initTrioState([ryo(), kei()]);
+    const entry = appendTurnHistory(state, {
+      round: 1,
+      speakerType: "bot",
+      timestamp: "2026-05-16T20:00:00Z",
+    });
+    expect(entry.timestamp).toBe("2026-05-16T20:00:00Z");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// annotateWarnings + emitWarnings (fail-soft sink)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("annotateWarnings", () => {
+  it("maps each warning to severity correctly", () => {
+    const annotated = annotateWarnings([
+      { kind: "dominance_detected", personaId: "ryo", reason: "r1", value: 0.7 },
+      { kind: "bot_ratio_exceeded", reason: "r2", value: 0.3 },
+    ]);
+    expect(annotated[0].severity).toBe("info");
+    expect(annotated[1].severity).toBe("warn");
+    expect(TRIO_WARNING_SEVERITY.bot_ratio_exceeded).toBe("warn");
+    expect(TRIO_WARNING_SEVERITY.absence_detected).toBe("info");
+  });
+});
+
+describe("emitWarnings", () => {
+  it("no-op when sink absent", async () => {
+    await emitWarnings(
+      {
+        target: "bot",
+        excludedParticipants: [],
+        warnings: [{ kind: "dominance_detected", reason: "r", value: 0.6 }],
+        turnDistribution: {},
+        botTurnRatio: 0.5,
+      },
+      { sessionId: "s1", roundNumber: 1 },
+    );
+    // No throw, no side-effect.
+  });
+
+  it("calls sink with annotated warnings + context", async () => {
+    const calls: Array<{ warnings: unknown; context: unknown }> = [];
+    const sink: WarningSink = async (warnings, context) => {
+      calls.push({ warnings, context });
+    };
+    await emitWarnings(
+      {
+        target: "child",
+        nextSpeakerHint: "ryo",
+        excludedParticipants: [],
+        warnings: [
+          {
+            kind: "absence_detected",
+            personaId: "kei",
+            reason: "silent",
+            value: 4,
+          },
+        ],
+        turnDistribution: { ryo: 3 },
+        botTurnRatio: 0.2,
+      },
+      { sessionId: "s1", roundNumber: 5 },
+      sink,
+    );
+    expect(calls).toHaveLength(1);
+    const ctx = calls[0].context as { decisionTarget: string; roundNumber: number };
+    expect(ctx.decisionTarget).toBe("child");
+    expect(ctx.roundNumber).toBe(5);
+  });
+
+  it("swallows sink errors (fail-soft)", async () => {
+    const sink: WarningSink = async () => {
+      throw new Error("event_log offline");
+    };
+    // No throw expected.
+    await emitWarnings(
+      {
+        target: "bot",
+        excludedParticipants: [],
+        warnings: [
+          { kind: "dominance_detected", personaId: "ryo", reason: "r", value: 0.7 },
+        ],
+        turnDistribution: {},
+        botTurnRatio: 0.1,
+      },
+      { sessionId: "s1", roundNumber: 1 },
+      sink,
+    );
+  });
+
+  it("no sink call when no warnings", async () => {
+    let called = false;
+    const sink: WarningSink = async () => {
+      called = true;
+    };
+    await emitWarnings(
+      {
+        target: "bot",
+        excludedParticipants: [],
+        warnings: [],
+        turnDistribution: {},
+        botTurnRatio: 0.1,
+      },
+      { sessionId: "s1", roundNumber: 1 },
+      sink,
+    );
+    expect(called).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// composeBrejoSignals (caller-side helper)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("composeBrejoSignals", () => {
+  it("emits no signal when matrices all baia", () => {
+    const matrix: StatusMatrix = {
+      emotional: "baia",
+      social_with_sibling: "baia",
+    };
+    const signals = composeBrejoSignals({
+      participants: [ryo(), kei(), saki()],
+      statusMatrixByPersona: { ryo: matrix, kei: matrix, saki: matrix },
+    });
+    expect(signals).toEqual([]);
+  });
+
+  it("emits emotional signal for any participant with emotional=brejo", () => {
+    const signals = composeBrejoSignals({
+      participants: [ryo(), kei(), saki()],
+      statusMatrixByPersona: {
+        ryo: { emotional: "baia" },
+        kei: { emotional: "brejo" },
+        saki: { emotional: "baia" },
+      },
+    });
+    expect(signals).toEqual([{ personaId: "kei", type: "emotional" }]);
+  });
+
+  it("emits sensory signal ONLY for participant w/ regulation_strategy=sensory", () => {
+    const signals = composeBrejoSignals({
+      participants: [ryo(), kei(), saki()],
+      statusMatrixByPersona: {
+        // Ryo NÃO tem regulation_strategy=sensory; mesmo com social_with_sibling=brejo
+        // não emite sensory signal.
+        ryo: { emotional: "baia", social_with_sibling: "brejo" },
+        kei: { emotional: "baia" },
+        saki: { emotional: "baia", social_with_sibling: "brejo" },
+      },
+    });
+    expect(signals).toEqual([{ personaId: "saki", type: "sensory" }]);
+  });
+
+  it("emits both emotional + sensory signals when applicable", () => {
+    const signals = composeBrejoSignals({
+      participants: [ryo(), saki()],
+      statusMatrixByPersona: {
+        ryo: { emotional: "brejo" },
+        saki: { emotional: "baia", social_with_sibling: "brejo" },
+      },
+    });
+    expect(signals).toContainEqual({ personaId: "ryo", type: "emotional" });
+    expect(signals).toContainEqual({ personaId: "saki", type: "sensory" });
+  });
+
+  it("ignores participants without matrix entry (graceful)", () => {
+    const signals = composeBrejoSignals({
+      participants: [ryo(), kei()],
+      statusMatrixByPersona: {
+        ryo: { emotional: "brejo" },
+        // kei sem matrix
+      },
+    });
+    expect(signals).toEqual([{ personaId: "ryo", type: "emotional" }]);
+  });
+
+  it("respects extraSensoryDimensions override", () => {
+    const signals = composeBrejoSignals({
+      participants: [saki()],
+      statusMatrixByPersona: {
+        saki: { emotional: "baia", auditory: "brejo" },
+      },
+      extraSensoryDimensions: ["auditory"],
+    });
+    expect(signals).toEqual([{ personaId: "saki", type: "sensory" }]);
+  });
+
+  it("DEFAULT_SENSORY_DIMENSIONS includes social_with_sibling + sensory", () => {
+    expect(DEFAULT_SENSORY_DIMENSIONS).toContain("social_with_sibling");
+    expect(DEFAULT_SENSORY_DIMENSIONS).toContain("sensory");
+  });
+});
+
+describe("trioParticipantFromPersona", () => {
+  it("extracts regulation_strategy + silence_tolerance_rounds", () => {
+    const p = trioParticipantFromPersona("saki", "Saki", {
+      regulation_strategy: "sensory",
+      silence_tolerance_rounds: 5,
+    });
+    expect(p.regulation_strategy).toBe("sensory");
+    expect(p.silence_tolerance_rounds).toBe(5);
+  });
+
+  it("omits invalid regulation_strategy", () => {
+    const p = trioParticipantFromPersona("x", "X", {
+      regulation_strategy: "invalid-value",
+    });
+    expect(p.regulation_strategy).toBeUndefined();
+  });
+
+  it("omits non-positive silence_tolerance_rounds", () => {
+    const p = trioParticipantFromPersona("x", "X", {
+      silence_tolerance_rounds: 0,
+    });
+    expect(p.silence_tolerance_rounds).toBeUndefined();
+  });
+
+  it("handles undefined profile gracefully", () => {
+    const p = trioParticipantFromPersona("x", "X", undefined);
+    expect(p.personaId).toBe("x");
+    expect(p.name).toBe("X");
+    expect(p.regulation_strategy).toBeUndefined();
+    expect(p.silence_tolerance_rounds).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Dyad backward-compat smoke (regression guard)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("dyad backward-compat", () => {
+  it("dyad runtime decisions stay identical to pre-wireup behavior", () => {
+    // Same scenarios cover by trio-runtime.unit.test.ts; here apenas
+    // verificamos que initTrioState + prepareTurn não muda thresholds dyad.
+    const state = initTrioState([ryo(), kei()]);
+    expect(state.mode).toBe("dyad");
+    const { decision } = prepareTurn(state, DEFAULT_TRIO_RUNTIME_CONFIG);
+    // Bot abre dinâmica (turnHistory vazio).
+    expect(decision.target).toBe("bot");
+    // Append, próximo turn:
+    appendTurnHistory(state, { round: 1, speakerType: "bot" });
+    const { decision: next } = prepareTurn(state, DEFAULT_TRIO_RUNTIME_CONFIG);
+    // bot ratio 100% > 25% cap → child.
+    expect(next.target).toBe("child");
+    expect(["ryo", "kei"]).toContain(next.nextSpeakerHint);
+  });
+});

--- a/orchestrator/tests/trio-runtime.unit.test.ts
+++ b/orchestrator/tests/trio-runtime.unit.test.ts
@@ -583,13 +583,22 @@ describe("buildTrioConfigFromPlaybook", () => {
   });
 
   it("integra com kids.group.playbook.yaml canônico (se presente)", () => {
-    // Procura o playbook canon em vários locais — tolerant pra dev local.
+    // Procura o playbook canon em vários locais — tolerant pra dev local + CI.
+    //
+    // Ordem de preferência (ops#1092 wire-up):
+    //   1. Cópia local em `<motor>/playbooks/kids.group.playbook.yaml` (canon
+    //      sincronizada com ops doctrine §11 trio Saki entry).
+    //   2. ops repo absolute path (dev local com ambos os repos checked out).
+    //
+    // Se nenhum disponível: skip (CI sem ops checked out).
     const candidates = [
+      // motor local copy (canon sincronizado em ops#1092, mantém max_group_size=3)
+      new URL("../../playbooks/kids.group.playbook.yaml", import.meta.url).pathname,
       "/home/alexa/ascendimacy-ops/docs/playbooks/kids.group.playbook.yaml",
     ];
     const found = candidates.find((p) => existsSync(p));
     if (!found) {
-      // Skip se ops repo não acessível neste ambiente.
+      // Skip se nenhuma cópia acessível neste ambiente.
       return;
     }
     const raw = readFileSync(found, "utf-8");

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -7,6 +7,7 @@ composition rules e fases.
 ## Origem
 
 - `kids.session.playbook.yaml` — importado de `ebrota/playbooks/kids.session.playbook.yaml`.
+- `kids.group.playbook.yaml` — importado de `ascendimacy-ops/docs/playbooks/kids.group.playbook.yaml` (canon doctrine §10+§11 dinâmicas-grupo; trio runtime config via `moderation_rules`).
 
 Referência: Handoff #17 Bloco 1.3, spec `ascendimacy-ops/docs/specs/2026-04-24-materialization-strategy.md`.
 

--- a/playbooks/kids.group.playbook.yaml
+++ b/playbooks/kids.group.playbook.yaml
@@ -1,0 +1,141 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# kids.group.playbook.yaml
+#
+# PROPOSTA v1 (2026-04-24) — para ser copiada para ebrota/playbooks/ pelo CC.
+# Sessões em dyad/grupo pequeno via WhatsApp group chat.
+# Dyad Ryo+Kei natural no piloto Nagareyama.
+# ──────────────────────────────────────────────────────────────────────────────
+
+schema_version: "1.1.0"
+version: "1.0"
+name: "kids.group"
+extends_playbook: "kids.base.playbook.yaml"
+deployment_profile: "kids-group"
+
+# ─── Ambição overrides ─────────────────────────────────────────────────────────
+ambition:
+  max_challenge_scale: grande
+  sessions_per_week: 1                       # 1 sessão grupo/semana no v1
+  minutes_per_session: 20                    # sessões grupo são mais longas
+  sacrifice_budget_weekly: 20
+  sacrifice_budget_screen: 20
+
+# ─── Escopo ────────────────────────────────────────────────────────────────────
+subjects:
+  mode: open
+  weight_on_weakness: 0.3
+  focus_techniques:                          # técnicas especialmente potentes em grupo
+    - Tribunal
+    - Tier List
+    - Profecia
+    - Teach Back
+    - Quest Chain
+    - Detetive
+    - Comedia
+
+# ─── Mixins ─────────────────────────────────────────────────────────────────────
+base_mixins:
+  - name: withConversation
+    config:
+      confirmation_mode: minimal
+      batch_mode: true
+
+  - name: withMemory
+    config:
+      ttl: "30d"
+      scope: group                           # memória compartilhada entre membros
+
+  - name: withTree
+    config:
+      zones: 6
+      half_life_days:
+        raiz: null
+        tronco: 90
+        galho: 60
+        folha: 30
+        crossing: 45
+        preferencia: 180
+
+  - name: withCrossing
+    config:
+      mode: multi_child                      # NOVO valor (além de parent_child)
+      max_group_size: 3                      # trio (Saki entry) por ops#1086 Jun 2026-05-16
+      moderation_protocol: asynchronous_whatsapp
+      moderation_rules:
+        max_consecutive_bot_turns: 2         # §10 invariante 2 (dyad + trio)
+        silence_tolerance_seconds: 30
+        # bot_turn_ratio: 0.25 em dyad → 0.20 em trio (§11.1 ops#1086)
+        bot_turn_ratio_dyad: 0.25
+        bot_turn_ratio_trio: 0.20            # bot ≤ 20% em 3-child
+        # dominance_threshold: 0.60 em dyad → 0.50 em trio (§11.2 ops#1086)
+        dominance_threshold_dyad: 0.6        # >60% → cede palavra (dyad)
+        dominance_threshold_trio: 0.5        # >50% → cede palavra (trio: 50% já é 1.5× equal-share)
+        absence_threshold_rounds_default: 3  # ping silencioso 3+ rounds
+        absence_threshold_rounds_saki: 5     # Saki ASD nível 1 — autorregulação, NÃO ping cedo (§11.3 ops#1086)
+        synthesis_at_end: true
+        # Brejo unilateral trio (§11.4 ops#1086):
+        # - sensory + Saki em brejo → partial pause (skip Saki rotation, Ryo/Kei continuam)
+        # - emocional qualquer membro → full pause (§10 invariante 6 dyad mantém)
+        brejo_pause_policy_trio:
+          sensory_saki: partial               # bot stops convidando Saki, Ryo/Kei continuam
+          emotional_any: full                 # qualquer membro afetivo → pause total
+
+# ─── Regras de composição ─────────────────────────────────────────────────────
+composition_rules:
+  - when: { signal: "first_group_session" }
+    apply_mixins:
+      - name: withOnboarding
+        config:
+          group_onboarding: true
+          mediator_required: false           # não exige pais presentes em dyad
+    priority: 10
+
+  - when: { signal: "conflict_detected" }
+    apply_mixins:
+      - name: withCrossing
+        config:
+          mode: parent_child                 # escala pra sessão conjunta pais+filho se persistir
+          trigger: "3 rounds unresolved disagreement"
+    priority: 15
+
+# ─── Fases ────────────────────────────────────────────────────────────────────
+phases:
+  onboarding:
+    mixins: [withConversation, withMemory, withOnboarding]
+    duration_sessions: 2
+    graduation:
+      type: completion
+      params:
+        completed_steps: [introductions, group_agreement]
+
+  regular:
+    mixins: [withConversation, withMemory, withTree, withCrossing]
+    graduation:
+      type: group_cohesion
+      params:
+        min_sessions: 4
+        engagement_balance: 0.7              # nenhum membro com engagement < 70% da média
+
+  graduated:
+    mixins: [withConversation, withMemory, withCrossing]
+    mixin_config_overrides:
+      withMemory:
+        ttl: "90d"
+
+signal_sources:
+  - type: webhook
+    config:
+      endpoint: /kids/group-signals
+      auth_ref: "secrets.webhook_kids_group"
+
+external_bridges: []
+
+metadata:
+  author: "Jun Ochiai"
+  product: "kids-group"
+  target_audience: "dyads e pequenos grupos (irmãos/primos/amigos próximos)"
+  description: "Sessões em grupo via WhatsApp com moderação assíncrona. v1 suporta dyad apenas."
+  tags: [kids, group, dyad, crossing, async_moderation]
+  v1_status: active
+  v1_supported_size: [2]
+  v2_planned_sizes: [2, 3, 4, 5, 6, 7, 8]


### PR DESCRIPTION
## Summary

Wire-up do **trio runtime engine** (pure functions de motor#129) no orchestrator
session loop. Resolve o gap "engine existe mas nenhuma sessão consome".

Refs ascendimacy/ascendimacy-ops#1092 (story de follow-up; cross-repo `Closes` não fecha auto, ver memory `reference_cross_repo_close_limitation`).
Source: motor#129 (pure engine + 41 unit tests, merged 2026-05-16).
Parent doctrine: ops#1086 (CLOSED 2026-05-16, Jun GO §11 trio Saki entry).

## Changes

### New files
- `orchestrator/src/brejo-composer.ts` — `composeBrejoSignals()` + `trioParticipantFromPersona()` helpers. Pure functions.
- `orchestrator/src/trio-orchestrator.ts` — config loader, state lifecycle, per-turn hook, warning sink. Wraps `decideNextSpeaker` sem invadir `runTurn`.
- `orchestrator/tests/trio-orchestrator.unit.test.ts` — 36 new unit tests.
- `playbooks/kids.group.playbook.yaml` — canon doctrine sync de `ascendimacy-ops/docs/playbooks/` (max_group_size=3 trio Saki entry).

### Modified files
- `orchestrator/tests/trio-runtime.unit.test.ts` — test "integra com canon" agora prefere cópia local (motor playbooks/) sobre ops absolute path. Fixa pre-existing failure quando ops repo tem versão stale dyad-only.
- `playbooks/README.md` — documenta nova cópia canon.

## CC defaults inline (aguardando ratify Jun)

| # | Decisão | Default aplicado | Justificativa |
|---|---------|-----------------|---------------|
| 1 | Per-turn hook location | Pré-prompt-build (call `decideNextSpeaker` antes de drota) | Target fresco; orchestrator chama `prepareTurn` per round |
| 2 | TrioState persistência | In-memory session-scoped (v1) | Cross-session SQL = separate story |
| 3 | BrejoSignal composer | `orchestrator/src/brejo-composer.ts` (módulo dedicado) | Próximo do session state; reusável por test + group loop |
| 4 | Warnings sink | event_log via callback opcional, **NUNCA throw** | Caller plugga `motor-execucao.log_event` w/ severity; sink errors swallowed |
| 5 | GroupSession API | Helpers funcionais (não class wrapper) sobre `runTurn` | Zero risco regressão dyad solo; group-session.ts classe é separate concern |
| 6 | Sensory dimensions default | `[social_with_sibling, sensory]` | Saki ASD-1: brejo sensory tipicamente surge via ruído social-irmão |

## Test delta

- **Orchestrator workspace**: 43 → 79 tests (36 novos, todos verdes)
- **Outros workspaces**: sem mudança (`@ascendimacy/shared`, `weekly-report`, `llm-gateway`, `motor-execucao`, `motor-drota` baseline mantido)
- **Pre-existing failure NÃO causada por este PR**: `planejador/tests/plan.test.ts > G-22 remaining gaps integration > kidsHelixState.current_day` (TypeError, ops#1033). Reproducido em /tmp baseline clone do origin/main, idêntico `1 failed | 293 passed`. Out of scope.

## Honest gaps deferidos

- **Cross-session persistência**: TrioState v1 é in-memory; SQL `group_sessions` table = story separada.
- **GroupSession class wrapper**: API surface atual é functional (initTrioState + prepareTurn + appendTurnHistory). Class lifecycle wrapper (com MCP clients embutidos) = follow-up se Jun preferir OO surface.
- **runTurn wire-up final**: este PR adiciona o engine + composer + per-turn hook **callables**, mas NÃO modifica `runTurn` em `orchestrator.ts` ainda. Próximo step: novo CLI subcommand `motor run-group --participants ryo,kei,saki` que usa `prepareTurn` → `runTurn(target)` em loop. Deixado pra follow-up pra manter PR pequeno e zero-risco em dyad solo paths.
- **Parental dashboard live feed**: warnings sink permite plug, mas sink concreto (UI/event consumer) é Phase 2.
- **WhatsApp group adapter** (`asynchronous_whatsapp` moderation protocol): Phase 2.
- **`doutrina:trio` label**: não existe no ops repo; PR usa labels existentes (`type:story`, `eBrota-Kids`, `sprint:2-prep`, `tier:1-autonomous`, `lane:ready-for-cc`, `phase:F1`).

## Test plan

- [x] `npm test -w @ascendimacy/orchestrator` — 79 passed (43 baseline + 36 novos)
- [x] `npm run build -w @ascendimacy/orchestrator` — tsc clean
- [x] Baseline regression check em `/tmp` clone — plan.test.ts failure é pre-existing em main
- [ ] Jun review CC defaults (#1-6 acima)
- [ ] Jun decide: follow-up CLI subcommand `motor run-group` agora ou deferred?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>