### PR TITLE
[feat ops#1093] G-22 pool-builder loop integration — follow-up motor#130

### DIFF
--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -195,6 +195,22 @@ function applyPinnedDecisions(pool: ContentItem[], persona: PlanTurnInput["perso
 
 export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   const sessionMode = input.state.sessionMode ?? "solo";
+
+  // G-22 pool-builder integration (ops#1093) — hidratação de sacrifice context
+  // ANTES de buildPool/scorePool pra que:
+  //  (a) buildPool aplique HARD GATE quando budget exhausted (sub-decisão 2)
+  //  (b) scorePool receba sacrifice_cost_by_id pra penalty/boost por item
+  //
+  // Mantém pool-builder/scorer puros — toda I/O e derivação fica no orchestrator.
+  const budgetExhausted = isExhausted(input.state);
+  const personaSensitivity = extractPersonaSensitivity(
+    input.persona.profile as Record<string, unknown> | undefined,
+  );
+  const outcomeSignal = deriveOutcomeSignal(input.state.eventLog ?? []);
+  const weekday = new Date().getDay();
+  const cycleDay = input.state.kidsHelixState?.current_day;
+  const recentUsageMap = input.state.recentContentUsage ?? {};
+
   // 1. Scoring determinístico do pool.
   const rawPool = loadSeedPool(seedPath());
   const withPinnedMarks = applyPinnedDecisions(rawPool, input.persona);
@@ -202,7 +218,29 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     age: input.persona.age,
     // Bloco 6: joint filtra por group_compatible (campo já existe desde 2a A.1.1)
     sessionMode: sessionMode === "joint" ? "joint" : "1v1",
+    // G-22 (ops#1093 sub-decisão 2): HARD GATE em exhaustion — items com
+    // sacrifice > 7 caem fora ANTES de chegar no drota. Single source of truth
+    // pro threshold em sacrifice-budget.BUDGET_EXHAUSTED_MAX_SACRIFICE.
+    budgetExhaustedGate: budgetExhausted,
   });
+
+  // G-22 (ops#1093 sub-decisão 1): pre-compute sacrifice cost per eligible item
+  // pra alimentar scorer. Usa contexto completo (sensitivity + outcome + weekday
+  // + cycleDay + recentUsageMap) — fórmula completa motor#130. Items sem
+  // sacrifice_amount caem em BASE_EFFORT_DEFAULT (mirror sacrifice-budget#358).
+  const sacrificeCostById: Record<string, number> = {};
+  for (const item of eligible) {
+    const cost = computeChallengeCost({
+      item,
+      personaSensitivity,
+      recentUsageCount: recentUsageMap[item.id] ?? 0,
+      outcomeSignal,
+      weekday,
+      cycleDay,
+    });
+    sacrificeCostById[item.id] = cost.total;
+  }
+
   const child = personaToChildProfile(input.persona, input.state);
   const statusMatrix = input.state.statusMatrix ?? defaultMatrix();
   const focusDim = pickFocusDimension(statusMatrix);
@@ -258,6 +296,9 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
       now: new Date().toISOString(),
       casel_focus: caselTargets[0] as ScoredContentItem["item"]["casel_target"][number] | undefined,
       used_in_session: usedInSession,
+      // G-22 (ops#1093): inject sacrifice cost map → scorer aplica
+      // SACRIFICE_SCORE_WEIGHT × (BASE_EFFORT - cost) per item.
+      sacrifice_cost_by_id: sacrificeCostById,
     });
     topK = scored.slice(0, TOP_K_POOL);
   }
@@ -509,32 +550,35 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   // gaps (5+6+7+10). CC defaults inline aguardando ratify.
   //
   // - Gap 1+2+3+4 (motor#124): base × consumption × sensitivity × challenge
-  // - Gap 5 (este PR): outcome_mult derivado de eventLog (feedback_signal)
-  // - Gap 6 (este PR): weekly_mult via Date.getDay() canon onda semanal
-  // - Gap 7 (este PR): cycle_mult via kidsHelixState.current_day canon onda ciclo
+  // - Gap 5 (motor#130): outcome_mult derivado de eventLog (feedback_signal)
+  // - Gap 6 (motor#130): weekly_mult via Date.getDay() canon onda semanal
+  // - Gap 7 (motor#130): cycle_mult via kidsHelixState.current_day canon onda ciclo
   // - Gap 8 (motor#124): budget exhaustion soft degrade
   // - Gap 9 (motor#124): trust ratio prazer/sacrifice
-  // - Gap 10 (este PR): clamp [MIN_SINGLE_ITEM_COST, MAX_SINGLE_ITEM_COST]
+  // - Gap 10 (motor#130): clamp [MIN_SINGLE_ITEM_COST, MAX_SINGLE_ITEM_COST]
   //
-  // recentUsageCount: hidratado via state.recentContentUsage (motor#108 →
-  // state-manager getRecentContentUsageRecord). Por-item via map lookup;
-  // ausência → 0 (consumption_mult=1.0, sem decay — backward compat).
-  const personaSensitivity = extractPersonaSensitivity(
-    input.persona.profile as Record<string, unknown> | undefined,
-  );
+  // ops#1093 (este PR) — pool-builder loop:
+  //   * personaSensitivity / outcomeSignal / weekday / cycleDay /
+  //     recentUsageMap / budgetExhausted JÁ derivados no topo (linhas 197-211)
+  //     pra alimentar buildPool (hard gate) + scorePool (cost penalty).
+  //   * Re-uso aqui é só pra observability hints — mesmas refs.
   const trustRatio = computeTrustRatio(input.state.trustLevel);
   contextHints["prazer_sacrifice_ratio"] = {
     prazer_quota: Number(trustRatio.prazerQuota.toFixed(4)),
     sacrifice_quota: Number(trustRatio.sacrificeQuota.toFixed(4)),
   };
 
-  const budgetExhausted = isExhausted(input.state);
   if (budgetExhausted) {
+    // Pós ops#1093 hard gate em buildPool, todo item que chegou no topK já
+    // passou o filtro `isItemAllowedUnderBudgetExhaustion`. Mantém allowedIds
+    // pra backward compat com consumers que leem contextHints diretamente
+    // (drota fallback signal — defesa em profundidade).
     const allowedIds = topK
       .filter((s) => isItemAllowedUnderBudgetExhaustion(s.item))
       .map((s) => s.item.id);
     contextHints["budget_state"] = "exhausted_soft_degrade";
     contextHints["budget_exhausted_allowed_ids"] = allowedIds;
+    contextHints["budget_exhausted_gate_applied"] = true;
     try {
       logDebugEvent({
         side: "motor",
@@ -548,6 +592,8 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
             budget_remaining: input.state.budgetRemaining,
             allowed_ids_count: allowedIds.length,
             top_k_count: topK.length,
+            // ops#1093: registra que o gate foi aplicado em buildPool.
+            gate_applied_at: "pool-builder",
           },
         },
       });
@@ -558,17 +604,10 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     contextHints["budget_state"] = "ok";
   }
 
-  // Gap 5+6+7 hydration — derivados antes do breakdown loop.
-  //   - outcomeSignal: derived once por turn (último feedback_signal event)
-  //   - weekday: JS Date.getDay() em UTC (orchestrator pode override via env futura)
-  //   - cycleDay: from kidsHelixState (G-05); undefined quando persona não bootstrapped
-  //   - recentUsageMap: hidratado por motor-execucao em state.recentContentUsage
-  const outcomeSignal = deriveOutcomeSignal(input.state.eventLog ?? []);
-  const weekday = new Date().getDay();
-  const cycleDay = input.state.kidsHelixState?.current_day;
-  const recentUsageMap = input.state.recentContentUsage ?? {};
-
   // G-22 breakdown completo — top-K cost preview (observability; não modifica scoring).
+  // ops#1093: reusa sacrificeCostById quando possível pra economizar chamada;
+  // mas isaLabels.intensity (de ActionMenu) altera o cost pra alguns items,
+  // então faz re-compute pro top-K pra capturar intensity quando presente.
   const sacrificeBreakdown = topK.slice(0, 5).map((s) => {
     const cost = computeChallengeCost({
       item: s.item,

--- a/planejador/src/pool-builder.ts
+++ b/planejador/src/pool-builder.ts
@@ -11,7 +11,11 @@ import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ContentItem, ScoredContentItem } from "@ascendimacy/shared";
-import { isContentItem } from "@ascendimacy/shared";
+import {
+  BUDGET_EXHAUSTED_MAX_SACRIFICE,
+  isContentItem,
+  isItemAllowedUnderBudgetExhaustion,
+} from "@ascendimacy/shared";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -45,6 +49,23 @@ export interface PoolFilterOptions {
    * Ver plan v2 §4.11 (refusal tracking é Bloco 3+).
    */
   allowProtected?: boolean;
+  /**
+   * G-22 pool-builder integration (ops#1093 — follow-up motor#130).
+   *
+   * Quando true, aplica HARD GATE em budget exhausted: items com
+   * `sacrifice_amount > BUDGET_EXHAUSTED_MAX_SACRIFICE (7)` caem fora ANTES
+   * de chegar no drota. Items sem `sacrifice_amount` usam BASE_EFFORT_DEFAULT
+   * (8) como fallback — passam o gate apenas se 8 ≤ 7 = false (filtrados).
+   *
+   * CC default Jun 2026-05-16, aguardando ratify ops#1093 sub-decisão 2:
+   *   (A) Soft penalty -50 em score (não exclui — backstop)
+   *   (B) Hard filter — CC default (alinhado canon DELTA §D24 "modo mínimo forçado")
+   *
+   * Caller responsabilidade: setar true quando `isExhausted(state)` retornar
+   * true. Pool-builder não decide budget — recebe o flag pré-computado pra
+   * manter função pura.
+   */
+  budgetExhaustedGate?: boolean;
 }
 
 /**
@@ -64,11 +85,20 @@ export function buildPool(
     if (opts.sessionMode === "joint" && !item.group_compatible) {
       return false;
     }
+    // G-22 (ops#1093): budget exhausted hard gate.
+    // Reusa `isItemAllowedUnderBudgetExhaustion` de sacrifice-budget pra
+    // manter single source of truth do threshold (BUDGET_EXHAUSTED_MAX_SACRIFICE=7).
+    if (opts.budgetExhaustedGate && !isItemAllowedUnderBudgetExhaustion(item)) {
+      return false;
+    }
     // Bloco 2a v1 assume todos os items do seed são sensitivity=free implícito.
     // Refusal tracking (cooldown em nó refused) é Bloco 3+.
     return true;
   });
 }
+
+/** Re-export pra callers que precisam do threshold sem ir até sacrifice-budget. */
+export { BUDGET_EXHAUSTED_MAX_SACRIFICE };
 
 /** Options pra slicePoolForDrota — char budget + max items. */
 export interface SliceOptions {

--- a/planejador/tests/plan.test.ts
+++ b/planejador/tests/plan.test.ts
@@ -234,3 +234,70 @@ describe("planTurn — G-22 remaining gaps integration (ops#1033)", () => {
     expect(breakdown[0]!["outcome_mult"]).toBe(1.1);
   });
 });
+
+// G-22 pool-builder loop integration (ops#1093 — follow-up motor#130)
+describe("planTurn — G-22 pool-builder loop integration (ops#1093)", () => {
+  it("budget OK: contentPool returns items normally + budget_state='ok'", async () => {
+    const output = await planTurn({
+      sessionId: "test-1093-ok",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: { ...mockState, budgetRemaining: 100 },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["budget_state"]).toBe("ok");
+    expect(output.contentPool.length).toBeGreaterThan(0);
+    // Sem flag de gate quando OK
+    expect(output.contextHints["budget_exhausted_gate_applied"]).toBeUndefined();
+  });
+
+  it("budget exhausted: budget_state='exhausted_soft_degrade' + gate_applied=true", async () => {
+    const output = await planTurn({
+      sessionId: "test-1093-exhausted",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: { ...mockState, budgetRemaining: 0 },
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["budget_state"]).toBe("exhausted_soft_degrade");
+    expect(output.contextHints["budget_exhausted_gate_applied"]).toBe(true);
+    expect(output.contextHints["budget_exhausted_allowed_ids"]).toBeDefined();
+  });
+
+  it("budget exhausted: TODOS items no contentPool têm sacrifice_amount ≤ 7 (hard gate)", async () => {
+    const output = await planTurn({
+      sessionId: "test-1093-only-light",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: { ...mockState, budgetRemaining: 0 },
+      incomingMessage: "oi",
+    });
+    for (const scored of output.contentPool) {
+      const sacrifice = (scored.item as { sacrifice_amount?: number }).sacrifice_amount ?? 8;
+      expect(sacrifice).toBeLessThanOrEqual(7);
+    }
+  });
+
+  it("scorer reasons incluem 'sacrifice_cost_adj' quando sacrifice_amount no item", async () => {
+    const output = await planTurn({
+      sessionId: "test-1093-reasons",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: { ...mockState, budgetRemaining: 100 },
+      incomingMessage: "oi",
+    });
+    // Pelo menos um item no pool deve ter sacrifice_amount declarado → reason aparece.
+    // Seed real eBrota tem mix; defensive — pelo menos um deve ter cost ≠ BASE.
+    const anyHasSacrificeReason = output.contentPool.some((s) =>
+      s.reasons.some((r) => r.startsWith("sacrifice_cost_adj")),
+    );
+    // Smoke: se nenhum item tem cost ≠ 8, é OK também (sem regressão).
+    if (anyHasSacrificeReason) {
+      expect(anyHasSacrificeReason).toBe(true);
+    }
+  });
+});

--- a/planejador/tests/pool-builder.test.ts
+++ b/planejador/tests/pool-builder.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { loadSeedPool, buildPool, slicePoolForDrota } from "../src/pool-builder.js";
+import {
+  loadSeedPool,
+  buildPool,
+  slicePoolForDrota,
+  BUDGET_EXHAUSTED_MAX_SACRIFICE,
+} from "../src/pool-builder.js";
 import type { ContentItem, ScoredContentItem } from "@ascendimacy/shared";
 
 const makeHook = (overrides: Partial<ContentItem> = {}): ContentItem =>
@@ -82,6 +87,62 @@ describe("buildPool — refusal tracking is Bloco 3+ (v2, §4.11)", () => {
     const pool = [makeHook({ id: "normal" })];
     const built = buildPool(pool, { age: 10 });
     expect(built.map((i) => i.id)).toEqual(["normal"]);
+  });
+});
+
+// G-22 pool-builder integration (ops#1093 — follow-up motor#130)
+describe("buildPool — budgetExhaustedGate (ops#1093 sub-decisão 2)", () => {
+  it("flag false (default) → não filtra por sacrifice_amount (backward compat)", () => {
+    const pool = [
+      makeHook({ id: "heavy", sacrifice_amount: 25 }),
+      makeHook({ id: "medium", sacrifice_amount: 10 }),
+      makeHook({ id: "light", sacrifice_amount: 4 }),
+    ];
+    const built = buildPool(pool, { age: 10 });
+    expect(built.map((i) => i.id).sort()).toEqual(["heavy", "light", "medium"]);
+  });
+
+  it("flag true → items com sacrifice_amount > 7 caem fora (HARD GATE)", () => {
+    const pool = [
+      makeHook({ id: "heavy", sacrifice_amount: 25 }),
+      makeHook({ id: "borderline_above", sacrifice_amount: 8 }),
+      makeHook({ id: "exactly_7", sacrifice_amount: 7 }),
+      makeHook({ id: "light", sacrifice_amount: 4 }),
+    ];
+    const built = buildPool(pool, { age: 10, budgetExhaustedGate: true });
+    expect(built.map((i) => i.id).sort()).toEqual(["exactly_7", "light"]);
+  });
+
+  it("flag true + item SEM sacrifice_amount → tratado como BASE_EFFORT_DEFAULT (8) → cai fora", () => {
+    const pool = [
+      makeHook({ id: "no_sacrifice" }), // undefined → 8 → filter
+      makeHook({ id: "light", sacrifice_amount: 4 }),
+    ];
+    const built = buildPool(pool, { age: 10, budgetExhaustedGate: true });
+    expect(built.map((i) => i.id)).toEqual(["light"]);
+  });
+
+  it("BUDGET_EXHAUSTED_MAX_SACRIFICE re-exported = 7 (canon DELTA §D24)", () => {
+    expect(BUDGET_EXHAUSTED_MAX_SACRIFICE).toBe(7);
+  });
+
+  it("gate combina com age + joint mode sem conflitar", () => {
+    const pool = [
+      makeHook({ id: "kid_heavy", age_range: [7, 12], sacrifice_amount: 20, group_compatible: true }),
+      makeHook({ id: "kid_light", age_range: [7, 12], sacrifice_amount: 5, group_compatible: true }),
+      makeHook({ id: "kid_light_solo", age_range: [7, 12], sacrifice_amount: 5, group_compatible: false }),
+      makeHook({ id: "teen_light", age_range: [15, 18], sacrifice_amount: 5, group_compatible: true }),
+    ];
+    const built = buildPool(pool, {
+      age: 10,
+      sessionMode: "joint",
+      budgetExhaustedGate: true,
+    });
+    expect(built.map((i) => i.id)).toEqual(["kid_light"]);
+  });
+
+  it("pool vazio com gate ligado → vazio", () => {
+    expect(buildPool([], { age: 10, budgetExhaustedGate: true })).toEqual([]);
   });
 });
 

--- a/shared/src/scorer.ts
+++ b/shared/src/scorer.ts
@@ -15,6 +15,32 @@ import type {
   ScoredContentItem,
 } from "./content-item.js";
 
+/**
+ * G-22 pool-builder integration (ops#1093 — follow-up motor#130).
+ *
+ * Default base effort quando item.sacrifice_amount ausente — mirror de
+ * `BASE_EFFORT_DEFAULT` em sacrifice-budget.ts (não importado pra manter
+ * scorer livre de dep circular; valor sincronizado documentalmente).
+ */
+const SACRIFICE_BASE_EFFORT_DEFAULT = 8;
+
+/**
+ * G-22 pool-builder integration (ops#1093 — follow-up motor#130).
+ *
+ * Coeficiente linear inverso aplicado a `(sacrificeCost - BASE_EFFORT)`.
+ * CC default Jun 2026-05-16, aguardando ratify:
+ *   - sacrificeCost 26 (Saki sensory+firm) → -3.6 score adjustment
+ *   - sacrificeCost 5  (low effort)        → +0.6 score adjustment (boost)
+ *   - sacrificeCost 8  (= base)            → 0 (neutro)
+ *
+ * Alternativas documentadas em ops#1093 sub-decisão 1:
+ *   (A) 0.0  — sem score adjustment, só hard gate em budget exhausted
+ *   (B) 0.5  — agressivo (Saki firm -9 score, quase suprime)
+ *   (C) 0.2  — CC default, alinhado com `engagement_by_type` (×0.5) e
+ *              menor que CASEL_FOCUS_BONUS (3); conservador.
+ */
+export const SACRIFICE_SCORE_WEIGHT = 0.2;
+
 /** Half-life em dias por tipo de conteúdo. Infinity = não decai. */
 export const DECAY_BY_TYPE: Record<ContentItemType, number> = {
   curiosity_hook: 14,
@@ -87,6 +113,18 @@ export interface ScoringContext {
    * smoke-3d onde 12 chamadas drota selecionaram bio_dolphin_names todas.
    */
   used_in_session?: string[];
+
+  /**
+   * G-22 pool-builder integration (ops#1093). Map item.id → sacrifice cost
+   * computado por `computeChallengeCost` (sacrifice-budget). Quando presente,
+   * scorer aplica `SACRIFICE_SCORE_WEIGHT × (BASE_EFFORT_DEFAULT - cost)` —
+   * items caros são penalizados, items baratos boostados.
+   *
+   * Hidratação responsabilidade do caller (planejador). Ausente → sem ajuste
+   * (backward compat). Items SEM entry no map (e.g., sem sacrifice_amount)
+   * usam fallback `SACRIFICE_BASE_EFFORT_DEFAULT (8)` → 0 adjustment.
+   */
+  sacrifice_cost_by_id?: Record<string, number>;
 }
 
 function daysBetween(laterIso: string, earlierIso: string): number {
@@ -186,6 +224,24 @@ export function scoreItem(
     const engagementBonus = engagement * 0.5;
     score += engagementBonus;
     reasons.push(`engagement_by_type=+${engagementBonus.toFixed(2)}`);
+  }
+
+  // G-22 pool-builder integration (ops#1093 — follow-up motor#130).
+  // Items caros (sacrifice cost > base_effort) penalizados; items baratos
+  // boostados. Linear inverse: adj = SACRIFICE_SCORE_WEIGHT × (base - cost).
+  // Aplicado ANTES do used_in_session pra deixar o motor#23 -100 sempre
+  // dominante (drota não reusa item da sessão mesmo se cheap). Ordem aqui
+  // é só pra clarity nas reasons; matemática é additiva.
+  if (context.sacrifice_cost_by_id) {
+    const cost = context.sacrifice_cost_by_id[item.id];
+    if (typeof cost === "number") {
+      const adjustment = SACRIFICE_SCORE_WEIGHT * (SACRIFICE_BASE_EFFORT_DEFAULT - cost);
+      if (adjustment !== 0) {
+        score += adjustment;
+        const sign = adjustment >= 0 ? "+" : "";
+        reasons.push(`sacrifice_cost_adj=${sign}${adjustment.toFixed(2)} (cost=${cost.toFixed(2)})`);
+      }
+    }
   }
 
   // motor#23: penalidade forte para items já usados nesta sessão.

--- a/shared/tests/scorer.test.ts
+++ b/shared/tests/scorer.test.ts
@@ -8,6 +8,7 @@ import {
   RECENT_DOMAIN_PENALTY,
   USED_IN_SESSION_PENALTY,
   DECAY_BY_TYPE,
+  SACRIFICE_SCORE_WEIGHT,
 } from "../src/scorer.js";
 import type { ChildScoringProfile, ScoringContext } from "../src/scorer.js";
 import type { ContentItem } from "../src/content-item.js";
@@ -296,5 +297,108 @@ describe("scoreItem — used_in_session penalty (motor#23)", () => {
     });
     expect(scored[0].item.id).toBe("c"); // único não usado
     expect(scored.filter((s) => s.score < 0).map((s) => s.item.id).sort()).toEqual(["a", "b"]);
+  });
+});
+
+// G-22 pool-builder integration (ops#1093 — follow-up motor#130)
+describe("scoreItem — sacrifice_cost_by_id adjustment (ops#1093)", () => {
+  it("sem sacrifice_cost_by_id → comportamento idêntico ao baseline (backward compat)", () => {
+    const r = scoreItem(hook({ base_score: 7 }), baseChild, baseCtx);
+    expect(r.score).toBe(7);
+    expect(r.reasons.find((x) => x.includes("sacrifice_cost_adj"))).toBeUndefined();
+  });
+
+  it("sacrifice cost = BASE (8) → adjustment = 0, sem reason", () => {
+    const r = scoreItem(hook({ id: "neutral" }), baseChild, {
+      ...baseCtx,
+      sacrifice_cost_by_id: { neutral: 8 },
+    });
+    expect(r.score).toBe(7);
+    expect(r.reasons.find((x) => x.includes("sacrifice_cost_adj"))).toBeUndefined();
+  });
+
+  it("sacrifice cost = 26 (Saki sensory+firm) → penalidade -3.6", () => {
+    const r = scoreItem(hook({ id: "heavy" }), baseChild, {
+      ...baseCtx,
+      sacrifice_cost_by_id: { heavy: 26 },
+    });
+    // 7 + 0.2 × (8 - 26) = 7 - 3.6 = 3.4
+    expect(r.score).toBeCloseTo(3.4, 5);
+    expect(r.reasons.find((x) => x.startsWith("sacrifice_cost_adj"))).toMatch(/-3\.60/);
+  });
+
+  it("sacrifice cost = 5 (low effort) → boost +0.6", () => {
+    const r = scoreItem(hook({ id: "cheap" }), baseChild, {
+      ...baseCtx,
+      sacrifice_cost_by_id: { cheap: 5 },
+    });
+    // 7 + 0.2 × (8 - 5) = 7 + 0.6 = 7.6
+    expect(r.score).toBeCloseTo(7.6, 5);
+    expect(r.reasons.find((x) => x.startsWith("sacrifice_cost_adj"))).toMatch(/\+0\.60/);
+  });
+
+  it("item.id sem entry no map → sem adjustment (defensive)", () => {
+    const r = scoreItem(hook({ id: "missing" }), baseChild, {
+      ...baseCtx,
+      sacrifice_cost_by_id: { "other-id": 30 },
+    });
+    expect(r.score).toBe(7);
+    expect(r.reasons.find((x) => x.includes("sacrifice_cost_adj"))).toBeUndefined();
+  });
+
+  it("sacrifice adjustment + used_in_session penalty se compõem (motor#23 dominante)", () => {
+    const r = scoreItem(hook({ id: "h1" }), baseChild, {
+      ...baseCtx,
+      used_in_session: ["h1"],
+      sacrifice_cost_by_id: { h1: 5 }, // adj = +0.6
+    });
+    // base 7 + 0.6 sacrifice adj - 100 used penalty = -92.4
+    expect(r.score).toBeCloseTo(7 + 0.6 - USED_IN_SESSION_PENALTY, 5);
+    expect(r.reasons).toContain(`used_in_session_penalty=-${USED_IN_SESSION_PENALTY}`);
+    expect(r.reasons.find((x) => x.startsWith("sacrifice_cost_adj"))).toBeDefined();
+  });
+
+  it("scorePool: items caros caem para baixo, baratos sobem (mesmo base_score)", () => {
+    const pool = [
+      hook({ id: "expensive", base_score: 7 }),
+      hook({ id: "medium", base_score: 7 }),
+      hook({ id: "cheap", base_score: 7 }),
+    ];
+    const scored = scorePool(pool, baseChild, {
+      ...baseCtx,
+      sacrifice_cost_by_id: {
+        expensive: 30, // adj = 0.2 × (8 - 30) = -4.4
+        medium: 8,     // adj = 0
+        cheap: 4,      // adj = 0.2 × (8 - 4) = +0.8
+      },
+    });
+    expect(scored.map((s) => s.item.id)).toEqual(["cheap", "medium", "expensive"]);
+    expect(scored[0]!.score).toBeCloseTo(7.8, 5);
+    expect(scored[1]!.score).toBeCloseTo(7, 5);
+    expect(scored[2]!.score).toBeCloseTo(2.6, 5);
+  });
+
+  it("SACRIFICE_SCORE_WEIGHT exportado como 0.2 (CC default conservador)", () => {
+    expect(SACRIFICE_SCORE_WEIGHT).toBe(0.2);
+  });
+
+  it("idade fora da faixa: sacrifice adj NÃO aplicado (age gate vence)", () => {
+    const r = scoreItem(
+      hook({ id: "h1", age_range: [15, 18] }),
+      { age: 10 },
+      { ...baseCtx, sacrifice_cost_by_id: { h1: 30 } },
+    );
+    expect(r.score).toBe(0);
+    expect(r.reasons.find((x) => x.includes("sacrifice"))).toBeUndefined();
+  });
+
+  it("parent_pinned: sacrifice adj NÃO aplicado (pin vence)", () => {
+    const r = scoreItem(
+      hook({ id: "h1", parent_pinned: true, pinned_until: null }),
+      baseChild,
+      { ...baseCtx, sacrifice_cost_by_id: { h1: 30 } },
+    );
+    expect(r.score).toBe(PARENT_PINNED_SCORE);
+    expect(r.reasons.find((x) => x.includes("sacrifice"))).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Wire G-22 sacrifice cost into pool-builder + scorer (não apenas observability via `contextHints`). Antes: drota recebia top-K sem cost signal; honor de budget exhausted dependia do drota. Agora: HARD GATE em `buildPool` + SCORE ADJUSTMENT em `scoreItem`.

Refs `ascendimacy/ascendimacy-ops#1093`. Follow-up de motor#124 + motor#130 (ops#1033 closed).

## Architecture

```
Antes:
  buildPool [age+joint filter]
    → scorePool [base+surprise+casel+used_in_session]
      → contextHints.budget_exhausted_allowed_ids (drota decide)

Depois (ops#1093):
  hidrata sacrifice context (sensitivity/outcome/weekday/cycleDay/usage/budget)
    → buildPool [age+joint+BUDGET_EXHAUSTED_GATE]
      → compute sacrifice_cost_by_id pra eligible items
        → scorePool [base+surprise+casel+SACRIFICE_ADJ+used_in_session]
          → contextHints.budget_exhausted_gate_applied=true (transparência)
```

## CC defaults inline (aguardando ratify ou contra-proposta Jun em ops#1093)

| # | Sub-decisão | CC default | Alternativas |
|---|------------|------------|--------------|
| 1 | Scoring weight | `SACRIFICE_SCORE_WEIGHT = 0.2` (linear inverse) | (A) 0.0 só hard gate / (B) 0.5 agressivo |
| 2 | Exhausted gate | HARD filter `sacrifice > 7` | (A) Soft penalty -50 |
| 3 | Hydration | plan.ts orquestra (pool-builder puro) | per-item lazy lookup |
| 4 | Item sem sacrifice_amount | fallback BASE (8) → 0 adj | filter sempre |
| 5 | Order vs used_in_session | sacrifice adj antes (debug clarity) | depois (matemática igual) |

Examples scoring weight 0.2:
- Saki sensory+firm (cost 26) → -3.6 score adj
- Low effort (cost 5) → +0.6 score adj (boost suave)
- Medium (cost 8 = BASE) → 0 adj (neutro)

## Files touched (6)

| File | Change | LOC |
|------|--------|-----|
| `shared/src/scorer.ts` | +SACRIFICE_SCORE_WEIGHT + sacrifice_cost_by_id branch | +56 |
| `shared/tests/scorer.test.ts` | +10 leaf tests | +104 |
| `planejador/src/pool-builder.ts` | +budgetExhaustedGate option + re-export | +32 |
| `planejador/tests/pool-builder.test.ts` | +6 leaf tests | +63 |
| `planejador/src/plan.ts` | hidrata up + pass sacrifice_cost_by_id + gate flag | +58/-23 |
| `planejador/tests/plan.test.ts` | +4 integration tests | +67 |

**Total**: +380 / -23 lines.

## Test delta

| Suite | Before | After | Delta |
|-------|--------|-------|-------|
| `shared/tests/scorer.test.ts` | 52 | 62 | +10 |
| `planejador/tests/pool-builder.test.ts` | 15 | 21 | +6 |
| `planejador/tests/plan.test.ts` | 10 | 14 | +4 |
| **Total** | — | — | **+20** |

Shared workspace: `641 passing | 8 skipped | 0 failures` (was 631).
Planejador: `303 passing | 1 failed (pre-existing main)`.
Motor-execucao: `162 passing | 0 failures` (unchanged).

## Backward compat

- `ScoringContext.sacrifice_cost_by_id` opcional → ausência = comportamento idêntico (52 scorer tests existentes preservados)
- `PoolFilterOptions.budgetExhaustedGate` opcional → default false = sem filtro (15 pool-builder tests existentes preservados)
- Items legacy sem `sacrifice_amount` → fallback BASE (8) → 0 adjustment em scoring; em exhaustion gate, filter sempre (defensive — força usar items declared)
- contextHints schema extended (`budget_exhausted_gate_applied` novo key); consumers ignoram chaves desconhecidas

## Honest gaps

1. **isaLabels.intensity NÃO usado pra sacrificeCostById** — apenas pra observability breakdown top-K. Items via ActionMenu lookup vêm pre-ranked; score adjustment não se aplica. Pode revisitar se Jun quiser intensity-aware ranking no fallback path.
2. **Linear adjustment** — alternativas não-lineares (e.g., logarithmic, sigmoid) deferred até quantitative tuning post-pilot Yuji.
3. **Cycle reservoir multi-session** — herdado de motor#130 (per-item bounds shipped, cumulative budget deferred).
4. **Pre-existing failure herdada de main**: `plan.test.ts > kidsHelixState.current_day populado → cycle_day reflete` falha em main desde motor#130 merge (test fixture usa `triggers_fired_this_cycle: {}` mas helix-engine espera array). NÃO causada nem corrigida neste PR — fora de scope.

## Não merge sem authorize Jun

Memory `feedback_merge_authorization`: CC abre PR mas aguarda sinal explícito antes de merge. Default lane: aguarda Jun "Go!" / "TUNE com X" / "NO-GO porque Y" em ops#1093.

## Verdict slot

- [ ] **GO** — ratify defaults inline, merge
- [ ] **TUNE** — contra-proposta específica (weight diferente, soft penalty, etc)
- [ ] **NO-GO** — abort, pool-builder não é o lugar