### PR TITLE
[hotfix motor#130] plan.test.ts:188 triggers_fired_this_cycle {} → []

### DIFF
--- a/planejador/tests/plan.test.ts
+++ b/planejador/tests/plan.test.ts
@@ -185,7 +185,7 @@ describe("planTurn — G-22 remaining gaps integration (ops#1033)", () => {
         queue: [],
         completed: [],
         deferred: [],
-        triggers_fired_this_cycle: {},
+        triggers_fired_this_cycle: [],
       },
     };
     const output = await planTurn({


### PR DESCRIPTION
## Summary

motor#130 (G-22 remaining gaps) introduziu phantom-mergeable test regression em `planejador/tests/plan.test.ts:188`. Fix: 2 chars (`{}` → `[]`).

## Root cause

Test fixture A45 escreveu `triggers_fired_this_cycle: {}` (object) onde schema G-07 (motor#128) espera `KidsHelixCadenceTrigger[]` (array). `as any` no `state: stateWithHelix as any` escapou o type check de TS.

`detectCadenceTriggers` em [helix-engine.ts:579](https://github.com/ascendimacy/ascendimacy-motor/blob/main/planejador/src/strategist/helix-engine.ts#L579) faz `new Set(state.triggers_fired_this_cycle)` que crash com `TypeError: object is not iterable` quando recebe `{}`.

## Detection

Detectado **independentemente por 2 agents** (A46 Trio orchestrator wire-up + A47 G-22 pool-builder loop) ao rodar suite contra `origin/main`. A45 (autor de motor#130) declarou "1310 passed | 0 failures" em seu worktree — provavelmente estado pré-merge diferente ou suite parcial.

Este é o **4º caso de phantom-mergeable** registrado nesta sessão (anteriores: motor#58 → ops#1083, motor#59 → ops#1084, motor#110 regression mascarada). Memory `feedback_phantom_mergeable_stale_prs` cobre stale PRs >7d; este caso é diferente — mesmo dia, branch fresh, mas agent worktree estado diverge de main pós-merge.

## Test plan

- [x] `npx vitest run tests/plan.test.ts -t "kidsHelixState.current_day populado"` PASS (era FAIL)
- [x] Full `tests/plan.test.ts`: 10 passed, 0 failed (era 1 failed)
- [ ] CI green

## Optional follow-up (não neste PR)

Defensive guard em `detectCadenceTriggers`: `new Set(state.triggers_fired_this_cycle ?? [])` + Array.isArray check. Adiciona belt+suspenders mas tipo já enforce; único escape foi `as any`. Pode ficar pra hardening sprint.