### PR TITLE
[feat ops#1070] S-T-10-09 skip drota composition (Sprint 2 PR 4)

### DIFF
--- a/motor-drota/src/compose-skip.ts
+++ b/motor-drota/src/compose-skip.ts
@@ -1,0 +1,85 @@
+/**
+ * S-T-10-09 (ops#1070): skip drota LLM composition quando item.content
+ * (do menu) é rich enough pra servir direto como linguisticMaterialization.
+ *
+ * Precedente metodológico: motor#115 (S-T-10-08 rationale skip).
+ *
+ * Gating condicional (default OFF — opt-in via env):
+ *   1. ASC_SKIP_DROTA_COMPOSITION === "true" (feature flag)
+ *   2. item.domain === "action_menu" (veio do menu lookup, não fallback)
+ *   3. extractMenuContent(item) length >= MIN_CONTENT_LEN (default 80)
+ *   4. !item.is_critical (sub-decisão Jun: critical items merecem drota fresh)
+ *
+ * Quando todas as condições passam, server.ts bypass callLlm e emite
+ * `linguisticMaterialization = extractMenuContent(item)` direto, salvando
+ * 1 LLM call per-turn em hit path.
+ *
+ * Trade-off (Jun ratificou GO em motor#134):
+ *   - Perde adaptação persona-specific contextual (ex: drota citaria
+ *     "Kei + raquete + treino" pra Ryo). Aceitável dado producer S-T-10-08
+ *     já emite items ancorados ao perfil.
+ *   - Ganha -100% LLM calls em turn que hita menu.
+ */
+
+import type { ContentItem } from "@ascendimacy/shared";
+
+/** Default mínimo de chars do content pra qualificar pra skip. */
+export const DEFAULT_MIN_CONTENT_LEN = 80;
+
+/** Field do ContentItem que carrega o item.content do menu (varia por type). */
+export function extractMenuContent(item: ContentItem): string | null {
+  switch (item.type) {
+    case "curiosity_hook":
+    case "cultural_diamond":
+      return item.fact || null;
+    case "challenge":
+      return item.description || null;
+    case "dynamic":
+      return item.setup || null;
+    default:
+      return null;
+  }
+}
+
+export interface SkipDecision {
+  shouldSkip: boolean;
+  reason: string;
+  content?: string;
+}
+
+/**
+ * Avalia se composition pode ser skipped. Pure function — testável sem mocks.
+ *
+ * @param item ContentItem selecionado pelo drota (após selectFromPool)
+ * @param env env vars (process.env normalmente; injetável pra test)
+ * @param minContentLen threshold de length (default DEFAULT_MIN_CONTENT_LEN)
+ */
+export function canSkipDrotaComposition(
+  item: ContentItem,
+  env: Record<string, string | undefined>,
+  minContentLen: number = DEFAULT_MIN_CONTENT_LEN,
+): SkipDecision {
+  if (env["ASC_SKIP_DROTA_COMPOSITION"] !== "true") {
+    return { shouldSkip: false, reason: "feature_flag_off" };
+  }
+  if (item.domain !== "action_menu") {
+    return { shouldSkip: false, reason: "not_from_action_menu" };
+  }
+  // is_critical opcional (forward-compat; planejador propaga via reasons no
+  // futuro — Sprint 3). Por ora, check field opcional se presente.
+  const isCritical = (item as { is_critical?: boolean }).is_critical === true;
+  if (isCritical) {
+    return { shouldSkip: false, reason: "item_is_critical" };
+  }
+  const content = extractMenuContent(item);
+  if (!content) {
+    return { shouldSkip: false, reason: "no_extractable_content" };
+  }
+  if (content.length < minContentLen) {
+    return {
+      shouldSkip: false,
+      reason: `content_too_short (${content.length} < ${minContentLen})`,
+    };
+  }
+  return { shouldSkip: true, reason: "skip_eligible", content };
+}

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -14,6 +14,7 @@ import { parseDrotaOutput } from "./parse-output.js";
 import { extractSignals } from "./signal-extractor.js";
 import { applyPostProcessors } from "./post-processor.js";
 import { buildInaugural } from "./inaugural.js";
+import { canSkipDrotaComposition } from "./compose-skip.js";
 import { logDebugEvent, getProviderForStep } from "@ascendimacy/shared";
 
 const server = new McpServer({
@@ -327,6 +328,32 @@ server.registerTool(
     // motor#36: select agora deduz budget; newState não propagado pra
     // EvaluateAndSelectOutput (compat — caller pega budget de outras camadas).
     const { selected } = selectFromPool(ranked, input.state);
+
+    // S-T-10-09 (ops#1070): skip drota composition path. Quando feature flag
+    // ASC_SKIP_DROTA_COMPOSITION=true + item veio do action_menu + content
+    // rich enough (>= 80 chars) + !is_critical → bypass callLlm, emite
+    // item.content direto como linguisticMaterialization. -100% LLM calls
+    // per-turn em hit path. Verdict GO ratificado Jun motor#134.
+    const skipDecision = canSkipDrotaComposition(selected.item, process.env);
+    if (skipDecision.shouldSkip && skipDecision.content) {
+      logDebugEvent({
+        side: "motor",
+        step: "drota_composition_skipped",
+        user_id: input.persona.id,
+        session_id: input.sessionId,
+        turn_number: input.state.turn,
+        outcome: "ok",
+      });
+      const output: EvaluateAndSelectOutput = {
+        selectedContent: selected,
+        selectionRationale: "skip_drota_composition (item.content rich enough)",
+        linguisticMaterialization: skipDecision.content,
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(output) }],
+      };
+    }
+
     // motor#22: provider-aware mock detection.
     const drotaProvider = getProviderForStep("drota");
     const drotaKeyMissing = drotaProvider === "anthropic"

--- a/motor-drota/tests/compose-skip.unit.test.ts
+++ b/motor-drota/tests/compose-skip.unit.test.ts
@@ -1,0 +1,143 @@
+/**
+ * S-T-10-09 (ops#1070) — unit tests pra canSkipDrotaComposition.
+ *
+ * Cobre as 4 gating conditions:
+ *   1. Feature flag ASC_SKIP_DROTA_COMPOSITION
+ *   2. item.domain === "action_menu"
+ *   3. content extractable + length >= threshold
+ *   4. !item.is_critical
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ContentItem } from "@ascendimacy/shared";
+import {
+  canSkipDrotaComposition,
+  extractMenuContent,
+  DEFAULT_MIN_CONTENT_LEN,
+} from "../src/compose-skip.js";
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────
+const baseCuriosityHook: ContentItem = {
+  id: "test-curio",
+  type: "curiosity_hook",
+  domain: "action_menu",
+  casel_target: [],
+  age_range: [7, 17],
+  surprise: 8,
+  verified: true,
+  base_score: 8,
+  fact: "Esta é uma curiosity rich enough pra passar threshold de 80 chars — tem certa densidade semântica.",
+  bridge: "",
+  quest: "",
+  sacrifice_type: "reflect",
+};
+
+const envOn = { ASC_SKIP_DROTA_COMPOSITION: "true" };
+const envOff = {};
+
+// ─── extractMenuContent ────────────────────────────────────────────────────
+describe("extractMenuContent", () => {
+  it("retorna fact pra curiosity_hook", () => {
+    expect(extractMenuContent(baseCuriosityHook)).toBe(baseCuriosityHook.fact);
+  });
+
+  it("retorna fact pra cultural_diamond", () => {
+    const item: ContentItem = {
+      ...baseCuriosityHook,
+      type: "cultural_diamond",
+    } as ContentItem;
+    expect(extractMenuContent(item)).toBe(item.fact);
+  });
+
+  it("retorna description pra challenge", () => {
+    const item: ContentItem = {
+      id: "test-chal",
+      type: "challenge",
+      domain: "action_menu",
+      casel_target: [],
+      age_range: [7, 17],
+      surprise: 7,
+      verified: true,
+      base_score: 7,
+      description: "Descrição do challenge longa o suficiente pra passar threshold de skip.",
+      expected_outcome: "",
+      estimated_minutes: 10,
+    } as ContentItem;
+    expect(extractMenuContent(item)).toBe(item.description);
+  });
+
+  it("retorna setup pra dynamic", () => {
+    const item: ContentItem = {
+      id: "test-dyn",
+      type: "dynamic",
+      domain: "action_menu",
+      casel_target: [],
+      age_range: [7, 17],
+      surprise: 7,
+      verified: true,
+      base_score: 7,
+      title: "x",
+      setup: "Setup do dynamic é o conteúdo principal do item — deve estar acima do threshold.",
+      execution: "",
+      closing: "",
+      multi_turn: false,
+    } as ContentItem;
+    expect(extractMenuContent(item)).toBe(item.setup);
+  });
+});
+
+// ─── canSkipDrotaComposition ───────────────────────────────────────────────
+describe("canSkipDrotaComposition", () => {
+  it("REJECT: feature flag off (default)", () => {
+    const d = canSkipDrotaComposition(baseCuriosityHook, envOff);
+    expect(d.shouldSkip).toBe(false);
+    expect(d.reason).toBe("feature_flag_off");
+  });
+
+  it("REJECT: item.domain != action_menu", () => {
+    const item = { ...baseCuriosityHook, domain: "fallback" };
+    const d = canSkipDrotaComposition(item as ContentItem, envOn);
+    expect(d.shouldSkip).toBe(false);
+    expect(d.reason).toBe("not_from_action_menu");
+  });
+
+  it("REJECT: item.is_critical=true", () => {
+    const item = { ...baseCuriosityHook, is_critical: true };
+    const d = canSkipDrotaComposition(item as ContentItem, envOn);
+    expect(d.shouldSkip).toBe(false);
+    expect(d.reason).toBe("item_is_critical");
+  });
+
+  it("REJECT: content < MIN_CONTENT_LEN", () => {
+    const item = { ...baseCuriosityHook, fact: "muito curto" };
+    const d = canSkipDrotaComposition(item as ContentItem, envOn);
+    expect(d.shouldSkip).toBe(false);
+    expect(d.reason).toMatch(/content_too_short/);
+  });
+
+  it("REJECT: content vazio retorna no_extractable_content", () => {
+    const item = { ...baseCuriosityHook, fact: "" };
+    const d = canSkipDrotaComposition(item as ContentItem, envOn);
+    expect(d.shouldSkip).toBe(false);
+    expect(d.reason).toBe("no_extractable_content");
+  });
+
+  it("ACCEPT: todas gating passam → skip_eligible + content populated", () => {
+    const d = canSkipDrotaComposition(baseCuriosityHook, envOn);
+    expect(d.shouldSkip).toBe(true);
+    expect(d.reason).toBe("skip_eligible");
+    expect(d.content).toBe(baseCuriosityHook.fact);
+  });
+
+  it("threshold customizável", () => {
+    const item = { ...baseCuriosityHook, fact: "tem 20 chars exatamente!" }; // < 80 mas >= 20
+    const dDefault = canSkipDrotaComposition(item as ContentItem, envOn);
+    expect(dDefault.shouldSkip).toBe(false);
+    const dLow = canSkipDrotaComposition(item as ContentItem, envOn, 20);
+    expect(dLow.shouldSkip).toBe(true);
+  });
+
+  it("DEFAULT_MIN_CONTENT_LEN exposto = 80", () => {
+    expect(DEFAULT_MIN_CONTENT_LEN).toBe(80);
+  });
+});


### PR DESCRIPTION
## S-T-10-09: skip drota composition quando item.content é rich enough

Implementa o skip path no drota.evaluate_and_select. Verdict GO ratificado Jun em motor#134 PoC qualitativo.

### Mudanças

**motor-drota/src/compose-skip.ts (novo)** — helper puro
- `canSkipDrotaComposition(item, env, minLen)` → SkipDecision { shouldSkip, reason, content? }
- `extractMenuContent(item)` → field-by-type (fact/description/setup)
- `DEFAULT_MIN_CONTENT_LEN = 80`

**motor-drota/src/server.ts (modificado)**
- Pré-LLM check após `selectFromPool`
- Se skip, bypass `callLlm` + emite `drota_composition_skipped` event
- linguisticMaterialization = extracted content direto

**motor-drota/tests/compose-skip.unit.test.ts (novo)** — 12 unit tests
- 4 gating conditions cobertas (flag, domain, is_critical, length)
- extractMenuContent por type discriminator
- threshold customizável + DEFAULT_MIN_CONTENT_LEN export

### Gating (default OFF, opt-in)

| Gate | Default | Override |
|---|---|---|
| `ASC_SKIP_DROTA_COMPOSITION` env | `false` | set `"true"` pra ativar |
| `item.domain === "action_menu"` | required | items fallback nunca skipam |
| content length | `>= 80` chars | env var futura ou param |
| `!item.is_critical` | required | critical items merecem drota fresh |

### Testes
- 12/12 unit tests pass
- 206/207 motor-drota suite ok (1 skip = LLM-LOCAL guard)
- TS build OK

### Trade-off (Jun motor#134 GO)
- Perde adaptação contextual persona-specific. Producer S-T-10-08 (motor#117 + prompt v0.4) já emite items pre-anchored.
- Ganha -100% LLM calls per-turn em hit path. Combinado com motor#115 rationale skip = full planner→drota LLM cascade short-circuit.

### Compat
- Default OFF preserva status quo. Rollout opt-in via env.
- Saki recovery item (`saki-recovery-sensorial-01` motor#135, `is_critical=true`) NUNCA skipa — drota fresh garantido pra brejo.

### Refs
- ops#1070 (story)
- motor#115 (rationale skip — precedente metodológico)
- motor#134 (PoC qualitativo gate, mergeado)
- Sprint 2 tracker ops#1076