### PR TITLE
[feat ops#1115] S-MX-06-05 router + ^card:<id>$ detector (PR 2/9)

### DIFF
--- a/packages/motor-channels/src/index.ts
+++ b/packages/motor-channels/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./types.js";
+export * from "./router.js";

--- a/packages/motor-channels/src/router.ts
+++ b/packages/motor-channels/src/router.ts
@@ -1,0 +1,66 @@
+/**
+ * Router de mensagens inbound — S-MX-06-05 (ops#1115).
+ *
+ * Função pura sem dependências Baileys/IO. Toma um InboundMessage e devolve
+ * a lista de eventos a emitir. PR2 implementa apenas o detector `^card:<id>$`.
+ * Outros prefixes (`/start`, slash commands) ficam como hooks extensíveis em
+ * iterações futuras — fora de escopo aqui.
+ */
+
+import type {
+  CardActivatedEvent,
+  ChannelEvent,
+  InboundMessage,
+  MessageReceivedEvent,
+} from "./types.js";
+
+/**
+ * Detector de carta-acionada. Strict, case-sensitive, sem multi-line.
+ * Casa exclusivamente `card:<cardId>` onde cardId ∈ [a-z0-9-]+, e a string
+ * inteira é exatamente esse formato (sem leading/trailing whitespace, sem
+ * conteúdo extra).
+ */
+export const CARD_ACTIVATION_REGEX = /^card:([a-z0-9-]+)$/;
+
+/**
+ * Roteia uma mensagem inbound em zero ou mais eventos.
+ *
+ * Contrato:
+ * - SEMPRE emite `MessageReceived` (uma vez por inbound).
+ * - Se o texto casar com `CARD_ACTIVATION_REGEX`, emite também
+ *   `CardActivated` ANTES de `MessageReceived` (consumidores de carta-acionada
+ *   tipicamente processam primeiro).
+ *
+ * A decisão de sempre emitir `MessageReceived` segue a "Interface MCP
+ * proposta" da ops#1115 §events, onde `MessageReceived` é canal genérico
+ * independente do detector. Orchestrator decide se ignora quando
+ * `CardActivated` precedente já encaminhou.
+ */
+export function routeInbound(msg: InboundMessage): ChannelEvent[] {
+  const events: ChannelEvent[] = [];
+
+  const cardMatch = CARD_ACTIVATION_REGEX.exec(msg.text);
+  if (cardMatch) {
+    const cardId = cardMatch[1]!;
+    const activated: CardActivatedEvent = {
+      type: "CardActivated",
+      cardId,
+      from: msg.from,
+      conversationId: msg.conversationId,
+      timestamp: msg.timestamp,
+      raw: msg.text,
+    };
+    events.push(activated);
+  }
+
+  const received: MessageReceivedEvent = {
+    type: "MessageReceived",
+    from: msg.from,
+    text: msg.text,
+    conversationId: msg.conversationId,
+    timestamp: msg.timestamp,
+  };
+  events.push(received);
+
+  return events;
+}

--- a/packages/motor-channels/src/types.ts
+++ b/packages/motor-channels/src/types.ts
@@ -54,13 +54,16 @@ export interface CardPackage {
   sourcePath: string;
 }
 
-/** Evento emitido quando detector `^card:<cardId>$` casa em inbound. */
+/** Evento emitido quando detector `^card:<cardId>$` casa em inbound.
+ *  `raw` preserva o texto original (S-MX-06-05) — útil pra telemetria e
+ *  debug do detector. */
 export interface CardActivatedEvent {
   type: "CardActivated";
   cardId: CardId;
   from: ChannelAddress;
   conversationId: ConversationId;
   timestamp: Iso8601;
+  raw: string;
 }
 
 /** Evento emitido pra toda mensagem inbound (após detector). */

--- a/packages/motor-channels/tests/router.test.ts
+++ b/packages/motor-channels/tests/router.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { routeInbound, CARD_ACTIVATION_REGEX } from "../src/router.js";
+import type {
+  CardActivatedEvent,
+  InboundMessage,
+  MessageReceivedEvent,
+} from "../src/types.js";
+
+const baseMsg = (text: string): InboundMessage => ({
+  from: "5511999990000@s.whatsapp.net",
+  text,
+  conversationId: "conv-router-001",
+  timestamp: "2026-05-23T12:00:00.000Z",
+});
+
+const assertActivated = (
+  events: ReturnType<typeof routeInbound>,
+  expectedCardId: string,
+) => {
+  expect(events).toHaveLength(2);
+  const [card, received] = events;
+  expect(card.type).toBe("CardActivated");
+  const c = card as CardActivatedEvent;
+  expect(c.cardId).toBe(expectedCardId);
+  expect(c.from).toBe(baseMsg("").from);
+  expect(c.conversationId).toBe(baseMsg("").conversationId);
+  expect(c.raw).toBe(`card:${expectedCardId}`);
+  expect(received.type).toBe("MessageReceived");
+};
+
+const assertOnlyReceived = (events: ReturnType<typeof routeInbound>) => {
+  expect(events).toHaveLength(1);
+  const [received] = events;
+  expect(received.type).toBe("MessageReceived");
+};
+
+describe("CARD_ACTIVATION_REGEX", () => {
+  it("matches simple alphanumeric+dash cardIds", () => {
+    expect(CARD_ACTIVATION_REGEX.test("card:tabuada-7")).toBe(true);
+    expect(CARD_ACTIVATION_REGEX.test("card:abc-123-xyz")).toBe(true);
+    expect(CARD_ACTIVATION_REGEX.test("card:a")).toBe(true);
+  });
+
+  it("rejects uppercase prefix", () => {
+    expect(CARD_ACTIVATION_REGEX.test("Card:tabuada")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("CARD:tabuada")).toBe(false);
+  });
+
+  it("rejects uppercase in cardId", () => {
+    expect(CARD_ACTIVATION_REGEX.test("card:Tabuada")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("card:UPPER")).toBe(false);
+  });
+
+  it("rejects leading/trailing whitespace", () => {
+    expect(CARD_ACTIVATION_REGEX.test(" card:x")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("card:x ")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("\tcard:x")).toBe(false);
+  });
+
+  it("rejects empty cardId", () => {
+    expect(CARD_ACTIVATION_REGEX.test("card:")).toBe(false);
+  });
+
+  it("rejects underscore + other special chars", () => {
+    expect(CARD_ACTIVATION_REGEX.test("card:x_y")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("card:x.y")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("card:x y")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("card:x/y")).toBe(false);
+  });
+
+  it("rejects multi-line (no /m flag, $ matches end-of-string only)", () => {
+    expect(CARD_ACTIVATION_REGEX.test("card:tabuada-7\nfoo")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("foo\ncard:tabuada-7")).toBe(false);
+  });
+
+  it("rejects trailing chars after valid cardId", () => {
+    expect(CARD_ACTIVATION_REGEX.test("card:tabuada-7!")).toBe(false);
+    expect(CARD_ACTIVATION_REGEX.test("card:tabuada-7?id=1")).toBe(false);
+  });
+});
+
+describe("routeInbound", () => {
+  it("emits CardActivated + MessageReceived on valid card", () => {
+    const events = routeInbound(baseMsg("card:tabuada-7"));
+    assertActivated(events, "tabuada-7");
+  });
+
+  it("preserves raw text in CardActivated", () => {
+    const events = routeInbound(baseMsg("card:abc-123"));
+    const [card] = events;
+    const c = card as CardActivatedEvent;
+    expect(c.raw).toBe("card:abc-123");
+  });
+
+  it("preserves InboundMessage fields in events", () => {
+    const msg = baseMsg("card:tabuada-7");
+    const events = routeInbound(msg);
+    for (const e of events) {
+      expect(e).toMatchObject({
+        from: msg.from,
+        conversationId: msg.conversationId,
+        timestamp: msg.timestamp,
+      });
+    }
+  });
+
+  it("emits only MessageReceived on common text", () => {
+    const events = routeInbound(baseMsg("oi tudo bem"));
+    assertOnlyReceived(events);
+    const m = events[0] as MessageReceivedEvent;
+    expect(m.text).toBe("oi tudo bem");
+  });
+
+  it("emits only MessageReceived on near-miss patterns", () => {
+    assertOnlyReceived(routeInbound(baseMsg("Card:tabuada")));
+    assertOnlyReceived(routeInbound(baseMsg(" card:x")));
+    assertOnlyReceived(routeInbound(baseMsg("card:")));
+    assertOnlyReceived(routeInbound(baseMsg("card:UPPER")));
+    assertOnlyReceived(routeInbound(baseMsg("card:x_y")));
+    assertOnlyReceived(routeInbound(baseMsg("card:tabuada-7\nfoo")));
+  });
+
+  it("emits only MessageReceived on empty text", () => {
+    assertOnlyReceived(routeInbound(baseMsg("")));
+  });
+});

--- a/packages/motor-channels/tests/smoke.test.ts
+++ b/packages/motor-channels/tests/smoke.test.ts
@@ -54,6 +54,7 @@ describe("motor-channels types smoke", () => {
         from: "5511999990000@s.whatsapp.net",
         conversationId: "conv-001",
         timestamp: "2026-05-23T12:00:00.000Z",
+        raw: "card:tabuada-7",
       } satisfies CardActivatedEvent,
       {
         type: "MessageReceived",


### PR DESCRIPTION
## Summary

PR 2/9 do plan C-MX-06 (ops#1115). Implementa o router de mensagens inbound + detector `^card:<id>$`. Função pura, zero IO, zero Baileys.

- **Sub-story coberta:** S-MX-06-05
- **Stacked em:** #137 PR1 (workspace + types). **Rebase pra main após PR1 merge.**
- **Branch:** `sprint2/pr6-mx-06-05-router-detector`

## O que entra

- `packages/motor-channels/src/router.ts`
  - `CARD_ACTIVATION_REGEX = /^card:([a-z0-9-]+)$/` — strict, case-sensitive, sem `/m`
  - `routeInbound(msg: InboundMessage): ChannelEvent[]` — toda inbound vira `MessageReceived`; match no detector emite `CardActivated` **adicional ANTES** (orchestrator processa carta-acionada primeiro, com fallback no MessageReceived caso ignore)
- `packages/motor-channels/tests/router.test.ts` — 14 unit tests
- `src/types.ts` — **edit aditivo** em `CardActivatedEvent`: novo campo `raw: string` (resolve inconsistência ops#1115: S-MX-06-05 lista `raw`, §"Interface MCP proposta" omite — adotamos union dos dois)
- `src/index.ts` — re-export do router
- `tests/smoke.test.ts` (PR1) — atualizado fixture com `raw`

## Decisões tomadas (default reasonable — flag se discordar)

1. **`MessageReceived` SEMPRE emitido**, mesmo em card match. Permite consumidores não-card processarem todas as mensagens uniformemente. Orchestrator decide se ignora quando `CardActivated` precedente já encaminhou.
2. **Ordem dos eventos:** `[CardActivated, MessageReceived]` quando match. Consumidor de carta vê primeiro.
3. **Detector strict:** sem `/m`, sem `/i`. `card:tabuada-7\nfoo` NÃO casa. Per spec: "case sensitive, multi-line, edge cases" — interpreto que multi-line é caso de REJEIÇÃO.

## Verificação (alvos P4)

- [x] `npm run build --workspace packages/motor-channels` — exit 0
- [x] `npm test --workspace packages/motor-channels` — 19/19 (5 smoke + 14 router)
- [x] Edge cases cobertos: case (prefix + cardId), whitespace (leading/trailing/tab), empty cardId, underscore/dot/space/slash, multi-line, trailing chars
- [x] Detector classifica 100% dos fixtures corretamente

## Cobertura de unit tests router

| Caso | Esperado | Cobertura |
|---|---|---|
| `card:tabuada-7` | match → `tabuada-7` | ✅ |
| `card:abc-123-xyz`, `card:a` | match | ✅ |
| `Card:x`, `CARD:x` | reject (prefix uppercase) | ✅ |
| `card:Tabuada`, `card:UPPER` | reject (cardId uppercase) | ✅ |
| ` card:x`, `card:x `, `\tcard:x` | reject (whitespace) | ✅ |
| `card:` | reject (empty) | ✅ |
| `card:x_y`, `card:x.y`, `card:x y`, `card:x/y` | reject (special chars) | ✅ |
| `card:tabuada-7\nfoo`, `foo\ncard:tabuada-7` | reject (multi-line) | ✅ |
| `card:tabuada-7!`, `card:tabuada-7?id=1` | reject (trailing) | ✅ |
| `oi tudo bem`, `""` | only MessageReceived | ✅ |

## Próximo

PR3 (S-MX-06-06 pacote pedagógico loader) — pode rodar em paralelo, mesmo stack base. Aguardo sinal Jun.

## Test plan

- [ ] Reviewer roda `npm test --workspace packages/motor-channels` → 19/19
- [ ] Confirma decisões 1-3 acima (`MessageReceived` sempre + ordem `[Card, Message]` + strict multi-line reject) — corrigir agora se diferente
- [ ] Confirma adição do campo `raw` em `CardActivatedEvent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)