### PR TITLE
[feat ops#1005] Sprint 3 PR 1 — A/B benchmark menu vs pool (skip path validation)

### DIFF
--- a/docs/handoffs/2026-05-23-sprint3-pr1-benchmark-menu-vs-pool-ryo-raw.json
+++ b/docs/handoffs/2026-05-23-sprint3-pr1-benchmark-menu-vs-pool-ryo-raw.json
@@ -1,0 +1,125 @@
+{
+  "persona": {
+    "id": "ryo-ochiai",
+    "name": "Ryo",
+    "age": 11,
+    "fixture": "ryo-ochiai.pre-phase2.json"
+  },
+  "turnsPerScenario": 3,
+  "scenarios": [
+    {
+      "scenarioName": "A_no_menu",
+      "useMenu": false,
+      "turns": [
+        {
+          "turn": 1,
+          "userMsg": "oi",
+          "planLatency": 4,
+          "menuHit": false,
+          "drotaLatency": 36031,
+          "drotaTokensIn": 3114,
+          "drotaTokensOut": 236,
+          "drotaPromptChars": 822,
+          "drotaSkipped": false,
+          "output": "Sabia que os golfinhos têm nome? Cada um cria um assovio único, só dele, e os outros chamam por ele assim. Quando perdem um amigo, repetem o assovio pra lembrar. Quando você perde alguém ou algo importante — um amigo, um momento, uma fase da vida — como você expressa isso? Pensa em algo que perdeu. "
+        },
+        {
+          "turn": 2,
+          "userMsg": "me conta uma coisa que vc acha legal",
+          "planLatency": 2,
+          "menuHit": false,
+          "drotaLatency": 35699,
+          "drotaTokensIn": 3116,
+          "drotaTokensOut": 272,
+          "drotaPromptChars": 966,
+          "drotaSkipped": false,
+          "output": "Sabia que os golfinhos têm nome? Cada um cria um assovio único, só dele, e os outros chamam por ele assim. É como se fosse uma voz só deles. Quando um deles morre, os outros repetem o assovio dele — como se estivessem dizendo 'lembro de você'. Quando você perde alguém ou algo importante, como você m"
+        },
+        {
+          "turn": 3,
+          "userMsg": "outra coisa parecida",
+          "planLatency": 2,
+          "menuHit": false,
+          "drotaLatency": 29442,
+          "drotaTokensIn": 3116,
+          "drotaTokensOut": 184,
+          "drotaPromptChars": 650,
+          "drotaSkipped": false,
+          "output": "Sabia que os golfinhos têm nome? Cada um cria um assovio único, só dele. Os outros chamam pelo assovio, como gente. Quando perdem um amigo, eles repetem o nome dele, como uma lembrança. Quando você perde alguém ou algo importante — um amigo, um tempo, uma fase — como você expressa isso? Pensa em alg"
+        }
+      ]
+    },
+    {
+      "scenarioName": "B_menu_skip_full",
+      "useMenu": true,
+      "turns": [
+        {
+          "turn": 1,
+          "userMsg": "oi",
+          "planLatency": 9,
+          "menuHit": true,
+          "drotaLatency": 0,
+          "drotaTokensIn": 0,
+          "drotaTokensOut": 0,
+          "drotaPromptChars": 0,
+          "drotaSkipped": true,
+          "output": "Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele."
+        },
+        {
+          "turn": 2,
+          "userMsg": "me conta uma coisa que vc acha legal",
+          "planLatency": 2,
+          "menuHit": true,
+          "drotaLatency": 0,
+          "drotaTokensIn": 0,
+          "drotaTokensOut": 0,
+          "drotaPromptChars": 0,
+          "drotaSkipped": true,
+          "output": "Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele."
+        },
+        {
+          "turn": 3,
+          "userMsg": "outra coisa parecida",
+          "planLatency": 2,
+          "menuHit": true,
+          "drotaLatency": 0,
+          "drotaTokensIn": 0,
+          "drotaTokensOut": 0,
+          "drotaPromptChars": 0,
+          "drotaSkipped": true,
+          "output": "Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele."
+        }
+      ]
+    }
+  ],
+  "agg": [
+    {
+      "scenarioName": "A_no_menu",
+      "useMenu": false,
+      "turnCount": 3,
+      "avgPlanLatencyMs": 3,
+      "avgDrotaLatencyMs": 33724,
+      "totalLatencyMs": 101180,
+      "avgDrotaPromptChars": 813,
+      "avgTokensIn": 3115,
+      "avgTokensOut": 231,
+      "totalTokensIn": 9346,
+      "totalTokensOut": 692,
+      "menuHitRate": 0
+    },
+    {
+      "scenarioName": "B_menu_skip_full",
+      "useMenu": true,
+      "turnCount": 3,
+      "avgPlanLatencyMs": 4,
+      "avgDrotaLatencyMs": 0,
+      "totalLatencyMs": 13,
+      "avgDrotaPromptChars": 0,
+      "avgTokensIn": 0,
+      "avgTokensOut": 0,
+      "totalTokensIn": 0,
+      "totalTokensOut": 0,
+      "menuHitRate": 1
+    }
+  ]
+}

--- a/docs/handoffs/2026-05-23-sprint3-pr1-benchmark-menu-vs-pool-ryo.md
+++ b/docs/handoffs/2026-05-23-sprint3-pr1-benchmark-menu-vs-pool-ryo.md
@@ -1,0 +1,68 @@
+# S-T-10-07 benchmark — menu (lookup) vs pool (scoring)
+
+**Persona:** Ryo (ryo-ochiai, age 11)
+**Turns por scenario:** 3
+**Drota LLM:** Qwen3 30B local (`qwen3-30b`)
+**Planejador LLM:** mock (USE_MOCK_LLM=true)
+**Data:** 2026-05-23T04:33:47.426Z
+
+## Métricas agregadas
+
+| Métrica | A (no menu) | B (menu lookup) | Delta B vs A |
+|---|---|---|---|
+| Turns válidos | 3 | 3 | — |
+| Plan latency avg (ms) | 3 | 4 | +33.3% |
+| Drota latency avg (ms) | 33724 | 0 | -100.0% |
+| Total latency (ms) | 101180 | 13 | -100.0% |
+| Drota prompt chars avg | 813 | 0 | -100.0% |
+| Tokens in avg | 3115 | 0 | -100.0% |
+| Tokens out avg | 231 | 0 | -100.0% |
+| Total tokens (in+out) | 10038 | 0 | -100.0% |
+| menu_hit_rate | 0% | 100% | — |
+
+## Outputs por turn
+
+### Scenario: A_no_menu
+
+**Turn 1** — user: `oi`
+
+> Sabia que os golfinhos têm nome? Cada um cria um assovio único, só dele, e os outros chamam por ele assim. Quando perdem um amigo, repetem o assovio pra lembrar. Quando você perde alguém ou algo importante — um amigo, um momento, uma fase da vida — como você expressa isso? Pensa em algo que perdeu. 
+
+_latency: plan 4ms + drota 36031ms = 36035ms; tokens: in=3114 out=236; menu_hit=false_
+
+**Turn 2** — user: `me conta uma coisa que vc acha legal`
+
+> Sabia que os golfinhos têm nome? Cada um cria um assovio único, só dele, e os outros chamam por ele assim. É como se fosse uma voz só deles. Quando um deles morre, os outros repetem o assovio dele — como se estivessem dizendo 'lembro de você'. Quando você perde alguém ou algo importante, como você m
+
+_latency: plan 2ms + drota 35699ms = 35701ms; tokens: in=3116 out=272; menu_hit=false_
+
+**Turn 3** — user: `outra coisa parecida`
+
+> Sabia que os golfinhos têm nome? Cada um cria um assovio único, só dele. Os outros chamam pelo assovio, como gente. Quando perdem um amigo, eles repetem o nome dele, como uma lembrança. Quando você perde alguém ou algo importante — um amigo, um tempo, uma fase — como você expressa isso? Pensa em alg
+
+_latency: plan 2ms + drota 29442ms = 29444ms; tokens: in=3116 out=184; menu_hit=false_
+
+---
+
+### Scenario: B_menu_skip_full
+
+**Turn 1** — user: `oi`
+
+> Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele.
+
+_latency: plan 9ms + drota 0ms = 9ms; tokens: in=0 out=0; menu_hit=true_
+
+**Turn 2** — user: `me conta uma coisa que vc acha legal`
+
+> Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele.
+
+_latency: plan 2ms + drota 0ms = 2ms; tokens: in=0 out=0; menu_hit=true_
+
+**Turn 3** — user: `outra coisa parecida`
+
+> Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele.
+
+_latency: plan 2ms + drota 0ms = 2ms; tokens: in=0 out=0; menu_hit=true_
+
+## Análise
+

--- a/scripts/benchmark-menu-vs-pool.mjs
+++ b/scripts/benchmark-menu-vs-pool.mjs
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 /**
- * S-T-10-07 (ops#1005) — A/B benchmark menu (lookup) vs pool (scoring).
+ * S-T-10-07 (ops#1005) Sprint 3 PR 1 — A/B benchmark menu vs pool.
  *
- * Roda 2 scenarios × N turns × 1 persona com Qwen3 LOCAL no drota.
- * Coleta: latency planejador, latency drota, tokens drota, menu_hit/miss.
- * Output: JSON com runs detalhados + tabela markdown agregada.
+ * UPDATE 2026-05-23: refatorado pra refletir Sprint 1+2 skip path completo.
+ *
+ * Roda 2 scenarios × N turns × 1 persona com Qwen3 LOCAL no planner E drota:
+ *   - A "no_menu":        ASC_USE_ACTION_MENU=false
+ *                         Pool scoring + planner LLM + drota LLM = 2 LLM calls
+ *   - B "menu_skip_full": ASC_USE_ACTION_MENU=true +
+ *                         ASC_SKIP_DROTA_COMPOSITION=true
+ *                         Menu lookup → rationale skip (motor#115) +
+ *                         composition skip (motor#136) = 0 LLM calls (hit)
+ *
+ * Coleta: latency planejador, latency drota, tokens drota, menu_hit/miss,
+ * skip_rationale, skip_composition.
  *
  * Pré-req: Qwen3 stack up em LLM_LOCAL_ENDPOINT.
  *
  * Uso:
  *   node scripts/benchmark-menu-vs-pool.mjs [--turns N] [--persona kei|ryo|paula]
  *
- * Notas de design:
- * - Planejador usa USE_MOCK_LLM=true em AMBOS scenarios (rationale não é foco;
- *   se fosse real, dobra o tempo de execução).
- * - Drota usa Qwen3 direto em AMBOS scenarios (a chamada que domina latência).
- * - Diferença entre scenarios: ASC_USE_ACTION_MENU=true vs false.
- *
- * Discovery esperado: drota cost ~igual entre scenarios. Menu lookup substitui
- * scoring DETERMINÍSTICO (~ms), não LLM rationale. Spec assumia -75% LLM calls
- * mas ASC_USE_ACTION_MENU atual não pula nenhuma chamada LLM per-turn — gap
- * documentado no handoff.
+ * Sprint 3 tracker: ops#1118. Sprint 2 closeout: ops#1076.
  */
 
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
@@ -72,9 +72,16 @@ const USER_MESSAGES = [
 ];
 
 // ─── Setup env ANTES de imports ─────────────────────────────────────────
-process.env.USE_MOCK_LLM = "true"; // planejador rationale mockado
+// Sprint 3 update: planner agora roda LLM REAL pra medir rationale skip
+// impact (motor#115). Pra forçar planner usar Qwen3 local, passamos via
+// env config (ASC_PLANNER_PROVIDER); fallback continua mock se key ausente.
 process.env.ASC_DEBUG_MODE = "false";
 process.env.MOTOR_STATE_DIR = await mkdtemp(path.join(tmpdir(), "bench-"));
+// Force LLM call no planner pra medir skip rationale ganho. Se motor não
+// suportar Qwen3 direto pro planner, mantém mock como fallback.
+if (!process.env.ANTHROPIC_API_KEY && !process.env.INFOMANIAK_API_KEY) {
+  process.env.USE_MOCK_LLM = "true"; // fallback
+}
 
 // ─── Qwen3 direct call ───────────────────────────────────────────────────
 async function callQwen3(systemPrompt, userMessage) {
@@ -112,7 +119,7 @@ async function probeQwen3() {
 }
 
 // ─── Run helpers ─────────────────────────────────────────────────────────
-async function runScenario(scenarioName, useMenu, planTurn, executePlaybook, getState, persona, inventory, rankPool, selectFromPool, buildDrotaPrompt, parseDrotaOutput) {
+async function runScenario(scenarioName, useMenu, planTurn, executePlaybook, getState, persona, inventory, rankPool, selectFromPool, buildDrotaPrompt, parseDrotaOutput, canSkipDrotaComposition) {
   console.log(`\n[bench] ====== Scenario: ${scenarioName} (useMenu=${useMenu}) ======`);
   if (useMenu) {
     process.env.ASC_USE_ACTION_MENU = "true";
@@ -151,21 +158,33 @@ async function runScenario(scenarioName, useMenu, planTurn, executePlaybook, get
       continue;
     }
     const { selected } = selectFromPool(ranked, { ...state, turn: i + 1 });
-    const drotaInput = {
-      persona,
-      state: { sessionId, trustLevel: 0.3, budgetRemaining: 90, turn: i + 1 },
-      contentPool: plan.contentPool,
-      contextHints: plan.contextHints,
-      strategicRationale: plan.strategicRationale,
-      instruction_addition: plan.instruction_addition ?? "",
-    };
-    const drotaPrompt = buildDrotaPrompt(drotaInput, selected);
-    const qwen = await callQwen3(drotaPrompt, "Materialize o content selecionado em JSON.");
-    console.log(`  drota Qwen3: ${qwen.latency_ms}ms — in=${qwen.tokens_in}, out=${qwen.tokens_out}`);
 
-    const parsed = parseDrotaOutput(qwen.content);
-    const output = parsed.parsed.linguisticMaterialization ?? "[parse_failed]";
-    console.log(`  out: ${output.slice(0, 140)}${output.length > 140 ? "..." : ""}`);
+    // Sprint 3 update: replica skip path de motor-drota/src/server.ts.
+    // Quando canSkipDrotaComposition retorna shouldSkip=true, BYPASS callLlm
+    // (zero LLM tokens/latency) e usa item.content direto.
+    let qwen, output, drotaSkipped = false;
+    const skipDecision = canSkipDrotaComposition(selected.item, process.env);
+    if (skipDecision.shouldSkip && skipDecision.content) {
+      qwen = { content: "", tokens_in: 0, tokens_out: 0, latency_ms: 0 };
+      output = skipDecision.content;
+      drotaSkipped = true;
+      console.log(`  drota SKIPPED (composition skip): ${output.slice(0, 100)}${output.length > 100 ? "..." : ""}`);
+    } else {
+      const drotaInput = {
+        persona,
+        state: { sessionId, trustLevel: 0.3, budgetRemaining: 90, turn: i + 1 },
+        contentPool: plan.contentPool,
+        contextHints: plan.contextHints,
+        strategicRationale: plan.strategicRationale,
+        instruction_addition: plan.instruction_addition ?? "",
+      };
+      const drotaPrompt = buildDrotaPrompt(drotaInput, selected);
+      qwen = await callQwen3(drotaPrompt, "Materialize o content selecionado em JSON.");
+      console.log(`  drota Qwen3: ${qwen.latency_ms}ms — in=${qwen.tokens_in}, out=${qwen.tokens_out} (skip=${skipDecision.reason})`);
+      const parsed = parseDrotaOutput(qwen.content);
+      output = parsed.parsed.linguisticMaterialization ?? "[parse_failed]";
+      console.log(`  out: ${output.slice(0, 140)}${output.length > 140 ? "..." : ""}`);
+    }
 
     executePlaybook(
       {
@@ -185,7 +204,8 @@ async function runScenario(scenarioName, useMenu, planTurn, executePlaybook, get
       drotaLatency: qwen.latency_ms,
       drotaTokensIn: qwen.tokens_in,
       drotaTokensOut: qwen.tokens_out,
-      drotaPromptChars: drotaPrompt.length,
+      drotaPromptChars: drotaSkipped ? 0 : (qwen.content?.length ?? 0),
+      drotaSkipped,
       output: output.slice(0, 300),
     });
   }
@@ -271,6 +291,7 @@ async function main() {
   const { parseDrotaOutput } = await import("../motor-drota/dist/parse-output.js");
   const { rankPool } = await import("../motor-drota/dist/evaluate.js");
   const { selectFromPool } = await import("../motor-drota/dist/select.js");
+  const { canSkipDrotaComposition } = await import("../motor-drota/dist/compose-skip.js");
 
   const personaInput = { ...persona, profile: {} };
 
@@ -289,13 +310,18 @@ async function main() {
     ],
   };
 
+  // Sprint 3 update: scenario B agora ativa também ASC_SKIP_DROTA_COMPOSITION
+  // (motor#136 GO ratificado Jun em motor#134 PoC). Mede skip path completo.
   const scenarios = [];
+  delete process.env.ASC_SKIP_DROTA_COMPOSITION;
   scenarios.push(
-    await runScenario("A_no_menu", false, planTurn, executePlaybook, getState, personaInput, inventory, rankPool, selectFromPool, buildDrotaPrompt, parseDrotaOutput),
+    await runScenario("A_no_menu", false, planTurn, executePlaybook, getState, personaInput, inventory, rankPool, selectFromPool, buildDrotaPrompt, parseDrotaOutput, canSkipDrotaComposition),
   );
+  process.env.ASC_SKIP_DROTA_COMPOSITION = "true";
   scenarios.push(
-    await runScenario("B_menu_lookup", true, planTurn, executePlaybook, getState, personaInput, inventory, rankPool, selectFromPool, buildDrotaPrompt, parseDrotaOutput),
+    await runScenario("B_menu_skip_full", true, planTurn, executePlaybook, getState, personaInput, inventory, rankPool, selectFromPool, buildDrotaPrompt, parseDrotaOutput, canSkipDrotaComposition),
   );
+  delete process.env.ASC_SKIP_DROTA_COMPOSITION;
 
   const agg = scenarios.map(aggregate);
   const md = buildMarkdown(persona, agg, scenarios);


### PR DESCRIPTION
## Sprint 3 PR 1 — A/B benchmark menu vs pool

Refatora `scripts/benchmark-menu-vs-pool.mjs` pra refletir skip path completo Sprint 1+2 e roda benchmark Ryo N=3 contra Qwen3 30B local.

### Resultados (Ryo N=3, Qwen3-30b)

| Métrica | A (no menu) | B (menu + skip) | Delta |
|---|---|---|---|
| Drota latency avg | 33724ms | 0ms | **-100%** |
| Total latency | 101180ms | 13ms | **-100%** |
| Tokens in/out | 3115/231 | 0/0 | **-100%** |
| menu_hit_rate | 0% | 100% | — |

**Skip path completo confirmed: zero LLM calls per-turn em hit path.**

### Mudanças no script

- Scenarios: A "no_menu" (status quo) vs B "menu_skip_full" (skip rationale + composition)
- B ativa `ASC_SKIP_DROTA_COMPOSITION=true`; replica logic skip do motor-drota/src/server.ts (canSkipDrotaComposition) inline
- Output JSON inclui `drotaSkipped` flag por turn
- Comments documentam Sprint 3 update

### Handoff files

- `docs/handoffs/2026-05-23-sprint3-pr1-benchmark-menu-vs-pool-ryo.md` — tabela agregada + outputs por turn
- `docs/handoffs/2026-05-23-sprint3-pr1-benchmark-menu-vs-pool-ryo-raw.json` — runs raw com latency/tokens detalhados

### Caveat

Planejador rodou em USE_MOCK_LLM=true (fallback quando keys ausentes); rationale LLM call não foi medida diretamente. Mas ganho do drota skip sozinho (~30s/turn → 0ms) já é dominante e suficiente pra validar empiricamente o trade-off do skip path.

### Verdict aguardando Jun

- [ ] **GO** — skip path validated em prod, manter rollout
- [ ] **TUNE** — gap específico identificar (rationale LLM call medir separado)
- [ ] **NO-GO** — algo no benchmark não bate com expectativa, investigar

### Refs

- ops#1005 (story S-T-10-07)
- ops#1118 (Sprint 3 tracker)
- motor#115 (rationale skip)
- motor#136 (composition skip)