### PR TITLE
[feat ops#1115] S-MX-06-03 channel interface + mock (PR 4/9)

### DIFF
--- a/packages/motor-channels/src/channel.ts
+++ b/packages/motor-channels/src/channel.ts
@@ -1,0 +1,53 @@
+/**
+ * Contrato `WhatsAppChannel` — S-MX-06-03 (ops#1115).
+ *
+ * Define a superfície que o motor-channels expõe ao orchestrator e a
+ * qualquer test/integração: ciclo de vida, envio, status e três streams
+ * de eventos (inbound, mudança de conexão, QR code de auth).
+ *
+ * PR4 (escopo magro): apenas a interface + mock in-memory. A impl real
+ * (Baileys + SQLite auth) entra em PR4b, atrás de QR scan manual pelo
+ * Jun. Mock é zero-IO, suficiente pra testar router/orchestrator wiring
+ * em PRs seguintes.
+ */
+
+import type {
+  ChannelAddress,
+  ConnectionChangedEvent,
+  ConnectionStatus,
+  InboundMessage,
+  SendResult,
+} from "./types.js";
+
+/** Função pra remover um handler previamente registrado. Idempotente. */
+export type Unsubscribe = () => void;
+
+export interface WhatsAppChannel {
+  /** Inicia ciclo de conexão. Para impl real dispara fluxo Baileys (QR se
+   *  primeiro acesso, reconnect se sessão persistida). Para mock apenas
+   *  marca `connected=true` e dispara `ConnectionChanged`. */
+  start(): Promise<void>;
+
+  /** Encerra conexão limpa. Marca `connected=false` + dispara evento. */
+  stop(): Promise<void>;
+
+  /** Envia mensagem outbound. Resolve com `messageId` opaco do canal. */
+  send(to: ChannelAddress, text: string): Promise<SendResult>;
+
+  /** Snapshot síncrono do estado atual da conexão. */
+  status(): ConnectionStatus;
+
+  /** Stream de mensagens recebidas. Caller decide se passa por `routeInbound`
+   *  ou processa direto. Múltiplos handlers permitidos. */
+  onMessage(handler: (msg: InboundMessage) => void): Unsubscribe;
+
+  /** Stream de mudanças de conexão (QR scan completo, drop, logout, etc.). */
+  onConnectionChange(
+    handler: (ev: ConnectionChangedEvent) => void,
+  ): Unsubscribe;
+
+  /** Emite QR code (texto) na primeira auth ou após logout. Mock pode
+   *  disparar via `simulateQrCode`. Impl real recebe do Baileys
+   *  `connection.update`. */
+  onQrCode(handler: (qrText: string) => void): Unsubscribe;
+}

--- a/packages/motor-channels/src/index.ts
+++ b/packages/motor-channels/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./types.js";
+export * from "./channel.js";
+export * from "./mock-channel.js";

--- a/packages/motor-channels/src/mock-channel.ts
+++ b/packages/motor-channels/src/mock-channel.ts
@@ -1,0 +1,122 @@
+/**
+ * Mock in-memory de `WhatsAppChannel` — zero IO, determinístico.
+ *
+ * Uso: testes unitários do router/orchestrator wiring sem dependência
+ * Baileys/WhatsApp. As três `simulate*` permitem ao teste injetar
+ * eventos como se viessem do canal real. `sentMessages` expõe o histórico
+ * de outbound pra asserções.
+ */
+
+import type { WhatsAppChannel, Unsubscribe } from "./channel.js";
+import type {
+  ChannelAddress,
+  ConnectionChangedEvent,
+  ConnectionStatus,
+  InboundMessage,
+  OutboundMessage,
+  SendResult,
+} from "./types.js";
+
+export interface MockChannel extends WhatsAppChannel {
+  /** Histórico de outbound desde a criação. Read-only pelo consumidor. */
+  readonly sentMessages: ReadonlyArray<OutboundMessage>;
+
+  /** Injeta uma mensagem inbound — handlers de `onMessage` recebem. */
+  simulateInbound(msg: InboundMessage): void;
+
+  /** Injeta uma mudança de conexão — handlers + `status()` atualizam. */
+  simulateConnectionChange(ev: ConnectionChangedEvent): void;
+
+  /** Injeta um QR code — handlers de `onQrCode` recebem. */
+  simulateQrCode(qrText: string): void;
+
+  /** Reseta histórico de outbound (útil entre asserções). */
+  resetSentMessages(): void;
+}
+
+export function createMockChannel(): MockChannel {
+  const sent: OutboundMessage[] = [];
+  const messageHandlers = new Set<(msg: InboundMessage) => void>();
+  const connHandlers = new Set<(ev: ConnectionChangedEvent) => void>();
+  const qrHandlers = new Set<(qrText: string) => void>();
+
+  let connected = false;
+  let lastSeen: string | undefined;
+  let messageCounter = 0;
+
+  const emitConnectionChange = (ev: ConnectionChangedEvent): void => {
+    connected = ev.connected;
+    lastSeen = ev.timestamp;
+    for (const h of connHandlers) h(ev);
+  };
+
+  const subscribe = <T>(set: Set<T>, handler: T): Unsubscribe => {
+    set.add(handler);
+    return () => {
+      set.delete(handler);
+    };
+  };
+
+  return {
+    async start(): Promise<void> {
+      emitConnectionChange({
+        type: "ConnectionChanged",
+        connected: true,
+        timestamp: new Date().toISOString(),
+      });
+    },
+
+    async stop(): Promise<void> {
+      emitConnectionChange({
+        type: "ConnectionChanged",
+        connected: false,
+        reason: "stopped",
+        timestamp: new Date().toISOString(),
+      });
+    },
+
+    async send(to: ChannelAddress, text: string): Promise<SendResult> {
+      sent.push({ to, text });
+      messageCounter += 1;
+      return { messageId: `mock-msg-${messageCounter}` };
+    },
+
+    status(): ConnectionStatus {
+      return {
+        connected,
+        ...(lastSeen !== undefined ? { lastSeen } : {}),
+        queueDepth: 0,
+      };
+    },
+
+    onMessage(handler) {
+      return subscribe(messageHandlers, handler);
+    },
+    onConnectionChange(handler) {
+      return subscribe(connHandlers, handler);
+    },
+    onQrCode(handler) {
+      return subscribe(qrHandlers, handler);
+    },
+
+    simulateInbound(msg: InboundMessage): void {
+      for (const h of messageHandlers) h(msg);
+    },
+
+    simulateConnectionChange(ev: ConnectionChangedEvent): void {
+      emitConnectionChange(ev);
+    },
+
+    simulateQrCode(qrText: string): void {
+      for (const h of qrHandlers) h(qrText);
+    },
+
+    get sentMessages(): ReadonlyArray<OutboundMessage> {
+      return sent;
+    },
+
+    resetSentMessages(): void {
+      sent.length = 0;
+    },
+  };
+}

--- a/packages/motor-channels/tests/mock-channel.test.ts
+++ b/packages/motor-channels/tests/mock-channel.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from "vitest";
+import { createMockChannel } from "../src/mock-channel.js";
+import type {
+  ConnectionChangedEvent,
+  InboundMessage,
+} from "../src/types.js";
+
+const sampleInbound: InboundMessage = {
+  from: "5511999990000@s.whatsapp.net",
+  text: "card:tabuada-7",
+  conversationId: "conv-mock-001",
+  timestamp: "2026-05-23T13:00:00.000Z",
+};
+
+describe("createMockChannel — lifecycle", () => {
+  it("starts disconnected", () => {
+    const ch = createMockChannel();
+    expect(ch.status().connected).toBe(false);
+    expect(ch.status().queueDepth).toBe(0);
+  });
+
+  it("start() flips connected + emits ConnectionChanged", async () => {
+    const ch = createMockChannel();
+    const handler = vi.fn();
+    ch.onConnectionChange(handler);
+    await ch.start();
+    expect(ch.status().connected).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [ev] = handler.mock.calls[0]!;
+    expect((ev as ConnectionChangedEvent).connected).toBe(true);
+  });
+
+  it("stop() flips connected back + emits ConnectionChanged", async () => {
+    const ch = createMockChannel();
+    await ch.start();
+    const handler = vi.fn();
+    ch.onConnectionChange(handler);
+    await ch.stop();
+    expect(ch.status().connected).toBe(false);
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [ev] = handler.mock.calls[0]!;
+    expect((ev as ConnectionChangedEvent).connected).toBe(false);
+    expect((ev as ConnectionChangedEvent).reason).toBe("stopped");
+  });
+});
+
+describe("createMockChannel — send", () => {
+  it("records sent messages with monotonic ids", async () => {
+    const ch = createMockChannel();
+    const a = await ch.send("5511111@s.whatsapp.net", "oi");
+    const b = await ch.send("5512222@s.whatsapp.net", "tchau");
+    expect(a.messageId).toBe("mock-msg-1");
+    expect(b.messageId).toBe("mock-msg-2");
+    expect(ch.sentMessages).toEqual([
+      { to: "5511111@s.whatsapp.net", text: "oi" },
+      { to: "5512222@s.whatsapp.net", text: "tchau" },
+    ]);
+  });
+
+  it("resetSentMessages clears history", async () => {
+    const ch = createMockChannel();
+    await ch.send("5511111@s.whatsapp.net", "oi");
+    ch.resetSentMessages();
+    expect(ch.sentMessages).toEqual([]);
+  });
+});
+
+describe("createMockChannel — onMessage", () => {
+  it("invokes handler on simulateInbound", () => {
+    const ch = createMockChannel();
+    const handler = vi.fn();
+    ch.onMessage(handler);
+    ch.simulateInbound(sampleInbound);
+    expect(handler).toHaveBeenCalledWith(sampleInbound);
+  });
+
+  it("supports multiple handlers; each receives the message", () => {
+    const ch = createMockChannel();
+    const a = vi.fn();
+    const b = vi.fn();
+    ch.onMessage(a);
+    ch.onMessage(b);
+    ch.simulateInbound(sampleInbound);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe stops further calls but leaves others active", () => {
+    const ch = createMockChannel();
+    const a = vi.fn();
+    const b = vi.fn();
+    const unsubA = ch.onMessage(a);
+    ch.onMessage(b);
+    ch.simulateInbound(sampleInbound);
+    unsubA();
+    ch.simulateInbound(sampleInbound);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(2);
+  });
+
+  it("unsubscribe is idempotent", () => {
+    const ch = createMockChannel();
+    const handler = vi.fn();
+    const unsub = ch.onMessage(handler);
+    unsub();
+    unsub();
+    ch.simulateInbound(sampleInbound);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("createMockChannel — onConnectionChange & onQrCode", () => {
+  it("simulateConnectionChange updates status + fires handlers", () => {
+    const ch = createMockChannel();
+    const handler = vi.fn();
+    ch.onConnectionChange(handler);
+    ch.simulateConnectionChange({
+      type: "ConnectionChanged",
+      connected: true,
+      timestamp: "2026-05-23T13:00:00.000Z",
+    });
+    expect(ch.status().connected).toBe(true);
+    expect(ch.status().lastSeen).toBe("2026-05-23T13:00:00.000Z");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("simulateQrCode fires only QR handlers (not message/conn)", () => {
+    const ch = createMockChannel();
+    const qr = vi.fn();
+    const msg = vi.fn();
+    const conn = vi.fn();
+    ch.onQrCode(qr);
+    ch.onMessage(msg);
+    ch.onConnectionChange(conn);
+    ch.simulateQrCode("2@abc...");
+    expect(qr).toHaveBeenCalledWith("2@abc...");
+    expect(msg).not.toHaveBeenCalled();
+    expect(conn).not.toHaveBeenCalled();
+  });
+
+  it("QR handler unsubscribe works", () => {
+    const ch = createMockChannel();
+    const qr = vi.fn();
+    const unsub = ch.onQrCode(qr);
+    unsub();
+    ch.simulateQrCode("2@abc...");
+    expect(qr).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

PR 4/9 do plan C-MX-06 (ops#1115). **Scope magro (Q6=a):** apenas a interface `WhatsAppChannel` + `createMockChannel()`. Impl real Baileys + SQLite auth state ficam pra **PR4b** (separado), porque essa exige QR scan manual com o celular do Jun.

- **Sub-story coberta:** S-MX-06-03 (parcial — contrato + mock)
- **Stacked em:** #137 PR1 (parallel sibling de PR2 #138 e PR3 #140)
- **Branch:** `sprint2/pr8-mx-06-03-channel-iface-mock`

## O que entra

- `packages/motor-channels/src/channel.ts` — interface `WhatsAppChannel` com:
  - lifecycle: `start()`, `stop()`, `status()`
  - envio: `send(to, text)` → `Promise<SendResult>`
  - 3 streams: `onMessage`, `onConnectionChange`, `onQrCode` — todos retornam `Unsubscribe`
- `packages/motor-channels/src/mock-channel.ts` — `createMockChannel()`:
  - implementa a interface integral (zero atalhos)
  - + extensões pra teste: `simulateInbound`, `simulateConnectionChange`, `simulateQrCode`, `sentMessages` (readonly), `resetSentMessages`
  - zero IO, determinístico, monotonic `messageId`
- `packages/motor-channels/tests/mock-channel.test.ts` — 12 unit tests

## O que NÃO entra (PR4b)

- `createBaileysChannel()` real (Baileys + reconnect lógica + QR loop)
- SQLite-backed `AuthenticationState` (D2 ratificado, ~150 LOC custom)
- `.session/` / `.baileys-auth/` `.gitignore` entries
- Integration test que tente conectar de verdade

PR4b é onde **precisarei do teu celular pra QR scan real**. Não vai ser autônomo.

## Decisões tomadas

1. **Unsubscribe pattern via return value** — `onX(handler)` retorna `() => void`. Idempotente. Mais simples que `removeListener` separado.
2. **Múltiplos handlers permitidos** em cada stream — orchestrator pode ter um listener pra router e outro pra telemetria sem ceremony.
3. **Mock estende interface, não wrapper** — `MockChannel extends WhatsAppChannel` adiciona `simulate*` + observability. Caller faz cast pra usar; consumer real usa só `WhatsAppChannel`.
4. **`sentMessages` é `ReadonlyArray<OutboundMessage>`** — sinaliza intent "história de outbound, não modifique". `resetSentMessages()` é o caminho pra limpar.
5. **`status()` síncrono** — match com NFR auditability + simplicidade. Estado interno é só boolean + lastSeen + queueDepth (que no mock sempre é 0).

## Verificação (alvos P4)

- [x] `npm run build --workspace packages/motor-channels` — exit 0
- [x] `npm test --workspace packages/motor-channels` — 17/17 (5 smoke + 12 mock)
- [x] Mock implementa interface integral (TS checa via `MockChannel extends WhatsAppChannel`)
- [x] Unsubscribe idempotente verificado
- [x] Múltiplos handlers funcionam independente

## Próximo

**PR4b** depende de ti — quando tiveres celular disponível, me dá sinal e codamos juntos:
1. `createBaileysChannel` com `useMultiFileAuthState` OU SQLite custom (Q7 reabre)
2. QR scan via teu celular
3. Sessão persiste; reconnect roda

**PR5** (S-MX-06-04 status MCP tool) depende de PR4 (esta) + um stdio MCP server skeleton. Posso disparar PR5 stacked em PR4 enquanto PR4b não roda — o status tool funciona sobre o mock perfeitamente.

## Test plan

- [ ] Reviewer roda `npm test --workspace packages/motor-channels` → 17/17
- [ ] Confirma decisões 1-5 — flagar se algo diferir
- [ ] Confirma split PR4 / PR4b (este PR sem real Baileys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)