### PR TITLE
[feat ops#1115] S-MX-06-04 channel.status MCP tool (PR 5/9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6298,13 +6298,24 @@
       "name": "@ascendimacy/motor-channels",
       "version": "0.1.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.10.2",
         "@whiskeysockets/baileys": "^6.7.0",
-        "pino": "^9.0.0"
+        "pino": "^9.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "*",
         "typescript": "*",
         "vitest": "*"
+      }
+    },
+    "packages/motor-channels/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "planejador": {

--- a/packages/motor-channels/package.json
+++ b/packages/motor-channels/package.json
@@ -11,8 +11,10 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.10.2",
     "@whiskeysockets/baileys": "^6.7.0",
-    "pino": "^9.0.0"
+    "pino": "^9.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "*",

--- a/packages/motor-channels/src/index.ts
+++ b/packages/motor-channels/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./channel.js";
 export * from "./mock-channel.js";
+export * from "./mcp-server.js";

--- a/packages/motor-channels/src/mcp-server.ts
+++ b/packages/motor-channels/src/mcp-server.ts
@@ -1,0 +1,46 @@
+/**
+ * Servidor MCP do motor-channels — S-MX-06-04 (ops#1115).
+ *
+ * `createMcpServer(channel)` devolve um `McpServer` configurado, sem
+ * transporte. Caller decide stdio (cli prod), in-memory (testes E2E),
+ * ou outro (HTTP futuro). Mantém o module testável sem subprocesso.
+ *
+ * Tools registradas neste PR:
+ * - `channel.status` — health/status snapshot do canal subjacente.
+ *
+ * Próximos PRs adicionam mais tools (`channel.send`, `cards.getPackage`).
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhatsAppChannel } from "./channel.js";
+
+/** Nome/versão do server. Versão acompanha o package.json. Bump quando a
+ *  superfície de tools muda de modo não-aditivo. */
+export const MCP_SERVER_NAME = "motor-channels";
+export const MCP_SERVER_VERSION = "0.1.0";
+
+/** Cria um `McpServer` com as tools do motor-channels registradas
+ *  contra o `channel` fornecido. Não conecta transporte — caller faz. */
+export function createMcpServer(channel: WhatsAppChannel): McpServer {
+  const server = new McpServer({
+    name: MCP_SERVER_NAME,
+    version: MCP_SERVER_VERSION,
+  });
+
+  server.registerTool(
+    "channel.status",
+    {
+      description:
+        "Snapshot do estado da conexão do canal. Retorna { connected, lastSeen?, queueDepth } como JSON.",
+      inputSchema: {},
+    },
+    async () => {
+      const status = channel.status();
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(status) }],
+      };
+    },
+  );
+
+  return server;
+}

--- a/packages/motor-channels/tests/mcp-server.test.ts
+++ b/packages/motor-channels/tests/mcp-server.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer, MCP_SERVER_NAME } from "../src/mcp-server.js";
+import { createMockChannel } from "../src/mock-channel.js";
+import type { ConnectionStatus } from "../src/types.js";
+
+const setup = async () => {
+  const channel = createMockChannel();
+  const server = createMcpServer(channel);
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test-client", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { channel, server, client };
+};
+
+const parseStatus = (result: {
+  content: Array<{ type: string; text?: string }>;
+}): ConnectionStatus => {
+  const block = result.content[0]!;
+  expect(block.type).toBe("text");
+  return JSON.parse(block.text!) as ConnectionStatus;
+};
+
+describe("motor-channels MCP server", () => {
+  it("lists channel.status as an available tool", async () => {
+    const { client, server } = await setup();
+    const tools = await client.listTools();
+    expect(tools.tools.some((t) => t.name === "channel.status")).toBe(true);
+    await client.close();
+    await server.close();
+  });
+
+  it("channel.status returns mock disconnected state on a fresh channel", async () => {
+    const { client, server } = await setup();
+    const result = await client.callTool({
+      name: "channel.status",
+      arguments: {},
+    });
+    const status = parseStatus(result as Parameters<typeof parseStatus>[0]);
+    expect(status).toEqual({ connected: false, queueDepth: 0 });
+    await client.close();
+    await server.close();
+  });
+
+  it("channel.status reflects state changes after channel.start()", async () => {
+    const { channel, client, server } = await setup();
+    await channel.start();
+    const result = await client.callTool({
+      name: "channel.status",
+      arguments: {},
+    });
+    const status = parseStatus(result as Parameters<typeof parseStatus>[0]);
+    expect(status.connected).toBe(true);
+    expect(typeof status.lastSeen).toBe("string");
+    expect(status.queueDepth).toBe(0);
+    await client.close();
+    await server.close();
+  });
+
+  it("server identifies itself with MCP_SERVER_NAME", async () => {
+    const { client, server } = await setup();
+    const info = client.getServerVersion();
+    expect(info?.name).toBe(MCP_SERVER_NAME);
+    await client.close();
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Summary

PR 5/9 do plan C-MX-06 (ops#1115). Primeira tool MCP do motor-channels — `channel.status`. Server factory testável, sem stdio amarrado.

- **Sub-story coberta:** S-MX-06-04
- **Stacked em:** #142 PR4 (precisa de `WhatsAppChannel`)
- **Branch:** `sprint2/pr9-mx-06-04-status-mcp-tool`

## O que entra

- `packages/motor-channels/src/mcp-server.ts`
  - `createMcpServer(channel: WhatsAppChannel): McpServer` — registra tools, NÃO conecta transporte
  - `channel.status` registrada: input `{}`, output JSON text com `{ connected, lastSeen?, queueDepth }`
  - exporta `MCP_SERVER_NAME` + `MCP_SERVER_VERSION` (canônico = `"motor-channels"` / `"0.1.0"`)
- `packages/motor-channels/tests/mcp-server.test.ts` — 4 E2E tests via `InMemoryTransport.createLinkedPair()` + `Client` SDK
- `package.json` — deps `@modelcontextprotocol/sdk@^1.10.2` (match orchestrator) e `zod@^4.3.6`
- `src/index.ts` — re-export

## Decisões tomadas

1. **Factory pattern, sem transporte amarrado.** `createMcpServer(channel)` devolve o `McpServer` configurado; caller decide stdio (cli prod) ou `InMemoryTransport` (testes). Module fica testável sem subprocesso. Padrão divergente do `planejador/server.ts` que tem top-level await + stdio inline — escolhi factory aqui pra permitir reuse no MCP client tests do orchestrator (PR6).
2. **Sem CLI entry script** — `cli.ts` que wire channel real + stdio fica pra PR9 (deploy artifacts). Aqui é só o building block.
3. **Tool name com `.`** (`channel.status`) — match com a "Interface MCP proposta" da ops#1115. SDK aceita; client `listTools` devolve igual.
4. **Output como JSON text content** — sigo padrão `planejador/server.ts:62-66`. Output schema estruturado fica como evolução futura quando o SDK estabilizar `outputSchema`.
5. **Versão hardcoded no source** — `MCP_SERVER_VERSION = "0.1.0"` espelha package.json. Bump quando superfície quebrar (não-aditivo).
6. **Empty inputSchema `{}`** — tool sem args. Funciona com SDK `^1.10.2`.

## Verificação (alvos P4)

- [x] `npm run build --workspace packages/motor-channels` — exit 0
- [x] `npm test --workspace packages/motor-channels` — 21/21 (5 smoke + 12 mock + 4 mcp)
- [x] `listTools` devolve `channel.status`
- [x] `callTool` retorna estado fresh `{ connected: false, queueDepth: 0 }`
- [x] Após `channel.start()`, `callTool` reflete `connected: true` + `lastSeen` ISO
- [x] `client.getServerVersion()` casa `MCP_SERVER_NAME`

## Próximo

**PR6 — S-MX-06-07+08 orchestrator bridge.** Wire `routeInbound` (PR2) + `cards.getPackage` loader (PR3) + `channel.send` tool. Caller principal vai consumir via `Client` do MCP — testes em PR6 podem reusar o pattern InMemoryTransport.

**PR4b** continua pendente do teu celular pra QR scan real.

## Test plan

- [ ] Reviewer roda `npm test --workspace packages/motor-channels` → 21/21
- [ ] Confirma decisões 1-6 — especialmente factory vs top-level await (1) e tool naming com `.` (3)
- [ ] Confirma adição de deps `@modelcontextprotocol/sdk` + `zod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)