### PR TITLE
[feat ops#1115] PR6b — orchestrator MCP server skeleton (não wireado)

### DIFF
--- a/orchestrator/src/mcp-server.ts
+++ b/orchestrator/src/mcp-server.ts
@@ -1,0 +1,95 @@
+/**
+ * Orchestrator MCP server SKELETON — S-MX-06-07 (ops#1115, PR6b da opção Z).
+ *
+ * STATUS: documentação executável da inversão arquitetural pendente.
+ * NÃO É USADO EM PRODUÇÃO. Não wire em cli.ts ainda.
+ *
+ * Hoje o orchestrator é CLI one-shot (`motor run --persona X --message Y`)
+ * que spawna a tríade planejador/drota/execucao como clientes stdio e roda
+ * um único turno. Esse arquivo expõe o shape do que ele PRECISARÁ se virar
+ * daemon long-running com MCP server — alvo do qual o motor-channels
+ * bridge (capability C-MX-06 PR6) depende pra capability futura
+ * (provavelmente C-MX-07: orchestrator daemon).
+ *
+ * O que falta pra essa inversão sair do skeleton:
+ *  1. orchestrator vira processo long-running em vez de CLI one-shot.
+ *  2. Resolver mapping `from` (JID WhatsApp) → persona — hoje persona vem
+ *     por --persona flag, não há lookup por canal.
+ *  3. Manter conversa entre turnos (carta vira sessão, não turno único) —
+ *     persistir conversationId → sessionId → SessionState rehydration.
+ *  4. Conectar o pacote pedagógico carregado pelo bridge ao system prompt
+ *     do motor-drota (route via planejador.contentPool? mixin novo?).
+ *  5. Decidir transport: stdio (motor-channels spawn o orchestrator?), HTTP,
+ *     ou shared lib.
+ *
+ * Esse arquivo dá a forma do `startCardSession` tool — o resto fica pra
+ * capability própria. createInboundBridge em motor-channels já consome
+ * essa interface (via `OrchestratorBridge`), então o skeleton aqui é
+ * compatível.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export const ORCHESTRATOR_MCP_NAME = "orchestrator";
+export const ORCHESTRATOR_MCP_VERSION = "0.0.0-skeleton";
+
+/**
+ * Marker pra identificar respostas vindas do skeleton vs. impl real.
+ * Quando capability futura wirar, esse prefixo desaparece da resposta.
+ */
+export const SKELETON_RESPONSE_PREFIX = "[orchestrator-skeleton]";
+
+/**
+ * Cria o MCP server skeleton do orchestrator. Tools registradas hoje:
+ * - `startCardSession` — stub que retorna placeholder. Documenta a
+ *   superfície que motor-channels bridge espera consumir.
+ *
+ * Não conecta transporte — caller decide. Não ative em cli.ts.
+ */
+export function createOrchestratorMcpServer(): McpServer {
+  const server = new McpServer({
+    name: ORCHESTRATOR_MCP_NAME,
+    version: ORCHESTRATOR_MCP_VERSION,
+  });
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  server.registerTool(
+    "startCardSession",
+    {
+      description:
+        "[SKELETON] Inicia sessão carta-acionada. Retorna texto a enviar pelo canal. " +
+        "Impl real fica pra capability futura — wiring com motor-drota + " +
+        "persistência de conversationId pendente.",
+      inputSchema: {
+        cardId: z.string(),
+        conversationId: z.string(),
+        from: z.string(),
+        // pkg passado como JSON serialized — schema completo vive em
+        // motor-channels CardPackage. Skeleton aceita qualquer objeto.
+        pkg: z.object({
+          cardId: z.string(),
+          raw: z.string(),
+          sourcePath: z.string(),
+        }),
+      } as any,
+    },
+    async (input: {
+      cardId: string;
+      conversationId: string;
+      from: string;
+      pkg: { cardId: string; raw: string; sourcePath: string };
+    }) => {
+      const text =
+        `${SKELETON_RESPONSE_PREFIX} sessão iniciada para cardId=${input.cardId}, ` +
+        `conversationId=${input.conversationId}. wiring real pendente.`;
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify({ text }) },
+        ],
+      };
+    },
+  );
+
+  return server;
+}

--- a/orchestrator/tests/mcp-server.skeleton.test.ts
+++ b/orchestrator/tests/mcp-server.skeleton.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  createOrchestratorMcpServer,
+  ORCHESTRATOR_MCP_NAME,
+  SKELETON_RESPONSE_PREFIX,
+} from "../src/mcp-server.js";
+
+const setup = async () => {
+  const server = createOrchestratorMcpServer();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test-client", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { server, client };
+};
+
+const parseJson = <T>(result: {
+  content: Array<{ type: string; text?: string }>;
+}): T => JSON.parse(result.content[0]!.text!) as T;
+
+describe("orchestrator MCP server skeleton", () => {
+  it("identifies itself with ORCHESTRATOR_MCP_NAME", async () => {
+    const { client, server } = await setup();
+    expect(client.getServerVersion()?.name).toBe(ORCHESTRATOR_MCP_NAME);
+    await client.close();
+    await server.close();
+  });
+
+  it("registers startCardSession as a tool", async () => {
+    const { client, server } = await setup();
+    const tools = await client.listTools();
+    expect(tools.tools.some((t) => t.name === "startCardSession")).toBe(true);
+    await client.close();
+    await server.close();
+  });
+
+  it("startCardSession returns a placeholder text marked by SKELETON prefix", async () => {
+    const { client, server } = await setup();
+    const result = await client.callTool({
+      name: "startCardSession",
+      arguments: {
+        cardId: "tabuada-7",
+        conversationId: "conv-001",
+        from: "5511999@s.whatsapp.net",
+        pkg: {
+          cardId: "tabuada-7",
+          raw: "# pkg",
+          sourcePath: "/fake/path",
+        },
+      },
+    });
+    const out = parseJson<{ text: string }>(
+      result as Parameters<typeof parseJson>[0],
+    );
+    expect(out.text.startsWith(SKELETON_RESPONSE_PREFIX)).toBe(true);
+    expect(out.text).toContain("cardId=tabuada-7");
+    expect(out.text).toContain("conversationId=conv-001");
+    expect(out.text).toContain("wiring real pendente");
+    await client.close();
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Summary

PR6b da opção Z (cf. ops#1115 PR #144). Documentação executável da inversão arquitetural pendente entre motor-channels e orchestrator. **NÃO É WIREADO em produção.**

- **Sub-story coberta:** documenta gap da S-MX-06-07 (full impl é capability futura)
- **Branch:** \`sprint2/pr11-mx-06-07-orchestrator-mcp-skeleton\` ← \`main\`
- **Parallel sibling** de todos os PRs MX-06; mergeable independente.

## Contexto

Orchestrator hoje é CLI one-shot. Spec da ops#1115 pede \`motor-channels chama orchestrator.startCardSession(...)\` — exige orchestrator daemon long-running com MCP server, inversão arquitetural maior que cabe no escopo C-MX-06.

PR6 (#144) definiu \`OrchestratorBridge\` interface em motor-channels. **PR6b (este)** entrega o lado orchestrator-side: skeleton executável com stub no lugar do wiring real.

## O que entra

- \`orchestrator/src/mcp-server.ts\` — \`createOrchestratorMcpServer()\` factory + \`startCardSession\` tool com stub
- \`orchestrator/tests/mcp-server.skeleton.test.ts\` — 3 E2E tests via InMemoryTransport
- Header comment lista 5 itens pendentes pra sair do skeleton

## NÃO está incluído

- Wiring em \`cli.ts\`
- Mapping from→persona / sessão persistida / pkg→system prompt

## Verificação

- [x] \`npm run build --workspace orchestrator\` — exit 0
- [x] \`npm test --workspace orchestrator\` — 82/82 verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)