### PR TITLE
[feat ops#1115] PR4b — Baileys real impl + QR scan script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ traces/
 *.js.map
 *.d.ts.map
 .motor-state.db
+.baileys-auth/
 logs/
 *.d.ts
 *.d.ts.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -4915,6 +4915,15 @@
       "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "license": "MIT"
     },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
@@ -6303,6 +6312,7 @@
       },
       "devDependencies": {
         "@types/node": "*",
+        "qrcode-terminal": "^0.12.0",
         "typescript": "*",
         "vitest": "*"
       }

--- a/packages/motor-channels/package.json
+++ b/packages/motor-channels/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "*",
+    "qrcode-terminal": "^0.12.0",
     "typescript": "*",
     "vitest": "*"
   },

--- a/packages/motor-channels/scripts/baileys-qr-scan.mjs
+++ b/packages/motor-channels/scripts/baileys-qr-scan.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Script manual de auth Baileys — S-MX-06-03 (PR4b).
+ *
+ * Roda createBaileysChannel(), imprime o QR no terminal, espera o usuário
+ * scanear com WhatsApp do celular. Sessão persistida em `<authDir>` (default
+ * `.baileys-auth/` no root do repo, já em .gitignore).
+ *
+ * Após primeira auth bem-sucedida, próximas execuções entram direto
+ * (sessão restaurada). Use isso quando precisar re-auth (ex: logout no
+ * WhatsApp móvel).
+ *
+ * USAGE:
+ *   node packages/motor-channels/scripts/baileys-qr-scan.mjs [--auth-dir <path>]
+ *
+ * Encerra com Ctrl+C após conexão estabelecida + uma mensagem recebida
+ * (smoke).
+ */
+
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import qrcode from "qrcode-terminal";
+import { createBaileysChannel } from "../dist/baileys-channel.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultAuthDir = resolve(__dirname, "../../../.baileys-auth");
+
+const args = process.argv.slice(2);
+const authDirFlag = args.indexOf("--auth-dir");
+const authDir =
+  authDirFlag !== -1 && args[authDirFlag + 1] !== undefined
+    ? resolve(args[authDirFlag + 1])
+    : defaultAuthDir;
+
+console.log(`[baileys-qr-scan] auth dir: ${authDir}`);
+
+const channel = createBaileysChannel({ authDir });
+
+channel.onQrCode((qr) => {
+  console.log("\n[baileys-qr-scan] escaneie o QR com WhatsApp do celular:\n");
+  qrcode.generate(qr, { small: true });
+});
+
+channel.onConnectionChange((ev) => {
+  if (ev.connected) {
+    console.log(
+      `\n[baileys-qr-scan] ✅ conectado às ${ev.timestamp}. ` +
+        `aguardando primeira mensagem inbound...`,
+    );
+  } else {
+    console.log(
+      `[baileys-qr-scan] ⚠️  desconectado (${ev.reason ?? "?"}) — ${ev.timestamp}`,
+    );
+  }
+});
+
+channel.onMessage((msg) => {
+  console.log(
+    `\n[baileys-qr-scan] 📥 mensagem recebida de ${msg.from}:\n` +
+      `    text: "${msg.text}"\n` +
+      `    timestamp: ${msg.timestamp}\n`,
+  );
+  console.log("[baileys-qr-scan] smoke OK. Ctrl+C pra encerrar.");
+});
+
+await channel.start();
+console.log("[baileys-qr-scan] channel started, aguardando QR ou reconnect...");
+
+process.on("SIGINT", async () => {
+  console.log("\n[baileys-qr-scan] shutting down...");
+  await channel.stop();
+  process.exit(0);
+});

--- a/packages/motor-channels/src/baileys-channel.ts
+++ b/packages/motor-channels/src/baileys-channel.ts
@@ -17,6 +17,7 @@
 
 import makeWASocket, {
   DisconnectReason,
+  fetchLatestBaileysVersion,
   useMultiFileAuthState,
   type WASocket,
 } from "@whiskeysockets/baileys";
@@ -38,6 +39,12 @@ export interface BaileysChannelOptions {
   socketFactory?: typeof makeWASocket;
   /** Idem pra auth state. Permite mock em testes. */
   authStateLoader?: typeof useMultiFileAuthState;
+  /** Fetcher da versão WhatsApp Web a usar no handshake. Default busca
+   *  via `fetchLatestBaileysVersion()` (GitHub raw). Sem isso o bundle
+   *  do Baileys vai com versão estática que pode estar stale — WhatsApp
+   *  rejeita com `Connection Failure` (code 405) durante registration.
+   *  Tests injetam stub pra evitar HTTP. */
+  versionFetcher?: () => Promise<{ version: readonly [number, number, number] }>;
   /** Quanto tempo esperar antes de reconectar após close não-logout.
    *  Default 3000ms. Em testes pode passar 0 pra acelerar. */
   reconnectDelayMs?: number;
@@ -48,6 +55,7 @@ export function createBaileysChannel(
 ): WhatsAppChannel {
   const socketFactory = opts.socketFactory ?? makeWASocket;
   const authStateLoader = opts.authStateLoader ?? useMultiFileAuthState;
+  const versionFetcher = opts.versionFetcher ?? fetchLatestBaileysVersion;
   const reconnectDelayMs = opts.reconnectDelayMs ?? 3000;
 
   const messageHandlers = new Set<(msg: InboundMessage) => void>();
@@ -113,8 +121,15 @@ export function createBaileysChannel(
   };
 
   const connectSocket = async (): Promise<void> => {
-    const { state, saveCreds } = await authStateLoader(opts.authDir);
-    sock = socketFactory({ auth: state, printQRInTerminal: false });
+    const [{ state, saveCreds }, { version }] = await Promise.all([
+      authStateLoader(opts.authDir),
+      versionFetcher(),
+    ]);
+    sock = socketFactory({
+      auth: state,
+      version: version as [number, number, number],
+      printQRInTerminal: false,
+    });
 
     sock.ev.on("creds.update", saveCreds);
 

--- a/packages/motor-channels/src/baileys-channel.ts
+++ b/packages/motor-channels/src/baileys-channel.ts
@@ -1,0 +1,221 @@
+/**
+ * Implementação real de `WhatsAppChannel` sobre Baileys — S-MX-06-03 (PR4b).
+ *
+ * Auth state file-based via `useMultiFileAuthState` (Baileys built-in).
+ * Default D2 ratificou SQLite — desviado temporariamente (Q7=β no thread).
+ * Migração SQLite vira PR follow-up dedicado quando houver sinal real que
+ * vale o trabalho (~150 LOC custom + signal key store).
+ *
+ * Lifecycle:
+ *  - start() → carrega auth state, cria socket, assina eventos
+ *  - eventos QR/connection/messages → repassados pros handlers do contrato
+ *  - reconnect automático em close não-logout (DisconnectReason.loggedOut
+ *    requer re-scan QR, então paramos)
+ *  - stop() → encerra socket sem reconnect
+ *  - send() → sock.sendMessage com text content
+ */
+
+import makeWASocket, {
+  DisconnectReason,
+  useMultiFileAuthState,
+  type WASocket,
+} from "@whiskeysockets/baileys";
+import type { WhatsAppChannel, Unsubscribe } from "./channel.js";
+import type {
+  ChannelAddress,
+  ConnectionChangedEvent,
+  ConnectionStatus,
+  InboundMessage,
+  SendResult,
+} from "./types.js";
+
+export interface BaileysChannelOptions {
+  /** Diretório pra auth state (multi-file). Será criado se não existir.
+   *  Default sugerido: `.baileys-auth/` (já em .gitignore). */
+  authDir: string;
+  /** Permite injetar uma factory custom de `makeWASocket` em testes pra
+   *  evitar IO real. Em prod usa o `makeWASocket` do Baileys diretamente. */
+  socketFactory?: typeof makeWASocket;
+  /** Idem pra auth state. Permite mock em testes. */
+  authStateLoader?: typeof useMultiFileAuthState;
+  /** Quanto tempo esperar antes de reconectar após close não-logout.
+   *  Default 3000ms. Em testes pode passar 0 pra acelerar. */
+  reconnectDelayMs?: number;
+}
+
+export function createBaileysChannel(
+  opts: BaileysChannelOptions,
+): WhatsAppChannel {
+  const socketFactory = opts.socketFactory ?? makeWASocket;
+  const authStateLoader = opts.authStateLoader ?? useMultiFileAuthState;
+  const reconnectDelayMs = opts.reconnectDelayMs ?? 3000;
+
+  const messageHandlers = new Set<(msg: InboundMessage) => void>();
+  const connHandlers = new Set<(ev: ConnectionChangedEvent) => void>();
+  const qrHandlers = new Set<(qrText: string) => void>();
+
+  let sock: WASocket | null = null;
+  let connected = false;
+  let lastSeen: string | undefined;
+  let stopped = false;
+
+  const emitConnectionChange = (
+    nextConnected: boolean,
+    reason?: string,
+  ): void => {
+    connected = nextConnected;
+    const ts = new Date().toISOString();
+    lastSeen = ts;
+    const ev: ConnectionChangedEvent = {
+      type: "ConnectionChanged",
+      connected: nextConnected,
+      ...(reason !== undefined ? { reason } : {}),
+      timestamp: ts,
+    };
+    for (const h of connHandlers) h(ev);
+  };
+
+  const parseInbound = (rawMsg: {
+    key?: { remoteJid?: string | null };
+    message?: {
+      conversation?: string | null;
+      extendedTextMessage?: { text?: string | null } | null;
+    } | null;
+    /** number em prod; Long (protobuf wrapper) em alguns paths. */
+    messageTimestamp?: unknown;
+  }): InboundMessage | null => {
+    const from = rawMsg.key?.remoteJid;
+    if (typeof from !== "string" || from.length === 0) return null;
+    const text =
+      rawMsg.message?.conversation ??
+      rawMsg.message?.extendedTextMessage?.text ??
+      null;
+    if (typeof text !== "string" || text.length === 0) return null;
+    let timestamp: string;
+    if (
+      rawMsg.messageTimestamp !== null &&
+      rawMsg.messageTimestamp !== undefined
+    ) {
+      const seconds =
+        typeof rawMsg.messageTimestamp === "number"
+          ? rawMsg.messageTimestamp
+          : Number(rawMsg.messageTimestamp);
+      timestamp = new Date(seconds * 1000).toISOString();
+    } else {
+      timestamp = new Date().toISOString();
+    }
+    return {
+      from,
+      text,
+      conversationId: from,
+      timestamp,
+    };
+  };
+
+  const connectSocket = async (): Promise<void> => {
+    const { state, saveCreds } = await authStateLoader(opts.authDir);
+    sock = socketFactory({ auth: state, printQRInTerminal: false });
+
+    sock.ev.on("creds.update", saveCreds);
+
+    sock.ev.on("connection.update", (update) => {
+      const { connection, qr, lastDisconnect } = update;
+      if (typeof qr === "string" && qr.length > 0) {
+        for (const h of qrHandlers) h(qr);
+      }
+      if (connection === "open") {
+        emitConnectionChange(true);
+      } else if (connection === "close") {
+        // lastDisconnect.error é tipicamente Boom (@hapi/boom) — tipamos
+        // inline pra não puxar dep transitiva do Baileys explicitamente.
+        const errLike = lastDisconnect?.error as
+          | { output?: { statusCode?: number } }
+          | undefined;
+        const code = errLike?.output?.statusCode;
+        const isLoggedOut = code === DisconnectReason.loggedOut;
+        const reason = isLoggedOut
+          ? "loggedOut"
+          : `code:${code ?? "unknown"}`;
+        emitConnectionChange(false, reason);
+        if (!stopped && !isLoggedOut) {
+          // reconnect com delay pequeno pra evitar tight loop em falhas
+          // persistentes (DNS, banimento, etc.)
+          setTimeout(() => {
+            if (!stopped) {
+              void connectSocket().catch((err) => {
+                console.error("[motor-channels] reconnect failed:", err);
+              });
+            }
+          }, reconnectDelayMs);
+        }
+      }
+    });
+
+    sock.ev.on("messages.upsert", ({ messages }) => {
+      for (const raw of messages) {
+        // ignora mensagens enviadas pelo próprio número (echo) e status
+        if (raw.key?.fromMe === true) continue;
+        const parsed = parseInbound(raw);
+        if (parsed === null) continue;
+        for (const h of messageHandlers) h(parsed);
+      }
+    });
+  };
+
+  const subscribe = <T>(set: Set<T>, handler: T): Unsubscribe => {
+    set.add(handler);
+    return () => {
+      set.delete(handler);
+    };
+  };
+
+  return {
+    async start(): Promise<void> {
+      stopped = false;
+      await connectSocket();
+    },
+
+    async stop(): Promise<void> {
+      stopped = true;
+      if (sock !== null) {
+        try {
+          sock.end(undefined);
+        } catch {
+          // sock pode estar em estado inconsistente — engole pra cleanup
+        }
+        sock = null;
+      }
+      if (connected) emitConnectionChange(false, "stopped");
+    },
+
+    async send(to: ChannelAddress, text: string): Promise<SendResult> {
+      if (sock === null) {
+        throw new Error(
+          "BaileysChannel.send: canal não iniciado. Chamar start() antes.",
+        );
+      }
+      const result = await sock.sendMessage(to, { text });
+      const messageId =
+        result?.key?.id ?? `unknown-${Date.now()}`;
+      return { messageId };
+    },
+
+    status(): ConnectionStatus {
+      return {
+        connected,
+        ...(lastSeen !== undefined ? { lastSeen } : {}),
+        queueDepth: 0,
+      };
+    },
+
+    onMessage(handler) {
+      return subscribe(messageHandlers, handler);
+    },
+    onConnectionChange(handler) {
+      return subscribe(connHandlers, handler);
+    },
+    onQrCode(handler) {
+      return subscribe(qrHandlers, handler);
+    },
+  };
+}

--- a/packages/motor-channels/src/index.ts
+++ b/packages/motor-channels/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./channel.js";
 export * from "./mock-channel.js";
+export * from "./baileys-channel.js";

--- a/packages/motor-channels/tests/baileys-channel.test.ts
+++ b/packages/motor-channels/tests/baileys-channel.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi } from "vitest";
+import { DisconnectReason } from "@whiskeysockets/baileys";
+import { createBaileysChannel } from "../src/baileys-channel.js";
+import type {
+  ConnectionChangedEvent,
+  InboundMessage,
+} from "../src/types.js";
+
+type EventHandler = (...args: unknown[]) => unknown;
+
+/**
+ * Mock socket que replica a superfície de eventos do Baileys que o
+ * wrapper consome (`creds.update`, `connection.update`, `messages.upsert`).
+ * Testes injetam um socketFactory que devolve esse mock + helpers pra
+ * disparar eventos manualmente.
+ */
+const makeMockSocket = () => {
+  const handlers = new Map<string, Set<EventHandler>>();
+  const sendMessage = vi.fn(async (_to: string, _content: unknown) => ({
+    key: { id: "wamid.123" },
+  }));
+  const end = vi.fn(() => undefined);
+
+  const on = (event: string, handler: EventHandler): void => {
+    let set = handlers.get(event);
+    if (set === undefined) {
+      set = new Set();
+      handlers.set(event, set);
+    }
+    set.add(handler);
+  };
+
+  const fire = (event: string, payload: unknown): void => {
+    const set = handlers.get(event);
+    if (set === undefined) return;
+    for (const h of set) h(payload);
+  };
+
+  return {
+    socket: {
+      ev: { on },
+      sendMessage,
+      end,
+    },
+    fire,
+    sendMessage,
+    end,
+  };
+};
+
+const makeMockAuthState = () => ({
+  state: { creds: {}, keys: {} } as unknown,
+  saveCreds: vi.fn(async () => undefined),
+});
+
+const baseOpts = (mock: ReturnType<typeof makeMockSocket>) => ({
+  authDir: "/tmp/test-not-used",
+  socketFactory: vi.fn(() => mock.socket) as never,
+  authStateLoader: vi.fn(async () => makeMockAuthState()) as never,
+  reconnectDelayMs: 0,
+});
+
+describe("createBaileysChannel — start lifecycle", () => {
+  it("loads auth state, creates socket, registers handlers on start()", async () => {
+    const mock = makeMockSocket();
+    const opts = baseOpts(mock);
+    const ch = createBaileysChannel(opts);
+    await ch.start();
+    expect(opts.authStateLoader).toHaveBeenCalledWith("/tmp/test-not-used");
+    expect(opts.socketFactory).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits ConnectionChanged{connected:true} on connection.update open", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    const handler = vi.fn();
+    ch.onConnectionChange(handler);
+    await ch.start();
+    mock.fire("connection.update", { connection: "open" });
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [ev] = handler.mock.calls[0]!;
+    expect((ev as ConnectionChangedEvent).connected).toBe(true);
+    expect(ch.status().connected).toBe(true);
+  });
+
+  it("emits ConnectionChanged{connected:false, reason:loggedOut} on logout", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    const handler = vi.fn();
+    ch.onConnectionChange(handler);
+    await ch.start();
+    mock.fire("connection.update", { connection: "open" });
+    handler.mockClear();
+    mock.fire("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DisconnectReason.loggedOut } },
+      },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [ev] = handler.mock.calls[0]!;
+    expect((ev as ConnectionChangedEvent).connected).toBe(false);
+    expect((ev as ConnectionChangedEvent).reason).toBe("loggedOut");
+  });
+});
+
+describe("createBaileysChannel — QR + messages", () => {
+  it("emits qr handler on connection.update with qr string", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    const qrHandler = vi.fn();
+    ch.onQrCode(qrHandler);
+    await ch.start();
+    mock.fire("connection.update", { qr: "2@some-qr-string..." });
+    expect(qrHandler).toHaveBeenCalledWith("2@some-qr-string...");
+  });
+
+  it("parses inbound text from messages.upsert (conversation field)", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    const msgHandler = vi.fn();
+    ch.onMessage(msgHandler);
+    await ch.start();
+    mock.fire("messages.upsert", {
+      messages: [
+        {
+          key: { remoteJid: "5511@s.whatsapp.net", fromMe: false },
+          message: { conversation: "card:tabuada-7" },
+          messageTimestamp: 1748000000,
+        },
+      ],
+    });
+    expect(msgHandler).toHaveBeenCalledTimes(1);
+    const [m] = msgHandler.mock.calls[0]!;
+    const inbound = m as InboundMessage;
+    expect(inbound.from).toBe("5511@s.whatsapp.net");
+    expect(inbound.text).toBe("card:tabuada-7");
+    expect(inbound.conversationId).toBe("5511@s.whatsapp.net");
+    expect(inbound.timestamp).toBe(
+      new Date(1748000000 * 1000).toISOString(),
+    );
+  });
+
+  it("parses inbound text from extendedTextMessage (long form)", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    const msgHandler = vi.fn();
+    ch.onMessage(msgHandler);
+    await ch.start();
+    mock.fire("messages.upsert", {
+      messages: [
+        {
+          key: { remoteJid: "5511@s.whatsapp.net", fromMe: false },
+          message: {
+            extendedTextMessage: { text: "uma mensagem longa qualquer" },
+          },
+          messageTimestamp: 1748000000,
+        },
+      ],
+    });
+    expect(msgHandler).toHaveBeenCalledTimes(1);
+    expect((msgHandler.mock.calls[0]![0] as InboundMessage).text).toBe(
+      "uma mensagem longa qualquer",
+    );
+  });
+
+  it("ignores fromMe (own echo) and unparseable messages", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    const msgHandler = vi.fn();
+    ch.onMessage(msgHandler);
+    await ch.start();
+    mock.fire("messages.upsert", {
+      messages: [
+        {
+          key: { remoteJid: "5511@s.whatsapp.net", fromMe: true },
+          message: { conversation: "echo" },
+          messageTimestamp: 1748000000,
+        },
+        {
+          key: { remoteJid: "5511@s.whatsapp.net", fromMe: false },
+          message: null,
+          messageTimestamp: 1748000000,
+        },
+        {
+          key: { remoteJid: null, fromMe: false },
+          message: { conversation: "sem from" },
+          messageTimestamp: 1748000000,
+        },
+      ],
+    });
+    expect(msgHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("createBaileysChannel — send", () => {
+  it("calls sock.sendMessage with text content and returns messageId", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    await ch.start();
+    const result = await ch.send("5511@s.whatsapp.net", "olá");
+    expect(mock.sendMessage).toHaveBeenCalledWith(
+      "5511@s.whatsapp.net",
+      { text: "olá" },
+    );
+    expect(result.messageId).toBe("wamid.123");
+  });
+
+  it("throws if send is called before start", async () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    await expect(ch.send("5511@s.whatsapp.net", "olá")).rejects.toThrow(
+      /canal não iniciado/,
+    );
+  });
+});
+
+describe("createBaileysChannel — reconnect", () => {
+  it("recreates socket after non-logout close", async () => {
+    const mock = makeMockSocket();
+    const opts = baseOpts(mock);
+    const ch = createBaileysChannel(opts);
+    await ch.start();
+    expect(opts.socketFactory).toHaveBeenCalledTimes(1);
+    mock.fire("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: 500 } },
+      },
+    });
+    // reconnectDelayMs=0 mas ainda passa pelo setTimeout — yield
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(opts.socketFactory).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT reconnect after loggedOut close", async () => {
+    const mock = makeMockSocket();
+    const opts = baseOpts(mock);
+    const ch = createBaileysChannel(opts);
+    await ch.start();
+    mock.fire("connection.update", {
+      connection: "close",
+      lastDisconnect: {
+        error: { output: { statusCode: DisconnectReason.loggedOut } },
+      },
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(opts.socketFactory).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() prevents reconnect on subsequent close", async () => {
+    const mock = makeMockSocket();
+    const opts = baseOpts(mock);
+    const ch = createBaileysChannel(opts);
+    await ch.start();
+    await ch.stop();
+    mock.fire("connection.update", {
+      connection: "close",
+      lastDisconnect: { error: { output: { statusCode: 500 } } },
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(opts.socketFactory).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createBaileysChannel — status", () => {
+  it("starts disconnected; status() is synchronous snapshot", () => {
+    const mock = makeMockSocket();
+    const ch = createBaileysChannel(baseOpts(mock));
+    expect(ch.status()).toEqual({ connected: false, queueDepth: 0 });
+  });
+});

--- a/packages/motor-channels/tests/baileys-channel.test.ts
+++ b/packages/motor-channels/tests/baileys-channel.test.ts
@@ -57,6 +57,7 @@ const baseOpts = (mock: ReturnType<typeof makeMockSocket>) => ({
   authDir: "/tmp/test-not-used",
   socketFactory: vi.fn(() => mock.socket) as never,
   authStateLoader: vi.fn(async () => makeMockAuthState()) as never,
+  versionFetcher: vi.fn(async () => ({ version: [2, 3000, 0] as const })),
   reconnectDelayMs: 0,
 });
 


### PR DESCRIPTION
## Summary

**PR4b** — impl real do `WhatsAppChannel` sobre Baileys + script CLI manual pra QR scan. Stacked em PR4 (#142, contrato + mock).

- **Sub-story coberta:** S-MX-06-03 (parte real, parcial de S-MX-06-04 conexão)
- **Stacked em:** #142 PR4 (WhatsAppChannel iface)
- **Branch:** `sprint2/pr12-mx-06-03b-baileys-real`

## Q7=β (file-based auth, deviação documentada de D2 ratificado)

**Auth state file-based** via `useMultiFileAuthState` (Baileys built-in). D2 ratificou SQLite, mas SQLite auth state custom ~150 LOC + signal key store impl. Foi melhor entregar PR4b enxuto e tratar SQLite migration como PR follow-up dedicado.

`.baileys-auth/` adicionado ao `.gitignore` pra não commitar credenciais.

## O que entra

### `src/baileys-channel.ts` (220 LOC)
- `createBaileysChannel({ authDir, socketFactory?, authStateLoader?, reconnectDelayMs? })` retorna `WhatsAppChannel`
- Lifecycle:
  - `start()` carrega auth, cria socket, assina `creds.update`/`connection.update`/`messages.upsert`
  - `stop()` seta flag pra impedir reconnect + chama `sock.end()`
  - `send(to, text)` → `sock.sendMessage(to, { text })`, retorna `{ messageId: result.key.id }`
- Events propagados:
  - `connection.update.qr` → `onQrCode(qr)` handlers
  - `connection.update.connection: "open"` → `ConnectionChanged{connected:true}`
  - `connection.update.connection: "close"` → `ConnectionChanged{connected:false, reason}`; `reason="loggedOut"` em `DisconnectReason.loggedOut`, `code:<N>` pra outros
  - `messages.upsert` → `parseInbound` extrai from/text/timestamp; ignora `fromMe`, message null, remoteJid null
- Reconnect:
  - Em close NÃO-logout: aguarda `reconnectDelayMs` (default 3s) + recria socket
  - Em close logout: para (precisa re-scan QR)
  - Após `stop()`: sem reconnect mesmo em non-logout

### `scripts/baileys-qr-scan.mjs`
- CLI manual: cria channel, imprime QR via `qrcode-terminal`, aguarda primeira mensagem como smoke
- Encerra com Ctrl+C
- `--auth-dir <path>` opcional, default `.baileys-auth/` na raiz do repo

### Outros
- `.gitignore` += `.baileys-auth/`
- `package.json` += `qrcode-terminal@^0.12.0` (devDep)
- `src/index.ts` re-export

## NÃO está incluído

- Real QR scan executado — **isso depende de ti** (script tá pronto, falta seu celular)
- SQLite auth state migration — PR follow-up
- Integration test contra WhatsApp real — manual via script

## Decisões tomadas

1. **`socketFactory` + `authStateLoader` injetáveis** — pra testar sem IO real. Default usa `makeWASocket` / `useMultiFileAuthState`. Padrão DI ao invés de `vi.mock()` que tem gotchas em ESM.
2. **`conversationId = from`** — mapping simples per-contato (chat 1:1). Group jids seriam `<id>@g.us` mas escopo desse PR é 1:1; revisar quando S-MX-06 lidar com grupos.
3. **`fromMe` ignorado** — evita loop quando o bot envia algo e o evento volta. Mensagens sem `text` parsável (sticker, image, etc.) também ignoradas — futuro PR pode mapear esses tipos.
4. **`onQrCode` recebe string raw** — consumidor decide renderização. Script CLI usa `qrcode-terminal`; bridge prod pode logar/postar webhook.
5. **Reconnect com setTimeout** — simples; sem backoff exponencial ou retry cap. Baileys lib lida com retry interno do socket também. Se houver issue de tight loop em prod, voltamos.
6. **`messageId = result?.key?.id ?? unknown-<ts>`** — fallback defensivo. Em prod o `key.id` (wamid) é sempre presente.
7. **printQRInTerminal: false** — desligo o auto-print do Baileys; consumidor renderiza via callback. Limpo + testável.

## Verificação (alvos P4)

- [x] `npm run build --workspace packages/motor-channels` — exit 0
- [x] `npm test --workspace packages/motor-channels` — 30/30 (5 smoke + 12 mock + 13 baileys)
- [x] Mock socket fires connection.update.open → status reflete `connected: true`
- [x] loggedOut detectado por code do disconnect error
- [x] parseInbound funciona pra conversation + extendedTextMessage
- [x] fromMe / message null / remoteJid null todos ignorados
- [x] Reconnect em non-logout, NOT em logout, NOT após stop()
- [x] Send pré-start lança erro

## Próximo (manual)

Quando estiver com celular pronto:

```
npm run build --workspace packages/motor-channels
node packages/motor-channels/scripts/baileys-qr-scan.mjs
```

1. QR aparece no terminal
2. Abrir WhatsApp no celular → Dispositivos vinculados → Vincular dispositivo
3. Escanear o QR
4. Aguardar "✅ conectado às ..."
5. Enviar uma mensagem qualquer pro número do bot
6. Confirmar "📥 mensagem recebida" no terminal
7. Ctrl+C pra encerrar

Sessão persistida em `.baileys-auth/`. Próximas execuções não pedem QR (sessão restaurada). Se quiser reset, deletar `.baileys-auth/` e re-rodar.

## Test plan

- [ ] Reviewer roda `npm test --workspace packages/motor-channels` → 30/30
- [ ] Jun roda o script manual + scaneia QR + envia mensagem teste — confirma fluxo end-to-end
- [ ] Confirma decisões 1-7 acima — especialmente (1) DI vs vi.mock, (2) conversationId=from, (3) ignore fromMe
- [ ] Confirma deviação D2 (file-based) com SQLite migration como follow-up PR aceita

🤖 Generated with [Claude Code](https://claude.com/claude-code)