### PR TITLE
[feat ops#1115] S-MX-06-10 telemetria CardActivated (PR 8/9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6299,9 +6299,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@whiskeysockets/baileys": "^6.7.0",
+        "better-sqlite3": "^11.0.0",
         "pino": "^9.0.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "*",
         "@types/node": "*",
         "typescript": "*",
         "vitest": "*"

--- a/packages/motor-channels/package.json
+++ b/packages/motor-channels/package.json
@@ -12,9 +12,11 @@
   },
   "dependencies": {
     "@whiskeysockets/baileys": "^6.7.0",
+    "better-sqlite3": "^11.0.0",
     "pino": "^9.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "*",
     "@types/node": "*",
     "typescript": "*",
     "vitest": "*"

--- a/packages/motor-channels/src/index.ts
+++ b/packages/motor-channels/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./types.js";
+export * from "./telemetry.js";

--- a/packages/motor-channels/src/telemetry.ts
+++ b/packages/motor-channels/src/telemetry.ts
@@ -1,0 +1,154 @@
+/**
+ * Telemetria de cartas-acionadas — S-MX-06-10 (ops#1115).
+ *
+ * D3 ratificado: sqlite local (V0.1); CF Analytics Engine fica pra V0.2.
+ *
+ * Cada `CardActivatedEvent` é persistido com:
+ *  - timestamp (ISO 8601 do evento)
+ *  - cardId
+ *  - fromHash (SHA-256 do `from` — LGPD/APPI: identifica usuário sem
+ *    expor o JID original; suficiente pra agregar sem permitir lookup
+ *    reverso fácil)
+ *  - conversationId
+ *  - recordedAt (ISO 8601 do momento do insert — diferente de timestamp
+ *    se o evento for replayed)
+ *
+ * NÃO é wireado automaticamente ao bridge — é uma sink que o caller
+ * (entry script / orchestrator) decide conectar via `record(ev)`.
+ * Mantém SRP: bridge faz routing, telemetry faz persistência.
+ */
+
+import { createHash } from "node:crypto";
+import Database from "better-sqlite3";
+import type { Database as DatabaseType } from "better-sqlite3";
+import type { CardActivatedEvent } from "./types.js";
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS card_activations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp TEXT NOT NULL,
+  card_id TEXT NOT NULL,
+  from_hash TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  recorded_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_card_activations_card_id
+  ON card_activations(card_id);
+CREATE INDEX IF NOT EXISTS idx_card_activations_timestamp
+  ON card_activations(timestamp);
+`;
+
+export interface CardTelemetryOptions {
+  /** Caminho do arquivo SQLite. Use `":memory:"` em testes pra evitar fs.
+   *  Schema é criado idempotentemente no construct se faltar. */
+  dbPath: string;
+  /** Função pra obter timestamp do insert. Default `Date.now()` (via
+   *  `new Date().toISOString()`). Tests injetam fixed clock. */
+  now?: () => string;
+}
+
+/** Registro persistido. Shape stable pra consumo por relatórios. */
+export interface CardActivationRecord {
+  id: number;
+  timestamp: string;
+  cardId: string;
+  fromHash: string;
+  conversationId: string;
+  recordedAt: string;
+}
+
+export interface CardTelemetry {
+  /** Persiste um CardActivatedEvent. Anonimiza `from` via SHA-256.
+   *  Retorna o `id` autoincrement do registro. */
+  record(event: CardActivatedEvent): number;
+  /** Últimas `n` ativações em ordem decrescente de `recorded_at`.
+   *  Útil pra debugging/dashboard. */
+  getRecent(limit: number): CardActivationRecord[];
+  /** Conta total por cardId. Útil pra "top cards". */
+  countByCardId(cardId: string): number;
+  /** Fecha o handle SQLite. Idempotente. */
+  close(): void;
+}
+
+const hashFrom = (from: string): string =>
+  createHash("sha256").update(from).digest("hex");
+
+const rowToRecord = (row: {
+  id: number;
+  timestamp: string;
+  card_id: string;
+  from_hash: string;
+  conversation_id: string;
+  recorded_at: string;
+}): CardActivationRecord => ({
+  id: row.id,
+  timestamp: row.timestamp,
+  cardId: row.card_id,
+  fromHash: row.from_hash,
+  conversationId: row.conversation_id,
+  recordedAt: row.recorded_at,
+});
+
+export function createCardTelemetry(
+  opts: CardTelemetryOptions,
+): CardTelemetry {
+  const db: DatabaseType = new Database(opts.dbPath);
+  db.pragma("journal_mode = WAL");
+  db.exec(SCHEMA_SQL);
+
+  const now = opts.now ?? (() => new Date().toISOString());
+
+  const insertStmt = db.prepare(`
+    INSERT INTO card_activations (
+      timestamp, card_id, from_hash, conversation_id, recorded_at
+    ) VALUES (?, ?, ?, ?, ?)
+  `);
+
+  const getRecentStmt = db.prepare(`
+    SELECT id, timestamp, card_id, from_hash, conversation_id, recorded_at
+    FROM card_activations
+    ORDER BY recorded_at DESC, id DESC
+    LIMIT ?
+  `);
+
+  const countByCardStmt = db.prepare(`
+    SELECT COUNT(*) AS n FROM card_activations WHERE card_id = ?
+  `);
+
+  let closed = false;
+
+  return {
+    record(event: CardActivatedEvent): number {
+      if (closed) throw new Error("CardTelemetry.record: db já fechado");
+      const result = insertStmt.run(
+        event.timestamp,
+        event.cardId,
+        hashFrom(event.from),
+        event.conversationId,
+        now(),
+      );
+      return Number(result.lastInsertRowid);
+    },
+
+    getRecent(limit: number): CardActivationRecord[] {
+      if (closed) throw new Error("CardTelemetry.getRecent: db já fechado");
+      const rows = getRecentStmt.all(limit) as Parameters<
+        typeof rowToRecord
+      >[0][];
+      return rows.map(rowToRecord);
+    },
+
+    countByCardId(cardId: string): number {
+      if (closed)
+        throw new Error("CardTelemetry.countByCardId: db já fechado");
+      const row = countByCardStmt.get(cardId) as { n: number };
+      return row.n;
+    },
+
+    close(): void {
+      if (closed) return;
+      db.close();
+      closed = true;
+    },
+  };
+}

--- a/packages/motor-channels/tests/telemetry.test.ts
+++ b/packages/motor-channels/tests/telemetry.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  createCardTelemetry,
+  type CardTelemetry,
+} from "../src/telemetry.js";
+import type { CardActivatedEvent } from "../src/types.js";
+
+const sha = (s: string): string =>
+  createHash("sha256").update(s).digest("hex");
+
+const activation = (
+  overrides: Partial<CardActivatedEvent> = {},
+): CardActivatedEvent => ({
+  type: "CardActivated",
+  cardId: "tabuada-7",
+  from: "5511999990000@s.whatsapp.net",
+  conversationId: "conv-tele-001",
+  timestamp: "2026-05-23T14:00:00.000Z",
+  raw: "card:tabuada-7",
+  ...overrides,
+});
+
+describe("createCardTelemetry — record + getRecent", () => {
+  let telemetry: CardTelemetry;
+  beforeEach(() => {
+    telemetry = createCardTelemetry({
+      dbPath: ":memory:",
+      now: () => "2026-05-23T14:00:01.000Z",
+    });
+  });
+  afterEach(() => {
+    telemetry.close();
+  });
+
+  it("persists a CardActivatedEvent and returns autoincrement id", () => {
+    const id = telemetry.record(activation());
+    expect(id).toBe(1);
+  });
+
+  it("anonymizes `from` via SHA-256 (deterministic, no raw JID stored)", () => {
+    telemetry.record(
+      activation({ from: "5511999990000@s.whatsapp.net" }),
+    );
+    const recent = telemetry.getRecent(10);
+    expect(recent[0]!.fromHash).toBe(
+      sha("5511999990000@s.whatsapp.net"),
+    );
+    expect(recent[0]!.fromHash).not.toContain("@");
+    expect(recent[0]!.fromHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("returns the full record shape on getRecent", () => {
+    telemetry.record(activation());
+    const recent = telemetry.getRecent(10);
+    expect(recent).toHaveLength(1);
+    expect(recent[0]).toMatchObject({
+      id: 1,
+      timestamp: "2026-05-23T14:00:00.000Z",
+      cardId: "tabuada-7",
+      fromHash: sha("5511999990000@s.whatsapp.net"),
+      conversationId: "conv-tele-001",
+      recordedAt: "2026-05-23T14:00:01.000Z",
+    });
+  });
+
+  it("orders getRecent by recorded_at DESC then id DESC", () => {
+    let now = 0;
+    const tele = createCardTelemetry({
+      dbPath: ":memory:",
+      now: () => `2026-05-23T14:00:${String(now++).padStart(2, "0")}.000Z`,
+    });
+    tele.record(activation({ cardId: "card-a" }));
+    tele.record(activation({ cardId: "card-b" }));
+    tele.record(activation({ cardId: "card-c" }));
+    const recent = tele.getRecent(10);
+    expect(recent.map((r) => r.cardId)).toEqual(["card-c", "card-b", "card-a"]);
+    tele.close();
+  });
+
+  it("respects limit param on getRecent", () => {
+    for (let i = 0; i < 5; i++) {
+      telemetry.record(activation({ cardId: `card-${i}` }));
+    }
+    expect(telemetry.getRecent(3)).toHaveLength(3);
+    expect(telemetry.getRecent(100)).toHaveLength(5);
+  });
+
+  it("different `from` JIDs yield different fromHash; same JID yields same hash", () => {
+    telemetry.record(activation({ from: "5511aaa@s.whatsapp.net" }));
+    telemetry.record(activation({ from: "5511bbb@s.whatsapp.net" }));
+    telemetry.record(activation({ from: "5511aaa@s.whatsapp.net" }));
+    const recent = telemetry.getRecent(10);
+    expect(recent[0]!.fromHash).toBe(recent[2]!.fromHash); // both 5511aaa
+    expect(recent[1]!.fromHash).not.toBe(recent[0]!.fromHash);
+  });
+});
+
+describe("createCardTelemetry — countByCardId", () => {
+  it("counts activations per cardId", () => {
+    const tele = createCardTelemetry({ dbPath: ":memory:" });
+    tele.record(activation({ cardId: "card-x" }));
+    tele.record(activation({ cardId: "card-x" }));
+    tele.record(activation({ cardId: "card-y" }));
+    expect(tele.countByCardId("card-x")).toBe(2);
+    expect(tele.countByCardId("card-y")).toBe(1);
+    expect(tele.countByCardId("nonexistent")).toBe(0);
+    tele.close();
+  });
+});
+
+describe("createCardTelemetry — close", () => {
+  it("close() is idempotent", () => {
+    const tele = createCardTelemetry({ dbPath: ":memory:" });
+    tele.close();
+    tele.close();
+    // no throw
+  });
+
+  it("record after close throws", () => {
+    const tele = createCardTelemetry({ dbPath: ":memory:" });
+    tele.close();
+    expect(() => tele.record(activation())).toThrow(/db já fechado/);
+  });
+
+  it("getRecent after close throws", () => {
+    const tele = createCardTelemetry({ dbPath: ":memory:" });
+    tele.close();
+    expect(() => tele.getRecent(10)).toThrow(/db já fechado/);
+  });
+});
+
+describe("createCardTelemetry — persistence smoke", () => {
+  it("schema persists across instances (file-backed)", async () => {
+    const { mkdtemp, rm } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const dir = await mkdtemp(join(tmpdir(), "motor-channels-tele-"));
+    const dbPath = join(dir, "telemetry.db");
+    try {
+      const t1 = createCardTelemetry({ dbPath });
+      t1.record(activation({ cardId: "persist-1" }));
+      t1.close();
+
+      const t2 = createCardTelemetry({ dbPath });
+      expect(t2.countByCardId("persist-1")).toBe(1);
+      t2.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**PR 8/9** do plan C-MX-06 (ops#1115). Telemetria sqlite local de `CardActivatedEvent` com anonimização SHA-256.

- **Sub-story coberta:** S-MX-06-10
- **D3 ratificado:** sqlite local (V0.1). CF Analytics Engine fica pra V0.2.
- **Base:** PR1 (#137) — só precisa de `CardActivatedEvent` type. Issue plan diz PR2, mas o type vive em PR1 e a telemetry não consome o router em si. Decisão flagada no commit.
- **Branch:** \`sprint2/pr14-mx-06-10-telemetry\`

## O que entra

### \`src/telemetry.ts\` (~140 LOC)

- \`createCardTelemetry({ dbPath, now? })\` factory
- API:
  - \`record(event): number\` — persiste, retorna autoincrement id
  - \`getRecent(limit): CardActivationRecord[]\` — ordem recorded_at DESC, id DESC
  - \`countByCardId(cardId): number\` — total por carta
  - \`close(): void\` — idempotente; record/getRecent pós-close lançam
- Schema auto-criado idempotentemente:

\`\`\`sql
CREATE TABLE IF NOT EXISTS card_activations (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  timestamp TEXT NOT NULL,
  card_id TEXT NOT NULL,
  from_hash TEXT NOT NULL,
  conversation_id TEXT NOT NULL,
  recorded_at TEXT NOT NULL
);
CREATE INDEX ... ON card_activations(card_id);
CREATE INDEX ... ON card_activations(timestamp);
\`\`\`

- WAL mode pra concorrência reader/writer
- LGPD/APPI compliance: \`from\` é SHA-256 antes de persistir (64 chars hex, sem o JID raw)

### Deps adicionadas

- \`better-sqlite3@^11.0.0\` (mesma versão em uso por motor-execucao)
- \`@types/better-sqlite3\` (devDep)

## Decisões tomadas

1. **NÃO wireado automaticamente ao bridge.** \`createInboundBridge\` (PR6) não chama \`telemetry.record\` — caller decide. Mantém SRP: bridge = routing; telemetry = persistência. Wiring real vira PR follow-up ou CLI entry script.
2. **SHA-256 sem salt** — agregação determinística (mesmo JID → mesmo hash) com privacy razoável. Salt rotativo ofereceria melhor anti-reidentificação mas quebra agregação por usuário. Pra LGPD/APPI o que importa é "não armazenar JID raw" — ✅. Se precisar de mais privacy depois (e.g., evitar correlação cross-tabela com outras stores que tenham SHA-256 de JID), trocar pra HMAC com chave secreta + rotação periódica.
3. **\`recorded_at\` separado de \`timestamp\`** — \`timestamp\` é do evento (pode ser replay); \`recorded_at\` é do insert. Permite distinguir "quando aconteceu" de "quando registramos".
4. **\`countByCardId\` pra "top cards"** — útil pra dashboard sem N+1; mais agregações vêm sob demanda.
5. **\`":memory:"\` pra testes** — zero fs, super rápido. Smoke file-backed verifica que schema persiste entre instances.
6. **Base = PR1 (não PR2)** — issue plan lista PR2 como base, mas telemetry só consome \`CardActivatedEvent\` type (vive em PR1). PR2 (router) seria o produtor natural mas não precisa estar no diff dessa PR — caller wires.

## Verificação (alvos P4)

- [x] \`npm run build --workspace packages/motor-channels\` — exit 0
- [x] \`npm test --workspace packages/motor-channels\` — 16/16 (5 smoke + 11 telemetry)
- [x] Anonimização: SHA-256 hex 64 chars, sem \`@\`, determinístico
- [x] Mesmo JID → mesmo hash (verifica agregação)
- [x] JIDs distintos → hashes distintos
- [x] Order DESC funciona
- [x] Limit param respeitado
- [x] countByCardId correto
- [x] Close idempotente; record/getRecent pós-close lançam
- [x] Schema persiste entre instances (file-backed smoke)

## Próximo

C-MX-06 fecha em código depois desta PR (PR9 deploy foi pulado per Q13=a; vira handoff em ascendimacy-ops quando for momento de deployar).

Resta:
- **Manual** — pedir alguém pra mandar mensagem pro número Baileys pra fechar smoke inbound real (PR4b #147)
- **Merge order** — discutir como destacar os 9 PRs abertos (4 stacks: PR1→PR2/3/4; PR4→PR5; PR1→PR6 com merges; PR1→PR4b; main→PR6b; main→PR7; PR1→PR8). Sem código, só coordenação.

## Test plan

- [ ] Reviewer roda \`npm test --workspace packages/motor-channels\` → 16/16
- [ ] Confirma decisões 1-6 — especialmente (1) "não wireado" e (2) SHA-256 sem salt
- [ ] Confirma D3 sqlite local cumprido (vs CF Analytics V0.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)