### PR TITLE
[feat ops#1122] C-MX-07 PR1 — daemon scaffolding (S-OD-01 + S-OD-02)

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "type": "module",
   "bin": {
-    "motor": "./dist/cli.js"
+    "motor": "./dist/cli.js",
+    "motor-daemon": "./dist/daemon.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "start": "node dist/cli.js",
+    "daemon": "node dist/daemon.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/orchestrator/src/cli.ts
+++ b/orchestrator/src/cli.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { connectAll, disconnectAll } from "./mcp-clients.js";
-import { runTurn } from "./orchestrator.js";
+import { runOneShot } from "./oneshot.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const tracesDir = join(__dirname, "../../traces");
@@ -32,12 +31,11 @@ const { persona, message, sessionId } = parseArgs();
 console.log(`[motor] Iniciando turno — persona: ${persona}, sessão: ${sessionId}`);
 console.log(`[motor] Mensagem: "${message}"`);
 
-const clients = await connectAll();
-
-try {
-  const { finalResponse, tracePath } = await runTurn(clients, sessionId, persona, message, tracesDir);
-  console.log(`\n[motor] Resposta:\n${finalResponse}`);
-  console.log(`\n[motor] Trace salvo em: ${tracePath}`);
-} finally {
-  await disconnectAll(clients);
-}
+const { finalResponse, tracePath } = await runOneShot({
+  persona,
+  message,
+  sessionId,
+  tracesDir,
+});
+console.log(`\n[motor] Resposta:\n${finalResponse}`);
+console.log(`\n[motor] Trace salvo em: ${tracePath}`);

--- a/orchestrator/src/daemon.ts
+++ b/orchestrator/src/daemon.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Orchestrator daemon — entry point pra modo long-running com MCP server.
+ * S-OD-02 (C-MX-07 PR1).
+ *
+ * Spawna trio (planejador + drota + execucao) UMA VEZ no startup, mantém
+ * conexões abertas até SIGINT/SIGTERM. Expõe MCP server via stdio.
+ *
+ * PR1 (este): SCAFFOLDING. Tools reais (startCardSession real impl,
+ * subscribe_turn_state streaming, list_options, override_selection,
+ * approve_or_edit) são entregues em PRs posteriores (S-OD-05..09).
+ * mcp-server.ts continua skeleton aqui — daemon só wireia o stdio
+ * transport + lifecycle.
+ *
+ * Logs vão pra stderr porque stdout é reservado pra JSON-RPC do MCP.
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { connectAll, disconnectAll, type McpClients } from "./mcp-clients.js";
+import { createOrchestratorMcpServer } from "./mcp-server.js";
+
+/**
+ * Estado por sessão. Map sessionId → SessionRuntime.
+ * PR1: estrutura minimalista; PR2 (S-OD-04) popula turn state, hooks
+ * pra subscribe_turn_state events, etc.
+ */
+export interface SessionRuntime {
+  sessionId: string;
+  personaId: string;
+  conversationId: string;
+  startedAt: string;
+}
+
+export interface OrchestratorDaemonOptions {
+  /** Factory pra trio MCP clients (default connectAll real). Tests injetam mock. */
+  clientsFactory?: () => Promise<McpClients>;
+  /** Idem disconnect (default disconnectAll real). */
+  clientsDisposer?: (clients: McpClients) => Promise<void>;
+  /** Logger; default escreve em stderr. Tests injetam silent ou spy. */
+  log?: (msg: string) => void;
+}
+
+export class OrchestratorDaemon {
+  private clients: McpClients | null = null;
+  private sessions = new Map<string, SessionRuntime>();
+  private shuttingDown = false;
+  private started = false;
+
+  private readonly factory: () => Promise<McpClients>;
+  private readonly dispose: (clients: McpClients) => Promise<void>;
+  private readonly log: (msg: string) => void;
+
+  constructor(opts: OrchestratorDaemonOptions = {}) {
+    this.factory = opts.clientsFactory ?? connectAll;
+    this.dispose = opts.clientsDisposer ?? disconnectAll;
+    this.log =
+      opts.log ?? ((msg: string) => process.stderr.write(`${msg}\n`));
+  }
+
+  /** Conecta o trio. Idempotente: chamadas subsequentes são no-op. */
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.clients = await this.factory();
+    this.started = true;
+    this.log("[orchestrator-daemon] trio connected");
+  }
+
+  /** Fecha sessions ativas + desconecta trio. Idempotente. */
+  async stop(): Promise<void> {
+    if (this.shuttingDown || !this.started) return;
+    this.shuttingDown = true;
+    this.log("[orchestrator-daemon] shutting down");
+    this.sessions.clear();
+    if (this.clients !== null) {
+      await this.dispose(this.clients);
+      this.clients = null;
+    }
+    this.started = false;
+    this.shuttingDown = false;
+  }
+
+  /** Snapshot do estado pra debug/testes. */
+  status(): { started: boolean; sessionCount: number } {
+    return {
+      started: this.started,
+      sessionCount: this.sessions.size,
+    };
+  }
+
+  /**
+   * Adiciona uma sessão ao registry. PR1: scaffolding minimalista — não
+   * conecta a clients ainda; PR2 (S-OD-04) liga state hydration + turn
+   * pipeline + subscribe_turn_state events.
+   */
+  registerSession(runtime: SessionRuntime): void {
+    if (this.sessions.has(runtime.sessionId)) {
+      throw new Error(
+        `OrchestratorDaemon.registerSession: sessionId duplicado ${runtime.sessionId}`,
+      );
+    }
+    this.sessions.set(runtime.sessionId, runtime);
+  }
+
+  /** Remove sessão. Idempotente quando ausente. */
+  unregisterSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  getSession(sessionId: string): SessionRuntime | undefined {
+    return this.sessions.get(sessionId);
+  }
+}
+
+/**
+ * Entry point: cria daemon, conecta MCP server stdio, instala signal
+ * handlers. Mantido fora da class pra facilitar testes (testes
+ * instanciam a class sem mexer em process.on).
+ */
+export async function bootDaemon(
+  opts: OrchestratorDaemonOptions = {},
+): Promise<{ daemon: OrchestratorDaemon }> {
+  const daemon = new OrchestratorDaemon(opts);
+
+  const server = createOrchestratorMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  (opts.log ?? ((m) => process.stderr.write(`${m}\n`)))(
+    "[orchestrator-daemon] stdio MCP server ready",
+  );
+
+  await daemon.start();
+
+  const onSignal = (sig: NodeJS.Signals): void => {
+    void (async () => {
+      (opts.log ?? ((m) => process.stderr.write(`${m}\n`)))(
+        `[orchestrator-daemon] received ${sig}`,
+      );
+      await daemon.stop();
+      await server.close();
+      process.exit(0);
+    })();
+  };
+
+  process.on("SIGINT", () => onSignal("SIGINT"));
+  process.on("SIGTERM", () => onSignal("SIGTERM"));
+
+  return { daemon };
+}
+
+// Top-level await entry. Não roda quando importado por testes (test files
+// importam a class direto, não esse módulo como entry).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isMainEntry =
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith("daemon.js") ||
+    process.argv[1].endsWith("daemon.ts"));
+
+if (isMainEntry) {
+  await bootDaemon();
+}

--- a/orchestrator/src/oneshot.ts
+++ b/orchestrator/src/oneshot.ts
@@ -1,0 +1,48 @@
+/**
+ * Runtime de "one-shot" — S-OD-01 (C-MX-07 PR1).
+ *
+ * Extraído do cli.ts pra ser reusável: o que era inline (connect trio →
+ * runTurn → disconnect) vira função importável. Permite o cli.ts ficar
+ * thin wrapper E o daemon (futuro PR2) reusar o mesmo padrão pra
+ * "single turn fora de sessão", se precisar.
+ *
+ * Comportamento preservado: spawn trio, executa 1 turn, desconecta.
+ * Sem mudança de external behavior do `motor run`.
+ */
+
+import { connectAll, disconnectAll, type McpClients } from "./mcp-clients.js";
+import { runTurn } from "./orchestrator.js";
+
+export interface OneShotOptions {
+  persona: string;
+  message: string;
+  sessionId: string;
+  tracesDir: string;
+  /** Permite injetar factory de clients pra testes (default = connectAll real). */
+  clientsFactory?: () => Promise<McpClients>;
+  /** Idem disconnect (default = disconnectAll real). */
+  clientsDisposer?: (clients: McpClients) => Promise<void>;
+}
+
+export interface OneShotResult {
+  finalResponse: string;
+  tracePath: string;
+}
+
+export async function runOneShot(opts: OneShotOptions): Promise<OneShotResult> {
+  const factory = opts.clientsFactory ?? connectAll;
+  const dispose = opts.clientsDisposer ?? disconnectAll;
+
+  const clients = await factory();
+  try {
+    return await runTurn(
+      clients,
+      opts.sessionId,
+      opts.persona,
+      opts.message,
+      opts.tracesDir,
+    );
+  } finally {
+    await dispose(clients);
+  }
+}

--- a/orchestrator/tests/daemon.test.ts
+++ b/orchestrator/tests/daemon.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+import { OrchestratorDaemon, type SessionRuntime } from "../src/daemon.js";
+import type { McpClients } from "../src/mcp-clients.js";
+
+const mockClients = (): McpClients =>
+  ({
+    planejador: {} as never,
+    motorDrota: {} as never,
+    motorExecucao: {} as never,
+  }) satisfies McpClients;
+
+const baseOpts = () => {
+  const factory = vi.fn(async () => mockClients());
+  const dispose = vi.fn(async () => undefined);
+  const log = vi.fn();
+  return { factory, dispose, log };
+};
+
+const sampleSession = (overrides?: Partial<SessionRuntime>): SessionRuntime => ({
+  sessionId: "sess-001",
+  personaId: "yuji-realista-v1",
+  conversationId: "5511999@s.whatsapp.net",
+  startedAt: "2026-05-24T12:00:00.000Z",
+  ...overrides,
+});
+
+describe("OrchestratorDaemon — lifecycle", () => {
+  it("start() connects clients via factory", async () => {
+    const { factory, dispose, log } = baseOpts();
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: factory,
+      clientsDisposer: dispose,
+      log,
+    });
+    await daemon.start();
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(daemon.status().started).toBe(true);
+    expect(log).toHaveBeenCalledWith("[orchestrator-daemon] trio connected");
+  });
+
+  it("start() is idempotent", async () => {
+    const { factory, dispose } = baseOpts();
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: factory,
+      clientsDisposer: dispose,
+      log: () => undefined,
+    });
+    await daemon.start();
+    await daemon.start();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() disposes clients", async () => {
+    const { factory, dispose } = baseOpts();
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: factory,
+      clientsDisposer: dispose,
+      log: () => undefined,
+    });
+    await daemon.start();
+    await daemon.stop();
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(daemon.status().started).toBe(false);
+  });
+
+  it("stop() is idempotent (sem start, com start+stop+stop)", async () => {
+    const { factory, dispose } = baseOpts();
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: factory,
+      clientsDisposer: dispose,
+      log: () => undefined,
+    });
+    await daemon.stop();
+    expect(dispose).not.toHaveBeenCalled();
+    await daemon.start();
+    await daemon.stop();
+    await daemon.stop();
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OrchestratorDaemon — session registry (PR1 scaffolding)", () => {
+  it("registers + retrieves a session", async () => {
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: async () => mockClients(),
+      clientsDisposer: async () => undefined,
+      log: () => undefined,
+    });
+    await daemon.start();
+    const s = sampleSession();
+    daemon.registerSession(s);
+    expect(daemon.getSession("sess-001")).toBe(s);
+    expect(daemon.status().sessionCount).toBe(1);
+  });
+
+  it("rejects duplicate sessionId", async () => {
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: async () => mockClients(),
+      clientsDisposer: async () => undefined,
+      log: () => undefined,
+    });
+    await daemon.start();
+    daemon.registerSession(sampleSession());
+    expect(() => daemon.registerSession(sampleSession())).toThrow(
+      /sessionId duplicado/,
+    );
+  });
+
+  it("unregisterSession removes from registry; idempotent quando ausente", async () => {
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: async () => mockClients(),
+      clientsDisposer: async () => undefined,
+      log: () => undefined,
+    });
+    await daemon.start();
+    daemon.registerSession(sampleSession());
+    daemon.unregisterSession("sess-001");
+    expect(daemon.getSession("sess-001")).toBeUndefined();
+    daemon.unregisterSession("nonexistent");
+    daemon.unregisterSession("sess-001");
+  });
+
+  it("stop() clears session registry", async () => {
+    const daemon = new OrchestratorDaemon({
+      clientsFactory: async () => mockClients(),
+      clientsDisposer: async () => undefined,
+      log: () => undefined,
+    });
+    await daemon.start();
+    daemon.registerSession(sampleSession({ sessionId: "a" }));
+    daemon.registerSession(sampleSession({ sessionId: "b" }));
+    expect(daemon.status().sessionCount).toBe(2);
+    await daemon.stop();
+    expect(daemon.status().sessionCount).toBe(0);
+  });
+});

--- a/orchestrator/tests/oneshot.test.ts
+++ b/orchestrator/tests/oneshot.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { runOneShot } from "../src/oneshot.js";
+import type { McpClients } from "../src/mcp-clients.js";
+
+/**
+ * runOneShot é thin wrapper sobre connectAll + runTurn + disconnectAll.
+ * Testa principalmente o contrato de DI (factory/dispose injetáveis).
+ * O `runTurn` real precisa de filesystem + LLM, então testamos com
+ * mock clients que NÃO percorrem o pipeline completo — basta verificar
+ * que factory e dispose são chamados corretamente.
+ */
+
+const mockClients = (): McpClients =>
+  ({
+    planejador: {} as never,
+    motorDrota: {} as never,
+    motorExecucao: {} as never,
+  }) satisfies McpClients;
+
+describe("runOneShot", () => {
+  it("chama factory + dispose mesmo quando runTurn lança", async () => {
+    const factory = vi.fn(async () => mockClients());
+    const dispose = vi.fn(async () => undefined);
+
+    // runTurn lança porque clients mock não têm callTool real.
+    await expect(
+      runOneShot({
+        persona: "paula-mendes",
+        message: "oi",
+        sessionId: "test-1",
+        tracesDir: "/tmp",
+        clientsFactory: factory,
+        clientsDisposer: dispose,
+      }),
+    ).rejects.toBeDefined();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("propaga erro do factory sem chamar dispose", async () => {
+    const factory = vi.fn(async () => {
+      throw new Error("factory boom");
+    });
+    const dispose = vi.fn(async () => undefined);
+
+    await expect(
+      runOneShot({
+        persona: "paula-mendes",
+        message: "oi",
+        sessionId: "test-2",
+        tracesDir: "/tmp",
+        clientsFactory: factory,
+        clientsDisposer: dispose,
+      }),
+    ).rejects.toThrow(/factory boom/);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(dispose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

**PR1 de C-MX-07** (orchestrator daemon). Scaffolding apenas — tools MCP reais entram nas PRs seguintes do plan.

- **Sub-stories cobertas:** S-OD-01 (refactor cli.ts) + S-OD-02 (daemon.ts entry)
- **Branch:** `sprint4/pr1-c-mx-07-daemon-scaffolding` ← `main`
- **Issue:** [ops#1122](https://github.com/ascendimacy/ascendimacy-ops/issues/1122)
- **Spec:** [`2026-05-24-c-mx-07-orchestrator-daemon-spec-v1.md`](https://github.com/ascendimacy/ascendimacy-ops/blob/docs/c-mx-07-c-mx-08-specs/docs/specs/2026-05-24-c-mx-07-orchestrator-daemon-spec-v1.md)

## O que entra

### `src/oneshot.ts` (novo, ~40 LOC)
- `runOneShot({persona, message, sessionId, tracesDir, clientsFactory?, clientsDisposer?})` extrai o runtime do `cli.ts` pra função reusável
- DI: `clientsFactory` + `clientsDisposer` opcionais (default `connectAll`/`disconnectAll`); permite testes sem spawn real do trio
- Comportamento externo do `motor run` PRESERVADO

### `src/cli.ts` (refatorado)
- Vira thin wrapper: parse args + chama `runOneShot`
- Zero regressão de behavior; CLI continua `motor run --persona X --message Y`

### `src/daemon.ts` (novo, ~160 LOC)
- Class `OrchestratorDaemon` com lifecycle:
  - `start()` — conecta trio via factory (idempotent)
  - `stop()` — dispose trio + clear sessions (idempotent)
  - `status()` — `{ started, sessionCount }`
  - `registerSession(runtime)` / `unregisterSession(id)` / `getSession(id)` — scaffolding pra session registry
- `bootDaemon(opts?)` entry point — cria daemon + conecta `StdioServerTransport` ao `createOrchestratorMcpServer()` (skeleton de PR6b) + signal handlers SIGINT/SIGTERM
- Logs em stderr (stdout reservado pra JSON-RPC MCP)
- DI completa (factory/dispose/log) pra testes sem spawn real

### `package.json`
- `bin` += `"motor-daemon": "./dist/daemon.js"`
- `scripts` += `"daemon": "node dist/daemon.js"`

## Decisões tomadas

1. **`oneshot.ts` separado de `orchestrator.ts`** — orchestrator.ts mantém o `runTurn` puro; oneshot wrappa connect+runTurn+disconnect. Daemon pode usar `runTurn` direto (sem oneshot) quando session lifecycle estiver pronto (PR2).
2. **`OrchestratorDaemon` como class** (não factory function) — encaixa melhor com state mutável (clients, sessions, started flag) + permite extender em PR2+ sem mudar surface.
3. **`bootDaemon` separado da class** — class é testável sem signal handlers nem stdio; entry point amarra tudo. Tests instanciam class direto, smoke real usa boot.
4. **`isMainEntry` detection** — `daemon.ts` tem top-level `await bootDaemon()` mas só dispara quando executado direto (não quando importado por testes). Detecção via `process.argv[1]`.
5. **`mcp-server.ts` continua skeleton** — daemon wireia o skeleton ao stdio transport (PR1 = scaffolding) mas não substitui ainda. Skeleton → real é S-OD-03 (PR2).
6. **Logs em stderr** — preserva stdout pro JSON-RPC. `(opts.log)` injetável (tests usam `vi.fn()` ou silent).
7. **`registerSession` rejeita duplicata** — fail-fast em vez de silently overwrite. Caller decide retry/replace.

## Verificação (alvos P4)

- [x] `npm run build --workspace orchestrator` — exit 0
- [x] `npm test --workspace orchestrator` — 92/92 (placeholder 1 + daemon 8 + skeleton 3 + oneshot 2 + orchestrator 1 + trio-orchestrator 36 + trio-runtime 41)
- [x] `cli.ts` comportamento preservado (refactor cirúrgico)
- [x] Daemon class lifecycle: start idempotent, stop idempotent (incluindo sem start prévio), stop limpa sessions
- [x] Session registry: register/get/unregister + rejeita duplicata + idempotent unregister
- [x] `runOneShot` chama dispose mesmo quando runTurn lança; propaga erro de factory sem chamar dispose

## Próximo (PR2)

**S-OD-03 + S-OD-04** — `mcp-server.ts` real (substitui skeleton; registra startCardSession impl real + endpoints futuros) + session lifecycle hooks no daemon (startSession/endSession ligados a state hydration + trio pipeline). Stacked nessa PR.

## Test plan

- [ ] Reviewer roda `npm test --workspace orchestrator` → 92/92
- [ ] Confirma `motor run --persona paula-mendes --message oi` continua funcional (refactor não quebra CLI)
- [ ] Confirma decisões 1-7 — especialmente (2) class vs function, (5) skeleton continua, (6) logs stderr
- [ ] Confirma DI signature (`clientsFactory`/`clientsDisposer`/`log`) — usada em PRs seguintes

🤖 Generated with [Claude Code](https://claude.com/claude-code)