### PR TITLE
[feat ops#1123] C-MX-08 PR4 — Vista motor + leque pedagógico TOP-N (4/10)

### DIFF
--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -3,12 +3,18 @@
   import Status from "./components/Status.svelte";
   import ChatFeed from "./components/ChatFeed.svelte";
   import SessionStart from "./components/SessionStart.svelte";
+  import MotorView from "./components/MotorView.svelte";
   import { createApiClient } from "./lib/api.js";
   import { bffStatus, consoleMode, globalError } from "./lib/stores.js";
+  import {
+    startTurnStateStream,
+    type TurnStateStreamManager,
+  } from "./lib/turn-state-stream.js";
 
   const api = createApiClient();
   const STATUS_POLL_INTERVAL_MS = 2000;
   let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let streamManager: TurnStateStreamManager | undefined;
 
   async function refreshStatus(): Promise<void> {
     try {
@@ -29,10 +35,12 @@
     pollTimer = setInterval(() => {
       void refreshStatus();
     }, STATUS_POLL_INTERVAL_MS);
+    streamManager = startTurnStateStream(api);
   });
 
   onDestroy(() => {
     if (pollTimer !== undefined) clearInterval(pollTimer);
+    streamManager?.stop();
   });
 </script>
 
@@ -47,19 +55,7 @@
 
   <main class="main-grid">
     <ChatFeed />
-    <aside class="motor-placeholder" data-testid="motor-placeholder">
-      <h2>Vista motor</h2>
-      <p class="muted">
-        Painel pedagógico (helix · statusMatrix · contentPool TOP-N ·
-        triggers) entra em <strong>PR4</strong>.
-      </p>
-      <ul class="upcoming">
-        <li>PR4 — Vista motor (helix + statusMatrix + leque)</li>
-        <li>PR5 — Approval gate UI + telemetria</li>
-        <li>PR6 — Session library + replay</li>
-        <li>PR7-10 — Smoke / debug / analytics / E2E</li>
-      </ul>
-    </aside>
+    <MotorView {api} />
   </main>
 
   <SessionStart {api} />
@@ -107,34 +103,9 @@
     }
   }
 
-  .motor-placeholder {
-    padding: 1rem;
-  }
-
-  .motor-placeholder h2 {
-    margin: 0 0 0.5rem;
-    font-size: 1rem;
-    opacity: 0.7;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
   .muted {
     opacity: 0.7;
     font-size: 0.9rem;
-  }
-
-  .upcoming {
-    list-style: none;
-    padding: 0;
-    margin: 1rem 0 0;
-    font-size: 0.85rem;
-    opacity: 0.7;
-  }
-
-  .upcoming li {
-    padding: 0.2rem 0;
-    border-bottom: 1px dashed rgba(127, 127, 127, 0.2);
   }
 
   code {

--- a/packages/ebrota-console-ui/src/components/ContentPool.svelte
+++ b/packages/ebrota-console-ui/src/components/ContentPool.svelte
@@ -1,0 +1,326 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import {
+    consoleMode,
+    currentContentPool,
+    currentSessionId,
+    currentTurnSnapshot,
+    globalError,
+  } from "../lib/stores.js";
+  import type { ApiClient } from "../lib/api.js";
+
+  export let api: ApiClient;
+  /** Top N cards mostrados por default; resto fica em "show all" toggle. */
+  export let topN = 3;
+  /** Polling interval ms — só ativo em semi-auto mode. */
+  export let pollIntervalMs = 250;
+
+  let expanded = false;
+  let overrideBusy: string | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+
+  $: pool = $currentContentPool;
+  $: snapshot = $currentTurnSnapshot;
+  $: mode = $consoleMode;
+  $: sessionId = $currentSessionId;
+  $: shouldPoll = mode === "semi-auto" && sessionId !== null;
+  $: selectedId = snapshot?.selectedContentId ?? null;
+
+  // listOptions polling (semi-auto only). Default 250ms — agressivo o
+  // suficiente pra Jun ver leque atualizado rápido sem ddos no BFF.
+  async function fetchPool(): Promise<void> {
+    if (sessionId === null) return;
+    try {
+      const res = await api.listOptions(sessionId);
+      currentContentPool.set(res.contentPool);
+    } catch (err) {
+      // silencioso — pool offline não trava UX; bffStatus indicator cobre
+      void err;
+    }
+  }
+
+  $: if (shouldPoll && pollTimer === undefined) {
+    void fetchPool();
+    pollTimer = setInterval(() => void fetchPool(), pollIntervalMs);
+  }
+
+  $: if (!shouldPoll && pollTimer !== undefined) {
+    clearInterval(pollTimer);
+    pollTimer = undefined;
+    currentContentPool.set([]);
+  }
+
+  onMount(() => {
+    if (shouldPoll) {
+      void fetchPool();
+      pollTimer = setInterval(() => void fetchPool(), pollIntervalMs);
+    }
+  });
+
+  onDestroy(() => {
+    if (pollTimer !== undefined) clearInterval(pollTimer);
+  });
+
+  async function overrideTo(contentItemId: string): Promise<void> {
+    if (sessionId === null || overrideBusy !== null) return;
+    overrideBusy = contentItemId;
+    globalError.set(null);
+    try {
+      const res = await api.overrideSelection(sessionId, contentItemId);
+      if (!res.accepted) {
+        const why = res.gateWasActive
+          ? `id ${contentItemId} não está no pool`
+          : "gate inativo (auto mode ou turn já passou)";
+        globalError.set(`Override falhou: ${why}`);
+      }
+    } catch (err) {
+      globalError.set(
+        `Override erro: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      overrideBusy = null;
+    }
+  }
+
+  /**
+   * Combina pool com snapshot.contentPoolIds (do planning_started)
+   * pra mostrar algo mesmo em auto mode (sem listOptions). Em semi-auto
+   * pool ativo terá objetos completos com fact/bridge/quest.
+   */
+  $: displayPool = (() => {
+    if (pool.length > 0) {
+      return pool.map((s) => ({
+        id: s.item.id,
+        score: s.score,
+        type: s.item.type ?? "",
+        fact: typeof s.item["fact"] === "string"
+          ? (s.item["fact"] as string)
+          : "",
+        full: true as const,
+      }));
+    }
+    // Fallback — só ids do TurnStateEvent
+    if (snapshot?.contentPoolIds !== undefined) {
+      return snapshot.contentPoolIds.map((id) => ({
+        id,
+        score: 0,
+        type: "",
+        fact: "",
+        full: false as const,
+      }));
+    }
+    return [];
+  })();
+
+  $: visiblePool = expanded ? displayPool : displayPool.slice(0, topN);
+</script>
+
+<section class="content-pool" data-testid="content-pool">
+  <h3>
+    Leque pedagógico
+    {#if mode === "semi-auto"}
+      <span class="mode-badge">semi-auto</span>
+    {/if}
+    {#if displayPool.length > 0}
+      <span class="count">({displayPool.length})</span>
+    {/if}
+  </h3>
+
+  {#if displayPool.length === 0}
+    <p class="empty" data-testid="pool-empty">
+      Pool não disponível. Em <strong>auto</strong>, snapshot do
+      planning_started lista ids; em <strong>semi-auto</strong>,
+      listOptions popula com fact/bridge/quest.
+    </p>
+  {:else}
+    <ul class="pool-list" data-testid="pool-list">
+      {#each visiblePool as card (card.id)}
+        <li
+          class="card"
+          class:selected={card.id === selectedId}
+          data-testid="pool-card"
+        >
+          <div class="card-header">
+            <code class="card-id">{card.id}</code>
+            {#if card.type !== ""}
+              <span class="type">{card.type}</span>
+            {/if}
+            {#if card.full}
+              <span class="score">score {card.score.toFixed(1)}</span>
+            {/if}
+            {#if card.id === selectedId}
+              <span class="selected-badge">selecionado</span>
+            {/if}
+          </div>
+          {#if card.fact !== ""}
+            <p class="fact">{card.fact}</p>
+          {/if}
+          {#if mode === "semi-auto" && card.id !== selectedId}
+            <button
+              type="button"
+              class="override-btn"
+              on:click={() => overrideTo(card.id)}
+              disabled={overrideBusy === card.id}
+              data-testid="override-button"
+            >
+              {overrideBusy === card.id ? "..." : "Override pra esse"}
+            </button>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+    {#if displayPool.length > topN}
+      <button
+        type="button"
+        class="expand-toggle"
+        on:click={() => (expanded = !expanded)}
+        data-testid="expand-toggle"
+      >
+        {expanded
+          ? `Mostrar só top ${topN}`
+          : `Mostrar todas (${displayPool.length})`}
+      </button>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .content-pool {
+    margin-top: 0.5rem;
+    padding: 0.5rem 0.7rem;
+    background: rgba(127, 127, 127, 0.06);
+    border-radius: 4px;
+  }
+
+  h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .mode-badge {
+    background: rgba(255, 193, 7, 0.25);
+    color: #b8860b;
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .count {
+    opacity: 0.6;
+    font-weight: 400;
+  }
+
+  .empty {
+    opacity: 0.6;
+    font-size: 0.85rem;
+    padding: 0.5rem;
+    border: 1px dashed rgba(127, 127, 127, 0.3);
+    border-radius: 4px;
+  }
+
+  .pool-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .card {
+    background: rgba(127, 127, 127, 0.06);
+    border: 1px solid rgba(127, 127, 127, 0.2);
+    border-radius: 4px;
+    padding: 0.4rem 0.6rem;
+  }
+
+  .card.selected {
+    border-color: rgba(76, 175, 80, 0.6);
+    background: rgba(76, 175, 80, 0.08);
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+  }
+
+  .card-id {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.85rem;
+    background: rgba(127, 127, 127, 0.2);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+
+  .type {
+    opacity: 0.6;
+    font-size: 0.75rem;
+  }
+
+  .score {
+    margin-left: auto;
+    opacity: 0.7;
+    font-size: 0.8rem;
+  }
+
+  .selected-badge {
+    background: rgba(76, 175, 80, 0.25);
+    color: #2e7d32;
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+
+  .fact {
+    margin: 0.3rem 0;
+    font-size: 0.85rem;
+    line-height: 1.3;
+  }
+
+  .override-btn {
+    margin-top: 0.3rem;
+    padding: 0.2rem 0.6rem;
+    border: 1px solid rgba(255, 193, 7, 0.6);
+    background: rgba(255, 193, 7, 0.15);
+    color: inherit;
+    border-radius: 3px;
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+
+  .override-btn:hover:not(:disabled) {
+    background: rgba(255, 193, 7, 0.3);
+  }
+
+  .override-btn:disabled {
+    opacity: 0.5;
+    cursor: wait;
+  }
+
+  .expand-toggle {
+    margin-top: 0.5rem;
+    width: 100%;
+    padding: 0.3rem;
+    background: transparent;
+    border: 1px dashed rgba(127, 127, 127, 0.4);
+    border-radius: 3px;
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.8rem;
+    opacity: 0.7;
+  }
+
+  .expand-toggle:hover {
+    opacity: 1;
+    background: rgba(127, 127, 127, 0.1);
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/MotorView.svelte
+++ b/packages/ebrota-console-ui/src/components/MotorView.svelte
@@ -1,0 +1,253 @@
+<script lang="ts">
+  import { currentTurnSnapshot } from "../lib/stores.js";
+  import ContentPool from "./ContentPool.svelte";
+  import type { ApiClient } from "../lib/api.js";
+
+  export let api: ApiClient;
+
+  $: snapshot = $currentTurnSnapshot;
+
+  // Lookup table pra rótulos das fases
+  const phaseLabel: Record<string, string> = {
+    planning_started: "1/4 Planejando",
+    selection_made: "2/4 Selecionando",
+    materialization_ready: "3/4 Materializando",
+    playbook_executed: "4/4 Executado",
+  };
+</script>
+
+<section class="motor-view" data-testid="motor-view">
+  <h2>Vista motor</h2>
+
+  {#if snapshot === null}
+    <p class="empty" data-testid="motor-empty">
+      Sem turn ativo. Painel pedagógico vai popular após
+      <code>startCardSession</code>.
+    </p>
+  {:else}
+    <div class="phase-tracker" data-testid="phase-tracker">
+      <span class="phase-label">{phaseLabel[snapshot.lastPhase]}</span>
+      <span class="turn-num">turn #{snapshot.turn}</span>
+      <span class="timestamp">{snapshot.lastTimestamp}</span>
+    </div>
+
+    {#if snapshot.strategicRationale !== undefined}
+      <details class="info-block" open data-testid="rationale-block">
+        <summary>Strategic rationale</summary>
+        <p class="rationale">{snapshot.strategicRationale}</p>
+      </details>
+    {/if}
+
+    {#if snapshot.contextHints !== undefined && Object.keys(snapshot.contextHints).length > 0}
+      <details class="info-block" data-testid="context-hints-block">
+        <summary>Context hints</summary>
+        <pre class="json">{JSON.stringify(snapshot.contextHints, null, 2)}</pre>
+      </details>
+    {/if}
+
+    {#if snapshot.transitionEvaluationsCount !== undefined && snapshot.transitionEvaluationsCount > 0}
+      <p class="meta" data-testid="transitions-count">
+        Transitions avaliadas: <strong>{snapshot.transitionEvaluationsCount}</strong>
+      </p>
+    {/if}
+
+    {#if snapshot.selectedContentId !== undefined}
+      <div class="selection" data-testid="selection-block">
+        <h3>Selecionado</h3>
+        <p class="selected-id">
+          <code>{snapshot.selectedContentId}</code>
+          {#if snapshot.selectedContentScore !== undefined}
+            <span class="score">score {snapshot.selectedContentScore.toFixed(1)}</span>
+          {/if}
+        </p>
+        {#if snapshot.selectionRationale !== undefined}
+          <p class="rationale">{snapshot.selectionRationale}</p>
+        {/if}
+      </div>
+    {/if}
+
+    {#if snapshot.proposedText !== undefined}
+      <details class="info-block" open data-testid="proposed-text-block">
+        <summary>Texto materializado</summary>
+        <blockquote class="proposed">{snapshot.proposedText}</blockquote>
+        {#if snapshot.instructionAdditionApplied}
+          <p class="meta">
+            <span class="badge">instruction_addition aplicado</span>
+            (pkg pedagógico fluiu pro motor-drota)
+          </p>
+        {/if}
+      </details>
+    {/if}
+
+    {#if snapshot.playbookId !== undefined}
+      <p class="meta" data-testid="playbook-info">
+        Playbook: <code>{snapshot.playbookId}</code>
+        {#if snapshot.playbookSuccess === true}
+          <span class="badge success">✓ sucesso</span>
+        {:else if snapshot.playbookSuccess === false}
+          <span class="badge fail">✗ falha</span>
+        {/if}
+        {#if snapshot.newTurnNumber !== undefined}
+          → próximo turn #{snapshot.newTurnNumber}
+        {/if}
+      </p>
+    {/if}
+
+    <ContentPool {api} />
+  {/if}
+</section>
+
+<style>
+  .motor-view {
+    padding: 1rem;
+    overflow-y: auto;
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    opacity: 0.7;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  h3 {
+    margin: 0 0 0.3rem;
+    font-size: 0.9rem;
+    opacity: 0.8;
+  }
+
+  .empty {
+    opacity: 0.6;
+    font-size: 0.9rem;
+    padding: 1rem;
+    border: 1px dashed rgba(127, 127, 127, 0.3);
+    border-radius: 4px;
+  }
+
+  .phase-tracker {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    background: rgba(33, 150, 243, 0.1);
+    border-left: 3px solid #2196f3;
+    padding: 0.4rem 0.7rem;
+    border-radius: 0 4px 4px 0;
+    font-size: 0.85rem;
+  }
+
+  .phase-label {
+    font-weight: 600;
+  }
+
+  .turn-num {
+    opacity: 0.6;
+  }
+
+  .timestamp {
+    margin-left: auto;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    opacity: 0.5;
+  }
+
+  .info-block {
+    background: rgba(127, 127, 127, 0.06);
+    border-radius: 4px;
+    padding: 0.5rem 0.7rem;
+  }
+
+  .info-block summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 600;
+    opacity: 0.8;
+    user-select: none;
+  }
+
+  .info-block summary:hover {
+    opacity: 1;
+  }
+
+  .rationale {
+    margin: 0.5rem 0 0;
+    font-size: 0.9rem;
+    line-height: 1.4;
+  }
+
+  .json {
+    margin: 0.5rem 0 0;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    background: rgba(0, 0, 0, 0.08);
+    padding: 0.5rem;
+    border-radius: 3px;
+    overflow-x: auto;
+  }
+
+  .selection {
+    background: rgba(76, 175, 80, 0.08);
+    border-left: 3px solid #4caf50;
+    padding: 0.5rem 0.7rem;
+    border-radius: 0 4px 4px 0;
+  }
+
+  .selected-id {
+    margin: 0 0 0.3rem;
+    font-size: 0.95rem;
+  }
+
+  .selected-id .score {
+    margin-left: 0.5rem;
+    font-size: 0.8rem;
+    opacity: 0.7;
+  }
+
+  .proposed {
+    margin: 0.5rem 0 0;
+    padding: 0.5rem 0.7rem;
+    border-left: 3px solid rgba(33, 150, 243, 0.5);
+    font-style: italic;
+    font-size: 0.9rem;
+    background: rgba(127, 127, 127, 0.05);
+  }
+
+  .meta {
+    margin: 0.3rem 0;
+    font-size: 0.85rem;
+    opacity: 0.8;
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: rgba(127, 127, 127, 0.2);
+    margin-left: 0.3rem;
+  }
+
+  .badge.success {
+    background: rgba(76, 175, 80, 0.25);
+    color: #2e7d32;
+  }
+
+  .badge.fail {
+    background: rgba(176, 0, 32, 0.25);
+    color: #b00020;
+  }
+
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    background: rgba(127, 127, 127, 0.2);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -1,14 +1,20 @@
 /**
  * Svelte stores — estado global da UI (BFF status, mode, sessão ativa,
- * chat bubbles).
+ * chat bubbles, turn snapshot, content pool).
  *
  * Pattern: stores writable simples; sync com BFF via polling no
- * App.svelte (toda ~2s pra /status). Reactive blocks Svelte propagam
- * mudanças automaticamente.
+ * App.svelte (~2s pra /status; ~250ms pra listOptions; SSE pra
+ * turn-state). Reactive blocks Svelte propagam mudanças automaticamente.
  */
 
 import { writable } from "svelte/store";
-import type { BffStatus, ChatBubble, ConsoleMode } from "./types.js";
+import type {
+  BffStatus,
+  ChatBubble,
+  ConsoleMode,
+  TurnSnapshot,
+} from "./types.js";
+import type { ScoredContentItemSummary } from "./api.js";
 
 /** Status do BFF (null = ainda não carregado / erro de conexão). */
 export const bffStatus = writable<BffStatus | null>(null);
@@ -22,6 +28,16 @@ export const currentSessionId = writable<string | null>(null);
 /** Chat bubbles da sessão ativa. Populado por SSE turn-state +
  *  startCardSession response (PR3 placeholder). */
 export const chatBubbles = writable<ChatBubble[]>([]);
+
+/** Snapshot agregado do turn corrente — derivado de TurnStateEvents
+ *  via reducer `applyTurnEvent`. Null = sem turn ativo. */
+export const currentTurnSnapshot = writable<TurnSnapshot | null>(null);
+
+/** Content pool corrente (sob gate ativo em semi-auto). Vazio em auto
+ *  mode ou fora de gate. Polled via listOptions endpoint. */
+export const currentContentPool = writable<ScoredContentItemSummary[]>(
+  [],
+);
 
 /** Erro global pra mostrar banner. Null = sem erro. */
 export const globalError = writable<string | null>(null);

--- a/packages/ebrota-console-ui/src/lib/turn-state-stream.ts
+++ b/packages/ebrota-console-ui/src/lib/turn-state-stream.ts
@@ -1,0 +1,102 @@
+/**
+ * Subscription manager — conecta SSE turn-state stream do BFF ao
+ * `currentTurnSnapshot` store. Lifecycle reactive a `currentSessionId`
+ * change: abre nova conexão quando session inicia, fecha quando muda
+ * ou esvazia.
+ *
+ * Também alimenta `chatBubbles` quando `materialization_ready` chega —
+ * substitui bubble bot placeholder com texto materializado real.
+ */
+
+import type { ApiClient } from "./api.js";
+import { subscribeTurnState } from "./api.js";
+import {
+  chatBubbles,
+  currentSessionId,
+  currentTurnSnapshot,
+  globalError,
+} from "./stores.js";
+import { applyTurnEvent, type ChatBubble } from "./types.js";
+
+export interface TurnStateStreamManager {
+  /** Para o subscriber corrente. Idempotente. */
+  stop(): void;
+}
+
+export function startTurnStateStream(
+  api: ApiClient,
+): TurnStateStreamManager {
+  let closeFn: (() => void) | null = null;
+  let lastSessionId: string | null = null;
+
+  // Reactive: quando currentSessionId muda, fecha conexão anterior +
+  // abre nova (se newSessionId não-null).
+  const unsubscribe = currentSessionId.subscribe((sessionId) => {
+    if (sessionId === lastSessionId) return;
+    lastSessionId = sessionId;
+    if (closeFn !== null) {
+      closeFn();
+      closeFn = null;
+    }
+    if (sessionId === null) {
+      currentTurnSnapshot.set(null);
+      return;
+    }
+    // Reset snapshot pra nova sessão
+    currentTurnSnapshot.set(null);
+    closeFn = subscribeTurnState(
+      api,
+      sessionId,
+      (ev) => {
+        currentTurnSnapshot.update((prev) => applyTurnEvent(prev, ev));
+        // materialization_ready substitui bubble bot placeholder
+        if (ev.type === "materialization_ready") {
+          chatBubbles.update((bubbles) =>
+            replaceBotBubble(bubbles, sessionId, ev.payload.proposedText),
+          );
+        }
+      },
+      (err) => {
+        globalError.set(`SSE turn-state error: ${String(err)}`);
+      },
+    );
+  });
+
+  return {
+    stop(): void {
+      if (closeFn !== null) {
+        closeFn();
+        closeFn = null;
+      }
+      unsubscribe();
+    },
+  };
+}
+
+const replaceBotBubble = (
+  bubbles: ChatBubble[],
+  sessionId: string,
+  proposedText: string,
+): ChatBubble[] => {
+  // Encontra última bubble bot da sessão e substitui text (se diferente).
+  // Se não existe, append.
+  const idx = [...bubbles]
+    .reverse()
+    .findIndex((b) => b.role === "bot" && b.id.startsWith(sessionId));
+  if (idx === -1) {
+    return [
+      ...bubbles,
+      {
+        id: `${sessionId}-bot-${Date.now()}`,
+        role: "bot",
+        text: proposedText,
+        timestamp: new Date().toISOString(),
+      },
+    ];
+  }
+  const realIdx = bubbles.length - 1 - idx;
+  if (bubbles[realIdx]!.text === proposedText) return bubbles;
+  return bubbles.map((b, i) =>
+    i === realIdx ? { ...b, text: proposedText } : b,
+  );
+};

--- a/packages/ebrota-console-ui/src/lib/types.ts
+++ b/packages/ebrota-console-ui/src/lib/types.ts
@@ -81,3 +81,97 @@ export interface ChatBubble {
   /** Marca bubble como pendente de aprovação (semi-auto). */
   pendingApproval?: boolean;
 }
+
+/**
+ * Snapshot agregado do estado pedagógico corrente — derivado de
+ * TurnStateEvents. Sequência canônica garantida pelo orchestrator:
+ * planning_started → selection_made → materialization_ready →
+ * playbook_executed. UI aplica eventos em ordem; campos populam
+ * incrementalmente.
+ */
+export interface TurnSnapshot {
+  sessionId: string;
+  turn: number;
+  /** Última fase recebida — UI usa pra renderizar progresso. */
+  lastPhase:
+    | "planning_started"
+    | "selection_made"
+    | "materialization_ready"
+    | "playbook_executed";
+  lastTimestamp: string;
+  /** Da planning_started. */
+  strategicRationale?: string;
+  contentPoolSize?: number;
+  contentPoolIds?: string[];
+  contextHints?: Record<string, unknown>;
+  transitionEvaluationsCount?: number;
+  /** Da selection_made. */
+  selectedContentId?: string;
+  selectedContentScore?: number;
+  selectionRationale?: string;
+  /** Da materialization_ready. */
+  proposedText?: string;
+  instructionAdditionApplied?: boolean;
+  /** Da playbook_executed. */
+  playbookId?: string;
+  playbookSuccess?: boolean;
+  newTurnNumber?: number;
+}
+
+/** Reducer canônico — aplica um event ao snapshot. Exportado pra reuse
+ *  em store update + tests. */
+export const applyTurnEvent = (
+  prev: TurnSnapshot | null,
+  ev: TurnStateEvent,
+): TurnSnapshot => {
+  const base: TurnSnapshot = prev !== null
+    ? { ...prev }
+    : {
+        sessionId: ev.sessionId,
+        turn: ev.turn,
+        lastPhase: ev.type,
+        lastTimestamp: ev.timestamp,
+      };
+  // Se mudou de turn, reset o snapshot
+  const isNewTurn =
+    prev !== null &&
+    (prev.sessionId !== ev.sessionId || prev.turn !== ev.turn);
+  const snap: TurnSnapshot = isNewTurn
+    ? {
+        sessionId: ev.sessionId,
+        turn: ev.turn,
+        lastPhase: ev.type,
+        lastTimestamp: ev.timestamp,
+      }
+    : base;
+  snap.sessionId = ev.sessionId;
+  snap.turn = ev.turn;
+  snap.lastPhase = ev.type;
+  snap.lastTimestamp = ev.timestamp;
+  switch (ev.type) {
+    case "planning_started":
+      snap.strategicRationale = ev.payload.strategicRationale;
+      snap.contentPoolSize = ev.payload.contentPoolSize;
+      snap.contentPoolIds = ev.payload.contentPoolIds;
+      snap.contextHints = ev.payload.contextHints;
+      snap.transitionEvaluationsCount =
+        ev.payload.transitionEvaluationsCount;
+      break;
+    case "selection_made":
+      snap.selectedContentId = ev.payload.selectedContentId;
+      snap.selectedContentScore = ev.payload.selectedContentScore;
+      snap.selectionRationale = ev.payload.selectionRationale;
+      break;
+    case "materialization_ready":
+      snap.proposedText = ev.payload.proposedText;
+      snap.instructionAdditionApplied =
+        ev.payload.instructionAdditionApplied;
+      break;
+    case "playbook_executed":
+      snap.playbookId = ev.payload.playbookId;
+      snap.playbookSuccess = ev.payload.success;
+      snap.newTurnNumber = ev.payload.newTurnNumber;
+      break;
+  }
+  return snap;
+};

--- a/packages/ebrota-console-ui/tests/components/ContentPool.test.ts
+++ b/packages/ebrota-console-ui/tests/components/ContentPool.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import ContentPool from "../../src/components/ContentPool.svelte";
+import {
+  consoleMode,
+  currentContentPool,
+  currentSessionId,
+  currentTurnSnapshot,
+  globalError,
+} from "../../src/lib/stores.js";
+import type { ApiClient } from "../../src/lib/api.js";
+
+const buildApi = (
+  overrides: Partial<ApiClient> = {},
+): ApiClient =>
+  ({
+    getStatus: vi.fn(),
+    getMode: vi.fn(),
+    setMode: vi.fn(),
+    startCardSession: vi.fn(),
+    listOptions: vi.fn(async () => ({ contentPool: [] })),
+    overrideSelection: vi.fn(),
+    getPendingApproval: vi.fn(),
+    approveOrEdit: vi.fn(),
+    endSession: vi.fn(),
+    turnStateSseUrl: () => "/api/sse",
+    ...overrides,
+  }) as never;
+
+beforeEach(() => {
+  consoleMode.set("auto");
+  currentSessionId.set(null);
+  currentContentPool.set([]);
+  currentTurnSnapshot.set(null);
+  globalError.set(null);
+});
+
+describe("ContentPool.svelte — display logic", () => {
+  it("mostra empty state quando sem pool e sem snapshot", () => {
+    render(ContentPool, { api: buildApi() });
+    expect(screen.getByTestId("pool-empty")).toBeDefined();
+  });
+
+  it("popula a partir de snapshot.contentPoolIds em auto mode (fallback)", () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "planning_started",
+      lastTimestamp: "t0",
+      contentPoolIds: ["card-a", "card-b", "card-c"],
+      contentPoolSize: 3,
+      contextHints: {},
+      transitionEvaluationsCount: 0,
+    });
+    render(ContentPool, { api: buildApi() });
+    expect(screen.getAllByTestId("pool-card").length).toBe(3);
+  });
+
+  it("popula com fact/score quando pool full disponível", () => {
+    currentContentPool.set([
+      {
+        item: { id: "card-a", type: "curiosity_hook", fact: "fato A" },
+        score: 9,
+      },
+      {
+        item: { id: "card-b", type: "sacrifice", fact: "fato B" },
+        score: 7,
+      },
+    ]);
+    render(ContentPool, { api: buildApi() });
+    expect(screen.getByText("fato A")).toBeDefined();
+    expect(screen.getByText("fato B")).toBeDefined();
+    expect(screen.getByText(/score 9\.0/)).toBeDefined();
+  });
+
+  it("topN limita visíveis com toggle expand", async () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "planning_started",
+      lastTimestamp: "t0",
+      contentPoolIds: ["a", "b", "c", "d", "e"],
+      contentPoolSize: 5,
+      contextHints: {},
+      transitionEvaluationsCount: 0,
+    });
+    render(ContentPool, { api: buildApi(), topN: 2 });
+    expect(screen.getAllByTestId("pool-card").length).toBe(2);
+    const toggle = screen.getByTestId("expand-toggle");
+    expect(toggle.textContent).toContain("Mostrar todas");
+    await fireEvent.click(toggle);
+    expect(screen.getAllByTestId("pool-card").length).toBe(5);
+  });
+
+  it("marca selected badge na carta selecionada", () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "selection_made",
+      lastTimestamp: "t0",
+      contentPoolIds: ["a", "b"],
+      selectedContentId: "b",
+    });
+    render(ContentPool, { api: buildApi() });
+    expect(screen.getByText(/selecionado/)).toBeDefined();
+  });
+});
+
+describe("ContentPool.svelte — semi-auto override", () => {
+  it("auto mode: NÃO mostra override buttons", () => {
+    consoleMode.set("auto");
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "planning_started",
+      lastTimestamp: "t0",
+      contentPoolIds: ["a", "b"],
+      contentPoolSize: 2,
+      contextHints: {},
+      transitionEvaluationsCount: 0,
+    });
+    render(ContentPool, { api: buildApi() });
+    expect(screen.queryAllByTestId("override-button").length).toBe(0);
+  });
+
+  it("semi-auto: mostra override buttons (exceto na carta selected)", async () => {
+    consoleMode.set("semi-auto");
+    currentSessionId.set("sess-1");
+    // listOptions retorna o pool; polling vai re-setar currentContentPool
+    const apiWithPool = buildApi({
+      listOptions: vi.fn(async () => ({
+        contentPool: [
+          { item: { id: "card-a" }, score: 9 },
+          { item: { id: "card-b" }, score: 7 },
+        ],
+      })),
+    });
+    currentTurnSnapshot.set({
+      sessionId: "sess-1",
+      turn: 0,
+      lastPhase: "selection_made",
+      lastTimestamp: "t0",
+      selectedContentId: "card-a",
+    });
+    render(ContentPool, { api: apiWithPool });
+    await new Promise<void>((r) => setTimeout(r, 60));
+    const buttons = screen.queryAllByTestId("override-button");
+    expect(buttons.length).toBe(1);
+  });
+
+  it("override click chama api.overrideSelection com contentItemId correto", async () => {
+    consoleMode.set("semi-auto");
+    currentSessionId.set("sess-1");
+    const overrideSelection = vi.fn(async () => ({
+      accepted: true,
+      foundInPool: true,
+      gateWasActive: true,
+    }));
+    const apiWithPool = buildApi({
+      listOptions: vi.fn(async () => ({
+        contentPool: [{ item: { id: "card-x" }, score: 8 }],
+      })),
+      overrideSelection,
+    });
+    render(ContentPool, { api: apiWithPool });
+    await new Promise<void>((r) => setTimeout(r, 60));
+    const btn = screen.getByTestId("override-button");
+    await fireEvent.click(btn);
+    await new Promise<void>((r) => setTimeout(r, 10));
+    expect(overrideSelection).toHaveBeenCalledWith("sess-1", "card-x");
+  });
+
+  it("override rejected: gateWasActive=false → globalError populado", async () => {
+    consoleMode.set("semi-auto");
+    currentSessionId.set("sess-1");
+    const overrideSelection = vi.fn(async () => ({
+      accepted: false,
+      foundInPool: false,
+      gateWasActive: false,
+    }));
+    const apiWithPool = buildApi({
+      listOptions: vi.fn(async () => ({
+        contentPool: [{ item: { id: "card-x" }, score: 8 }],
+      })),
+      overrideSelection,
+    });
+    render(ContentPool, { api: apiWithPool });
+    await new Promise<void>((r) => setTimeout(r, 60));
+    const btn = screen.getByTestId("override-button");
+    await fireEvent.click(btn);
+    await new Promise<void>((r) => setTimeout(r, 10));
+    expect(get(globalError)).toContain("Override falhou");
+  });
+});

--- a/packages/ebrota-console-ui/tests/components/MotorView.test.ts
+++ b/packages/ebrota-console-ui/tests/components/MotorView.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import MotorView from "../../src/components/MotorView.svelte";
+import {
+  currentTurnSnapshot,
+  currentContentPool,
+  consoleMode,
+  currentSessionId,
+} from "../../src/lib/stores.js";
+import type { ApiClient } from "../../src/lib/api.js";
+import type { TurnSnapshot } from "../../src/lib/types.js";
+
+const buildApi = (): ApiClient =>
+  ({
+    getStatus: vi.fn(),
+    getMode: vi.fn(),
+    setMode: vi.fn(),
+    startCardSession: vi.fn(),
+    listOptions: vi.fn(async () => ({ contentPool: [] })),
+    overrideSelection: vi.fn(),
+    getPendingApproval: vi.fn(),
+    approveOrEdit: vi.fn(),
+    endSession: vi.fn(),
+    turnStateSseUrl: () => "/api/sse",
+  }) as never;
+
+beforeEach(() => {
+  currentTurnSnapshot.set(null);
+  currentContentPool.set([]);
+  consoleMode.set("auto");
+  currentSessionId.set(null);
+});
+
+describe("MotorView.svelte", () => {
+  it("mostra empty state quando sem snapshot", () => {
+    render(MotorView, { api: buildApi() });
+    expect(screen.getByTestId("motor-empty")).toBeDefined();
+  });
+
+  it("renderiza phase-tracker quando snapshot populated", () => {
+    const snap: TurnSnapshot = {
+      sessionId: "s1",
+      turn: 3,
+      lastPhase: "planning_started",
+      lastTimestamp: "2026-05-24T13:00:00.000Z",
+      strategicRationale: "test rationale",
+      contentPoolSize: 2,
+      contentPoolIds: ["a", "b"],
+      contextHints: { mood: "calm" },
+      transitionEvaluationsCount: 1,
+    };
+    currentTurnSnapshot.set(snap);
+    render(MotorView, { api: buildApi() });
+    expect(screen.getByTestId("phase-tracker")).toBeDefined();
+    expect(screen.getByText(/Planejando/)).toBeDefined();
+    expect(screen.getByText(/turn #3/)).toBeDefined();
+  });
+
+  it("renderiza rationale block expandido em planning_started", () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "planning_started",
+      lastTimestamp: "t0",
+      strategicRationale: "estratégia X",
+      contentPoolSize: 0,
+      contentPoolIds: [],
+      contextHints: {},
+      transitionEvaluationsCount: 0,
+    });
+    render(MotorView, { api: buildApi() });
+    expect(screen.getByTestId("rationale-block")).toBeDefined();
+    expect(screen.getByText("estratégia X")).toBeDefined();
+  });
+
+  it("mostra selection block quando selection_made aplicado", () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "selection_made",
+      lastTimestamp: "t0",
+      selectedContentId: "card-a",
+      selectedContentScore: 8.5,
+      selectionRationale: "score mais alto",
+    });
+    render(MotorView, { api: buildApi() });
+    expect(screen.getByTestId("selection-block")).toBeDefined();
+    expect(screen.getByText("card-a")).toBeDefined();
+    expect(screen.getByText(/score 8\.5/)).toBeDefined();
+  });
+
+  it("mostra proposed text + instruction_addition badge", () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "materialization_ready",
+      lastTimestamp: "t0",
+      proposedText: "Vamos descobrir!",
+      instructionAdditionApplied: true,
+    });
+    render(MotorView, { api: buildApi() });
+    expect(screen.getByText("Vamos descobrir!")).toBeDefined();
+    expect(screen.getByText(/instruction_addition aplicado/)).toBeDefined();
+  });
+
+  it("mostra playbook info + success badge no playbook_executed", () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "playbook_executed",
+      lastTimestamp: "t0",
+      playbookId: "kids.session",
+      playbookSuccess: true,
+      newTurnNumber: 1,
+    });
+    render(MotorView, { api: buildApi() });
+    expect(screen.getByTestId("playbook-info")).toBeDefined();
+    expect(screen.getByText("kids.session")).toBeDefined();
+    expect(screen.getByText(/sucesso/)).toBeDefined();
+  });
+
+  it("contextHints empty NÃO renderiza bloco (evita 'No data')", () => {
+    currentTurnSnapshot.set({
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "planning_started",
+      lastTimestamp: "t0",
+      strategicRationale: "x",
+      contentPoolSize: 0,
+      contentPoolIds: [],
+      contextHints: {},
+      transitionEvaluationsCount: 0,
+    });
+    render(MotorView, { api: buildApi() });
+    expect(screen.queryByTestId("context-hints-block")).toBeNull();
+  });
+});

--- a/packages/ebrota-console-ui/tests/lib/types.test.ts
+++ b/packages/ebrota-console-ui/tests/lib/types.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { applyTurnEvent, type TurnSnapshot } from "../../src/lib/types.js";
+
+describe("applyTurnEvent reducer", () => {
+  it("planning_started inicializa snapshot do zero", () => {
+    const ev = {
+      type: "planning_started" as const,
+      sessionId: "s1",
+      turn: 0,
+      timestamp: "2026-05-24T13:00:00.000Z",
+      payload: {
+        strategicRationale: "rationale",
+        contentPoolSize: 3,
+        contentPoolIds: ["a", "b", "c"],
+        contextHints: { foo: "bar" },
+        transitionEvaluationsCount: 0,
+      },
+    };
+    const snap = applyTurnEvent(null, ev);
+    expect(snap.sessionId).toBe("s1");
+    expect(snap.turn).toBe(0);
+    expect(snap.lastPhase).toBe("planning_started");
+    expect(snap.contentPoolSize).toBe(3);
+    expect(snap.contentPoolIds).toEqual(["a", "b", "c"]);
+    expect(snap.strategicRationale).toBe("rationale");
+  });
+
+  it("selection_made + materialization_ready acumulam no mesmo turn", () => {
+    const planning: TurnSnapshot = {
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "planning_started",
+      lastTimestamp: "t0",
+      strategicRationale: "rat",
+      contentPoolSize: 1,
+    };
+    const sel = applyTurnEvent(planning, {
+      type: "selection_made",
+      sessionId: "s1",
+      turn: 0,
+      timestamp: "t1",
+      payload: {
+        selectedContentId: "card-a",
+        selectedContentScore: 7,
+        selectionRationale: "drota",
+      },
+    });
+    expect(sel.lastPhase).toBe("selection_made");
+    expect(sel.selectedContentId).toBe("card-a");
+    expect(sel.strategicRationale).toBe("rat"); // preservado
+
+    const mat = applyTurnEvent(sel, {
+      type: "materialization_ready",
+      sessionId: "s1",
+      turn: 0,
+      timestamp: "t2",
+      payload: {
+        proposedText: "olá",
+        instructionAdditionApplied: true,
+      },
+    });
+    expect(mat.lastPhase).toBe("materialization_ready");
+    expect(mat.proposedText).toBe("olá");
+    expect(mat.selectedContentId).toBe("card-a"); // preservado
+  });
+
+  it("playbook_executed completa o ciclo", () => {
+    const prev: TurnSnapshot = {
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "materialization_ready",
+      lastTimestamp: "t2",
+    };
+    const exec = applyTurnEvent(prev, {
+      type: "playbook_executed",
+      sessionId: "s1",
+      turn: 0,
+      timestamp: "t3",
+      payload: {
+        playbookId: "default",
+        success: true,
+        newTurnNumber: 1,
+      },
+    });
+    expect(exec.playbookId).toBe("default");
+    expect(exec.playbookSuccess).toBe(true);
+    expect(exec.newTurnNumber).toBe(1);
+  });
+
+  it("novo turn (turn number diferente) reseta snapshot", () => {
+    const prev: TurnSnapshot = {
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "playbook_executed",
+      lastTimestamp: "t3",
+      strategicRationale: "old",
+      selectedContentId: "card-a",
+    };
+    const next = applyTurnEvent(prev, {
+      type: "planning_started",
+      sessionId: "s1",
+      turn: 1,
+      timestamp: "t4",
+      payload: {
+        strategicRationale: "new",
+        contentPoolSize: 2,
+        contentPoolIds: ["x", "y"],
+        contextHints: {},
+        transitionEvaluationsCount: 0,
+      },
+    });
+    expect(next.turn).toBe(1);
+    expect(next.selectedContentId).toBeUndefined();
+    expect(next.strategicRationale).toBe("new");
+  });
+
+  it("sessionId diferente reseta snapshot", () => {
+    const prev: TurnSnapshot = {
+      sessionId: "s1",
+      turn: 0,
+      lastPhase: "planning_started",
+      lastTimestamp: "t0",
+      contentPoolIds: ["a"],
+    };
+    const next = applyTurnEvent(prev, {
+      type: "planning_started",
+      sessionId: "s2",
+      turn: 0,
+      timestamp: "t0",
+      payload: {
+        strategicRationale: "fresh",
+        contentPoolSize: 0,
+        contentPoolIds: [],
+        contextHints: {},
+        transitionEvaluationsCount: 0,
+      },
+    });
+    expect(next.sessionId).toBe("s2");
+    expect(next.contentPoolIds).toEqual([]);
+  });
+});

--- a/packages/ebrota-console-ui/tests/smoke.test.ts
+++ b/packages/ebrota-console-ui/tests/smoke.test.ts
@@ -1,22 +1,12 @@
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-  type Mock,
-} from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/svelte";
 import App from "../src/App.svelte";
 import { globalError } from "../src/lib/stores.js";
 
-let fetchMock: Mock;
-
 beforeEach(() => {
   globalError.set(null);
   // Mock fetch pra evitar errors de network real durante mount.
-  fetchMock = vi.fn(async () => ({
+  const fetchMock = vi.fn(async () => ({
     ok: false,
     status: 503,
     statusText: "Service Unavailable",
@@ -42,10 +32,10 @@ describe("App.svelte smoke (PR3 layout)", () => {
     expect(screen.getByText(/v0\.1\.0/)).toBeDefined();
   });
 
-  it("renderiza chat feed + motor placeholder", () => {
+  it("renderiza chat feed + motor view", () => {
     render(App);
     expect(screen.getByTestId("chat-feed")).toBeDefined();
-    expect(screen.getByTestId("motor-placeholder")).toBeDefined();
+    expect(screen.getByTestId("motor-view")).toBeDefined();
   });
 
   it("renderiza session start form", () => {


### PR DESCRIPTION
## Summary

PR4 da capability **C-MX-08 eBrota Console**. Vista motor real-time + leque pedagógico TOP-N expansível com override (S-OC-07 + S-OC-09). Substitui placeholder do PR3 por painel rico que consome SSE turn-state + polling listOptions.

- **Sub-stories cobertas:** S-OC-07 + S-OC-09
- **Stacked em:** #160 PR3
- **Issue:** [ops#1123](https://github.com/ascendimacy/ascendimacy-ops/issues/1123)

## O que entra

### `src/lib/types.ts` + reducer
- `TurnSnapshot` — estado pedagógico agregado dos 4 TurnStateEvents
- `applyTurnEvent(prev, ev)` reducer — aplica event preservando fases anteriores; reseta em new turn/sessionId

### `src/lib/turn-state-stream.ts` (novo)
- `startTurnStateStream(api)` reativo a `currentSessionId`:
  - Fecha SSE anterior + abre nova quando session muda
  - Reset snapshot
  - `materialization_ready` também atualiza `chatBubbles` (substitui placeholder bot bubble do PR3 com texto real)

### `src/components/MotorView.svelte`
- Phase tracker (1/4 → 4/4) + turn + timestamp
- Strategic rationale (expanded em planning_started)
- Context hints JSON expansível (só renderiza non-empty)
- Selection block (id + score + rationale) com green left border
- Proposed text blockquote + badge "instruction_addition aplicado"
- Playbook info + success/fail badge

### `src/components/ContentPool.svelte`
- Leque TOP-N expansível (default topN=3)
- **Semi-auto mode**: polling `listOptions` @ 250ms pra pool full (fact/bridge/quest)
- **Auto mode**: fallback pra `snapshot.contentPoolIds` (só ids)
- Override button por card (exceto selected) → `api.overrideSelection`
- Expand toggle "Mostrar todas (N)"
- Selected card com green border + badge

### `src/App.svelte`
- Remove motor-placeholder, usa `<MotorView api={api} />`
- Wireia `startTurnStateStream(api)` no `onMount` + cleanup `onDestroy`

## Decisões tomadas

1. **`applyTurnEvent` reducer puro** — testável isolado (não dentro do componente). Pattern Redux-like sem Redux. Reset semântico em new turn evita state ranço.
2. **Polling listOptions @ 250ms só em semi-auto** — NFR latency ≤200ms target. Auto mode não precisa (sem gate).
3. **Fallback pra `contentPoolIds`** — UI mostra algo em auto mode mesmo sem listOptions. Cards só com id (sem fact/bridge/quest) ainda dá pra ver o leque considerado.
4. **`materialization_ready` substitui bubble bot do PR3** — quando turn roda real, o texto placeholder de `startCardSession` response vira o real do motor-drota. Bubble update por id matching.
5. **Componentes "burros" (lê stores, dispara api)** — não recebem props complexas. Estado fluí via stores. Reactividade Svelte propaga.
6. **Phase tracker visual em vez de mostrar todos os fields sempre** — operador entende "estou em 2/4 selecionando" sem ler timestamps. Reduz cognição.
7. **`<details open>` no rationale + proposedText** — abertos por default pra serem visíveis; operador colapsa se cluttered.

## Verificação

- [x] `npm run build --workspace packages/ebrota-console-ui` → tsc clean + vite build OK (bundle 32.73kB gzip 11.44kB)
- [x] `npm test --workspace packages/ebrota-console-ui` → **43/43** verde em 8 files
- [x] applyTurnEvent reducer cobre todos os 4 phases + reset em new turn/sessionId
- [x] MotorView renderiza cada bloco condicional corretamente (empty, phase, rationale, selection, proposed, playbook)
- [x] ContentPool: empty → fallback ids → full pool; topN/expand; semi-auto override flow

## Como rodar local

```bash
# Terminal 1 — BFF
EBROTA_BFF_USE_MOCK_DAEMON=true npm run start --workspace packages/ebrota-console-bff

# Terminal 2 — UI
npm run dev --workspace packages/ebrota-console-ui
```

`http://localhost:5173`:
1. Click "Iniciar" no SessionStart — user/bot bubbles aparecem no chat
2. MotorView agora mostra empty (mock daemon não emite SSE events)
3. Toggle mode pra "semi-auto" — ContentPool tenta polling

Pra ver SSE real flowing, precisa de daemon real (C-MX-07 PRs #151-157 mergeados ou stack já tem tudo).

## Próximo (PR5)

**S-OC-08 + S-OC-10/11** — ApprovalGate UI + Edit Learner telemetria. Bubble pendente clicável + form Approve/Edit/Reject + rationale freeform + BFF endpoint persistindo `jun_decisions` na SQLite (tabela já criada PR2).

## Test plan

- [ ] Reviewer roda `npm test --workspace packages/ebrota-console-ui` → 43/43
- [ ] Roda local com BFF + UI — confirma MotorView aparece (sem dados em mock; PR final/E2E testa com daemon real)
- [ ] Confirma decisões 1-7 — especialmente (3) fallback em auto, (4) materialization_ready substituir bubble, (5) componentes leem stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)