### PR TITLE
[feat ops#1123] C-MX-08 PR6 — Session library + replay (6/10)

### DIFF
--- a/packages/ebrota-console-bff/src/cli.ts
+++ b/packages/ebrota-console-bff/src/cli.ts
@@ -18,14 +18,22 @@
  * pra UI dev workflow não bloquear.
  */
 
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { initDb } from "./db.js";
 import { createBffServer } from "./server.js";
 import { createMockDaemonClient } from "./daemon-client.js";
+import { scanTraces } from "./traces-scanner.js";
 import type { ConsoleMode } from "./types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_TRACES_DIR = resolve(join(__dirname, "../../../traces"));
 
 const port = Number(process.env["EBROTA_BFF_PORT"] ?? "3737");
 const host = process.env["EBROTA_BFF_HOST"] ?? "127.0.0.1";
 const dbPath = process.env["EBROTA_BFF_DB_PATH"] ?? "./.ebrota-console.db";
+const tracesDir =
+  process.env["EBROTA_BFF_TRACES_DIR"] ?? DEFAULT_TRACES_DIR;
 const modeEnv = process.env["EBROTA_BFF_INITIAL_MODE"];
 const initialMode: ConsoleMode =
   modeEnv === "semi-auto" ? "semi-auto" : "auto";
@@ -39,6 +47,7 @@ const log = (msg: string): void => {
 
 log(`starting on ${host}:${port}`);
 log(`db path: ${dbPath}`);
+log(`traces dir: ${tracesDir}`);
 log(`mode: ${initialMode}`);
 
 if (useMockDaemon) {
@@ -65,6 +74,14 @@ const server = createBffServer({
   initialMode,
   logger: true,
 });
+
+// Scan traces ANTES de listen (idempotente; ok mesmo se dir não existe).
+const scanResult = await scanTraces({ tracesDir, db, log });
+log(
+  `traces scan: ${scanResult.sessionsIndexed} sessions, ` +
+    `${scanResult.messagesIndexed} messages, ` +
+    `${scanResult.errors.length} errors`,
+);
 
 await server.listen(port, host);
 log(`✅ ready on http://${host}:${port}`);

--- a/packages/ebrota-console-bff/src/index.ts
+++ b/packages/ebrota-console-bff/src/index.ts
@@ -3,3 +3,4 @@ export * from "./daemon-client.js";
 export * from "./db.js";
 export * from "./decisions.js";
 export * from "./server.js";
+export * from "./traces-scanner.js";

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -34,6 +34,11 @@ import {
   listRecentJunDecisions,
   recordJunDecision,
 } from "./decisions.js";
+import {
+  listSessionLibrary,
+  readSessionTrace,
+  type SessionLibraryFilters,
+} from "./traces-scanner.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -273,6 +278,59 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
     const limit = req.query.limit ? Number(req.query.limit) : 50;
     return { decisions: listRecentJunDecisions(opts.db, req.params.id, limit) };
   });
+
+  // GET /sessions/library — session library com filtros (S-OC-30/31/32)
+  fastify.get<{
+    Querystring: {
+      persona?: string;
+      kind?: string;
+      from?: string;
+      to?: string;
+      hasOverrides?: string;
+      q?: string;
+      limit?: string;
+    };
+  }>("/sessions/library", async (req) => {
+    const q = req.query;
+    const filters: SessionLibraryFilters = {};
+    if (typeof q.persona === "string" && q.persona.length > 0) {
+      filters.persona = q.persona;
+    }
+    if (q.kind === "real" || q.kind === "sts") {
+      filters.kind = q.kind;
+    }
+    if (typeof q.from === "string" && q.from.length > 0) {
+      filters.fromIso = q.from;
+    }
+    if (typeof q.to === "string" && q.to.length > 0) {
+      filters.toIso = q.to;
+    }
+    if (q.hasOverrides === "true") {
+      filters.hasOverrides = true;
+    }
+    if (typeof q.q === "string" && q.q.length > 0) {
+      filters.q = q.q;
+    }
+    if (typeof q.limit === "string") {
+      const n = Number(q.limit);
+      if (!Number.isNaN(n)) filters.limit = n;
+    }
+    return { sessions: listSessionLibrary(opts.db, filters) };
+  });
+
+  // GET /sessions/:id/replay — trace JSON full pra replay UI
+  fastify.get<{ Params: { id: string } }>(
+    "/sessions/:id/replay",
+    async (req, reply) => {
+      const trace = await readSessionTrace(opts.db, req.params.id);
+      if (trace === null) {
+        return reply
+          .code(404)
+          .send({ error: `trace not found for sessionId=${req.params.id}` });
+      }
+      return trace;
+    },
+  );
 
   // POST /sessions/:id/end — endSession
   fastify.post<{ Params: { id: string } }>(

--- a/packages/ebrota-console-bff/src/traces-scanner.ts
+++ b/packages/ebrota-console-bff/src/traces-scanner.ts
@@ -1,0 +1,395 @@
+/**
+ * Scanner de trace JSON files → SQLite índice — S-OC-30 (storage híbrido
+ * D-OC-14).
+ *
+ * Source-of-truth = `~/ascendimacy-motor/traces/<traceId>/trace.json`
+ * (orchestrator escreve via trace-writer.ts). Esse scanner walks o dir,
+ * parsea cada trace, popula tabelas `sessions` + `messages_fts`.
+ *
+ * Idempotent: re-scan substitui rows existentes via UPSERT. Permite
+ * rebuild on startup + watcher incremental (futuro).
+ *
+ * Schema dos trace JSON é parcial-aware: extrai apenas campos necessários
+ * pra library. Variações entre versões do orchestrator não quebram o
+ * scanner (campos undefined → defaults).
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+export interface TracesScannerOptions {
+  /** Diretório dos traces (recursive). */
+  tracesDir: string;
+  /** Database conectado com schema do db.ts já aplicado. */
+  db: DatabaseType;
+  /** Logger pra status/errors. */
+  log?: (msg: string) => void;
+}
+
+interface RawTraceEntry {
+  service?: string;
+  timestamp?: string;
+  durationMs?: number;
+  input?: unknown;
+  output?: unknown;
+}
+
+interface RawTraceTurn {
+  turnNumber?: number;
+  sessionId?: string;
+  incomingMessage?: string;
+  entries?: RawTraceEntry[];
+  finalResponse?: string;
+  timestamp?: string;
+}
+
+interface RawTrace {
+  sessionId?: string;
+  persona?: string;
+  startedAt?: string;
+  endedAt?: string;
+  turns?: RawTraceTurn[];
+}
+
+export interface ScanResult {
+  filesScanned: number;
+  sessionsIndexed: number;
+  turnsIndexed: number;
+  messagesIndexed: number;
+  errors: Array<{ file: string; error: string }>;
+}
+
+const UPSERT_SESSION_SQL = `
+  INSERT INTO sessions (
+    session_id, persona_id, conversation_id, kind, started_at,
+    ended_at, turn_count, has_overrides, trace_path
+  ) VALUES (
+    @sessionId, @personaId, @conversationId, @kind, @startedAt,
+    @endedAt, @turnCount, @hasOverrides, @tracePath
+  )
+  ON CONFLICT(session_id) DO UPDATE SET
+    persona_id = excluded.persona_id,
+    conversation_id = excluded.conversation_id,
+    kind = excluded.kind,
+    started_at = excluded.started_at,
+    ended_at = excluded.ended_at,
+    turn_count = excluded.turn_count,
+    has_overrides = excluded.has_overrides,
+    trace_path = excluded.trace_path
+`;
+
+const DELETE_FTS_BY_SESSION_SQL = `
+  DELETE FROM messages_fts WHERE session_id = @sessionId
+`;
+
+const INSERT_FTS_SQL = `
+  INSERT INTO messages_fts (session_id, turn, role, text)
+  VALUES (@sessionId, @turn, @role, @text)
+`;
+
+const COUNT_OVERRIDES_SQL = `
+  SELECT COUNT(*) AS n FROM jun_decisions
+  WHERE session_id = @sessionId AND decision IN ('edit', 'override')
+`;
+
+/**
+ * Detecta kind heuristicamente:
+ *  - sessionId que começa com "sts-" → "sts"
+ *  - caso contrário → "real"
+ *
+ * Convenção pode evoluir; PR seguinte pode ler campo explícito do trace.
+ */
+const inferKind = (sessionId: string): "real" | "sts" =>
+  sessionId.startsWith("sts-") ? "sts" : "real";
+
+/**
+ * Extrai conversationId do sessionId quando padrão `<persona>__<conv>`,
+ * senão usa sessionId inteiro como fallback.
+ */
+const extractConversationId = (sessionId: string): string => {
+  const idx = sessionId.indexOf("__");
+  return idx === -1 ? sessionId : sessionId.slice(idx + 2);
+};
+
+const indexTrace = (
+  db: DatabaseType,
+  trace: RawTrace,
+  tracePath: string,
+  hasOverridesFn: (sessionId: string) => number,
+): { turnsIndexed: number; messagesIndexed: number } => {
+  if (typeof trace.sessionId !== "string" || trace.sessionId === "") {
+    throw new Error("trace.sessionId missing");
+  }
+  const sessionId = trace.sessionId;
+  const personaId = trace.persona ?? "unknown";
+  const turns = trace.turns ?? [];
+  const turnCount = turns.length;
+  const startedAt = trace.startedAt ?? turns[0]?.timestamp ?? "1970-01-01T00:00:00.000Z";
+  const endedAt = trace.endedAt ?? turns[turns.length - 1]?.timestamp ?? null;
+  const hasOverrides = hasOverridesFn(sessionId);
+
+  db.prepare(UPSERT_SESSION_SQL).run({
+    sessionId,
+    personaId,
+    conversationId: extractConversationId(sessionId),
+    kind: inferKind(sessionId),
+    startedAt,
+    endedAt,
+    turnCount,
+    hasOverrides: hasOverrides > 0 ? 1 : 0,
+    tracePath,
+  });
+
+  // Re-populate FTS pra essa sessão (delete-then-insert pra idempotência)
+  db.prepare(DELETE_FTS_BY_SESSION_SQL).run({ sessionId });
+
+  let messagesIndexed = 0;
+  const insertFts = db.prepare(INSERT_FTS_SQL);
+  for (const turn of turns) {
+    const turnNumber = turn.turnNumber ?? 0;
+    if (
+      typeof turn.incomingMessage === "string" &&
+      turn.incomingMessage.length > 0
+    ) {
+      insertFts.run({
+        sessionId,
+        turn: turnNumber,
+        role: "user",
+        text: turn.incomingMessage,
+      });
+      messagesIndexed += 1;
+    }
+    if (
+      typeof turn.finalResponse === "string" &&
+      turn.finalResponse.length > 0
+    ) {
+      insertFts.run({
+        sessionId,
+        turn: turnNumber,
+        role: "bot",
+        text: turn.finalResponse,
+      });
+      messagesIndexed += 1;
+    }
+  }
+
+  return { turnsIndexed: turnCount, messagesIndexed };
+};
+
+/**
+ * Recursive walk procurando trace.json files. Skip nodes com erro
+ * (não trava scan).
+ */
+async function* walkTraceFiles(
+  dir: string,
+): AsyncGenerator<string, void, void> {
+  let entries: Array<{
+    name: string;
+    isDirectory: () => boolean;
+    isFile: () => boolean;
+  }>;
+  try {
+    entries = (await readdir(dir, { withFileTypes: true })) as never;
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const name = String(entry.name);
+    const full = join(dir, name);
+    if (entry.isDirectory()) {
+      yield* walkTraceFiles(full);
+    } else if (entry.isFile() && name === "trace.json") {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Scan trace files no tracesDir + popula índice. Idempotente.
+ * Retorna stats agregados.
+ */
+export async function scanTraces(
+  opts: TracesScannerOptions,
+): Promise<ScanResult> {
+  const log = opts.log ?? (() => undefined);
+  const result: ScanResult = {
+    filesScanned: 0,
+    sessionsIndexed: 0,
+    turnsIndexed: 0,
+    messagesIndexed: 0,
+    errors: [],
+  };
+
+  // Sanity check: dir existe?
+  try {
+    await stat(opts.tracesDir);
+  } catch {
+    log(`[traces-scanner] dir not found: ${opts.tracesDir} — skip`);
+    return result;
+  }
+
+  const overrideCountStmt = opts.db.prepare(COUNT_OVERRIDES_SQL);
+  const countOverrides = (sessionId: string): number => {
+    const row = overrideCountStmt.get({ sessionId }) as
+      | { n: number }
+      | undefined;
+    return row?.n ?? 0;
+  };
+
+  const tx = opts.db.transaction(
+    (traces: Array<{ trace: RawTrace; tracePath: string }>) => {
+      for (const { trace, tracePath } of traces) {
+        try {
+          const r = indexTrace(opts.db, trace, tracePath, countOverrides);
+          result.sessionsIndexed += 1;
+          result.turnsIndexed += r.turnsIndexed;
+          result.messagesIndexed += r.messagesIndexed;
+        } catch (err) {
+          result.errors.push({
+            file: tracePath,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    },
+  );
+
+  const batch: Array<{ trace: RawTrace; tracePath: string }> = [];
+  for await (const tracePath of walkTraceFiles(opts.tracesDir)) {
+    result.filesScanned += 1;
+    try {
+      const raw = await readFile(tracePath, "utf-8");
+      const trace = JSON.parse(raw) as RawTrace;
+      batch.push({ trace, tracePath });
+    } catch (err) {
+      result.errors.push({
+        file: tracePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  tx(batch);
+  log(
+    `[traces-scanner] ${result.sessionsIndexed} sessions indexed ` +
+      `(${result.filesScanned} files, ${result.messagesIndexed} messages, ` +
+      `${result.errors.length} errors)`,
+  );
+  return result;
+}
+
+export interface SessionLibraryFilters {
+  /** Filtra por persona_id (exato). */
+  persona?: string;
+  /** Filtra por kind (real | sts). */
+  kind?: "real" | "sts";
+  /** started_at >= esse ISO. */
+  fromIso?: string;
+  /** started_at <= esse ISO. */
+  toIso?: string;
+  /** Só sessões com overrides. */
+  hasOverrides?: boolean;
+  /** Full-text search nas mensagens. */
+  q?: string;
+  /** Default 50. */
+  limit?: number;
+}
+
+export interface SessionLibraryEntry {
+  sessionId: string;
+  personaId: string;
+  conversationId: string;
+  kind: "real" | "sts";
+  startedAt: string;
+  endedAt: string | null;
+  turnCount: number;
+  hasOverrides: boolean;
+  tracePath: string | null;
+}
+
+export function listSessionLibrary(
+  db: DatabaseType,
+  filters: SessionLibraryFilters = {},
+): SessionLibraryEntry[] {
+  const where: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  if (filters.persona !== undefined) {
+    where.push("persona_id = @persona");
+    params["persona"] = filters.persona;
+  }
+  if (filters.kind !== undefined) {
+    where.push("kind = @kind");
+    params["kind"] = filters.kind;
+  }
+  if (filters.fromIso !== undefined) {
+    where.push("started_at >= @fromIso");
+    params["fromIso"] = filters.fromIso;
+  }
+  if (filters.toIso !== undefined) {
+    where.push("started_at <= @toIso");
+    params["toIso"] = filters.toIso;
+  }
+  if (filters.hasOverrides === true) {
+    where.push("has_overrides = 1");
+  }
+  if (filters.q !== undefined && filters.q.length > 0) {
+    where.push(
+      "session_id IN (SELECT DISTINCT session_id FROM messages_fts WHERE text MATCH @q)",
+    );
+    params["q"] = filters.q;
+  }
+
+  const limit = Math.max(1, Math.min(500, filters.limit ?? 50));
+  const sql = `
+    SELECT
+      session_id AS sessionId,
+      persona_id AS personaId,
+      conversation_id AS conversationId,
+      kind,
+      started_at AS startedAt,
+      ended_at AS endedAt,
+      turn_count AS turnCount,
+      has_overrides AS hasOverridesInt,
+      trace_path AS tracePath
+    FROM sessions
+    ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+    ORDER BY started_at DESC
+    LIMIT ${limit}
+  `;
+  const rows = db.prepare(sql).all(params) as Array<
+    SessionLibraryEntry & { hasOverridesInt: number }
+  >;
+  return rows.map((row) => ({
+    sessionId: row.sessionId,
+    personaId: row.personaId,
+    conversationId: row.conversationId,
+    kind: row.kind,
+    startedAt: row.startedAt,
+    endedAt: row.endedAt,
+    turnCount: row.turnCount,
+    hasOverrides: row.hasOverridesInt === 1,
+    tracePath: row.tracePath,
+  }));
+}
+
+/**
+ * Lê o trace JSON full de uma sessão. Retorna null se sessionId não
+ * está indexado ou file não acessível.
+ */
+export async function readSessionTrace(
+  db: DatabaseType,
+  sessionId: string,
+): Promise<RawTrace | null> {
+  const row = db
+    .prepare("SELECT trace_path AS tracePath FROM sessions WHERE session_id = ?")
+    .get(sessionId) as { tracePath: string | null } | undefined;
+  if (row?.tracePath === undefined || row.tracePath === null) return null;
+  try {
+    const raw = await readFile(row.tracePath, "utf-8");
+    return JSON.parse(raw) as RawTrace;
+  } catch {
+    return null;
+  }
+}

--- a/packages/ebrota-console-bff/tests/traces-scanner.test.ts
+++ b/packages/ebrota-console-bff/tests/traces-scanner.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import {
+  listSessionLibrary,
+  readSessionTrace,
+  scanTraces,
+} from "../src/traces-scanner.js";
+
+let db: DatabaseType;
+let tmpRoot: string;
+
+const writeTrace = (
+  subdir: string,
+  trace: Record<string, unknown>,
+): string => {
+  const dir = join(tmpRoot, subdir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "trace.json");
+  writeFileSync(path, JSON.stringify(trace));
+  return path;
+};
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  tmpRoot = mkdtempSync(join(tmpdir(), "traces-scanner-"));
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("scanTraces", () => {
+  it("indexa traces recursivamente", async () => {
+    writeTrace("session-1", {
+      sessionId: "yuji__conv-1",
+      persona: "yuji",
+      startedAt: "2026-05-24T13:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 0,
+          incomingMessage: "card:tabuada-7",
+          finalResponse: "Vamos lá Yuji!",
+        },
+      ],
+    });
+    writeTrace("session-2/deep/nested", {
+      sessionId: "kei__conv-2",
+      persona: "kei",
+      startedAt: "2026-05-24T14:00:00.000Z",
+      turns: [],
+    });
+
+    const result = await scanTraces({ tracesDir: tmpRoot, db });
+    expect(result.filesScanned).toBe(2);
+    expect(result.sessionsIndexed).toBe(2);
+    expect(result.errors).toHaveLength(0);
+
+    const sessions = listSessionLibrary(db);
+    expect(sessions).toHaveLength(2);
+    expect(sessions.map((s) => s.sessionId).sort()).toEqual([
+      "kei__conv-2",
+      "yuji__conv-1",
+    ]);
+  });
+
+  it("popula messages_fts com finalResponse + incomingMessage", async () => {
+    writeTrace("s1", {
+      sessionId: "yuji__conv-fts",
+      persona: "yuji",
+      startedAt: "2026-05-24T13:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 0,
+          incomingMessage: "card:tabuada-frutas-vermelhas",
+          finalResponse: "Vamos descobrir frutas vermelhas como morango!",
+        },
+        {
+          turnNumber: 1,
+          incomingMessage: "morango é minha favorita",
+          finalResponse: "Que bom!",
+        },
+      ],
+    });
+
+    await scanTraces({ tracesDir: tmpRoot, db });
+
+    // FTS5 search
+    const rows = db
+      .prepare(
+        "SELECT session_id, text FROM messages_fts WHERE text MATCH ? ORDER BY turn",
+      )
+      .all("morango") as Array<{ session_id: string; text: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some((r) => r.text.includes("morango"))).toBe(true);
+  });
+
+  it("idempotent — re-scan substitui rows", async () => {
+    const tracePath = writeTrace("s1", {
+      sessionId: "yuji__idem",
+      persona: "yuji",
+      startedAt: "2026-05-24T13:00:00.000Z",
+      turns: [{ turnNumber: 0, finalResponse: "v1" }],
+    });
+    await scanTraces({ tracesDir: tmpRoot, db });
+    let sessions = listSessionLibrary(db);
+    expect(sessions[0]!.turnCount).toBe(1);
+
+    // Update trace + re-scan
+    writeFileSync(
+      tracePath,
+      JSON.stringify({
+        sessionId: "yuji__idem",
+        persona: "yuji",
+        startedAt: "2026-05-24T13:00:00.000Z",
+        turns: [
+          { turnNumber: 0, finalResponse: "v1" },
+          { turnNumber: 1, finalResponse: "v2" },
+        ],
+      }),
+    );
+    await scanTraces({ tracesDir: tmpRoot, db });
+    sessions = listSessionLibrary(db);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.turnCount).toBe(2);
+  });
+
+  it("dir inexistente → result vazio sem error", async () => {
+    const result = await scanTraces({
+      tracesDir: "/nonexistent/path/zzz",
+      db,
+    });
+    expect(result).toEqual({
+      filesScanned: 0,
+      sessionsIndexed: 0,
+      turnsIndexed: 0,
+      messagesIndexed: 0,
+      errors: [],
+    });
+  });
+
+  it("trace JSON malformado → error registrado, continua scan", async () => {
+    writeFileSync(
+      join(tmpRoot, "trace.json"),
+      "not valid json {{{",
+    );
+    writeTrace("good", {
+      sessionId: "good__1",
+      persona: "good",
+      startedAt: "2026-05-24T13:00:00.000Z",
+      turns: [],
+    });
+    const result = await scanTraces({ tracesDir: tmpRoot, db });
+    expect(result.errors.length).toBe(1);
+    expect(result.sessionsIndexed).toBe(1);
+  });
+
+  it("kind inferido como 'sts' quando sessionId começa com 'sts-'", async () => {
+    writeTrace("a", {
+      sessionId: "sts-yuji-001",
+      persona: "yuji",
+      startedAt: "2026-05-24T13:00:00.000Z",
+      turns: [],
+    });
+    writeTrace("b", {
+      sessionId: "yuji__real-conv",
+      persona: "yuji",
+      startedAt: "2026-05-24T14:00:00.000Z",
+      turns: [],
+    });
+    await scanTraces({ tracesDir: tmpRoot, db });
+    const sessions = listSessionLibrary(db);
+    const sts = sessions.find((s) => s.kind === "sts");
+    const real = sessions.find((s) => s.kind === "real");
+    expect(sts?.sessionId).toBe("sts-yuji-001");
+    expect(real?.sessionId).toBe("yuji__real-conv");
+  });
+});
+
+describe("listSessionLibrary filters", () => {
+  beforeEach(async () => {
+    // Setup pré-populado: 3 sessões
+    writeTrace("a", {
+      sessionId: "yuji__a",
+      persona: "yuji",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turns: [{ turnNumber: 0, finalResponse: "morango doce" }],
+    });
+    writeTrace("b", {
+      sessionId: "kei__b",
+      persona: "kei",
+      startedAt: "2026-05-22T10:00:00.000Z",
+      turns: [{ turnNumber: 0, finalResponse: "frutas amargas" }],
+    });
+    writeTrace("c", {
+      sessionId: "sts-yuji-c",
+      persona: "yuji",
+      startedAt: "2026-05-23T10:00:00.000Z",
+      turns: [{ turnNumber: 0, finalResponse: "tabuada" }],
+    });
+    await scanTraces({ tracesDir: tmpRoot, db });
+  });
+
+  it("filter por persona", () => {
+    expect(
+      listSessionLibrary(db, { persona: "yuji" }).map((s) => s.sessionId).sort(),
+    ).toEqual(["sts-yuji-c", "yuji__a"]);
+  });
+
+  it("filter por kind", () => {
+    expect(
+      listSessionLibrary(db, { kind: "real" }).map((s) => s.sessionId).sort(),
+    ).toEqual(["kei__b", "yuji__a"]);
+    expect(
+      listSessionLibrary(db, { kind: "sts" }).map((s) => s.sessionId),
+    ).toEqual(["sts-yuji-c"]);
+  });
+
+  it("filter por date range", () => {
+    expect(
+      listSessionLibrary(db, {
+        fromIso: "2026-05-22T00:00:00.000Z",
+      }).map((s) => s.sessionId).sort(),
+    ).toEqual(["kei__b", "sts-yuji-c"]);
+    expect(
+      listSessionLibrary(db, {
+        toIso: "2026-05-21T00:00:00.000Z",
+      }).map((s) => s.sessionId),
+    ).toEqual(["yuji__a"]);
+  });
+
+  it("full-text search q via FTS5", () => {
+    expect(
+      listSessionLibrary(db, { q: "morango" }).map((s) => s.sessionId),
+    ).toEqual(["yuji__a"]);
+    expect(
+      listSessionLibrary(db, { q: "frutas" }).map((s) => s.sessionId),
+    ).toEqual(["kei__b"]);
+  });
+
+  it("filter combinado (persona + kind)", () => {
+    expect(
+      listSessionLibrary(db, { persona: "yuji", kind: "real" }).map(
+        (s) => s.sessionId,
+      ),
+    ).toEqual(["yuji__a"]);
+  });
+
+  it("ORDER BY started_at DESC", () => {
+    const all = listSessionLibrary(db);
+    expect(all.map((s) => s.sessionId)).toEqual([
+      "sts-yuji-c",
+      "kei__b",
+      "yuji__a",
+    ]);
+  });
+
+  it("limit respeitado", () => {
+    expect(listSessionLibrary(db, { limit: 2 }).length).toBe(2);
+  });
+});
+
+describe("readSessionTrace", () => {
+  it("retorna trace JSON full", async () => {
+    writeTrace("a", {
+      sessionId: "yuji__a",
+      persona: "yuji",
+      startedAt: "2026-05-24T13:00:00.000Z",
+      turns: [{ turnNumber: 0, finalResponse: "olá" }],
+    });
+    await scanTraces({ tracesDir: tmpRoot, db });
+    const trace = await readSessionTrace(db, "yuji__a");
+    expect(trace).not.toBeNull();
+    expect(trace!.sessionId).toBe("yuji__a");
+    expect(trace!.turns).toHaveLength(1);
+  });
+
+  it("sessionId desconhecido → null", async () => {
+    const trace = await readSessionTrace(db, "nonexistent");
+    expect(trace).toBeNull();
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -5,6 +5,8 @@
   import SessionStart from "./components/SessionStart.svelte";
   import MotorView from "./components/MotorView.svelte";
   import ApprovalGate from "./components/ApprovalGate.svelte";
+  import SessionLibrary from "./components/SessionLibrary.svelte";
+  import Replay from "./components/Replay.svelte";
   import { createApiClient } from "./lib/api.js";
   import { bffStatus, consoleMode, globalError } from "./lib/stores.js";
   import {
@@ -62,6 +64,9 @@
   </main>
 
   <SessionStart {api} />
+
+  <SessionLibrary {api} />
+  <Replay {api} />
 
   <footer>
     <p class="muted">

--- a/packages/ebrota-console-ui/src/components/Replay.svelte
+++ b/packages/ebrota-console-ui/src/components/Replay.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+  import { replaySessionId, globalError } from "../lib/stores.js";
+  import type { ApiClient, ReplayTrace } from "../lib/api.js";
+
+  export let api: ApiClient;
+
+  let trace: ReplayTrace | null = null;
+  let loading = false;
+  let currentSessionId: string | null = null;
+
+  $: sessionId = $replaySessionId;
+
+  // Quando replaySessionId muda, fetch novo trace
+  $: if (sessionId !== currentSessionId) {
+    currentSessionId = sessionId;
+    trace = null;
+    if (sessionId !== null) {
+      void loadTrace(sessionId);
+    }
+  }
+
+  async function loadTrace(id: string): Promise<void> {
+    loading = true;
+    try {
+      trace = await api.getSessionReplay(id);
+    } catch (err) {
+      globalError.set(
+        `Replay falhou: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      trace = null;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function close(): void {
+    replaySessionId.set(null);
+  }
+</script>
+
+{#if sessionId !== null}
+  <div
+    class="replay-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Replay de sessão"
+    data-testid="replay-overlay"
+    on:click|self={close}
+    on:keydown={(e) => {
+      if (e.key === "Escape") close();
+    }}
+  >
+    <div class="replay-modal" data-testid="replay-modal">
+      <header>
+        <h2>Replay</h2>
+        <code class="session-id">{sessionId}</code>
+        <button
+          type="button"
+          class="close"
+          on:click={close}
+          aria-label="Fechar replay"
+          data-testid="replay-close"
+        >
+          ×
+        </button>
+      </header>
+
+      {#if loading}
+        <p class="muted">Carregando trace...</p>
+      {:else if trace === null}
+        <p class="muted">Trace não disponível.</p>
+      {:else}
+        <div class="meta-block">
+          <p>
+            <strong>persona:</strong> {trace.persona ?? "(unknown)"}
+          </p>
+          {#if trace.startedAt !== undefined}
+            <p>
+              <strong>started:</strong>
+              <code>{trace.startedAt}</code>
+            </p>
+          {/if}
+          {#if trace.endedAt !== undefined}
+            <p>
+              <strong>ended:</strong>
+              <code>{trace.endedAt}</code>
+            </p>
+          {/if}
+          <p>
+            <strong>turns:</strong> {trace.turns?.length ?? 0}
+          </p>
+        </div>
+
+        {#if trace.turns !== undefined && trace.turns.length > 0}
+          <ol class="turns" data-testid="replay-turns">
+            {#each trace.turns as turn (turn.turnNumber ?? Math.random())}
+              <li class="turn" data-testid="replay-turn">
+                <header class="turn-header">
+                  <strong>turn #{turn.turnNumber ?? "?"}</strong>
+                  {#if turn.timestamp !== undefined}
+                    <span class="time">{turn.timestamp}</span>
+                  {/if}
+                </header>
+                {#if turn.incomingMessage !== undefined}
+                  <div class="message user">
+                    <span class="role">user</span>
+                    <p>{turn.incomingMessage}</p>
+                  </div>
+                {/if}
+                {#if turn.finalResponse !== undefined}
+                  <div class="message bot">
+                    <span class="role">bot</span>
+                    <p>{turn.finalResponse}</p>
+                  </div>
+                {/if}
+              </li>
+            {/each}
+          </ol>
+        {:else}
+          <p class="muted">Nenhum turn registrado.</p>
+        {/if}
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .replay-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+    padding: 1rem;
+  }
+
+  .replay-modal {
+    background: var(--bg, #ffffff);
+    border-radius: 8px;
+    width: min(800px, 100%);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .replay-modal {
+      background: #1e1e1e;
+    }
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.7rem 1rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.8;
+  }
+
+  .session-id {
+    flex: 1;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.8rem;
+    opacity: 0.6;
+  }
+
+  .close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 1.5rem;
+    line-height: 1;
+    padding: 0.2rem 0.5rem;
+  }
+
+  .close:hover {
+    background: rgba(127, 127, 127, 0.15);
+    border-radius: 4px;
+  }
+
+  .meta-block {
+    padding: 0.7rem 1rem;
+    background: rgba(127, 127, 127, 0.05);
+    border-bottom: 1px solid rgba(127, 127, 127, 0.2);
+    font-size: 0.85rem;
+  }
+
+  .meta-block p {
+    margin: 0.15rem 0;
+  }
+
+  .muted {
+    opacity: 0.6;
+    text-align: center;
+    padding: 1rem;
+  }
+
+  .turns {
+    list-style: none;
+    padding: 0.5rem 1rem;
+    margin: 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .turn {
+    margin-bottom: 0.7rem;
+    padding-bottom: 0.7rem;
+    border-bottom: 1px dashed rgba(127, 127, 127, 0.2);
+  }
+
+  .turn-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.3rem;
+  }
+
+  .turn-header strong {
+    font-size: 0.85rem;
+  }
+
+  .turn-header .time {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.7rem;
+    opacity: 0.5;
+  }
+
+  .message {
+    margin: 0.3rem 0;
+    padding: 0.4rem 0.6rem;
+    border-radius: 6px;
+  }
+
+  .message.user {
+    background: rgba(76, 175, 80, 0.1);
+    border-left: 2px solid rgba(76, 175, 80, 0.5);
+  }
+
+  .message.bot {
+    background: rgba(33, 150, 243, 0.1);
+    border-left: 2px solid rgba(33, 150, 243, 0.5);
+  }
+
+  .role {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    opacity: 0.6;
+  }
+
+  .message p {
+    margin: 0.1rem 0 0;
+    line-height: 1.4;
+    font-size: 0.9rem;
+    white-space: pre-wrap;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/SessionLibrary.svelte
+++ b/packages/ebrota-console-ui/src/components/SessionLibrary.svelte
@@ -1,0 +1,399 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    libraryOpen,
+    replaySessionId,
+    globalError,
+  } from "../lib/stores.js";
+  import type {
+    ApiClient,
+    SessionLibraryEntry,
+    SessionLibraryFilters,
+  } from "../lib/api.js";
+
+  export let api: ApiClient;
+
+  let sessions: SessionLibraryEntry[] = [];
+  let loading = false;
+  let persona = "";
+  let kind: "" | "real" | "sts" = "";
+  let q = "";
+  let hasOverrides = false;
+  let lastFetch = Date.now();
+
+  $: open = $libraryOpen;
+
+  async function refresh(): Promise<void> {
+    loading = true;
+    const filters: SessionLibraryFilters = {};
+    if (persona.length > 0) filters.persona = persona;
+    if (kind === "real" || kind === "sts") filters.kind = kind;
+    if (q.length > 0) filters.q = q;
+    if (hasOverrides) filters.hasOverrides = true;
+    filters.limit = 50;
+    try {
+      const res = await api.listSessionLibrary(filters);
+      sessions = res.sessions;
+      lastFetch = Date.now();
+    } catch (err) {
+      globalError.set(
+        `Library falhou: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      sessions = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  $: if (open) {
+    void refresh();
+  }
+
+  onMount(() => {
+    if (open) void refresh();
+  });
+
+  function openReplay(sessionId: string): void {
+    replaySessionId.set(sessionId);
+  }
+
+  function clearFilters(): void {
+    persona = "";
+    kind = "";
+    q = "";
+    hasOverrides = false;
+    void refresh();
+  }
+
+  void lastFetch;
+</script>
+
+{#if open}
+  <aside class="library" data-testid="session-library">
+    <header>
+      <h2>Histórico</h2>
+      <button
+        type="button"
+        class="close"
+        on:click={() => libraryOpen.set(false)}
+        data-testid="library-close"
+        aria-label="Fechar histórico"
+      >
+        ×
+      </button>
+    </header>
+
+    <div class="filters">
+      <label class="filter">
+        <span>persona</span>
+        <input
+          type="text"
+          bind:value={persona}
+          placeholder="yuji, kei, ..."
+          data-testid="filter-persona"
+        />
+      </label>
+      <label class="filter">
+        <span>kind</span>
+        <select bind:value={kind} data-testid="filter-kind">
+          <option value="">all</option>
+          <option value="real">real</option>
+          <option value="sts">sts</option>
+        </select>
+      </label>
+      <label class="filter">
+        <span>busca</span>
+        <input
+          type="text"
+          bind:value={q}
+          placeholder="full-text (FTS5)"
+          data-testid="filter-q"
+        />
+      </label>
+      <label class="filter inline">
+        <input
+          type="checkbox"
+          bind:checked={hasOverrides}
+          data-testid="filter-has-overrides"
+        />
+        <span>só com overrides</span>
+      </label>
+      <div class="filter-actions">
+        <button
+          type="button"
+          on:click={refresh}
+          disabled={loading}
+          data-testid="filter-apply"
+        >
+          {loading ? "..." : "Aplicar"}
+        </button>
+        <button
+          type="button"
+          class="ghost"
+          on:click={clearFilters}
+          disabled={loading}
+          data-testid="filter-clear"
+        >
+          Limpar
+        </button>
+      </div>
+    </div>
+
+    <div class="list" data-testid="library-list">
+      {#if loading}
+        <p class="muted">Carregando...</p>
+      {:else if sessions.length === 0}
+        <p class="muted">Nenhuma sessão.</p>
+      {:else}
+        {#each sessions as session (session.sessionId)}
+          <button
+            type="button"
+            class="entry"
+            class:has-overrides={session.hasOverrides}
+            on:click={() => openReplay(session.sessionId)}
+            data-testid="library-entry"
+          >
+            <div class="entry-row1">
+              <span class="persona">{session.personaId}</span>
+              <span class="kind kind-{session.kind}">{session.kind}</span>
+              {#if session.hasOverrides}
+                <span class="badge">overrides</span>
+              {/if}
+            </div>
+            <div class="entry-row2">
+              <code class="conv">{session.conversationId}</code>
+              <span class="meta">{session.turnCount} turns</span>
+            </div>
+            <div class="entry-row3">
+              <span class="time">{session.startedAt}</span>
+            </div>
+          </button>
+        {/each}
+      {/if}
+    </div>
+  </aside>
+{/if}
+
+<style>
+  .library {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: min(420px, 100%);
+    height: 100vh;
+    background: var(--bg, #ffffff);
+    border-left: 1px solid rgba(127, 127, 127, 0.3);
+    display: flex;
+    flex-direction: column;
+    z-index: 30;
+    box-shadow: -4px 0 12px rgba(0, 0, 0, 0.15);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .library {
+      background: #222;
+    }
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.7rem 1rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.8;
+  }
+
+  .close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 1.5rem;
+    line-height: 1;
+    padding: 0.2rem 0.5rem;
+  }
+
+  .close:hover {
+    background: rgba(127, 127, 127, 0.15);
+    border-radius: 4px;
+  }
+
+  .filters {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    padding: 0.7rem 1rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.2);
+    background: rgba(127, 127, 127, 0.04);
+  }
+
+  .filter {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .filter span {
+    font-size: 0.7rem;
+    opacity: 0.6;
+    margin-bottom: 0.15rem;
+  }
+
+  .filter.inline {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+    grid-column: 1 / 3;
+  }
+
+  .filter.inline span {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    margin: 0;
+  }
+
+  input,
+  select {
+    padding: 0.3rem 0.4rem;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    background: rgba(127, 127, 127, 0.05);
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.85rem;
+  }
+
+  .filter-actions {
+    grid-column: 1 / 3;
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.3rem;
+  }
+
+  button {
+    padding: 0.3rem 0.8rem;
+    border: 1px solid rgba(33, 150, 243, 0.5);
+    background: rgba(33, 150, 243, 0.15);
+    color: inherit;
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+  }
+
+  button:hover:not(:disabled) {
+    background: rgba(33, 150, 243, 0.3);
+  }
+
+  button.ghost {
+    background: transparent;
+    border-color: rgba(127, 127, 127, 0.3);
+  }
+
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .muted {
+    opacity: 0.6;
+    text-align: center;
+    padding: 1rem;
+  }
+
+  .entry {
+    text-align: left;
+    background: rgba(127, 127, 127, 0.06);
+    border: 1px solid rgba(127, 127, 127, 0.2);
+    border-radius: 4px;
+    padding: 0.5rem 0.7rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    color: inherit;
+  }
+
+  .entry:hover {
+    background: rgba(33, 150, 243, 0.1);
+    border-color: rgba(33, 150, 243, 0.5);
+  }
+
+  .entry.has-overrides {
+    border-left: 3px solid rgba(255, 193, 7, 0.7);
+  }
+
+  .entry-row1 {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.9rem;
+  }
+
+  .persona {
+    font-weight: 600;
+  }
+
+  .kind {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    opacity: 0.7;
+  }
+
+  .kind.kind-real {
+    background: rgba(76, 175, 80, 0.2);
+    color: #2e7d32;
+  }
+
+  .kind.kind-sts {
+    background: rgba(156, 39, 176, 0.2);
+    color: #6a1b9a;
+  }
+
+  .badge {
+    background: rgba(255, 193, 7, 0.3);
+    color: #b8860b;
+    font-size: 0.7rem;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    margin-left: auto;
+  }
+
+  .entry-row2 {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    opacity: 0.7;
+  }
+
+  .conv {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+  }
+
+  .meta {
+    margin-left: auto;
+  }
+
+  .entry-row3 {
+    font-size: 0.7rem;
+    opacity: 0.5;
+  }
+
+  .time {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/Status.svelte
+++ b/packages/ebrota-console-ui/src/components/Status.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { bffStatus, consoleMode } from "../lib/stores.js";
+  import { bffStatus, consoleMode, libraryOpen } from "../lib/stores.js";
   import type { ApiClient } from "../lib/api.js";
   import type { ConsoleMode } from "../lib/types.js";
 
@@ -52,6 +52,16 @@
       {status?.sessionCount ?? 0} sessões
     </span>
   </div>
+
+  <button
+    type="button"
+    class="history-toggle"
+    on:click={() => libraryOpen.update((o) => !o)}
+    data-testid="history-toggle"
+    title="Histórico de sessões"
+  >
+    Histórico
+  </button>
 
   <button
     type="button"
@@ -123,6 +133,7 @@
     opacity: 0.7;
   }
 
+  .history-toggle,
   .mode-toggle {
     background: rgba(127, 127, 127, 0.15);
     border: 1px solid rgba(127, 127, 127, 0.4);
@@ -132,6 +143,10 @@
     font-family: inherit;
     font-size: 0.85rem;
     color: inherit;
+  }
+
+  .history-toggle:hover {
+    background: rgba(127, 127, 127, 0.25);
   }
 
   .mode-toggle:hover {

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -84,6 +84,45 @@ export interface JunDecisionEntry {
   recordedAt: string;
 }
 
+export interface SessionLibraryFilters {
+  persona?: string;
+  kind?: "real" | "sts";
+  fromIso?: string;
+  toIso?: string;
+  hasOverrides?: boolean;
+  q?: string;
+  limit?: number;
+}
+
+export interface SessionLibraryEntry {
+  sessionId: string;
+  personaId: string;
+  conversationId: string;
+  kind: "real" | "sts";
+  startedAt: string;
+  endedAt: string | null;
+  turnCount: number;
+  hasOverrides: boolean;
+  tracePath: string | null;
+}
+
+export interface ReplayTraceTurn {
+  turnNumber?: number;
+  sessionId?: string;
+  incomingMessage?: string;
+  finalResponse?: string;
+  timestamp?: string;
+  entries?: Array<Record<string, unknown>>;
+}
+
+export interface ReplayTrace {
+  sessionId?: string;
+  persona?: string;
+  startedAt?: string;
+  endedAt?: string;
+  turns?: ReplayTraceTurn[];
+}
+
 export interface ApiClient {
   getStatus(): Promise<BffStatus>;
   getMode(): Promise<{ mode: ConsoleMode }>;
@@ -111,6 +150,10 @@ export interface ApiClient {
     decision: ApprovalDecisionRequest,
   ): Promise<ApproveOrEditResult>;
   endSession(sessionId: string): Promise<{ closed: boolean }>;
+  listSessionLibrary(
+    filters?: SessionLibraryFilters,
+  ): Promise<{ sessions: SessionLibraryEntry[] }>;
+  getSessionReplay(sessionId: string): Promise<ReplayTrace>;
   /** Resolve URL completa pro EventSource consumir SSE. */
   turnStateSseUrl(sessionId: string): string;
 }
@@ -176,6 +219,27 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     endSession: (sessionId) =>
       post<{ closed: boolean }>(
         `/sessions/${encodeURIComponent(sessionId)}/end`,
+      ),
+    listSessionLibrary: (filters) => {
+      const params = new URLSearchParams();
+      if (filters?.persona !== undefined) params.set("persona", filters.persona);
+      if (filters?.kind !== undefined) params.set("kind", filters.kind);
+      if (filters?.fromIso !== undefined) params.set("from", filters.fromIso);
+      if (filters?.toIso !== undefined) params.set("to", filters.toIso);
+      if (filters?.hasOverrides === true)
+        params.set("hasOverrides", "true");
+      if (filters?.q !== undefined && filters.q.length > 0)
+        params.set("q", filters.q);
+      if (filters?.limit !== undefined)
+        params.set("limit", String(filters.limit));
+      const query = params.toString();
+      return get<{ sessions: SessionLibraryEntry[] }>(
+        `/sessions/library${query.length > 0 ? `?${query}` : ""}`,
+      );
+    },
+    getSessionReplay: (sessionId) =>
+      get<ReplayTrace>(
+        `/sessions/${encodeURIComponent(sessionId)}/replay`,
       ),
     turnStateSseUrl: (sessionId) =>
       `${baseUrl}/sessions/${encodeURIComponent(sessionId)}/turn-state`,

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -47,3 +47,9 @@ export const globalError = writable<string | null>(null);
 export const pendingApproval = writable<{ proposedText: string } | null>(
   null,
 );
+
+/** Sidebar Histórico aberto? */
+export const libraryOpen = writable<boolean>(false);
+
+/** Replay modal open com qual sessionId. Null = fechado. */
+export const replaySessionId = writable<string | null>(null);

--- a/packages/ebrota-console-ui/tests/components/Replay.test.ts
+++ b/packages/ebrota-console-ui/tests/components/Replay.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import Replay from "../../src/components/Replay.svelte";
+import { replaySessionId } from "../../src/lib/stores.js";
+import type { ApiClient, ReplayTrace } from "../../src/lib/api.js";
+
+const buildApi = (trace: ReplayTrace | (() => never)): ApiClient =>
+  ({
+    getStatus: vi.fn(),
+    getMode: vi.fn(),
+    setMode: vi.fn(),
+    startCardSession: vi.fn(),
+    listOptions: vi.fn(),
+    overrideSelection: vi.fn(),
+    listDecisions: vi.fn(),
+    getPendingApproval: vi.fn(),
+    approveOrEdit: vi.fn(),
+    endSession: vi.fn(),
+    listSessionLibrary: vi.fn(),
+    getSessionReplay: vi.fn(async () =>
+      typeof trace === "function" ? trace() : trace,
+    ),
+    turnStateSseUrl: () => "/api/sse",
+  }) as never;
+
+beforeEach(() => {
+  replaySessionId.set(null);
+});
+
+describe("Replay.svelte", () => {
+  it("não renderiza quando replaySessionId=null", () => {
+    render(Replay, { api: buildApi({ sessionId: "x" }) });
+    expect(screen.queryByTestId("replay-overlay")).toBeNull();
+  });
+
+  it("renderiza modal quando replaySessionId set + fetch resolve", async () => {
+    const trace: ReplayTrace = {
+      sessionId: "yuji__a",
+      persona: "yuji",
+      startedAt: "2026-05-24T13:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 0,
+          incomingMessage: "card:tabuada-7",
+          finalResponse: "Vamos descobrir!",
+          timestamp: "2026-05-24T13:00:01.000Z",
+        },
+        {
+          turnNumber: 1,
+          incomingMessage: "deu certo?",
+          finalResponse: "Sim!",
+          timestamp: "2026-05-24T13:00:30.000Z",
+        },
+      ],
+    };
+    render(Replay, { api: buildApi(trace) });
+    replaySessionId.set("yuji__a");
+    await waitFor(() => {
+      expect(screen.getByTestId("replay-modal")).toBeDefined();
+    });
+    expect(screen.getByText("card:tabuada-7")).toBeDefined();
+    expect(screen.getByText("Vamos descobrir!")).toBeDefined();
+    expect(screen.getByText("deu certo?")).toBeDefined();
+    expect(screen.getAllByTestId("replay-turn").length).toBe(2);
+  });
+
+  it("close button reseta replaySessionId", async () => {
+    render(Replay, {
+      api: buildApi({ sessionId: "x", turns: [] }),
+    });
+    replaySessionId.set("x");
+    await waitFor(() =>
+      expect(screen.getByTestId("replay-close")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("replay-close"));
+    expect(get(replaySessionId)).toBeNull();
+  });
+
+  it("backdrop click fecha modal (click no overlay self)", async () => {
+    render(Replay, {
+      api: buildApi({ sessionId: "x", turns: [] }),
+    });
+    replaySessionId.set("x");
+    const overlay = await waitFor(() =>
+      screen.getByTestId("replay-overlay"),
+    );
+    await fireEvent.click(overlay);
+    expect(get(replaySessionId)).toBeNull();
+  });
+
+  it("Escape fecha modal", async () => {
+    render(Replay, {
+      api: buildApi({ sessionId: "x", turns: [] }),
+    });
+    replaySessionId.set("x");
+    const overlay = await waitFor(() =>
+      screen.getByTestId("replay-overlay"),
+    );
+    await fireEvent.keyDown(overlay, { key: "Escape" });
+    expect(get(replaySessionId)).toBeNull();
+  });
+
+  it("trace sem turns mostra 'Nenhum turn registrado'", async () => {
+    render(Replay, {
+      api: buildApi({ sessionId: "x", persona: "yuji", turns: [] }),
+    });
+    replaySessionId.set("x");
+    await waitFor(() => {
+      expect(screen.getByText(/Nenhum turn registrado/)).toBeDefined();
+    });
+  });
+
+  it("muda sessionId → faz nova fetch", async () => {
+    const getReplay = vi.fn(async (id: string) => ({
+      sessionId: id,
+      turns: [],
+    }));
+    const api = {
+      getStatus: vi.fn(),
+      getMode: vi.fn(),
+      setMode: vi.fn(),
+      startCardSession: vi.fn(),
+      listOptions: vi.fn(),
+      overrideSelection: vi.fn(),
+      listDecisions: vi.fn(),
+      getPendingApproval: vi.fn(),
+      approveOrEdit: vi.fn(),
+      endSession: vi.fn(),
+      listSessionLibrary: vi.fn(),
+      getSessionReplay: getReplay,
+      turnStateSseUrl: () => "/api/sse",
+    } as never;
+    render(Replay, { api });
+    replaySessionId.set("s1");
+    await waitFor(() => expect(getReplay).toHaveBeenCalledWith("s1"));
+    replaySessionId.set("s2");
+    await waitFor(() => expect(getReplay).toHaveBeenCalledWith("s2"));
+    expect(getReplay).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ebrota-console-ui/tests/components/SessionLibrary.test.ts
+++ b/packages/ebrota-console-ui/tests/components/SessionLibrary.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import SessionLibrary from "../../src/components/SessionLibrary.svelte";
+import {
+  libraryOpen,
+  replaySessionId,
+} from "../../src/lib/stores.js";
+import type {
+  ApiClient,
+  SessionLibraryEntry,
+} from "../../src/lib/api.js";
+
+const sampleEntry = (
+  overrides: Partial<SessionLibraryEntry> = {},
+): SessionLibraryEntry => ({
+  sessionId: "yuji__a",
+  personaId: "yuji",
+  conversationId: "a",
+  kind: "real",
+  startedAt: "2026-05-24T13:00:00.000Z",
+  endedAt: null,
+  turnCount: 3,
+  hasOverrides: false,
+  tracePath: "/tmp/trace.json",
+  ...overrides,
+});
+
+const buildApi = (
+  listResponse: SessionLibraryEntry[] = [],
+): ApiClient =>
+  ({
+    getStatus: vi.fn(),
+    getMode: vi.fn(),
+    setMode: vi.fn(),
+    startCardSession: vi.fn(),
+    listOptions: vi.fn(),
+    overrideSelection: vi.fn(),
+    listDecisions: vi.fn(),
+    getPendingApproval: vi.fn(),
+    approveOrEdit: vi.fn(),
+    endSession: vi.fn(),
+    listSessionLibrary: vi.fn(async () => ({ sessions: listResponse })),
+    getSessionReplay: vi.fn(),
+    turnStateSseUrl: () => "/api/sse",
+  }) as never;
+
+beforeEach(() => {
+  libraryOpen.set(true);
+  replaySessionId.set(null);
+});
+
+describe("SessionLibrary.svelte", () => {
+  it("não renderiza quando libraryOpen=false", () => {
+    libraryOpen.set(false);
+    render(SessionLibrary, { api: buildApi() });
+    expect(screen.queryByTestId("session-library")).toBeNull();
+  });
+
+  it("renderiza quando libraryOpen=true", async () => {
+    render(SessionLibrary, { api: buildApi([sampleEntry()]) });
+    await waitFor(() => {
+      expect(screen.getByTestId("library-entry")).toBeDefined();
+    });
+    // Após entry carregar, verifica content
+    const entry = screen.getByTestId("library-entry");
+    expect(entry.textContent).toContain("yuji");
+  });
+
+  it("close button seta libraryOpen=false", async () => {
+    render(SessionLibrary, { api: buildApi() });
+    await waitFor(() =>
+      expect(screen.getByTestId("session-library")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("library-close"));
+    expect(get(libraryOpen)).toBe(false);
+  });
+
+  it("filter persona dispara refresh com filters", async () => {
+    const list = vi.fn(async () => ({
+      sessions: [sampleEntry({ personaId: "kei" })],
+    }));
+    const api = buildApi();
+    (api as unknown as { listSessionLibrary: typeof list }).listSessionLibrary =
+      list;
+    render(SessionLibrary, { api });
+    await waitFor(() =>
+      expect(screen.getByTestId("filter-persona")).toBeDefined(),
+    );
+    const input = screen.getByTestId(
+      "filter-persona",
+    ) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "kei" } });
+    await fireEvent.click(screen.getByTestId("filter-apply"));
+    await new Promise<void>((r) => setTimeout(r, 30));
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ persona: "kei" }),
+    );
+  });
+
+  it("filter clear reseta inputs", async () => {
+    render(SessionLibrary, { api: buildApi() });
+    await waitFor(() =>
+      expect(screen.getByTestId("filter-clear")).toBeDefined(),
+    );
+    const input = screen.getByTestId(
+      "filter-persona",
+    ) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "yuji" } });
+    expect(input.value).toBe("yuji");
+    await fireEvent.click(screen.getByTestId("filter-clear"));
+    await new Promise<void>((r) => setTimeout(r, 20));
+    expect(input.value).toBe("");
+  });
+
+  it("entry click seta replaySessionId", async () => {
+    render(SessionLibrary, {
+      api: buildApi([sampleEntry({ sessionId: "yuji__click-test" })]),
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("library-entry")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("library-entry"));
+    expect(get(replaySessionId)).toBe("yuji__click-test");
+  });
+
+  it("badge 'overrides' renderiza pra sessões com hasOverrides", async () => {
+    render(SessionLibrary, {
+      api: buildApi([sampleEntry({ hasOverrides: true })]),
+    });
+    await waitFor(() =>
+      expect(screen.getByText("overrides")).toBeDefined(),
+    );
+  });
+
+  it("estado vazio mostra 'Nenhuma sessão'", async () => {
+    render(SessionLibrary, { api: buildApi([]) });
+    await waitFor(() => {
+      expect(screen.getByText(/Nenhuma sessão/)).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR6 entrega a **session library + replay** (S-OC-12 + S-OC-30/31/32). Permite Jun referenciar sessões anteriores durante piloto ativo, com filter+search FTS5 e replay completo de traces.

- **Stacked em:** #162 PR5
- **Issue:** [ops#1123](https://github.com/ascendimacy/ascendimacy-ops/issues/1123)

## Storage híbrido (D-OC-14 ratificado)

- **Source-of-truth**: trace JSON files em `~/ascendimacy-motor/traces/` (orchestrator escreve via trace-writer.ts)
- **SQLite índice derivado**: tabelas `sessions` + `messages_fts` FTS5 populadas no startup
- Rebuild trivial se schema mudar (re-scan filesystem)

## O que entra

### BFF (`traces-scanner.ts` + endpoints)
- `scanTraces({tracesDir, db})` recursive walk + parse trace.json → upsert sessions + FTS5
- Transaction batch pra perf + idempotent (re-scan substitui rows)
- `inferKind` heurística: sessionId começa com `sts-` → sts, senão real
- COUNT `jun_decisions` pra populate `has_overrides`
- Fail-soft: malformed JSON registra error mas continua; dir inexistente → no-op
- `GET /sessions/library?persona=&kind=&from=&to=&hasOverrides=&q=&limit=` com filtros
- `GET /sessions/:id/replay` → trace JSON full (404 se não indexado)
- CLI boot: `initDb → scanTraces → server listen`
- `EBROTA_BFF_TRACES_DIR` env override

### UI (`SessionLibrary` + `Replay` + stores)
- `libraryOpen` + `replaySessionId` writables
- `api.listSessionLibrary(filters)` + `api.getSessionReplay(id)`
- **SessionLibrary.svelte**: drawer right sidebar com filtros (persona/kind/q/hasOverrides) + list entries (persona+kind badge+turns+overrides badge) + click → seta replaySessionId
- **Replay.svelte**: modal overlay com close (button/backdrop/Escape) + fetch reactive a replaySessionId + display turns (incomingMessage user / finalResponse bot)
- Status.svelte: novo "Histórico" button toggle `libraryOpen`
- App.svelte: wireia SessionLibrary + Replay

## Decisões tomadas

1. **Storage híbrido (D-OC-14)** — trace JSON é source-of-truth (preserve transparência + git-friendly); SQLite índice = velocidade. Schema migration trauma = zero (rebuild from filesystem).
2. **Scan idempotent UPSERT** — re-scan no startup substitui rows; futuro watcher incremental pode evoluir.
3. **FTS5 tokenize unicode61** — funciona pt-br sem stemming explícito. Tradeoff: "morango" não casa "morangos" (sem stemming); aceitável V0.1.
4. **inferKind heurística** (não campo explícito no trace) — convenção sessionId prefix. Quando trace-writer adicionar field `kind`, scanner lê direto (PR follow-up).
5. **listSessionLibrary com SQL builder simples** — `where[]` array em vez de query builder; menos abstração; 50 LOC totais.
6. **Replay modal vs panel** — modal cobre 90vh, foco no replay; close via Escape/backdrop pra UX rápida. Não-disruptivo: chat feed + motor view continuam vivos por baixo (z-index).
7. **transaction batch no scan** — single tx pra todos os traces, atomic update. Falha de um trace não corrompe state.

## Verificação

- [x] `npm run build --workspace packages/ebrota-console-bff` → exit 0
- [x] `npm test --workspace packages/ebrota-console-bff` → **56 → 71** (+15 traces-scanner)
- [x] `npm run build --workspace packages/ebrota-console-ui` → bundle 53.40kB gzip 17.21kB
- [x] `npm test --workspace packages/ebrota-console-ui` → **55 → 70** (+15: 8 library + 7 replay)

## Como rodar local

```bash
# Terminal 1 — BFF (scan traces no startup)
EBROTA_BFF_USE_MOCK_DAEMON=true npm run start --workspace packages/ebrota-console-bff

# Terminal 2 — UI
npm run dev --workspace packages/ebrota-console-ui
```

`http://localhost:5173`:
1. Click "Histórico" no header — drawer abre à direita
2. Sem traces na `~/ascendimacy-motor/traces/` → lista vazia (esperado)
3. Filtros aplicáveis: persona text, kind dropdown, busca FTS5, só com overrides
4. Click entry → modal Replay abre com turns formatados
5. Escape / backdrop click / X button → fecha

## Próximo (PR7)

**S-OC-20/21/22/23** — Smoke visualizer hooks (Fase F do spec). STS scenarios + Baileys smoke imprimem `→ visualizer (live/replay)` URL clicável apontando pra eBrota Console. Workflow operacional (memory feedback ratificado Q15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)