### PR TITLE
[feat ops#1123] C-MX-08 PR7 — Smoke visualizer hooks (7/10)

### DIFF
--- a/packages/ebrota-console-bff/src/index.ts
+++ b/packages/ebrota-console-bff/src/index.ts
@@ -4,3 +4,4 @@ export * from "./db.js";
 export * from "./decisions.js";
 export * from "./server.js";
 export * from "./traces-scanner.js";
+export * from "./visualizer-url.js";

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -52,6 +52,10 @@ export interface CreateBffServerOptions {
   /** Logger desabilitado por default em testes — Fastify usa pino que
    *  polui stdout. */
   logger?: boolean;
+  /** Base URL do UI dev server pra redirect das rotas /replay /live.
+   *  Default http://localhost:5173 (vite). PR9 deploy serviria o
+   *  build estático no próprio BFF. */
+  uiBaseUrl?: string;
 }
 
 export interface BffServer {
@@ -68,6 +72,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   const fastify = Fastify({ logger: opts.logger ?? false });
   const startedAt = new Date().toISOString();
   const pollMs = opts.ssePollIntervalMs ?? 200;
+  const uiBaseUrl = opts.uiBaseUrl ?? "http://localhost:5173";
   let mode: ConsoleMode = opts.initialMode ?? "auto";
 
   // GET /status — health + observabilidade
@@ -329,6 +334,27 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
           .send({ error: `trace not found for sessionId=${req.params.id}` });
       }
       return trace;
+    },
+  );
+
+  // GET /replay/:id — visualizer deep link (S-OC-22 / Fase F). Redirect
+  // pro UI dev server com query param. Em PR9 deploy, pode servir
+  // build estático aqui mesmo. STS scenarios + Baileys smoke imprimem
+  // essa URL no output (memory feedback Q15).
+  fastify.get<{ Params: { id: string } }>(
+    "/replay/:id",
+    async (req, reply) => {
+      const target = `${uiBaseUrl}/?replay=${encodeURIComponent(req.params.id)}`;
+      return reply.redirect(target, 302);
+    },
+  );
+
+  // GET /live/:id — visualizer live deep link
+  fastify.get<{ Params: { id: string } }>(
+    "/live/:id",
+    async (req, reply) => {
+      const target = `${uiBaseUrl}/?live=${encodeURIComponent(req.params.id)}`;
+      return reply.redirect(target, 302);
     },
   );
 

--- a/packages/ebrota-console-bff/src/visualizer-url.ts
+++ b/packages/ebrota-console-bff/src/visualizer-url.ts
@@ -1,0 +1,71 @@
+/**
+ * Helper pra montar URL do visualizer (eBrota Console) — C-MX-08
+ * S-OC-20/21 (Fase F).
+ *
+ * Convenção ratificada Q15 (memory feedback): smoke runs imprimem
+ * link clicável no output. Format:
+ *   http://<host>:<bff-port>/replay/<traceId>   ← pós-mortem
+ *   http://<host>:<bff-port>/live/<sessionId>   ← sessão ativa
+ *
+ * BFF tem rotas que redirecionam pro UI dev server ou servem o build
+ * estático (PR9+). Pure helper — caller (Baileys smoke, STS, etc.)
+ * usa standalone sem dep de Fastify/runtime.
+ */
+
+export type VisualizerKind = "live" | "replay";
+
+export interface VisualizerUrlOptions {
+  /** Default 'localhost' — caller pode override pra deploy. */
+  host?: string;
+  /** Default 3737 (D-OC-02). */
+  port?: number;
+  /** Default 'http'. */
+  protocol?: "http" | "https";
+}
+
+/**
+ * Monta URL canônica do visualizer. Sem side-effects, sem fetch.
+ * Caller imprime no output do script smoke.
+ */
+export function formatVisualizerUrl(
+  kind: VisualizerKind,
+  id: string,
+  opts: VisualizerUrlOptions = {},
+): string {
+  const host = opts.host ?? "localhost";
+  const port = opts.port ?? 3737;
+  const protocol = opts.protocol ?? "http";
+  const encodedId = encodeURIComponent(id);
+  return `${protocol}://${host}:${port}/${kind}/${encodedId}`;
+}
+
+/**
+ * Helper de print pra scripts smoke. Loga em stderr (stdout reservado
+ * pra JSON-RPC quando relevante). Inclui hint sobre BFF offline.
+ *
+ * Exemplo de output:
+ *   [smoke] → visualizer (live): http://localhost:3737/live/yuji__conv-1
+ *   [smoke]   (se BFF não estiver rodando, abra o link após:
+ *              npm run start --workspace packages/ebrota-console-bff)
+ */
+export function printVisualizerLink(
+  kind: VisualizerKind,
+  id: string,
+  opts: VisualizerUrlOptions & {
+    /** Prefixo de log (ex: "[smoke]"). Default vazio. */
+    prefix?: string;
+    /** Custom writer (default process.stderr.write). */
+    write?: (msg: string) => void;
+  } = {},
+): string {
+  const url = formatVisualizerUrl(kind, id, opts);
+  const prefix = opts.prefix ?? "";
+  const write = opts.write ?? ((m: string) => process.stderr.write(m));
+  const label = kind === "live" ? "live" : "replay";
+  write(`${prefix}→ visualizer (${label}): ${url}\n`);
+  write(
+    `${prefix}  (se BFF não estiver rodando: ` +
+      `npm run start --workspace packages/ebrota-console-bff)\n`,
+  );
+  return url;
+}

--- a/packages/ebrota-console-bff/tests/server-visualizer.test.ts
+++ b/packages/ebrota-console-bff/tests/server-visualizer.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+let server: BffServer;
+let db: DatabaseType;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  server = createBffServer({
+    daemon,
+    db,
+    logger: false,
+    uiBaseUrl: "http://localhost:5173",
+  });
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+describe("GET /replay/:id — redirect pro UI", () => {
+  it("302 redirect com query ?replay=ID", async () => {
+    const res = await server.fastify.inject({
+      method: "GET",
+      url: "/replay/yuji__a",
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["location"]).toBe(
+      "http://localhost:5173/?replay=yuji__a",
+    );
+  });
+
+  it("encoda sessionId com special chars", async () => {
+    const res = await server.fastify.inject({
+      method: "GET",
+      url: "/replay/yuji__5511%40s.whatsapp.net",
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["location"]).toContain(
+      "%40s.whatsapp.net",
+    );
+  });
+});
+
+describe("GET /live/:id — redirect pro UI", () => {
+  it("302 redirect com query ?live=ID", async () => {
+    const res = await server.fastify.inject({
+      method: "GET",
+      url: "/live/sess-x",
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["location"]).toBe(
+      "http://localhost:5173/?live=sess-x",
+    );
+  });
+});
+
+describe("uiBaseUrl custom (deploy ou test override)", () => {
+  it("respeita opts.uiBaseUrl", async () => {
+    await server.close();
+    const daemon = createMockDaemonClient();
+    server = createBffServer({
+      daemon,
+      db: initDb({ dbPath: ":memory:" }),
+      logger: false,
+      uiBaseUrl: "https://console.ebrota.example.com",
+    });
+    const res = await server.fastify.inject({
+      method: "GET",
+      url: "/replay/x",
+    });
+    expect(res.headers["location"]).toBe(
+      "https://console.ebrota.example.com/?replay=x",
+    );
+  });
+});

--- a/packages/ebrota-console-bff/tests/visualizer-url.test.ts
+++ b/packages/ebrota-console-bff/tests/visualizer-url.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  formatVisualizerUrl,
+  printVisualizerLink,
+} from "../src/visualizer-url.js";
+
+describe("formatVisualizerUrl", () => {
+  it("default localhost:3737 http", () => {
+    expect(formatVisualizerUrl("replay", "yuji__a")).toBe(
+      "http://localhost:3737/replay/yuji__a",
+    );
+    expect(formatVisualizerUrl("live", "sess-x")).toBe(
+      "http://localhost:3737/live/sess-x",
+    );
+  });
+
+  it("override host + port + protocol", () => {
+    expect(
+      formatVisualizerUrl("replay", "x", {
+        host: "ebrota.example.com",
+        port: 443,
+        protocol: "https",
+      }),
+    ).toBe("https://ebrota.example.com:443/replay/x");
+  });
+
+  it("encoda sessionId com chars especiais", () => {
+    expect(
+      formatVisualizerUrl("live", "yuji__5511aaa@s.whatsapp.net"),
+    ).toBe(
+      "http://localhost:3737/live/yuji__5511aaa%40s.whatsapp.net",
+    );
+  });
+});
+
+describe("printVisualizerLink", () => {
+  it("imprime URL + warning hint no writer injetado", () => {
+    const writes: string[] = [];
+    const url = printVisualizerLink("replay", "sess-1", {
+      write: (m) => writes.push(m),
+    });
+    expect(url).toBe("http://localhost:3737/replay/sess-1");
+    expect(writes.join("")).toContain("→ visualizer (replay):");
+    expect(writes.join("")).toContain("http://localhost:3737/replay/sess-1");
+    expect(writes.join("")).toContain("se BFF não estiver rodando");
+  });
+
+  it("prefix custom aplicado em ambas as linhas", () => {
+    const writes: string[] = [];
+    printVisualizerLink("live", "x", {
+      prefix: "[smoke] ",
+      write: (m) => writes.push(m),
+    });
+    expect(writes[0]).toMatch(/^\[smoke\] → visualizer/);
+    expect(writes[1]?.startsWith("[smoke] ")).toBe(true);
+    expect(writes[1]).toContain("(se BFF");
+  });
+
+  it("default writer escreve em stderr (sem trash console.log)", () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
+      () => true as never,
+    );
+    printVisualizerLink("live", "x");
+    expect(stderrSpy).toHaveBeenCalled();
+    stderrSpy.mockRestore();
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -8,11 +8,19 @@
   import SessionLibrary from "./components/SessionLibrary.svelte";
   import Replay from "./components/Replay.svelte";
   import { createApiClient } from "./lib/api.js";
-  import { bffStatus, consoleMode, globalError } from "./lib/stores.js";
+  import {
+    bffStatus,
+    consoleMode,
+    currentSessionId,
+    globalError,
+    libraryOpen,
+    replaySessionId,
+  } from "./lib/stores.js";
   import {
     startTurnStateStream,
     type TurnStateStreamManager,
   } from "./lib/turn-state-stream.js";
+  import { parseUrlParams } from "./lib/url-params.js";
 
   const api = createApiClient();
   const STATUS_POLL_INTERVAL_MS = 2000;
@@ -33,7 +41,26 @@
     }
   }
 
+  /**
+   * Aplica deep links de visualizer (S-OC-22 / Fase F): ?replay=ID ou
+   * ?live=ID. Convenção: BFF redireciona /replay/:id ou /live/:id pra
+   * UI com esses params. parseUrlParams() é pure helper testável.
+   */
+  function applyUrlParams(): void {
+    if (typeof window === "undefined") return;
+    const { replaySessionId: r, liveSessionId: l } = parseUrlParams(
+      window.location.search,
+    );
+    if (r !== null) {
+      replaySessionId.set(r);
+      libraryOpen.set(false);
+    } else if (l !== null) {
+      currentSessionId.set(l);
+    }
+  }
+
   onMount(() => {
+    applyUrlParams();
     void refreshStatus();
     pollTimer = setInterval(() => {
       void refreshStatus();

--- a/packages/ebrota-console-ui/src/lib/url-params.ts
+++ b/packages/ebrota-console-ui/src/lib/url-params.ts
@@ -1,0 +1,32 @@
+/**
+ * Parse de URL query params pra deep links do smoke visualizer
+ * (S-OC-22 / Fase F C-MX-08).
+ *
+ * Convenção: BFF /replay/:id e /live/:id redirecionam pro UI com
+ * ?replay=ID ou ?live=ID. UI lê no mount + atualiza stores
+ * apropriadas.
+ *
+ * Pure function pra testabilidade — App.svelte chama on mount com
+ * window.location.search.
+ */
+
+export interface UrlParamsResult {
+  /** sessionId pra abrir replay modal. */
+  replaySessionId: string | null;
+  /** sessionId pra setar como currentSessionId (live SSE). */
+  liveSessionId: string | null;
+}
+
+export function parseUrlParams(search: string): UrlParamsResult {
+  const params = new URLSearchParams(search);
+  const replay = params.get("replay");
+  const live = params.get("live");
+  // Replay tem precedência sobre live se ambos presentes (mais explicit).
+  if (typeof replay === "string" && replay.length > 0) {
+    return { replaySessionId: replay, liveSessionId: null };
+  }
+  if (typeof live === "string" && live.length > 0) {
+    return { replaySessionId: null, liveSessionId: live };
+  }
+  return { replaySessionId: null, liveSessionId: null };
+}

--- a/packages/ebrota-console-ui/tests/url-params.test.ts
+++ b/packages/ebrota-console-ui/tests/url-params.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { parseUrlParams } from "../src/lib/url-params.js";
+
+describe("parseUrlParams — S-OC-22 smoke visualizer deep links", () => {
+  it("?replay=ID retorna replaySessionId", () => {
+    expect(parseUrlParams("?replay=yuji__abc")).toEqual({
+      replaySessionId: "yuji__abc",
+      liveSessionId: null,
+    });
+  });
+
+  it("?live=ID retorna liveSessionId", () => {
+    expect(parseUrlParams("?live=sess-live-1")).toEqual({
+      replaySessionId: null,
+      liveSessionId: "sess-live-1",
+    });
+  });
+
+  it("search vazio retorna ambos null", () => {
+    expect(parseUrlParams("")).toEqual({
+      replaySessionId: null,
+      liveSessionId: null,
+    });
+  });
+
+  it("?replay= (vazio) é ignorado", () => {
+    expect(parseUrlParams("?replay=")).toEqual({
+      replaySessionId: null,
+      liveSessionId: null,
+    });
+  });
+
+  it("?replay=ID precedence sobre ?live=ID (replay wins)", () => {
+    expect(parseUrlParams("?replay=r1&live=l1")).toEqual({
+      replaySessionId: "r1",
+      liveSessionId: null,
+    });
+  });
+
+  it("decoda sessionId encoded", () => {
+    expect(
+      parseUrlParams("?replay=yuji__5511%40s.whatsapp.net"),
+    ).toEqual({
+      replaySessionId: "yuji__5511@s.whatsapp.net",
+      liveSessionId: null,
+    });
+  });
+
+  it("ignora outros params irrelevantes", () => {
+    expect(parseUrlParams("?foo=bar&replay=x&baz=qux")).toEqual({
+      replaySessionId: "x",
+      liveSessionId: null,
+    });
+  });
+});

--- a/packages/motor-channels/scripts/baileys-qr-scan.mjs
+++ b/packages/motor-channels/scripts/baileys-qr-scan.mjs
@@ -42,11 +42,27 @@ channel.onQrCode((qr) => {
   qrcode.generate(qr, { small: true });
 });
 
+// C-MX-08 S-OC-21: visualizer URL convention (memory feedback Q15).
+// Print após connect pra Jun abrir o eBrota Console + ver sessões
+// chegando. URL aponta pro BFF (default 3737) que redireciona pro UI.
+const visualizerBaseUrl = `http://localhost:${
+  process.env["EBROTA_BFF_PORT"] ?? "3737"
+}`;
+
 channel.onConnectionChange((ev) => {
   if (ev.connected) {
     console.log(
       `\n[baileys-qr-scan] ✅ conectado às ${ev.timestamp}. ` +
         `aguardando primeira mensagem inbound...`,
+    );
+    console.log(
+      `[baileys-qr-scan] → visualizer: ${visualizerBaseUrl}/ ` +
+        `(abra pra ver sessões via Histórico)`,
+    );
+    console.log(
+      `[baileys-qr-scan]   (se BFF offline: ` +
+        `EBROTA_BFF_USE_MOCK_DAEMON=true npm run start ` +
+        `--workspace packages/ebrota-console-bff)`,
     );
   } else {
     console.log(
@@ -60,6 +76,13 @@ channel.onMessage((msg) => {
     `\n[baileys-qr-scan] 📥 mensagem recebida de ${msg.from}:\n` +
       `    text: "${msg.text}"\n` +
       `    timestamp: ${msg.timestamp}\n`,
+  );
+  // Live deep-link — convenção sessionId quando daemon real spawnar
+  // sessão será `<persona>__<conversationId>`. Em smoke standalone
+  // (sem daemon), o link redireciona pro UI mas não há sessão ativa
+  // até daemon estar wired. Operador pode abrir e usar Histórico.
+  console.log(
+    `[baileys-qr-scan] → visualizer (live): ${visualizerBaseUrl}/live/${encodeURIComponent(msg.conversationId)}`,
   );
   console.log("[baileys-qr-scan] smoke OK. Ctrl+C pra encerrar.");
 });


### PR DESCRIPTION
## Summary

PR7 entrega **Fase F do spec** (S-OC-20/21/22/23). STS scenarios + Baileys smoke imprimem `→ visualizer URL` clicável apontando pro eBrota Console; URL chega no BFF (3737) que redireciona pro UI com query param `?replay=ID` ou `?live=ID`. Workflow operacional ratificado (memory feedback Q15).

- **Stacked em:** #163 PR6
- **Issue:** [ops#1123](https://github.com/ascendimacy/ascendimacy-ops/issues/1123)

## Format do link

```
http://localhost:3737/replay/<sessionId>   ← pós-mortem (trace JSON)
http://localhost:3737/live/<sessionId>     ← sessão ativa (SSE)
```

BFF intercepta + 302 redirect pra `<uiBaseUrl>/?replay=...` ou `?live=...`. UI parsa query no mount + aplica state.

## O que entra

### BFF (`visualizer-url.ts` + routes)
- `formatVisualizerUrl(kind, id, opts?)` pure helper — host/port/protocol overridable
- `printVisualizerLink` helper pra scripts smoke imprimirem URL em stderr com warning sobre BFF offline
- `GET /replay/:id` → 302 redirect `<uiBaseUrl>/?replay=<id>`
- `GET /live/:id` → 302 redirect `<uiBaseUrl>/?live=<id>`
- `uiBaseUrl` configurável (default `http://localhost:5173` dev vite)

### UI (`url-params.ts`)
- `parseUrlParams(search)` pure → `{replaySessionId, liveSessionId}` (replay precedence se ambos)
- App.svelte `onMount` aplica params: `?replay=ID` abre modal + fecha library; `?live=ID` seta currentSessionId (SSE conecta auto)

### motor-channels (`baileys-qr-scan.mjs`)
- Após connect: imprime URL root do visualizer + hint se BFF offline
- Após cada inbound: imprime `/live/<conversationId>` deep link
- `EBROTA_BFF_PORT` env respeitado

## Decisões tomadas

1. **Pure helper extraído (`parseUrlParams`)** — testável sem mexer com `window.location` em jsdom (Object.defineProperty causa issues). App.svelte chama no mount com `window.location.search`.
2. **Replay precedence sobre live** — se ambos params presentes, replay vence. Mais explícito (operador pediu replay).
3. **302 redirect** em vez de servir UI estático no BFF — em dev, vite serve UI; em prod (PR9), BFF pode servir build.
4. **printVisualizerLink em stderr** — não polui stdout (reservado pra JSON-RPC futuro). Stack consistente com daemon-smoke.mjs do C-MX-07 PR7.
5. **Baileys script duplica visualizerBaseUrl inline** — evita cross-workspace dep entre motor-channels e ebrota-console-bff. ~3 linhas duplicadas; trade-off aceito.
6. **STS scenarios não tocados em PR7** — STS lives em `~/ascendimacy-sts/` (repo separado). Pattern documentado pra adopção quando harness fizer ajuste; convenção idêntica ao Baileys smoke.

## Verificação

- [x] `npm run build --workspace packages/ebrota-console-bff` → exit 0
- [x] `npm test --workspace packages/ebrota-console-bff` → **71 → 82** (+11)
- [x] `npm run build --workspace packages/ebrota-console-ui` → bundle 53.83kB gzip 17.35kB
- [x] `npm test --workspace packages/ebrota-console-ui` → **70 → 77** (+7)
- [x] `npm test --workspace packages/motor-channels` → ainda 95/95 (smoke script não testado em CI; manual smoke pelo Jun)

## Como rodar local

```bash
# Terminal 1 — BFF
EBROTA_BFF_USE_MOCK_DAEMON=true npm run start --workspace packages/ebrota-console-bff

# Terminal 2 — UI
npm run dev --workspace packages/ebrota-console-ui
```

Testar deep links manualmente:
- `http://localhost:3737/replay/some-session-id` → redireciona pra `http://localhost:5173/?replay=some-session-id` → abre modal replay
- `http://localhost:3737/live/sess-1` → redireciona + seta currentSessionId (SSE conecta)

Smoke Baileys (precisa scan QR e mensagem real):
```bash
node packages/motor-channels/scripts/baileys-qr-scan.mjs
# → após connect: "→ visualizer: http://localhost:3737/"
# → após inbound: "→ visualizer (live): http://localhost:3737/live/<jid>"
```

## Próximo (PR8)

**Fase G parcial (S-OC-24..29)** — Debug mode tail: LLM prompt inspection panel. Hook em `gateway-client.ts` (shared workspace) emite `llm_call_pending` events; UI Debug Panel mostra prompts cronológicos com provider+model badge. Tail-only (passive) per ratificação Q11; gate mode V0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)