### PR TITLE
[feat ops#1123] C-MX-08 PR8 — Debug mode tail (8/10)

### DIFF
--- a/packages/ebrota-console-bff/src/debug-events.ts
+++ b/packages/ebrota-console-bff/src/debug-events.ts
@@ -1,0 +1,153 @@
+/**
+ * Ring buffer in-memory + helpers pra LLM call events — S-OC-24/25/29
+ * (Fase G parcial / tail mode).
+ *
+ * shared/gateway-client.ts (consumer) emite events via POST quando
+ * `ASC_LLM_DEBUG_MODE=true`. PR8 entrega a infraestrutura no BFF; o
+ * hook real em gateway-client é PR follow-up (shared workspace é
+ * mais invasivo).
+ *
+ * V0.1 = tail-only (Q11 ratificado): emit + UI mostra. Sem pausa,
+ * sem gate. Gate mode (pausa pra Jun aprovar cada call) fica V0.2.
+ *
+ * Memória apenas — prompts NÃO persistem em SQLite por default
+ * (D-OC-13 LGPD). Telemetry de actions agregadas em debug_actions
+ * (sem prompt content).
+ */
+
+import type { Database as DatabaseType } from "better-sqlite3";
+
+/** Provider conhecido — usado pra colorir badge no UI. */
+export type LlmProvider = "anthropic" | "infomaniak" | "local" | "unknown";
+
+export interface LlmCallEventPayload {
+  /** Step pedagógico (assessor, planejador, drota, etc.) */
+  step: string;
+  provider: LlmProvider;
+  model: string;
+  /** Prompt como objeto estruturado — system/user/assistant prefill etc. */
+  prompt: {
+    system?: string;
+    user?: string;
+    assistantPrefill?: string;
+    /** Texto raw pra display rápida quando structure não está disponível. */
+    raw?: string;
+  };
+  params?: {
+    temperature?: number;
+    maxTokens?: number;
+    [key: string]: unknown;
+  };
+  /** sessionId que originou a call (se disponível). */
+  sessionId?: string;
+  /** Turn number da sessão. */
+  turn?: number;
+}
+
+export interface LlmCallEvent extends LlmCallEventPayload {
+  /** Index sequencial (monotônico) — caller passa `sinceId` pra paginar. */
+  id: number;
+  /** ISO 8601 — quando BFF recebeu. */
+  receivedAt: string;
+}
+
+export const DEBUG_EVENTS_BUFFER_CAP = 200;
+
+export interface DebugEventsStore {
+  /** Adiciona event ao buffer. Cap respeitado (FIFO eviction). */
+  push(payload: LlmCallEventPayload): LlmCallEvent;
+  /** Pega events com id > sinceId. */
+  since(sinceId: number): LlmCallEvent[];
+  /** Snapshot completo (top latest, capped). */
+  snapshot(): LlmCallEvent[];
+  /** Limpa buffer. */
+  clear(): void;
+  /** Total emitido desde init (não cap-bounded). */
+  totalEmitted(): number;
+}
+
+export function createDebugEventsStore(opts: {
+  /** Override clock pra testes. */
+  now?: () => string;
+  /** Cap override. Default DEBUG_EVENTS_BUFFER_CAP. */
+  cap?: number;
+} = {}): DebugEventsStore {
+  const now = opts.now ?? (() => new Date().toISOString());
+  const cap = opts.cap ?? DEBUG_EVENTS_BUFFER_CAP;
+  let buffer: LlmCallEvent[] = [];
+  let nextId = 1;
+  let total = 0;
+
+  return {
+    push(payload) {
+      const event: LlmCallEvent = {
+        id: nextId++,
+        receivedAt: now(),
+        ...payload,
+      };
+      buffer.push(event);
+      total += 1;
+      if (buffer.length > cap) {
+        buffer = buffer.slice(-cap);
+      }
+      return event;
+    },
+    since(sinceId) {
+      return buffer.filter((e) => e.id > sinceId);
+    },
+    snapshot() {
+      return [...buffer];
+    },
+    clear() {
+      buffer = [];
+    },
+    totalEmitted() {
+      return total;
+    },
+  };
+}
+
+/** Telemetry de actions debug (S-OC-29) — agregada, SEM prompt content
+ *  (LGPD; prompts ficam só em memória). Caller pode logar
+ *  approve/edit/cancel/swap actions em debug_actions table. */
+export interface RecordDebugActionInput {
+  sessionId: string;
+  llmCallId?: string;
+  action: "tail" | "approve" | "edit" | "cancel" | "swap" | "bypass";
+  /** SHA-256 ou similar (não plaintext). */
+  originalPromptHash?: string;
+  editedPromptHash?: string;
+  swapTo?: string;
+  rationale?: string;
+}
+
+export function recordDebugAction(
+  db: DatabaseType,
+  input: RecordDebugActionInput,
+  now: () => string = () => new Date().toISOString(),
+): { id: number } | { error: string } {
+  try {
+    const stmt = db.prepare(`
+      INSERT INTO debug_actions (
+        session_id, llm_call_id, action, original_prompt_hash,
+        edited_prompt_hash, swap_to, rationale, recorded_at
+      ) VALUES (
+        @sessionId, @llmCallId, @action, @originalPromptHash,
+        @editedPromptHash, @swapTo, @rationale, @recordedAt
+      )
+    `);
+    const result = stmt.run({
+      sessionId: input.sessionId,
+      llmCallId: input.llmCallId ?? null,
+      action: input.action,
+      originalPromptHash: input.originalPromptHash ?? null,
+      editedPromptHash: input.editedPromptHash ?? null,
+      swapTo: input.swapTo ?? null,
+      rationale: input.rationale ?? null,
+      recordedAt: now(),
+    });
+    return { id: Number(result.lastInsertRowid) };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/ebrota-console-bff/src/index.ts
+++ b/packages/ebrota-console-bff/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types.js";
 export * from "./daemon-client.js";
 export * from "./db.js";
+export * from "./debug-events.js";
 export * from "./decisions.js";
 export * from "./server.js";
 export * from "./traces-scanner.js";

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -39,6 +39,12 @@ import {
   readSessionTrace,
   type SessionLibraryFilters,
 } from "./traces-scanner.js";
+import {
+  createDebugEventsStore,
+  recordDebugAction,
+  type DebugEventsStore,
+  type LlmCallEventPayload,
+} from "./debug-events.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -62,6 +68,8 @@ export interface BffServer {
   readonly fastify: FastifyInstance;
   /** Modo corrente — leitura sync; PATCH via endpoint /mode. */
   getMode(): ConsoleMode;
+  /** Debug events store pra teste/injection. */
+  readonly debugEvents: DebugEventsStore;
   /** Inicia o servidor escutando na porta. */
   listen(port: number, host?: string): Promise<void>;
   /** Fecha o servidor (graceful). */
@@ -73,6 +81,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   const startedAt = new Date().toISOString();
   const pollMs = opts.ssePollIntervalMs ?? 200;
   const uiBaseUrl = opts.uiBaseUrl ?? "http://localhost:5173";
+  const debugEvents = createDebugEventsStore();
   let mode: ConsoleMode = opts.initialMode ?? "auto";
 
   // GET /status — health + observabilidade
@@ -358,6 +367,79 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
     },
   );
 
+  // POST /debug/llm-calls — gateway-client (futuro hook) ou tests
+  // publicam events. body = LlmCallEventPayload.
+  fastify.post<{ Body: LlmCallEventPayload }>(
+    "/debug/llm-calls",
+    async (req, reply) => {
+      const body = req.body;
+      if (
+        body === undefined ||
+        typeof body.step !== "string" ||
+        typeof body.provider !== "string" ||
+        typeof body.model !== "string" ||
+        typeof body.prompt !== "object"
+      ) {
+        return reply.code(400).send({
+          error: "campos obrigatórios: step, provider, model, prompt",
+        });
+      }
+      const event = debugEvents.push(body);
+      return { id: event.id, receivedAt: event.receivedAt };
+    },
+  );
+
+  // GET /debug/llm-calls?sinceId=N — UI polling
+  fastify.get<{ Querystring: { sinceId?: string } }>(
+    "/debug/llm-calls",
+    async (req) => {
+      const sinceId =
+        req.query.sinceId !== undefined
+          ? Number(req.query.sinceId)
+          : 0;
+      const events = debugEvents.since(Number.isNaN(sinceId) ? 0 : sinceId);
+      return {
+        events,
+        totalEmitted: debugEvents.totalEmitted(),
+      };
+    },
+  );
+
+  // DELETE /debug/llm-calls — clear buffer (dev utility)
+  fastify.delete("/debug/llm-calls", async () => {
+    debugEvents.clear();
+    return { cleared: true };
+  });
+
+  // POST /debug/actions — log telemetry de actions (S-OC-29)
+  fastify.post<{
+    Body: {
+      sessionId: string;
+      llmCallId?: string;
+      action: "tail" | "approve" | "edit" | "cancel" | "swap" | "bypass";
+      originalPromptHash?: string;
+      editedPromptHash?: string;
+      swapTo?: string;
+      rationale?: string;
+    };
+  }>("/debug/actions", async (req, reply) => {
+    const body = req.body;
+    if (
+      body === undefined ||
+      typeof body.sessionId !== "string" ||
+      typeof body.action !== "string"
+    ) {
+      return reply.code(400).send({
+        error: "campos obrigatórios: sessionId, action",
+      });
+    }
+    const result = recordDebugAction(opts.db, body);
+    if ("error" in result) {
+      return reply.code(500).send({ error: result.error });
+    }
+    return { id: result.id };
+  });
+
   // POST /sessions/:id/end — endSession
   fastify.post<{ Params: { id: string } }>(
     "/sessions/:id/end",
@@ -367,6 +449,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   return {
     fastify,
     getMode: () => mode,
+    debugEvents,
     async listen(port, host = "127.0.0.1") {
       await fastify.listen({ port, host });
     },

--- a/packages/ebrota-console-bff/tests/debug-events.test.ts
+++ b/packages/ebrota-console-bff/tests/debug-events.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import {
+  createDebugEventsStore,
+  recordDebugAction,
+  type LlmCallEventPayload,
+} from "../src/debug-events.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+const samplePayload = (): LlmCallEventPayload => ({
+  step: "planejador.plan_turn",
+  provider: "anthropic",
+  model: "claude-opus-4",
+  prompt: {
+    system: "You are Brota...",
+    user: "card:tabuada-7",
+  },
+  params: { temperature: 0.7, maxTokens: 800 },
+  sessionId: "yuji__a",
+  turn: 0,
+});
+
+describe("createDebugEventsStore", () => {
+  it("push retorna event com id + receivedAt", () => {
+    const store = createDebugEventsStore({
+      now: () => "2026-05-24T13:00:00.000Z",
+    });
+    const ev = store.push(samplePayload());
+    expect(ev.id).toBe(1);
+    expect(ev.receivedAt).toBe("2026-05-24T13:00:00.000Z");
+    expect(ev.step).toBe("planejador.plan_turn");
+  });
+
+  it("id incrementa monotonicamente", () => {
+    const store = createDebugEventsStore();
+    expect(store.push(samplePayload()).id).toBe(1);
+    expect(store.push(samplePayload()).id).toBe(2);
+    expect(store.push(samplePayload()).id).toBe(3);
+  });
+
+  it("since retorna events com id > sinceId", () => {
+    const store = createDebugEventsStore();
+    store.push(samplePayload());
+    store.push(samplePayload());
+    store.push(samplePayload());
+    expect(store.since(0)).toHaveLength(3);
+    expect(store.since(1)).toHaveLength(2);
+    expect(store.since(3)).toHaveLength(0);
+  });
+
+  it("cap respeitado, eviction FIFO", () => {
+    const store = createDebugEventsStore({ cap: 3 });
+    store.push(samplePayload());
+    store.push(samplePayload());
+    store.push(samplePayload());
+    store.push(samplePayload());
+    store.push(samplePayload());
+    expect(store.snapshot()).toHaveLength(3);
+    expect(store.snapshot()[0]!.id).toBe(3);
+    expect(store.snapshot()[2]!.id).toBe(5);
+    expect(store.totalEmitted()).toBe(5);
+  });
+
+  it("clear esvazia buffer mas total preserva", () => {
+    const store = createDebugEventsStore();
+    store.push(samplePayload());
+    store.push(samplePayload());
+    store.clear();
+    expect(store.snapshot()).toHaveLength(0);
+    expect(store.totalEmitted()).toBe(2);
+  });
+});
+
+describe("recordDebugAction", () => {
+  let db: DatabaseType;
+
+  beforeEach(() => {
+    db = initDb({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("persiste action em debug_actions", () => {
+    const res = recordDebugAction(db, {
+      sessionId: "s1",
+      action: "tail",
+      llmCallId: "1",
+      originalPromptHash: "abc123",
+    });
+    expect("id" in res).toBe(true);
+    const row = db
+      .prepare("SELECT * FROM debug_actions WHERE id = ?")
+      .get(("id" in res ? res.id : 0)) as Record<string, unknown>;
+    expect(row["session_id"]).toBe("s1");
+    expect(row["action"]).toBe("tail");
+  });
+
+  it("action constraint enforced via schema (qualquer string aceita; check no schema é por CHECK lógico)", () => {
+    // Schema tem CHECK pra junreddecision; debug_actions não. Apenas
+    // verificamos que NULL é OK pra campos opcionais.
+    const res = recordDebugAction(db, {
+      sessionId: "s2",
+      action: "approve",
+    });
+    expect("id" in res).toBe(true);
+  });
+});
+
+describe("BFF debug endpoints", () => {
+  let server: BffServer;
+  let db: DatabaseType;
+
+  beforeEach(() => {
+    db = initDb({ dbPath: ":memory:" });
+    server = createBffServer({
+      daemon: createMockDaemonClient(),
+      db,
+      logger: false,
+    });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  const inject = async (method: "GET" | "POST" | "DELETE", url: string, payload?: unknown) => {
+    const res = await server.fastify.inject({
+      method,
+      url,
+      ...(payload !== undefined ? { payload } : {}),
+    });
+    return {
+      status: res.statusCode,
+      body: res.body ? (JSON.parse(res.body) as unknown) : null,
+    };
+  };
+
+  it("POST /debug/llm-calls push event + retorna id", async () => {
+    const res = await inject("POST", "/debug/llm-calls", samplePayload());
+    expect(res.status).toBe(200);
+    expect((res.body as { id: number }).id).toBe(1);
+  });
+
+  it("POST /debug/llm-calls 400 sem campos obrigatórios", async () => {
+    const res = await inject("POST", "/debug/llm-calls", { step: "x" });
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /debug/llm-calls retorna snapshot + totalEmitted", async () => {
+    await inject("POST", "/debug/llm-calls", samplePayload());
+    await inject("POST", "/debug/llm-calls", samplePayload());
+    const res = await inject("GET", "/debug/llm-calls");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      events: Array<{ id: number }>;
+      totalEmitted: number;
+    };
+    expect(body.events).toHaveLength(2);
+    expect(body.totalEmitted).toBe(2);
+  });
+
+  it("GET /debug/llm-calls?sinceId=N filtra", async () => {
+    await inject("POST", "/debug/llm-calls", samplePayload());
+    await inject("POST", "/debug/llm-calls", samplePayload());
+    const res = await inject("GET", "/debug/llm-calls?sinceId=1");
+    const body = res.body as { events: unknown[] };
+    expect(body.events).toHaveLength(1);
+  });
+
+  it("DELETE /debug/llm-calls limpa buffer", async () => {
+    await inject("POST", "/debug/llm-calls", samplePayload());
+    await inject("DELETE", "/debug/llm-calls");
+    const res = await inject("GET", "/debug/llm-calls");
+    expect((res.body as { events: unknown[] }).events).toHaveLength(0);
+  });
+
+  it("POST /debug/actions persiste em debug_actions", async () => {
+    const res = await inject("POST", "/debug/actions", {
+      sessionId: "s1",
+      action: "tail",
+      llmCallId: "5",
+    });
+    expect(res.status).toBe(200);
+    const row = db
+      .prepare(
+        "SELECT * FROM debug_actions WHERE session_id = 's1'",
+      )
+      .get() as { action: string } | undefined;
+    expect(row?.action).toBe("tail");
+  });
+
+  it("POST /debug/actions 400 sem sessionId ou action", async () => {
+    const res = await inject("POST", "/debug/actions", {});
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -7,6 +7,7 @@
   import ApprovalGate from "./components/ApprovalGate.svelte";
   import SessionLibrary from "./components/SessionLibrary.svelte";
   import Replay from "./components/Replay.svelte";
+  import DebugPanel from "./components/DebugPanel.svelte";
   import { createApiClient } from "./lib/api.js";
   import {
     bffStatus,
@@ -94,6 +95,7 @@
 
   <SessionLibrary {api} />
   <Replay {api} />
+  <DebugPanel {api} />
 
   <footer>
     <p class="muted">

--- a/packages/ebrota-console-ui/src/components/DebugPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/DebugPanel.svelte
@@ -1,0 +1,436 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import {
+    debugLlmEvents,
+    debugPanelOpen,
+    globalError,
+  } from "../lib/stores.js";
+  import type { ApiClient, DebugLlmCallEvent } from "../lib/api.js";
+
+  export let api: ApiClient;
+  /** Polling ms — V0.1 tail mode. Default 500ms (debug = passive,
+   *  não NFR-critical). */
+  export let pollIntervalMs = 500;
+
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let lastSeenId = 0;
+  let expandedIds = new Set<number>();
+  let totalEmitted = 0;
+
+  $: open = $debugPanelOpen;
+  $: events = $debugLlmEvents;
+
+  async function fetchEvents(): Promise<void> {
+    try {
+      const res = await api.listDebugLlmCalls(lastSeenId);
+      if (res.events.length > 0) {
+        debugLlmEvents.update((prev) => [...prev, ...res.events]);
+        lastSeenId = res.events[res.events.length - 1]!.id;
+      }
+      totalEmitted = res.totalEmitted;
+    } catch (err) {
+      void err;
+    }
+  }
+
+  $: if (open && pollTimer === undefined) {
+    void fetchEvents();
+    pollTimer = setInterval(() => void fetchEvents(), pollIntervalMs);
+  }
+
+  $: if (!open && pollTimer !== undefined) {
+    clearInterval(pollTimer);
+    pollTimer = undefined;
+  }
+
+  onMount(() => {
+    if (open) {
+      void fetchEvents();
+      pollTimer = setInterval(() => void fetchEvents(), pollIntervalMs);
+    }
+  });
+
+  onDestroy(() => {
+    if (pollTimer !== undefined) clearInterval(pollTimer);
+  });
+
+  function toggleExpanded(id: number): void {
+    if (expandedIds.has(id)) {
+      expandedIds.delete(id);
+    } else {
+      expandedIds.add(id);
+    }
+    expandedIds = new Set(expandedIds);
+  }
+
+  async function clearAll(): Promise<void> {
+    try {
+      await api.clearDebugLlmCalls();
+      debugLlmEvents.set([]);
+      lastSeenId = 0;
+      expandedIds.clear();
+      expandedIds = new Set();
+    } catch (err) {
+      globalError.set(
+        `Clear debug falhou: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  function providerColor(provider: DebugLlmCallEvent["provider"]): string {
+    switch (provider) {
+      case "anthropic":
+        return "anthropic";
+      case "infomaniak":
+        return "infomaniak";
+      case "local":
+        return "local";
+      default:
+        return "unknown";
+    }
+  }
+
+  /** Token estimate rough (~4 chars/token). */
+  function estimateTokens(event: DebugLlmCallEvent): number {
+    const parts = [
+      event.prompt.system ?? "",
+      event.prompt.user ?? "",
+      event.prompt.assistantPrefill ?? "",
+      event.prompt.raw ?? "",
+    ];
+    return Math.ceil(parts.join("").length / 4);
+  }
+</script>
+
+{#if open}
+  <aside class="debug-panel" data-testid="debug-panel">
+    <header>
+      <h2>
+        Debug LLM
+        <span class="tail-badge">tail</span>
+      </h2>
+      <span class="total" data-testid="debug-total">
+        {totalEmitted} total
+      </span>
+      <button
+        type="button"
+        class="ghost"
+        on:click={clearAll}
+        data-testid="debug-clear"
+      >
+        Limpar
+      </button>
+      <button
+        type="button"
+        class="close"
+        on:click={() => debugPanelOpen.set(false)}
+        aria-label="Fechar debug panel"
+        data-testid="debug-close"
+      >
+        ×
+      </button>
+    </header>
+
+    <div class="list" data-testid="debug-list">
+      {#if events.length === 0}
+        <p class="muted" data-testid="debug-empty">
+          Nenhum LLM call interceptado. Em produção, requer
+          <code>ASC_LLM_DEBUG_MODE=true</code> +
+          <code>shared/gateway-client.ts</code> POSTando aqui (hook
+          é PR follow-up).
+        </p>
+      {:else}
+        {#each events as event (event.id)}
+          <article
+            class="event"
+            class:expanded={expandedIds.has(event.id)}
+            data-testid="debug-event"
+          >
+            <header class="event-header">
+              <button
+                type="button"
+                class="event-toggle"
+                on:click={() => toggleExpanded(event.id)}
+                data-testid="debug-event-toggle"
+              >
+                <span class="provider provider-{providerColor(event.provider)}"
+                  >{event.provider}</span
+                >
+                <code class="model">{event.model}</code>
+                <span class="step">{event.step}</span>
+                <span class="tokens" title="estimate (~4 chars/token)">
+                  ~{estimateTokens(event)} tok
+                </span>
+                <span class="time">{event.receivedAt}</span>
+              </button>
+            </header>
+
+            {#if expandedIds.has(event.id)}
+              <div class="event-body" data-testid="debug-event-body">
+                {#if event.prompt.system !== undefined && event.prompt.system.length > 0}
+                  <details open>
+                    <summary>system</summary>
+                    <pre>{event.prompt.system}</pre>
+                  </details>
+                {/if}
+                {#if event.prompt.user !== undefined && event.prompt.user.length > 0}
+                  <details open>
+                    <summary>user</summary>
+                    <pre>{event.prompt.user}</pre>
+                  </details>
+                {/if}
+                {#if event.prompt.assistantPrefill !== undefined && event.prompt.assistantPrefill.length > 0}
+                  <details>
+                    <summary>assistant prefill</summary>
+                    <pre>{event.prompt.assistantPrefill}</pre>
+                  </details>
+                {/if}
+                {#if event.prompt.raw !== undefined && event.prompt.raw.length > 0}
+                  <details>
+                    <summary>raw</summary>
+                    <pre>{event.prompt.raw}</pre>
+                  </details>
+                {/if}
+                {#if event.params !== undefined && Object.keys(event.params).length > 0}
+                  <details>
+                    <summary>params</summary>
+                    <pre>{JSON.stringify(event.params, null, 2)}</pre>
+                  </details>
+                {/if}
+                {#if event.sessionId !== undefined}
+                  <p class="meta">
+                    session: <code>{event.sessionId}</code>
+                    {#if event.turn !== undefined}
+                      &middot; turn #{event.turn}
+                    {/if}
+                  </p>
+                {/if}
+              </div>
+            {/if}
+          </article>
+        {/each}
+      {/if}
+    </div>
+  </aside>
+{/if}
+
+<style>
+  .debug-panel {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 50vh;
+    background: var(--bg, #ffffff);
+    border-top: 2px solid rgba(33, 150, 243, 0.5);
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    z-index: 40;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .debug-panel {
+      background: #1c1c1c;
+    }
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+    background: rgba(33, 150, 243, 0.05);
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.85;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .tail-badge {
+    background: rgba(33, 150, 243, 0.3);
+    color: #1565c0;
+    font-size: 0.7rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+
+  .total {
+    margin-left: auto;
+    font-size: 0.8rem;
+    opacity: 0.6;
+  }
+
+  button {
+    background: rgba(127, 127, 127, 0.15);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    padding: 0.2rem 0.5rem;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+
+  button.close {
+    background: transparent;
+    border: none;
+    font-size: 1.3rem;
+    padding: 0.2rem 0.5rem;
+  }
+
+  button:hover {
+    background: rgba(127, 127, 127, 0.25);
+  }
+
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.4rem;
+  }
+
+  .muted {
+    opacity: 0.6;
+    padding: 1rem;
+    text-align: center;
+  }
+
+  .event {
+    margin-bottom: 0.3rem;
+    border: 1px solid rgba(127, 127, 127, 0.2);
+    border-radius: 4px;
+    background: rgba(127, 127, 127, 0.04);
+  }
+
+  .event.expanded {
+    background: rgba(127, 127, 127, 0.08);
+  }
+
+  .event-toggle {
+    background: transparent;
+    border: none;
+    width: 100%;
+    text-align: left;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    padding: 0.4rem 0.6rem;
+    font-family: inherit;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .provider {
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+  }
+
+  .provider-anthropic {
+    background: rgba(176, 0, 32, 0.2);
+    color: #b00020;
+  }
+
+  .provider-infomaniak {
+    background: rgba(33, 150, 243, 0.2);
+    color: #1565c0;
+  }
+
+  .provider-local {
+    background: rgba(127, 127, 127, 0.25);
+    color: #555;
+  }
+
+  .provider-unknown {
+    background: rgba(127, 127, 127, 0.15);
+    color: #777;
+  }
+
+  .model {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    background: rgba(127, 127, 127, 0.15);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+
+  .step {
+    font-size: 0.8rem;
+    opacity: 0.85;
+  }
+
+  .tokens {
+    margin-left: auto;
+    font-size: 0.7rem;
+    opacity: 0.6;
+  }
+
+  .time {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.7rem;
+    opacity: 0.5;
+  }
+
+  .event-body {
+    padding: 0.4rem 0.7rem 0.6rem;
+    border-top: 1px dashed rgba(127, 127, 127, 0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .event-body details {
+    background: rgba(0, 0, 0, 0.06);
+    border-radius: 3px;
+    padding: 0.3rem 0.5rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .event-body details {
+      background: rgba(255, 255, 255, 0.06);
+    }
+  }
+
+  .event-body summary {
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 600;
+    opacity: 0.8;
+  }
+
+  .event-body pre {
+    margin: 0.3rem 0 0;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 150px;
+    overflow-y: auto;
+  }
+
+  .meta {
+    font-size: 0.75rem;
+    opacity: 0.7;
+    margin: 0.2rem 0 0;
+  }
+
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    background: rgba(127, 127, 127, 0.15);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/Status.svelte
+++ b/packages/ebrota-console-ui/src/components/Status.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { bffStatus, consoleMode, libraryOpen } from "../lib/stores.js";
+  import {
+    bffStatus,
+    consoleMode,
+    debugPanelOpen,
+    libraryOpen,
+  } from "../lib/stores.js";
   import type { ApiClient } from "../lib/api.js";
   import type { ConsoleMode } from "../lib/types.js";
 
@@ -61,6 +66,17 @@
     title="Histórico de sessões"
   >
     Histórico
+  </button>
+
+  <button
+    type="button"
+    class="debug-toggle"
+    class:active={$debugPanelOpen}
+    on:click={() => debugPanelOpen.update((o) => !o)}
+    data-testid="debug-toggle"
+    title="Debug LLM (raio-X tail)"
+  >
+    🔬 Debug
   </button>
 
   <button
@@ -145,8 +161,26 @@
     color: inherit;
   }
 
-  .history-toggle:hover {
+  .history-toggle,
+  .debug-toggle {
+    background: rgba(127, 127, 127, 0.15);
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 4px;
+    padding: 0.3rem 0.7rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+  }
+
+  .history-toggle:hover,
+  .debug-toggle:hover {
     background: rgba(127, 127, 127, 0.25);
+  }
+
+  .debug-toggle.active {
+    background: rgba(33, 150, 243, 0.25);
+    border-color: rgba(33, 150, 243, 0.6);
   }
 
   .mode-toggle:hover {

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -123,6 +123,23 @@ export interface ReplayTrace {
   turns?: ReplayTraceTurn[];
 }
 
+export interface DebugLlmCallEvent {
+  id: number;
+  receivedAt: string;
+  step: string;
+  provider: "anthropic" | "infomaniak" | "local" | "unknown";
+  model: string;
+  prompt: {
+    system?: string;
+    user?: string;
+    assistantPrefill?: string;
+    raw?: string;
+  };
+  params?: Record<string, unknown>;
+  sessionId?: string;
+  turn?: number;
+}
+
 export interface ApiClient {
   getStatus(): Promise<BffStatus>;
   getMode(): Promise<{ mode: ConsoleMode }>;
@@ -154,6 +171,10 @@ export interface ApiClient {
     filters?: SessionLibraryFilters,
   ): Promise<{ sessions: SessionLibraryEntry[] }>;
   getSessionReplay(sessionId: string): Promise<ReplayTrace>;
+  listDebugLlmCalls(
+    sinceId?: number,
+  ): Promise<{ events: DebugLlmCallEvent[]; totalEmitted: number }>;
+  clearDebugLlmCalls(): Promise<{ cleared: boolean }>;
   /** Resolve URL completa pro EventSource consumir SSE. */
   turnStateSseUrl(sessionId: string): string;
 }
@@ -236,6 +257,23 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
       return get<{ sessions: SessionLibraryEntry[] }>(
         `/sessions/library${query.length > 0 ? `?${query}` : ""}`,
       );
+    },
+    listDebugLlmCalls: (sinceId) =>
+      get<{ events: DebugLlmCallEvent[]; totalEmitted: number }>(
+        sinceId !== undefined
+          ? `/debug/llm-calls?sinceId=${sinceId}`
+          : "/debug/llm-calls",
+      ),
+    clearDebugLlmCalls: async () => {
+      const res = await f(`${baseUrl}/debug/llm-calls`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        throw new Error(
+          `BFF DELETE /debug/llm-calls failed: ${res.status}`,
+        );
+      }
+      return (await res.json()) as { cleared: boolean };
     },
     getSessionReplay: (sessionId) =>
       get<ReplayTrace>(

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -53,3 +53,11 @@ export const libraryOpen = writable<boolean>(false);
 
 /** Replay modal open com qual sessionId. Null = fechado. */
 export const replaySessionId = writable<string | null>(null);
+
+/** Debug panel (raio-X LLM) aberto? */
+export const debugPanelOpen = writable<boolean>(false);
+
+/** Events LLM calls (tail mode). Append-only durante polling; clear
+ *  via API + store reset. */
+import type { DebugLlmCallEvent } from "./api.js";
+export const debugLlmEvents = writable<DebugLlmCallEvent[]>([]);

--- a/packages/ebrota-console-ui/tests/components/DebugPanel.test.ts
+++ b/packages/ebrota-console-ui/tests/components/DebugPanel.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import DebugPanel from "../../src/components/DebugPanel.svelte";
+import {
+  debugLlmEvents,
+  debugPanelOpen,
+} from "../../src/lib/stores.js";
+import type { ApiClient, DebugLlmCallEvent } from "../../src/lib/api.js";
+
+const sampleEvent = (
+  overrides: Partial<DebugLlmCallEvent> = {},
+): DebugLlmCallEvent => ({
+  id: 1,
+  receivedAt: "2026-05-24T13:00:00.000Z",
+  step: "planejador.plan_turn",
+  provider: "anthropic",
+  model: "claude-opus-4",
+  prompt: {
+    system: "You are Brota...",
+    user: "card:tabuada-7",
+  },
+  params: { temperature: 0.7 },
+  sessionId: "yuji__a",
+  turn: 0,
+  ...overrides,
+});
+
+const buildApi = (
+  events: DebugLlmCallEvent[] = [],
+  totalEmitted = events.length,
+): ApiClient =>
+  ({
+    getStatus: vi.fn(),
+    getMode: vi.fn(),
+    setMode: vi.fn(),
+    startCardSession: vi.fn(),
+    listOptions: vi.fn(),
+    overrideSelection: vi.fn(),
+    listDecisions: vi.fn(),
+    getPendingApproval: vi.fn(),
+    approveOrEdit: vi.fn(),
+    endSession: vi.fn(),
+    listSessionLibrary: vi.fn(),
+    getSessionReplay: vi.fn(),
+    listDebugLlmCalls: vi.fn(async () => ({ events, totalEmitted })),
+    clearDebugLlmCalls: vi.fn(async () => ({ cleared: true })),
+    turnStateSseUrl: () => "/api/sse",
+  }) as never;
+
+const NO_POLLING = 999_999;
+
+beforeEach(() => {
+  debugPanelOpen.set(true);
+  debugLlmEvents.set([]);
+});
+
+describe("DebugPanel.svelte — visibility", () => {
+  it("não renderiza quando debugPanelOpen=false", () => {
+    debugPanelOpen.set(false);
+    render(DebugPanel, { api: buildApi(), pollIntervalMs: NO_POLLING });
+    expect(screen.queryByTestId("debug-panel")).toBeNull();
+  });
+
+  it("renderiza header + tail badge quando open", () => {
+    render(DebugPanel, { api: buildApi(), pollIntervalMs: NO_POLLING });
+    expect(screen.getByTestId("debug-panel")).toBeDefined();
+    expect(screen.getByText("tail")).toBeDefined();
+  });
+
+  it("close button seta debugPanelOpen=false", async () => {
+    render(DebugPanel, { api: buildApi(), pollIntervalMs: NO_POLLING });
+    await fireEvent.click(screen.getByTestId("debug-close"));
+    expect(get(debugPanelOpen)).toBe(false);
+  });
+});
+
+describe("DebugPanel.svelte — events display", () => {
+  it("estado vazio mostra hint sobre ASC_LLM_DEBUG_MODE", () => {
+    render(DebugPanel, { api: buildApi([]), pollIntervalMs: NO_POLLING });
+    expect(screen.getByTestId("debug-empty")).toBeDefined();
+  });
+
+  it("renderiza eventos populados via store", async () => {
+    debugLlmEvents.set([sampleEvent()]);
+    render(DebugPanel, { api: buildApi(), pollIntervalMs: NO_POLLING });
+    await waitFor(() => {
+      expect(screen.getByTestId("debug-event")).toBeDefined();
+    });
+    expect(screen.getByText("anthropic")).toBeDefined();
+    expect(screen.getByText("claude-opus-4")).toBeDefined();
+    expect(screen.getByText("planejador.plan_turn")).toBeDefined();
+  });
+
+  it("expand toggle revela prompt body", async () => {
+    debugLlmEvents.set([sampleEvent()]);
+    render(DebugPanel, { api: buildApi(), pollIntervalMs: NO_POLLING });
+    await waitFor(() =>
+      expect(screen.getByTestId("debug-event-toggle")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("debug-event-toggle"));
+    await waitFor(() =>
+      expect(screen.getByTestId("debug-event-body")).toBeDefined(),
+    );
+    expect(screen.getByText("You are Brota...")).toBeDefined();
+  });
+
+  it("provider classes aplicadas (anthropic/infomaniak/local/unknown)", async () => {
+    debugLlmEvents.set([
+      sampleEvent({ id: 1, provider: "anthropic" }),
+      sampleEvent({ id: 2, provider: "infomaniak" }),
+      sampleEvent({ id: 3, provider: "local" }),
+      sampleEvent({ id: 4, provider: "unknown" }),
+    ]);
+    render(DebugPanel, { api: buildApi(), pollIntervalMs: NO_POLLING });
+    await waitFor(() => {
+      const events = screen.getAllByTestId("debug-event");
+      expect(events).toHaveLength(4);
+    });
+    const providers = screen.getAllByText(/anthropic|infomaniak|local|unknown/);
+    // 4 spans .provider matching
+    expect(providers.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("clear button chama api.clearDebugLlmCalls + reset store", async () => {
+    debugLlmEvents.set([sampleEvent(), sampleEvent({ id: 2 })]);
+    const clearFn = vi.fn(async () => ({ cleared: true }));
+    const api = buildApi();
+    (api as unknown as { clearDebugLlmCalls: typeof clearFn }).clearDebugLlmCalls =
+      clearFn;
+    render(DebugPanel, { api, pollIntervalMs: NO_POLLING });
+    await waitFor(() =>
+      expect(screen.getByTestId("debug-clear")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("debug-clear"));
+    await new Promise<void>((r) => setTimeout(r, 20));
+    expect(clearFn).toHaveBeenCalled();
+    expect(get(debugLlmEvents)).toEqual([]);
+  });
+
+  it("total emitted mostrado", async () => {
+    debugLlmEvents.set([sampleEvent()]);
+    const api = buildApi([sampleEvent({ id: 999 })], 999);
+    render(DebugPanel, { api, pollIntervalMs: 30 });
+    await waitFor(() => {
+      expect(screen.getByTestId("debug-total").textContent).toMatch(/999/);
+    });
+  });
+});
+
+describe("DebugPanel.svelte — polling", () => {
+  it("polling busca novos events e append ao store", async () => {
+    let counter = 0;
+    const list = vi.fn(async (sinceId?: number) => {
+      counter++;
+      if (counter === 1) {
+        return { events: [sampleEvent({ id: 1 })], totalEmitted: 1 };
+      }
+      if (counter === 2 && (sinceId ?? 0) < 2) {
+        return { events: [sampleEvent({ id: 2 })], totalEmitted: 2 };
+      }
+      return { events: [], totalEmitted: 2 };
+    });
+    const api = buildApi();
+    (api as unknown as { listDebugLlmCalls: typeof list }).listDebugLlmCalls =
+      list;
+    render(DebugPanel, { api, pollIntervalMs: 30 });
+    await waitFor(() => expect(list).toHaveBeenCalled());
+    await new Promise<void>((r) => setTimeout(r, 80));
+    expect(get(debugLlmEvents).length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary

**C-MX-08 eBrota Console — PR8 (Fase G parcial — S-OC-24..29).** Drawer Debug LLM com tail passivo de calls; provider badges + event cards expansíveis com system/user/assistantPrefill/raw/params.

- **BFF**: ring buffer in-memory (cap 200) + 4 endpoints (POST/GET/DELETE /debug/llm-calls + POST /debug/actions). 14 novos tests, total **80/80** ✅
- **UI**: `DebugPanel.svelte` drawer 50vh + polling 500ms + provider color badges (anthropic red / infomaniak blue / local gray) + estimateTokens helper. 8 novos tests, total **87/87** ✅
- **Hook** `gateway-client.ts → POST /debug/llm-calls` fica como PR follow-up (V0.2). UI já pronta pra consumir quando hook landar.

## Stack

```
main
 └── PR1..6 (mergeado consolidação)
      └── PR7 #164 — smoke-visualizer hooks
           └── PR8 (este) — debug-tail
```

## Karpathy constraints (CLAUDE.md §0)

- **P1 Ask before code** — escopo S-OC-24..29 já explícito no spec ratificado
- **P2 Simplicity first** — ring buffer Array com 2 ops (push/since); zero abstrações especulativas
- **P3 Surgery** — só novos arquivos + endpoints aditivos; zero refactor em código existente
- **P4 Verifiable** — testes BDD: "push event", "emit since", "cap eviction", "clear resets", "400 on missing field"

## Test plan

- [ ] Manual smoke: toggle 🔬 Debug button → drawer abre; "Limpar" reseta; × fecha
- [ ] curl POST /debug/llm-calls com payload válido → 201; sem provider → 400
- [ ] curl GET /debug/llm-calls?sinceId=N → só events newer
- [ ] Ring buffer eviction: empurrar >200 events → older descartados

🤖 Generated with [Claude Code](https://claude.com/claude-code)