### PR TITLE
[feat ops#1123] C-MX-08 PR9 — Analytics V0.1 (9/10)

### DIFF
--- a/packages/ebrota-console-bff/src/analytics.ts
+++ b/packages/ebrota-console-bff/src/analytics.ts
@@ -1,0 +1,161 @@
+/**
+ * Analytics module — C-MX-08 PR9 (Fase H parcial, S-OC-34/35/36).
+ *
+ * V0.1 = básico cross-session + per-persona drill-down. Tudo derivado
+ * do SQLite índice existente (sessions + jun_decisions); nenhum schema
+ * novo. Métricas mais ricas (Helix state, mood timeline, Dreyfus level)
+ * requerem parse profundo de trace.json — fica pra V0.2.
+ *
+ * P2 simplicidade: 2 queries SQL, zero abstrações. Caller wrappa em
+ * endpoint Fastify.
+ */
+
+import type { Database as DatabaseType } from "better-sqlite3";
+
+export interface PersonaSummary {
+  personaId: string;
+  sessionCount: number;
+  realCount: number;
+  stsCount: number;
+  totalTurns: number;
+  totalOverrides: number;
+  overrideRate: number;
+  lastSessionAt: string | null;
+  firstSessionAt: string | null;
+}
+
+export interface PersonaEvolutionSession {
+  sessionId: string;
+  startedAt: string;
+  kind: "real" | "sts";
+  turnCount: number;
+  hasOverrides: boolean;
+  overrideCount: number;
+}
+
+export interface PersonaEvolution {
+  personaId: string;
+  summary: PersonaSummary;
+  sessions: PersonaEvolutionSession[];
+}
+
+const SUMMARIZE_PERSONAS_SQL = `
+  SELECT
+    s.persona_id AS personaId,
+    COUNT(*) AS sessionCount,
+    SUM(CASE WHEN s.kind = 'real' THEN 1 ELSE 0 END) AS realCount,
+    SUM(CASE WHEN s.kind = 'sts' THEN 1 ELSE 0 END) AS stsCount,
+    COALESCE(SUM(s.turn_count), 0) AS totalTurns,
+    MIN(s.started_at) AS firstSessionAt,
+    MAX(s.started_at) AS lastSessionAt
+  FROM sessions s
+  GROUP BY s.persona_id
+  ORDER BY lastSessionAt DESC
+`;
+
+const COUNT_OVERRIDES_PER_PERSONA_SQL = `
+  SELECT
+    s.persona_id AS personaId,
+    COUNT(j.id) AS overrideCount
+  FROM sessions s
+  LEFT JOIN jun_decisions j
+    ON j.session_id = s.session_id
+    AND j.decision IN ('edit', 'override')
+  GROUP BY s.persona_id
+`;
+
+const PERSONA_SESSIONS_SQL = `
+  SELECT
+    s.session_id AS sessionId,
+    s.started_at AS startedAt,
+    s.kind AS kind,
+    s.turn_count AS turnCount,
+    s.has_overrides AS hasOverridesInt,
+    (
+      SELECT COUNT(*) FROM jun_decisions j
+      WHERE j.session_id = s.session_id
+        AND j.decision IN ('edit', 'override')
+    ) AS overrideCount
+  FROM sessions s
+  WHERE s.persona_id = @personaId
+  ORDER BY s.started_at ASC
+`;
+
+/**
+ * Agrega métricas básicas por persona (S-OC-34 feed cross-session).
+ * Returns array ordered by last session DESC.
+ */
+export function summarizePersonas(db: DatabaseType): PersonaSummary[] {
+  const rows = db.prepare(SUMMARIZE_PERSONAS_SQL).all() as Array<{
+    personaId: string;
+    sessionCount: number;
+    realCount: number | null;
+    stsCount: number | null;
+    totalTurns: number;
+    firstSessionAt: string | null;
+    lastSessionAt: string | null;
+  }>;
+  const overrideRows = db
+    .prepare(COUNT_OVERRIDES_PER_PERSONA_SQL)
+    .all() as Array<{ personaId: string; overrideCount: number }>;
+  const overridesByPersona = new Map(
+    overrideRows.map((r) => [r.personaId, r.overrideCount]),
+  );
+
+  return rows.map((r) => {
+    const overrides = overridesByPersona.get(r.personaId) ?? 0;
+    const rate = r.totalTurns > 0 ? overrides / r.totalTurns : 0;
+    return {
+      personaId: r.personaId,
+      sessionCount: r.sessionCount,
+      realCount: r.realCount ?? 0,
+      stsCount: r.stsCount ?? 0,
+      totalTurns: r.totalTurns,
+      totalOverrides: overrides,
+      overrideRate: Math.round(rate * 1000) / 1000,
+      firstSessionAt: r.firstSessionAt,
+      lastSessionAt: r.lastSessionAt,
+    };
+  });
+}
+
+/**
+ * Drill-down per persona (S-OC-35 + S-OC-36 básico): sessions
+ * cronológicas + summary agregado pra cards de evolução.
+ */
+export function getPersonaEvolution(
+  db: DatabaseType,
+  personaId: string,
+): PersonaEvolution | null {
+  const sessions = db
+    .prepare(PERSONA_SESSIONS_SQL)
+    .all({ personaId }) as Array<
+    PersonaEvolutionSession & { hasOverridesInt: number }
+  >;
+  if (sessions.length === 0) return null;
+
+  const mapped: PersonaEvolutionSession[] = sessions.map((s) => ({
+    sessionId: s.sessionId,
+    startedAt: s.startedAt,
+    kind: s.kind,
+    turnCount: s.turnCount,
+    hasOverrides: s.hasOverridesInt === 1,
+    overrideCount: s.overrideCount,
+  }));
+
+  const summaries = summarizePersonas(db);
+  const summary =
+    summaries.find((s) => s.personaId === personaId) ?? {
+      personaId,
+      sessionCount: mapped.length,
+      realCount: mapped.filter((s) => s.kind === "real").length,
+      stsCount: mapped.filter((s) => s.kind === "sts").length,
+      totalTurns: mapped.reduce((acc, s) => acc + s.turnCount, 0),
+      totalOverrides: mapped.reduce((acc, s) => acc + s.overrideCount, 0),
+      overrideRate: 0,
+      firstSessionAt: mapped[0]?.startedAt ?? null,
+      lastSessionAt: mapped[mapped.length - 1]?.startedAt ?? null,
+    };
+
+  return { personaId, summary, sessions: mapped };
+}

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -45,6 +45,10 @@ import {
   type DebugEventsStore,
   type LlmCallEventPayload,
 } from "./debug-events.js";
+import {
+  summarizePersonas,
+  getPersonaEvolution,
+} from "./analytics.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -439,6 +443,25 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
     }
     return { id: result.id };
   });
+
+  // GET /analytics/personas — cross-session summary (S-OC-34)
+  fastify.get("/analytics/personas", async () => {
+    return { personas: summarizePersonas(opts.db) };
+  });
+
+  // GET /analytics/personas/:id/evolution — drill-down (S-OC-35/36)
+  fastify.get<{ Params: { id: string } }>(
+    "/analytics/personas/:id/evolution",
+    async (req, reply) => {
+      const evolution = getPersonaEvolution(opts.db, req.params.id);
+      if (evolution === null) {
+        return reply
+          .code(404)
+          .send({ error: `persona não encontrada: ${req.params.id}` });
+      }
+      return evolution;
+    },
+  );
 
   // POST /sessions/:id/end — endSession
   fastify.post<{ Params: { id: string } }>(

--- a/packages/ebrota-console-bff/tests/analytics.test.ts
+++ b/packages/ebrota-console-bff/tests/analytics.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import {
+  summarizePersonas,
+  getPersonaEvolution,
+} from "../src/analytics.js";
+import { recordJunDecision } from "../src/decisions.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+const insertSession = (
+  db: DatabaseType,
+  args: {
+    sessionId: string;
+    personaId: string;
+    kind: "real" | "sts";
+    startedAt: string;
+    turnCount: number;
+    hasOverrides?: boolean;
+  },
+): void => {
+  db.prepare(
+    `INSERT INTO sessions (
+      session_id, persona_id, conversation_id, kind, started_at,
+      turn_count, has_overrides, trace_path
+    ) VALUES (@sessionId, @personaId, @sessionId, @kind, @startedAt,
+      @turnCount, @hasOverrides, NULL)`,
+  ).run({
+    ...args,
+    hasOverrides: args.hasOverrides ? 1 : 0,
+  });
+};
+
+describe("summarizePersonas", () => {
+  let db: DatabaseType;
+
+  beforeEach(() => {
+    db = initDb({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("retorna array vazio quando não há sessions", () => {
+    expect(summarizePersonas(db)).toEqual([]);
+  });
+
+  it("agrega session_count + turn_count por persona", () => {
+    insertSession(db, {
+      sessionId: "yuji__a",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 5,
+    });
+    insertSession(db, {
+      sessionId: "yuji__b",
+      personaId: "yuji",
+      kind: "sts",
+      startedAt: "2026-05-21T10:00:00.000Z",
+      turnCount: 8,
+    });
+    insertSession(db, {
+      sessionId: "kei__a",
+      personaId: "kei",
+      kind: "real",
+      startedAt: "2026-05-22T10:00:00.000Z",
+      turnCount: 3,
+    });
+
+    const summary = summarizePersonas(db);
+    expect(summary).toHaveLength(2);
+    const yuji = summary.find((s) => s.personaId === "yuji");
+    const kei = summary.find((s) => s.personaId === "kei");
+    expect(yuji?.sessionCount).toBe(2);
+    expect(yuji?.realCount).toBe(1);
+    expect(yuji?.stsCount).toBe(1);
+    expect(yuji?.totalTurns).toBe(13);
+    expect(kei?.sessionCount).toBe(1);
+    expect(kei?.totalTurns).toBe(3);
+  });
+
+  it("conta overrides via jun_decisions", () => {
+    insertSession(db, {
+      sessionId: "yuji__a",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 10,
+    });
+    recordJunDecision(db, {
+      sessionId: "yuji__a",
+      turn: 1,
+      decision: "override",
+      overrideCardId: "card-x",
+    });
+    recordJunDecision(db, {
+      sessionId: "yuji__a",
+      turn: 3,
+      decision: "edit",
+      finalText: "edited",
+    });
+    recordJunDecision(db, {
+      sessionId: "yuji__a",
+      turn: 5,
+      decision: "approve",
+    });
+
+    const summary = summarizePersonas(db);
+    expect(summary[0]!.totalOverrides).toBe(2);
+    expect(summary[0]!.overrideRate).toBeCloseTo(0.2, 3);
+  });
+
+  it("ordem por lastSessionAt DESC", () => {
+    insertSession(db, {
+      sessionId: "old",
+      personaId: "kei",
+      kind: "real",
+      startedAt: "2026-04-01T10:00:00.000Z",
+      turnCount: 1,
+    });
+    insertSession(db, {
+      sessionId: "new",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-22T10:00:00.000Z",
+      turnCount: 1,
+    });
+    const summary = summarizePersonas(db);
+    expect(summary[0]!.personaId).toBe("yuji");
+    expect(summary[1]!.personaId).toBe("kei");
+  });
+
+  it("override_rate é 0 quando totalTurns=0", () => {
+    insertSession(db, {
+      sessionId: "empty",
+      personaId: "ryo",
+      kind: "real",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 0,
+    });
+    expect(summarizePersonas(db)[0]!.overrideRate).toBe(0);
+  });
+});
+
+describe("getPersonaEvolution", () => {
+  let db: DatabaseType;
+
+  beforeEach(() => {
+    db = initDb({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("retorna null pra persona inexistente", () => {
+    expect(getPersonaEvolution(db, "nobody")).toBeNull();
+  });
+
+  it("retorna sessions ordenadas cronologicamente", () => {
+    insertSession(db, {
+      sessionId: "s3",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-22T10:00:00.000Z",
+      turnCount: 4,
+    });
+    insertSession(db, {
+      sessionId: "s1",
+      personaId: "yuji",
+      kind: "sts",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 6,
+    });
+    insertSession(db, {
+      sessionId: "s2",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-21T10:00:00.000Z",
+      turnCount: 2,
+    });
+
+    const evo = getPersonaEvolution(db, "yuji");
+    expect(evo).not.toBeNull();
+    expect(evo!.sessions.map((s) => s.sessionId)).toEqual([
+      "s1",
+      "s2",
+      "s3",
+    ]);
+  });
+
+  it("includes override_count per session", () => {
+    insertSession(db, {
+      sessionId: "yuji__a",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 5,
+      hasOverrides: true,
+    });
+    recordJunDecision(db, {
+      sessionId: "yuji__a",
+      turn: 1,
+      decision: "override",
+      overrideCardId: "x",
+    });
+    recordJunDecision(db, {
+      sessionId: "yuji__a",
+      turn: 2,
+      decision: "override",
+      overrideCardId: "y",
+    });
+
+    const evo = getPersonaEvolution(db, "yuji");
+    expect(evo!.sessions[0]!.overrideCount).toBe(2);
+    expect(evo!.sessions[0]!.hasOverrides).toBe(true);
+  });
+
+  it("summary embedded coincide com summarizePersonas", () => {
+    insertSession(db, {
+      sessionId: "kei__a",
+      personaId: "kei",
+      kind: "real",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 7,
+    });
+    const evo = getPersonaEvolution(db, "kei");
+    expect(evo!.summary.personaId).toBe("kei");
+    expect(evo!.summary.totalTurns).toBe(7);
+  });
+});
+
+describe("BFF analytics endpoints", () => {
+  let server: BffServer;
+  let db: DatabaseType;
+
+  beforeEach(() => {
+    db = initDb({ dbPath: ":memory:" });
+    server = createBffServer({
+      daemon: createMockDaemonClient(),
+      db,
+      logger: false,
+    });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  const inject = async (url: string) => {
+    const res = await server.fastify.inject({ method: "GET", url });
+    return {
+      status: res.statusCode,
+      body: JSON.parse(res.body) as unknown,
+    };
+  };
+
+  it("GET /analytics/personas retorna lista vazia inicialmente", async () => {
+    const { status, body } = await inject("/analytics/personas");
+    expect(status).toBe(200);
+    expect(body).toEqual({ personas: [] });
+  });
+
+  it("GET /analytics/personas agrega corretamente", async () => {
+    insertSession(db, {
+      sessionId: "yuji__a",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 5,
+    });
+    const { body } = await inject("/analytics/personas");
+    const personas = (body as { personas: Array<{ personaId: string }> })
+      .personas;
+    expect(personas).toHaveLength(1);
+    expect(personas[0]!.personaId).toBe("yuji");
+  });
+
+  it("GET /analytics/personas/:id/evolution retorna 404 pra inexistente", async () => {
+    const { status } = await inject("/analytics/personas/nobody/evolution");
+    expect(status).toBe(404);
+  });
+
+  it("GET /analytics/personas/:id/evolution retorna sessions", async () => {
+    insertSession(db, {
+      sessionId: "yuji__a",
+      personaId: "yuji",
+      kind: "real",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      turnCount: 3,
+    });
+    const { status, body } = await inject(
+      "/analytics/personas/yuji/evolution",
+    );
+    expect(status).toBe(200);
+    const evo = body as { sessions: unknown[]; summary: unknown };
+    expect(evo.sessions).toHaveLength(1);
+    expect(evo.summary).toBeDefined();
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -8,6 +8,7 @@
   import SessionLibrary from "./components/SessionLibrary.svelte";
   import Replay from "./components/Replay.svelte";
   import DebugPanel from "./components/DebugPanel.svelte";
+  import Analytics from "./components/Analytics.svelte";
   import { createApiClient } from "./lib/api.js";
   import {
     bffStatus,
@@ -96,6 +97,7 @@
   <SessionLibrary {api} />
   <Replay {api} />
   <DebugPanel {api} />
+  <Analytics {api} />
 
   <footer>
     <p class="muted">

--- a/packages/ebrota-console-ui/src/components/Analytics.svelte
+++ b/packages/ebrota-console-ui/src/components/Analytics.svelte
@@ -1,0 +1,622 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    analyticsOpen,
+    replaySessionId,
+    globalError,
+  } from "../lib/stores.js";
+  import type {
+    ApiClient,
+    PersonaEvolution,
+    PersonaSummary,
+  } from "../lib/api.js";
+
+  export let api: ApiClient;
+
+  let personas: PersonaSummary[] = [];
+  let loadingList = false;
+  let selectedPersona: string | null = null;
+  let evolution: PersonaEvolution | null = null;
+  let loadingEvolution = false;
+  let kindFilter: "" | "real" | "sts" = "";
+  let fromDate = "";
+  let toDate = "";
+  let hasOverridesOnly = false;
+
+  $: open = $analyticsOpen;
+
+  async function loadPersonas(): Promise<void> {
+    loadingList = true;
+    try {
+      const res = await api.listAnalyticsPersonas();
+      personas = res.personas;
+    } catch (err) {
+      globalError.set(
+        `Analytics falhou: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      personas = [];
+    } finally {
+      loadingList = false;
+    }
+  }
+
+  async function loadEvolution(personaId: string): Promise<void> {
+    loadingEvolution = true;
+    selectedPersona = personaId;
+    try {
+      evolution = await api.getPersonaEvolution(personaId);
+    } catch (err) {
+      globalError.set(
+        `Evolution falhou: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      evolution = null;
+    } finally {
+      loadingEvolution = false;
+    }
+  }
+
+  function backToList(): void {
+    selectedPersona = null;
+    evolution = null;
+    kindFilter = "";
+    fromDate = "";
+    toDate = "";
+    hasOverridesOnly = false;
+  }
+
+  $: if (open) {
+    void loadPersonas();
+  }
+
+  onMount(() => {
+    if (open) void loadPersonas();
+  });
+
+  function openReplay(sessionId: string): void {
+    replaySessionId.set(sessionId);
+    analyticsOpen.set(false);
+  }
+
+  function formatDate(iso: string | null): string {
+    if (iso === null) return "—";
+    try {
+      return new Date(iso).toLocaleDateString();
+    } catch {
+      return iso.slice(0, 10);
+    }
+  }
+
+  function formatRate(rate: number): string {
+    return `${(rate * 100).toFixed(1)}%`;
+  }
+
+  /** Filtra sessions do drill-down (S-OC-35 filtros). */
+  $: filteredSessions =
+    evolution === null
+      ? []
+      : evolution.sessions.filter((s) => {
+          if (kindFilter !== "" && s.kind !== kindFilter) return false;
+          if (hasOverridesOnly && !s.hasOverrides) return false;
+          if (fromDate !== "" && s.startedAt < fromDate) return false;
+          if (toDate !== "" && s.startedAt > `${toDate}T23:59:59.999Z`)
+            return false;
+          return true;
+        });
+
+  /** Max turn count pra barra normalizada (visual). */
+  $: maxTurns =
+    filteredSessions.length === 0
+      ? 1
+      : Math.max(...filteredSessions.map((s) => s.turnCount), 1);
+</script>
+
+{#if open}
+  <aside class="analytics" data-testid="analytics-panel">
+    <header>
+      <h2>
+        Analytics
+        <span class="version-badge">V0.1</span>
+      </h2>
+      {#if selectedPersona !== null}
+        <button
+          type="button"
+          class="back"
+          on:click={backToList}
+          data-testid="analytics-back"
+        >
+          ← Personas
+        </button>
+      {/if}
+      <button
+        type="button"
+        class="close"
+        on:click={() => analyticsOpen.set(false)}
+        aria-label="Fechar analytics"
+        data-testid="analytics-close"
+      >
+        ×
+      </button>
+    </header>
+
+    {#if selectedPersona === null}
+      <!-- S-OC-34 — Cross-session feed (persona cards) -->
+      <section class="personas-list" data-testid="personas-list">
+        {#if loadingList}
+          <p class="muted" data-testid="analytics-loading">Carregando…</p>
+        {:else if personas.length === 0}
+          <p class="muted" data-testid="analytics-empty">
+            Nenhuma sessão indexada ainda. Rode um STS smoke ou inicie
+            uma sessão real pra popular o histórico.
+          </p>
+        {:else}
+          <div class="cards-grid">
+            {#each personas as p (p.personaId)}
+              <button
+                type="button"
+                class="persona-card"
+                on:click={() => loadEvolution(p.personaId)}
+                data-testid="persona-card"
+              >
+                <h3>{p.personaId}</h3>
+                <dl>
+                  <div class="stat">
+                    <dt>sessões</dt>
+                    <dd>{p.sessionCount}</dd>
+                  </div>
+                  <div class="stat">
+                    <dt>turns</dt>
+                    <dd>{p.totalTurns}</dd>
+                  </div>
+                  <div class="stat">
+                    <dt>real / sts</dt>
+                    <dd>{p.realCount} / {p.stsCount}</dd>
+                  </div>
+                  <div class="stat">
+                    <dt>override rate</dt>
+                    <dd
+                      class:warn={p.overrideRate > 0.2}
+                      data-testid="override-rate"
+                    >
+                      {formatRate(p.overrideRate)}
+                    </dd>
+                  </div>
+                </dl>
+                <p class="last-session">
+                  últ. sessão: <code>{formatDate(p.lastSessionAt)}</code>
+                </p>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </section>
+    {:else}
+      <!-- S-OC-35/36 — Drill-down + evolução -->
+      <section class="evolution" data-testid="evolution-view">
+        {#if loadingEvolution}
+          <p class="muted">Carregando evolução…</p>
+        {:else if evolution !== null}
+          <div class="summary-strip" data-testid="evolution-summary">
+            <h3>{evolution.summary.personaId}</h3>
+            <dl class="inline-stats">
+              <div><dt>sessões</dt><dd>{evolution.summary.sessionCount}</dd></div>
+              <div><dt>turns</dt><dd>{evolution.summary.totalTurns}</dd></div>
+              <div>
+                <dt>overrides</dt>
+                <dd>{evolution.summary.totalOverrides}</dd>
+              </div>
+              <div>
+                <dt>rate</dt>
+                <dd>{formatRate(evolution.summary.overrideRate)}</dd>
+              </div>
+              <div>
+                <dt>desde</dt>
+                <dd><code>{formatDate(evolution.summary.firstSessionAt)}</code></dd>
+              </div>
+            </dl>
+          </div>
+
+          <div class="filters" data-testid="evolution-filters">
+            <label class="filter">
+              <span>kind</span>
+              <select bind:value={kindFilter} data-testid="filter-kind">
+                <option value="">all</option>
+                <option value="real">real</option>
+                <option value="sts">sts</option>
+              </select>
+            </label>
+            <label class="filter">
+              <span>de</span>
+              <input
+                type="date"
+                bind:value={fromDate}
+                data-testid="filter-from"
+              />
+            </label>
+            <label class="filter">
+              <span>até</span>
+              <input
+                type="date"
+                bind:value={toDate}
+                data-testid="filter-to"
+              />
+            </label>
+            <label class="filter inline">
+              <input
+                type="checkbox"
+                bind:checked={hasOverridesOnly}
+                data-testid="filter-overrides"
+              />
+              <span>só com overrides</span>
+            </label>
+          </div>
+
+          <div class="timeline" data-testid="evolution-timeline">
+            {#if filteredSessions.length === 0}
+              <p class="muted">Nenhuma sessão com esses filtros.</p>
+            {:else}
+              {#each filteredSessions as s (s.sessionId)}
+                <div
+                  class="session-row"
+                  class:has-overrides={s.hasOverrides}
+                  data-testid="session-row"
+                >
+                  <span class="kind-badge kind-{s.kind}">{s.kind}</span>
+                  <span class="date">{formatDate(s.startedAt)}</span>
+                  <div class="turns-bar" title="{s.turnCount} turns">
+                    <div
+                      class="bar-fill"
+                      style="width: {Math.round((s.turnCount / maxTurns) * 100)}%"
+                    />
+                  </div>
+                  <span class="turns-count">{s.turnCount} turns</span>
+                  {#if s.hasOverrides}
+                    <span class="override-pill" title="overrides count">
+                      ✎ {s.overrideCount}
+                    </span>
+                  {/if}
+                  <button
+                    type="button"
+                    class="replay-btn"
+                    on:click={() => openReplay(s.sessionId)}
+                    data-testid="open-replay"
+                  >
+                    Replay
+                  </button>
+                </div>
+              {/each}
+            {/if}
+          </div>
+
+          <p class="hint">
+            <small>
+              Métricas profundas (Helix state, mood timeline, Dreyfus
+              level, cards trabalhadas) ficam pra V0.2 — requerem parse
+              do trace.json.
+            </small>
+          </p>
+        {/if}
+      </section>
+    {/if}
+  </aside>
+{/if}
+
+<style>
+  .analytics {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 60vw;
+    max-width: 900px;
+    height: 100vh;
+    background: var(--bg, #ffffff);
+    border-left: 2px solid rgba(76, 175, 80, 0.4);
+    box-shadow: -4px 0 12px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    z-index: 35;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .analytics {
+      background: #1c1c1c;
+    }
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+    background: rgba(76, 175, 80, 0.05);
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.85;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .version-badge {
+    background: rgba(76, 175, 80, 0.25);
+    color: #2e7d32;
+    font-size: 0.7rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+
+  button {
+    background: rgba(127, 127, 127, 0.15);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    padding: 0.2rem 0.6rem;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+
+  button.close {
+    background: transparent;
+    border: none;
+    font-size: 1.3rem;
+    padding: 0.2rem 0.5rem;
+  }
+
+  button:hover {
+    background: rgba(127, 127, 127, 0.25);
+  }
+
+  .personas-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
+  .cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 0.8rem;
+  }
+
+  .persona-card {
+    background: rgba(127, 127, 127, 0.08);
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-radius: 6px;
+    padding: 0.8rem;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .persona-card:hover {
+    background: rgba(76, 175, 80, 0.12);
+    border-color: rgba(76, 175, 80, 0.4);
+  }
+
+  .persona-card h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.95rem;
+    text-transform: capitalize;
+  }
+
+  .persona-card dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.3rem 0.6rem;
+  }
+
+  .stat {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stat dt {
+    font-size: 0.7rem;
+    opacity: 0.6;
+    text-transform: uppercase;
+  }
+
+  .stat dd {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+  }
+
+  .stat dd.warn {
+    color: #ff9800;
+  }
+
+  .last-session {
+    margin: 0.6rem 0 0;
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+
+  .evolution {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.8rem 1rem 1rem;
+  }
+
+  .summary-strip {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 0.8rem;
+    flex-wrap: wrap;
+  }
+
+  .summary-strip h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    text-transform: capitalize;
+  }
+
+  .inline-stats {
+    margin: 0;
+    display: flex;
+    gap: 1.2rem;
+    flex-wrap: wrap;
+  }
+
+  .inline-stats > div {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .inline-stats dt {
+    font-size: 0.65rem;
+    opacity: 0.6;
+    text-transform: uppercase;
+  }
+
+  .inline-stats dd {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .filters {
+    display: flex;
+    gap: 0.7rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.7rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px dashed rgba(127, 127, 127, 0.25);
+  }
+
+  .filter {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.75rem;
+    opacity: 0.85;
+  }
+
+  .filter.inline {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .filter input,
+  .filter select {
+    background: rgba(127, 127, 127, 0.1);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    padding: 0.2rem 0.4rem;
+    font-family: inherit;
+    color: inherit;
+    font-size: 0.85rem;
+  }
+
+  .timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .session-row {
+    display: grid;
+    grid-template-columns: 50px 90px 1fr 70px 60px 70px;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.3rem 0.5rem;
+    background: rgba(127, 127, 127, 0.05);
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  .session-row.has-overrides {
+    background: rgba(255, 152, 0, 0.08);
+    border-left: 3px solid #ff9800;
+  }
+
+  .kind-badge {
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-align: center;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+
+  .kind-real {
+    background: rgba(76, 175, 80, 0.2);
+    color: #2e7d32;
+  }
+
+  .kind-sts {
+    background: rgba(33, 150, 243, 0.2);
+    color: #1565c0;
+  }
+
+  .date {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    opacity: 0.75;
+  }
+
+  .turns-bar {
+    height: 14px;
+    background: rgba(127, 127, 127, 0.15);
+    border-radius: 7px;
+    overflow: hidden;
+  }
+
+  .bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #4caf50, #8bc34a);
+  }
+
+  .turns-count {
+    font-size: 0.75rem;
+    opacity: 0.85;
+    text-align: right;
+  }
+
+  .override-pill {
+    background: rgba(255, 152, 0, 0.25);
+    color: #e65100;
+    font-size: 0.7rem;
+    padding: 0.05rem 0.35rem;
+    border-radius: 3px;
+    font-weight: 600;
+    text-align: center;
+  }
+
+  .replay-btn {
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+  }
+
+  .muted {
+    opacity: 0.6;
+    text-align: center;
+    padding: 2rem 1rem;
+  }
+
+  .hint {
+    margin-top: 1rem;
+    opacity: 0.6;
+    border-top: 1px dashed rgba(127, 127, 127, 0.25);
+    padding-top: 0.7rem;
+    text-align: center;
+  }
+
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.75rem;
+    background: rgba(127, 127, 127, 0.15);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/Status.svelte
+++ b/packages/ebrota-console-ui/src/components/Status.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    analyticsOpen,
     bffStatus,
     consoleMode,
     debugPanelOpen,
@@ -66,6 +67,17 @@
     title="Histórico de sessões"
   >
     Histórico
+  </button>
+
+  <button
+    type="button"
+    class="analytics-toggle"
+    class:active={$analyticsOpen}
+    on:click={() => analyticsOpen.update((o) => !o)}
+    data-testid="analytics-toggle"
+    title="Analytics V0.1 — cross-session + evolução"
+  >
+    📊 Analytics
   </button>
 
   <button
@@ -162,7 +174,8 @@
   }
 
   .history-toggle,
-  .debug-toggle {
+  .debug-toggle,
+  .analytics-toggle {
     background: rgba(127, 127, 127, 0.15);
     border: 1px solid rgba(127, 127, 127, 0.4);
     border-radius: 4px;
@@ -174,13 +187,19 @@
   }
 
   .history-toggle:hover,
-  .debug-toggle:hover {
+  .debug-toggle:hover,
+  .analytics-toggle:hover {
     background: rgba(127, 127, 127, 0.25);
   }
 
   .debug-toggle.active {
     background: rgba(33, 150, 243, 0.25);
     border-color: rgba(33, 150, 243, 0.6);
+  }
+
+  .analytics-toggle.active {
+    background: rgba(76, 175, 80, 0.25);
+    border-color: rgba(76, 175, 80, 0.6);
   }
 
   .mode-toggle:hover {

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -123,6 +123,33 @@ export interface ReplayTrace {
   turns?: ReplayTraceTurn[];
 }
 
+export interface PersonaSummary {
+  personaId: string;
+  sessionCount: number;
+  realCount: number;
+  stsCount: number;
+  totalTurns: number;
+  totalOverrides: number;
+  overrideRate: number;
+  lastSessionAt: string | null;
+  firstSessionAt: string | null;
+}
+
+export interface PersonaEvolutionSession {
+  sessionId: string;
+  startedAt: string;
+  kind: "real" | "sts";
+  turnCount: number;
+  hasOverrides: boolean;
+  overrideCount: number;
+}
+
+export interface PersonaEvolution {
+  personaId: string;
+  summary: PersonaSummary;
+  sessions: PersonaEvolutionSession[];
+}
+
 export interface DebugLlmCallEvent {
   id: number;
   receivedAt: string;
@@ -175,6 +202,8 @@ export interface ApiClient {
     sinceId?: number,
   ): Promise<{ events: DebugLlmCallEvent[]; totalEmitted: number }>;
   clearDebugLlmCalls(): Promise<{ cleared: boolean }>;
+  listAnalyticsPersonas(): Promise<{ personas: PersonaSummary[] }>;
+  getPersonaEvolution(personaId: string): Promise<PersonaEvolution>;
   /** Resolve URL completa pro EventSource consumir SSE. */
   turnStateSseUrl(sessionId: string): string;
 }
@@ -278,6 +307,12 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     getSessionReplay: (sessionId) =>
       get<ReplayTrace>(
         `/sessions/${encodeURIComponent(sessionId)}/replay`,
+      ),
+    listAnalyticsPersonas: () =>
+      get<{ personas: PersonaSummary[] }>("/analytics/personas"),
+    getPersonaEvolution: (personaId) =>
+      get<PersonaEvolution>(
+        `/analytics/personas/${encodeURIComponent(personaId)}/evolution`,
       ),
     turnStateSseUrl: (sessionId) =>
       `${baseUrl}/sessions/${encodeURIComponent(sessionId)}/turn-state`,

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -57,6 +57,9 @@ export const replaySessionId = writable<string | null>(null);
 /** Debug panel (raio-X LLM) aberto? */
 export const debugPanelOpen = writable<boolean>(false);
 
+/** Analytics panel (cross-session + drill-down) aberto? */
+export const analyticsOpen = writable<boolean>(false);
+
 /** Events LLM calls (tail mode). Append-only durante polling; clear
  *  via API + store reset. */
 import type { DebugLlmCallEvent } from "./api.js";

--- a/packages/ebrota-console-ui/tests/components/Analytics.test.ts
+++ b/packages/ebrota-console-ui/tests/components/Analytics.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import Analytics from "../../src/components/Analytics.svelte";
+import {
+  analyticsOpen,
+  replaySessionId,
+} from "../../src/lib/stores.js";
+import type {
+  ApiClient,
+  PersonaEvolution,
+  PersonaSummary,
+} from "../../src/lib/api.js";
+
+const yujiSummary = (): PersonaSummary => ({
+  personaId: "yuji",
+  sessionCount: 5,
+  realCount: 2,
+  stsCount: 3,
+  totalTurns: 42,
+  totalOverrides: 3,
+  overrideRate: 0.071,
+  firstSessionAt: "2026-05-01T10:00:00.000Z",
+  lastSessionAt: "2026-05-23T15:00:00.000Z",
+});
+
+const keiSummary = (): PersonaSummary => ({
+  personaId: "kei",
+  sessionCount: 1,
+  realCount: 1,
+  stsCount: 0,
+  totalTurns: 6,
+  totalOverrides: 2,
+  overrideRate: 0.333,
+  firstSessionAt: "2026-05-20T10:00:00.000Z",
+  lastSessionAt: "2026-05-20T10:00:00.000Z",
+});
+
+const yujiEvolution = (): PersonaEvolution => ({
+  personaId: "yuji",
+  summary: yujiSummary(),
+  sessions: [
+    {
+      sessionId: "yuji__a",
+      startedAt: "2026-05-01T10:00:00.000Z",
+      kind: "real",
+      turnCount: 8,
+      hasOverrides: false,
+      overrideCount: 0,
+    },
+    {
+      sessionId: "yuji__b",
+      startedAt: "2026-05-15T10:00:00.000Z",
+      kind: "sts",
+      turnCount: 12,
+      hasOverrides: true,
+      overrideCount: 2,
+    },
+    {
+      sessionId: "yuji__c",
+      startedAt: "2026-05-23T15:00:00.000Z",
+      kind: "real",
+      turnCount: 6,
+      hasOverrides: false,
+      overrideCount: 0,
+    },
+  ],
+});
+
+const buildApi = (
+  personas: PersonaSummary[] = [],
+  evolution: PersonaEvolution | null = null,
+): ApiClient =>
+  ({
+    getStatus: vi.fn(),
+    getMode: vi.fn(),
+    setMode: vi.fn(),
+    startCardSession: vi.fn(),
+    listOptions: vi.fn(),
+    overrideSelection: vi.fn(),
+    listDecisions: vi.fn(),
+    getPendingApproval: vi.fn(),
+    approveOrEdit: vi.fn(),
+    endSession: vi.fn(),
+    listSessionLibrary: vi.fn(),
+    getSessionReplay: vi.fn(),
+    listDebugLlmCalls: vi.fn(),
+    clearDebugLlmCalls: vi.fn(),
+    listAnalyticsPersonas: vi.fn(async () => ({ personas })),
+    getPersonaEvolution: vi.fn(async () => {
+      if (evolution === null) throw new Error("not found");
+      return evolution;
+    }),
+    turnStateSseUrl: () => "/api/sse",
+  }) as never;
+
+beforeEach(() => {
+  analyticsOpen.set(true);
+  replaySessionId.set(null);
+});
+
+describe("Analytics.svelte — visibility", () => {
+  it("não renderiza quando analyticsOpen=false", () => {
+    analyticsOpen.set(false);
+    render(Analytics, { api: buildApi() });
+    expect(screen.queryByTestId("analytics-panel")).toBeNull();
+  });
+
+  it("close button fecha o panel", async () => {
+    render(Analytics, { api: buildApi() });
+    await fireEvent.click(screen.getByTestId("analytics-close"));
+    expect(get(analyticsOpen)).toBe(false);
+  });
+});
+
+describe("Analytics.svelte — personas list", () => {
+  it("estado vazio renderiza hint", async () => {
+    render(Analytics, { api: buildApi([]) });
+    await waitFor(() =>
+      expect(screen.getByTestId("analytics-empty")).toBeDefined(),
+    );
+  });
+
+  it("cards de persona renderizados com stats", async () => {
+    render(Analytics, { api: buildApi([yujiSummary(), keiSummary()]) });
+    await waitFor(() => {
+      const cards = screen.getAllByTestId("persona-card");
+      expect(cards).toHaveLength(2);
+    });
+    expect(screen.getByText("yuji")).toBeDefined();
+    expect(screen.getByText("kei")).toBeDefined();
+    // totalTurns visible
+    expect(screen.getByText("42")).toBeDefined();
+  });
+
+  it("override rate warn class quando >20%", async () => {
+    render(Analytics, { api: buildApi([keiSummary()]) });
+    await waitFor(() => {
+      const rate = screen.getAllByTestId("override-rate")[0];
+      expect(rate?.className).toMatch(/warn/);
+    });
+  });
+});
+
+describe("Analytics.svelte — drill-down", () => {
+  it("click em persona card abre evolution view", async () => {
+    render(Analytics, {
+      api: buildApi([yujiSummary()], yujiEvolution()),
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-card")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("persona-card"));
+    await waitFor(() =>
+      expect(screen.getByTestId("evolution-view")).toBeDefined(),
+    );
+    expect(screen.getByTestId("evolution-summary")).toBeDefined();
+  });
+
+  it("timeline lista session rows", async () => {
+    render(Analytics, {
+      api: buildApi([yujiSummary()], yujiEvolution()),
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-card")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("persona-card"));
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("session-row");
+      expect(rows).toHaveLength(3);
+    });
+  });
+
+  it("filtro kind=sts mostra só sts sessions", async () => {
+    render(Analytics, {
+      api: buildApi([yujiSummary()], yujiEvolution()),
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-card")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("persona-card"));
+    await waitFor(() =>
+      expect(screen.getByTestId("filter-kind")).toBeDefined(),
+    );
+    const select = screen.getByTestId("filter-kind") as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: "sts" } });
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("session-row");
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  it("filtro só-overrides mostra apenas com overrides", async () => {
+    render(Analytics, {
+      api: buildApi([yujiSummary()], yujiEvolution()),
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-card")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("persona-card"));
+    await waitFor(() =>
+      expect(screen.getByTestId("filter-overrides")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("filter-overrides"));
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("session-row");
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  it("back button retorna pra lista de personas", async () => {
+    render(Analytics, {
+      api: buildApi([yujiSummary()], yujiEvolution()),
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-card")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("persona-card"));
+    await waitFor(() =>
+      expect(screen.getByTestId("analytics-back")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("analytics-back"));
+    await waitFor(() =>
+      expect(screen.getByTestId("personas-list")).toBeDefined(),
+    );
+  });
+
+  it("replay button seta replaySessionId + fecha panel", async () => {
+    render(Analytics, {
+      api: buildApi([yujiSummary()], yujiEvolution()),
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-card")).toBeDefined(),
+    );
+    await fireEvent.click(screen.getByTestId("persona-card"));
+    await waitFor(() =>
+      expect(screen.getAllByTestId("open-replay")).toBeDefined(),
+    );
+    const buttons = screen.getAllByTestId("open-replay");
+    await fireEvent.click(buttons[0]!);
+    expect(get(replaySessionId)).toBe("yuji__a");
+    expect(get(analyticsOpen)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

**C-MX-08 eBrota Console — PR9 (Fase H parcial — S-OC-34/35/36).** Painel Analytics V0.1 com cross-session feed + per-persona drill-down + evolução básica.

- **BFF**: \`summarizePersonas\` + \`getPersonaEvolution\` queries SQL agregando \`sessions\` + \`jun_decisions\` (zero schema novo). 2 endpoints. **13 novos tests** → total **93/93** ✅
- **UI**: \`Analytics.svelte\` drawer 60vw com dois modos — persona cards grid + drill-down (summary strip + filtros kind/date/só-overrides + timeline com bar chart de turns + replay deep link). **11 novos tests** → total **98/98** ✅
- **📊 Analytics toggle** em \`Status.svelte\`.

## Escopo entregue vs deferido

✅ S-OC-34 Cross-session feed (persona cards)
✅ S-OC-35 Per-user drill-down (filtros kind/from/to/só-overrides)
✅ S-OC-36 básico (turn count timeline, override rate, real/sts breakdown, first/last session)

⏸ S-OC-36 profundo (Helix state, mood timeline, Dreyfus, cards trabalhadas) — requer parse trace.json → **V0.2**
⏸ S-OC-37/38 (export PDF/markdown, aggregations cross-persona) → **V0.2**

## Stack

\`\`\`
main
 └── PR7 #164 — smoke-visualizer
      └── PR8 #165 — debug-tail
           └── PR9 (este) — analytics-v01
\`\`\`

## Karpathy constraints (CLAUDE.md §0)

- **P2 Simplicity** — 2 queries SQL puras; \`Math.round(rate*1000)/1000\` (zero biblioteca de números); bar chart com pure CSS width (sem chart lib)
- **P3 Surgery** — só arquivos novos + endpoints aditivos; \`server.ts\` ganhou 2 routes; nenhum existing refactor
- **P4 Verifiable** — BDD: \"agrega session_count + turn_count\", \"conta overrides via jun_decisions\", \"ordem por lastSessionAt DESC\", \"override rate=0 quando totalTurns=0\", \"404 pra persona inexistente\"

## Test plan

- [ ] Toggle 📊 Analytics → drawer abre na direita
- [ ] Persona cards mostram stats agregadas; click → drill-down
- [ ] Drill-down: filtro kind=sts → só sts; só-overrides → 1 row
- [ ] Bar de turns proporcional ao max; pill ✎N visível quando overrides
- [ ] Replay button fecha analytics + abre replay modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)