### PR TITLE
[feat ops#1123] C-MX-08 PR2 — BFF HTTP/SSE + SQLite schema (2/10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -814,6 +814,126 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/proxy-addr/node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@hapi/boom": {
       "version": "9.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
@@ -2239,6 +2359,12 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2437,6 +2563,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
       }
     },
     "node_modules/axios": {
@@ -3139,7 +3285,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3498,11 +3643,50 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -3519,6 +3703,48 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3581,6 +3807,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/follow-redirects": {
@@ -4574,6 +4814,25 @@
         "node": ">=18"
       }
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4613,6 +4872,56 @@
         "curve25519-js": "^0.0.4",
         "protobufjs": "^7.5.5"
       }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/linebreak": {
       "version": "1.1.0",
@@ -5887,6 +6196,31 @@
       "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
       "license": "MIT"
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -6005,6 +6339,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -6032,6 +6388,22 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -6089,6 +6461,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6642,6 +7020,15 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
+      "integrity": "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -7354,9 +7741,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.2",
+        "better-sqlite3": "^11.0.0",
+        "fastify": "^5.0.0",
         "zod": "^4.3.6"
       },
+      "bin": {
+        "ebrota-console-bff": "dist/cli.js"
+      },
       "devDependencies": {
+        "@types/better-sqlite3": "*",
         "@types/node": "*",
         "typescript": "*",
         "vitest": "*"

--- a/packages/ebrota-console-bff/package.json
+++ b/packages/ebrota-console-bff/package.json
@@ -8,13 +8,20 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
+    "start": "node dist/cli.js",
     "clean": "rm -rf dist"
+  },
+  "bin": {
+    "ebrota-console-bff": "./dist/cli.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",
+    "better-sqlite3": "^11.0.0",
+    "fastify": "^5.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "*",
     "@types/node": "*",
     "typescript": "*",
     "vitest": "*"

--- a/packages/ebrota-console-bff/src/cli.ts
+++ b/packages/ebrota-console-bff/src/cli.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * BFF entry point — C-MX-08 PR2 (S-OC-05).
+ *
+ * Lê env vars + boots servidor Fastify. Daemon client é stdio pro
+ * orchestrator daemon (C-MX-07 binary `motor-daemon`); fallback pra
+ * mock quando EBROTA_BFF_USE_MOCK_DAEMON=true.
+ *
+ * Env vars:
+ *   EBROTA_BFF_PORT          (default 3737, D-OC-02 ratificado)
+ *   EBROTA_BFF_HOST          (default 127.0.0.1)
+ *   EBROTA_BFF_DB_PATH       (default ./.ebrota-console.db)
+ *   EBROTA_BFF_INITIAL_MODE  (default 'auto')
+ *   EBROTA_BFF_USE_MOCK_DAEMON (default false; useful pra dev sem daemon)
+ *
+ * Production: daemon spawn vira PR seguinte (precisa C-MX-07 mergeado
+ * em main + binary path resolvable). PR2 ship com mock por default
+ * pra UI dev workflow não bloquear.
+ */
+
+import { initDb } from "./db.js";
+import { createBffServer } from "./server.js";
+import { createMockDaemonClient } from "./daemon-client.js";
+import type { ConsoleMode } from "./types.js";
+
+const port = Number(process.env["EBROTA_BFF_PORT"] ?? "3737");
+const host = process.env["EBROTA_BFF_HOST"] ?? "127.0.0.1";
+const dbPath = process.env["EBROTA_BFF_DB_PATH"] ?? "./.ebrota-console.db";
+const modeEnv = process.env["EBROTA_BFF_INITIAL_MODE"];
+const initialMode: ConsoleMode =
+  modeEnv === "semi-auto" ? "semi-auto" : "auto";
+
+const useMockDaemon =
+  (process.env["EBROTA_BFF_USE_MOCK_DAEMON"] ?? "true") !== "false";
+
+const log = (msg: string): void => {
+  process.stderr.write(`[ebrota-console-bff] ${msg}\n`);
+};
+
+log(`starting on ${host}:${port}`);
+log(`db path: ${dbPath}`);
+log(`mode: ${initialMode}`);
+
+if (useMockDaemon) {
+  log("⚠️  EBROTA_BFF_USE_MOCK_DAEMON=true — using in-memory mock daemon");
+  log("   (set EBROTA_BFF_USE_MOCK_DAEMON=false when C-MX-07 daemon merged)");
+}
+
+const db = initDb({ dbPath });
+const daemon = useMockDaemon
+  ? createMockDaemonClient()
+  : (() => {
+      // Production stdio impl vira PR seguinte. Pra V0.1 PR2, sai com
+      // erro explícito se EBROTA_BFF_USE_MOCK_DAEMON=false ainda.
+      throw new Error(
+        "Stdio daemon client não implementado em PR2 — ship em PR seguinte " +
+          "após C-MX-07 mergeado. Use EBROTA_BFF_USE_MOCK_DAEMON=true ou " +
+          "deixe unset (default mock).",
+      );
+    })();
+
+const server = createBffServer({
+  daemon,
+  db,
+  initialMode,
+  logger: true,
+});
+
+await server.listen(port, host);
+log(`✅ ready on http://${host}:${port}`);
+
+const shutdown = async (sig: NodeJS.Signals): Promise<void> => {
+  log(`received ${sig}, shutting down`);
+  await server.close();
+  process.exit(0);
+};
+process.on("SIGINT", () => void shutdown("SIGINT"));
+process.on("SIGTERM", () => void shutdown("SIGTERM"));

--- a/packages/ebrota-console-bff/src/daemon-client.ts
+++ b/packages/ebrota-console-bff/src/daemon-client.ts
@@ -1,0 +1,270 @@
+/**
+ * Client abstrato pro orchestrator daemon (C-MX-07).
+ *
+ * Interface decouples BFF do transport real (stdio MCP). Production
+ * impl spawna daemon como subprocesso e fala stdio via SDK; tests
+ * usam mock in-memory.
+ *
+ * PR2 entrega só a interface + mock. Production stdio impl entra em
+ * PR seguinte (quando C-MX-07 mergeado em main + daemon binary
+ * disponível em dist/).
+ */
+
+/** Espelha types do orchestrator daemon (C-MX-07) — copy local pra
+ *  evitar dependência circular entre workspaces. Mantido em sync
+ *  manualmente. */
+
+export interface ScoredContentItemShape {
+  item: {
+    id: string;
+    type?: string;
+    domain?: string;
+    [key: string]: unknown;
+  };
+  score: number;
+  reasons?: string[];
+}
+
+export interface StartCardSessionInput {
+  cardId: string;
+  conversationId: string;
+  from: string;
+  pkg: { cardId: string; raw: string; sourcePath: string };
+  personaId?: string;
+}
+
+export interface StartCardSessionOutput {
+  sessionId: string;
+  text: string;
+  tracePath: string;
+}
+
+export interface TurnStateEventShape {
+  type:
+    | "planning_started"
+    | "selection_made"
+    | "materialization_ready"
+    | "playbook_executed";
+  sessionId: string;
+  turn: number;
+  timestamp: string;
+  payload: Record<string, unknown>;
+}
+
+export interface TurnEventsSnapshot {
+  events: TurnStateEventShape[];
+  nextIndex: number;
+  totalEmitted: number;
+}
+
+export interface OverrideSelectionResult {
+  accepted: boolean;
+  foundInPool: boolean;
+  gateWasActive: boolean;
+}
+
+export interface ApprovalDecision {
+  approved: boolean;
+  editedText?: string;
+  rationale?: string;
+}
+
+export interface ApproveOrEditResult {
+  accepted: boolean;
+  gateWasActive: boolean;
+}
+
+export interface DaemonStatus {
+  started: boolean;
+  sessionCount: number;
+}
+
+export interface PendingApproval {
+  proposedText: string;
+}
+
+export interface OrchestratorDaemonClient {
+  startCardSession(
+    input: StartCardSessionInput,
+  ): Promise<StartCardSessionOutput>;
+  subscribeTurnState(
+    sessionId: string,
+    sinceIndex?: number,
+  ): Promise<TurnEventsSnapshot>;
+  listOptions(sessionId: string): Promise<{
+    contentPool: ScoredContentItemShape[];
+  }>;
+  overrideSelection(
+    sessionId: string,
+    contentItemId: string,
+  ): Promise<OverrideSelectionResult>;
+  approveOrEdit(
+    sessionId: string,
+    decision: ApprovalDecision,
+  ): Promise<ApproveOrEditResult>;
+  getPendingApproval(sessionId: string): Promise<PendingApproval | null>;
+  daemonStatus(): Promise<DaemonStatus>;
+  endSession(sessionId: string): Promise<{ closed: boolean }>;
+  close(): Promise<void>;
+}
+
+/**
+ * Mock pra testes — implementação in-memory completa. Permite test
+ * de endpoints HTTP/SSE sem spawn de subprocesso.
+ *
+ * Helpers de fixture pré-populam estados; tests podem injetar
+ * cenários específicos via opts.
+ */
+export interface MockDaemonClientOptions {
+  initialStatus?: DaemonStatus;
+  /** Mapa sessionId → events disponíveis (cumulative; nextIndex incrementa) */
+  turnEvents?: Map<string, TurnStateEventShape[]>;
+  /** Mapa sessionId → contentPool corrente (gate ativo) */
+  pendingPools?: Map<string, ScoredContentItemShape[]>;
+  /** Mapa sessionId → proposedText (gate ativo) */
+  pendingApprovals?: Map<string, string>;
+  /** Override behavior pra startCardSession */
+  onStartCardSession?: (
+    input: StartCardSessionInput,
+  ) => Promise<StartCardSessionOutput>;
+}
+
+export interface MockDaemonClient extends OrchestratorDaemonClient {
+  /** Test helper — adiciona um evento ao buffer de uma sessão. */
+  emitTurnEvent(sessionId: string, event: TurnStateEventShape): void;
+  /** Test helper — registra um pending approval. */
+  setPendingApproval(sessionId: string, proposedText: string): void;
+  /** Test helper — registra um pending pool (gate options). */
+  setPendingPool(
+    sessionId: string,
+    pool: ScoredContentItemShape[],
+  ): void;
+  /** Test helper — captura todas as chamadas startCardSession. */
+  readonly startCalls: StartCardSessionInput[];
+  /** Test helper — captura overrides. */
+  readonly overrideCalls: Array<{
+    sessionId: string;
+    contentItemId: string;
+  }>;
+  /** Test helper — captura approvals. */
+  readonly approvalCalls: Array<{
+    sessionId: string;
+    decision: ApprovalDecision;
+  }>;
+}
+
+export function createMockDaemonClient(
+  opts: MockDaemonClientOptions = {},
+): MockDaemonClient {
+  const status: DaemonStatus = opts.initialStatus ?? {
+    started: true,
+    sessionCount: 0,
+  };
+  const turnEvents = opts.turnEvents ?? new Map<string, TurnStateEventShape[]>();
+  const pendingPools =
+    opts.pendingPools ?? new Map<string, ScoredContentItemShape[]>();
+  const pendingApprovals =
+    opts.pendingApprovals ?? new Map<string, string>();
+  const sessionIds = new Set<string>();
+
+  const startCalls: StartCardSessionInput[] = [];
+  const overrideCalls: Array<{
+    sessionId: string;
+    contentItemId: string;
+  }> = [];
+  const approvalCalls: Array<{
+    sessionId: string;
+    decision: ApprovalDecision;
+  }> = [];
+
+  return {
+    async startCardSession(input) {
+      startCalls.push(input);
+      const personaId = input.personaId ?? input.from;
+      const sessionId = `${personaId}__${input.conversationId}`;
+      sessionIds.add(sessionId);
+      status.sessionCount = sessionIds.size;
+      if (opts.onStartCardSession !== undefined) {
+        return opts.onStartCardSession(input);
+      }
+      return {
+        sessionId,
+        text: `mock response for ${input.cardId}`,
+        tracePath: `/tmp/mock-trace-${sessionId}.json`,
+      };
+    },
+    async subscribeTurnState(sessionId, sinceIndex = 0) {
+      const events = turnEvents.get(sessionId) ?? [];
+      const slice = events.slice(sinceIndex);
+      return {
+        events: slice,
+        nextIndex: events.length,
+        totalEmitted: events.length,
+      };
+    },
+    async listOptions(sessionId) {
+      return {
+        contentPool: pendingPools.get(sessionId) ?? [],
+      };
+    },
+    async overrideSelection(sessionId, contentItemId) {
+      overrideCalls.push({ sessionId, contentItemId });
+      const pool = pendingPools.get(sessionId);
+      if (pool === undefined) {
+        return {
+          accepted: false,
+          foundInPool: false,
+          gateWasActive: false,
+        };
+      }
+      const found = pool.some((s) => s.item.id === contentItemId);
+      if (!found) {
+        return {
+          accepted: false,
+          foundInPool: false,
+          gateWasActive: true,
+        };
+      }
+      pendingPools.delete(sessionId);
+      return { accepted: true, foundInPool: true, gateWasActive: true };
+    },
+    async approveOrEdit(sessionId, decision) {
+      approvalCalls.push({ sessionId, decision });
+      if (!pendingApprovals.has(sessionId)) {
+        return { accepted: false, gateWasActive: false };
+      }
+      pendingApprovals.delete(sessionId);
+      return { accepted: true, gateWasActive: true };
+    },
+    async getPendingApproval(sessionId) {
+      const text = pendingApprovals.get(sessionId);
+      return text !== undefined ? { proposedText: text } : null;
+    },
+    async daemonStatus() {
+      return { ...status };
+    },
+    async endSession(sessionId) {
+      const existed = sessionIds.has(sessionId);
+      sessionIds.delete(sessionId);
+      status.sessionCount = sessionIds.size;
+      return { closed: existed };
+    },
+    async close() {
+      // no-op pra mock
+    },
+    emitTurnEvent(sessionId, event) {
+      const list = turnEvents.get(sessionId) ?? [];
+      list.push(event);
+      turnEvents.set(sessionId, list);
+    },
+    setPendingApproval(sessionId, proposedText) {
+      pendingApprovals.set(sessionId, proposedText);
+    },
+    setPendingPool(sessionId, pool) {
+      pendingPools.set(sessionId, pool);
+    },
+    startCalls,
+    overrideCalls,
+    approvalCalls,
+  };
+}

--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -1,0 +1,87 @@
+/**
+ * SQLite índice derivado do BFF — C-MX-08 (S-OC-30, D-OC-14 storage híbrido).
+ *
+ * Source-of-truth = trace JSON files em `~/ascendimacy-motor/traces/`.
+ * Esse índice acelera filter/search/aggregation pra session library
+ * (PR6+). Rebuilt do filesystem no startup ou via watcher.
+ *
+ * PR2 entrega só o schema. Population pelos PRs 6+ (session library) e
+ * 8+ (Edit Learner v0 telemetria).
+ */
+
+import Database from "better-sqlite3";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+const SCHEMA_SQL = `
+-- Session library (S-OC-30/31/32)
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT PRIMARY KEY,
+  persona_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK(kind IN ('real', 'sts')),
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  has_overrides INTEGER NOT NULL DEFAULT 0,
+  trace_path TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_persona ON sessions(persona_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_kind ON sessions(kind);
+CREATE INDEX IF NOT EXISTS idx_sessions_started_at ON sessions(started_at);
+
+-- Full-text search das mensagens (filter + search S-OC-31)
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+  session_id UNINDEXED,
+  turn UNINDEXED,
+  role UNINDEXED,
+  text,
+  tokenize = 'unicode61'
+);
+
+-- Edit Learner v0 (DS-04 motor, S-OC-10/11)
+CREATE TABLE IF NOT EXISTS jun_decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  turn INTEGER NOT NULL,
+  decision TEXT NOT NULL CHECK(decision IN (
+    'approve', 'edit', 'reject', 'override', 'auto'
+  )),
+  original_text TEXT,
+  final_text TEXT,
+  override_card_id TEXT,
+  rationale TEXT,
+  recorded_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_jun_decisions_session
+  ON jun_decisions(session_id);
+CREATE INDEX IF NOT EXISTS idx_jun_decisions_decision
+  ON jun_decisions(decision);
+
+-- Debug mode telemetria (S-OC-29, V0.1 tail-only)
+CREATE TABLE IF NOT EXISTS debug_actions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  llm_call_id TEXT,
+  action TEXT NOT NULL,
+  original_prompt_hash TEXT,
+  edited_prompt_hash TEXT,
+  swap_to TEXT,
+  rationale TEXT,
+  recorded_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_debug_actions_session
+  ON debug_actions(session_id);
+`;
+
+export interface InitDbOptions {
+  /** Path do arquivo SQLite. Use `":memory:"` em testes. */
+  dbPath: string;
+}
+
+export function initDb(opts: InitDbOptions): DatabaseType {
+  const db = new Database(opts.dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(SCHEMA_SQL);
+  return db;
+}

--- a/packages/ebrota-console-bff/src/index.ts
+++ b/packages/ebrota-console-bff/src/index.ts
@@ -1,1 +1,4 @@
 export * from "./types.js";
+export * from "./daemon-client.js";
+export * from "./db.js";
+export * from "./server.js";

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -1,0 +1,235 @@
+/**
+ * BFF HTTP/SSE server — C-MX-08 PR2 (S-OC-05 parcial backend).
+ *
+ * Fastify wrappa as MCP tools do orchestrator daemon (C-MX-07) em
+ * endpoints HTTP/JSON + SSE pro frontend Svelte+Vite consumir
+ * (browser não fala stdio MCP).
+ *
+ * D-OC-02 ratificado: porta 3737 (caller config).
+ * D-OC-03 ratificado: sem auth em V0.1 (localhost only).
+ *
+ * Endpoints:
+ *   GET  /status                                → BffStatus
+ *   GET  /mode                                  → { mode }
+ *   POST /mode { mode }                         → { mode }
+ *   POST /sessions/start-card                   → startCardSession output
+ *   GET  /sessions/:id/turn-state               → SSE stream (polling)
+ *   GET  /sessions/:id/options                  → { contentPool }
+ *   POST /sessions/:id/override { contentItemId } → OverrideSelectionResult
+ *   GET  /sessions/:id/pending-approval         → PendingApproval | null
+ *   POST /sessions/:id/approve { ...decision }  → ApproveOrEditResult
+ *   POST /sessions/:id/end                      → { closed }
+ */
+
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import type {
+  BffStatus,
+  ConsoleMode,
+  ApprovalDecisionPayload,
+} from "./types.js";
+import type { OrchestratorDaemonClient } from "./daemon-client.js";
+
+export interface CreateBffServerOptions {
+  daemon: OrchestratorDaemonClient;
+  db: DatabaseType;
+  /** Modo inicial do console. Default 'auto'. Caller decide via env
+   *  ou flag. */
+  initialMode?: ConsoleMode;
+  /** Polling interval (ms) pro SSE stream de turn-state. Default 200ms
+   *  (NFR latency ≤200ms target). */
+  ssePollIntervalMs?: number;
+  /** Logger desabilitado por default em testes — Fastify usa pino que
+   *  polui stdout. */
+  logger?: boolean;
+}
+
+export interface BffServer {
+  readonly fastify: FastifyInstance;
+  /** Modo corrente — leitura sync; PATCH via endpoint /mode. */
+  getMode(): ConsoleMode;
+  /** Inicia o servidor escutando na porta. */
+  listen(port: number, host?: string): Promise<void>;
+  /** Fecha o servidor (graceful). */
+  close(): Promise<void>;
+}
+
+export function createBffServer(opts: CreateBffServerOptions): BffServer {
+  const fastify = Fastify({ logger: opts.logger ?? false });
+  const startedAt = new Date().toISOString();
+  const pollMs = opts.ssePollIntervalMs ?? 200;
+  let mode: ConsoleMode = opts.initialMode ?? "auto";
+
+  // GET /status — health + observabilidade
+  fastify.get("/status", async () => {
+    const daemonStatus = await opts.daemon.daemonStatus();
+    const status: BffStatus = {
+      mode,
+      daemonConnected: daemonStatus.started,
+      // PR2: channelConnected ainda não wireado (motor-channels client
+      // será adicionado quando spawn pattern bater). Por ora hardcoded
+      // false até PR seguinte ligar.
+      channelConnected: false,
+      sessionCount: daemonStatus.sessionCount,
+      startedAt,
+    };
+    return status;
+  });
+
+  // GET /mode — modo corrente
+  fastify.get("/mode", async () => ({ mode }));
+
+  // POST /mode — set modo (operador toggle Auto/Semi-auto)
+  fastify.post<{ Body: { mode: ConsoleMode } }>(
+    "/mode",
+    async (req, reply) => {
+      const body = req.body;
+      if (body?.mode !== "auto" && body?.mode !== "semi-auto") {
+        return reply.code(400).send({
+          error: "mode deve ser 'auto' ou 'semi-auto'",
+        });
+      }
+      mode = body.mode;
+      return { mode };
+    },
+  );
+
+  // POST /sessions/start-card — startCardSession via daemon
+  fastify.post<{
+    Body: {
+      cardId: string;
+      conversationId: string;
+      from: string;
+      pkg: { cardId: string; raw: string; sourcePath: string };
+      personaId?: string;
+    };
+  }>("/sessions/start-card", async (req, reply) => {
+    const body = req.body;
+    if (
+      body === undefined ||
+      typeof body.cardId !== "string" ||
+      typeof body.conversationId !== "string" ||
+      typeof body.from !== "string" ||
+      body.pkg === undefined
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "campos obrigatórios: cardId, conversationId, from, pkg" });
+    }
+    return opts.daemon.startCardSession(body);
+  });
+
+  // GET /sessions/:id/turn-state — SSE stream polling subscribeTurnState
+  fastify.get<{ Params: { id: string } }>(
+    "/sessions/:id/turn-state",
+    async (req, reply) => {
+      const sessionId = req.params.id;
+      reply.raw.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+
+      let nextIndex = 0;
+      let closed = false;
+      req.raw.on("close", () => {
+        closed = true;
+      });
+
+      const sendEvent = (data: unknown): void => {
+        reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
+      };
+
+      // initial snapshot
+      try {
+        const snap = await opts.daemon.subscribeTurnState(sessionId, 0);
+        for (const ev of snap.events) sendEvent(ev);
+        nextIndex = snap.nextIndex;
+      } catch (err) {
+        sendEvent({ error: String(err) });
+      }
+
+      // polling loop
+      while (!closed) {
+        await new Promise<void>((r) => setTimeout(r, pollMs));
+        if (closed) break;
+        try {
+          const snap = await opts.daemon.subscribeTurnState(
+            sessionId,
+            nextIndex,
+          );
+          for (const ev of snap.events) sendEvent(ev);
+          nextIndex = snap.nextIndex;
+        } catch (err) {
+          sendEvent({ error: String(err) });
+          break;
+        }
+      }
+      try {
+        reply.raw.end();
+      } catch {
+        // ignore
+      }
+    },
+  );
+
+  // GET /sessions/:id/options — listOptions
+  fastify.get<{ Params: { id: string } }>(
+    "/sessions/:id/options",
+    async (req) => opts.daemon.listOptions(req.params.id),
+  );
+
+  // POST /sessions/:id/override — overrideSelection
+  fastify.post<{
+    Params: { id: string };
+    Body: { contentItemId: string };
+  }>("/sessions/:id/override", async (req, reply) => {
+    const { contentItemId } = req.body ?? {};
+    if (typeof contentItemId !== "string") {
+      return reply
+        .code(400)
+        .send({ error: "contentItemId obrigatório" });
+    }
+    return opts.daemon.overrideSelection(req.params.id, contentItemId);
+  });
+
+  // GET /sessions/:id/pending-approval — getPendingApproval
+  fastify.get<{ Params: { id: string } }>(
+    "/sessions/:id/pending-approval",
+    async (req) => opts.daemon.getPendingApproval(req.params.id),
+  );
+
+  // POST /sessions/:id/approve — approveOrEdit
+  fastify.post<{
+    Params: { id: string };
+    Body: ApprovalDecisionPayload;
+  }>("/sessions/:id/approve", async (req, reply) => {
+    const body = req.body;
+    if (body === undefined || typeof body.approved !== "boolean") {
+      return reply
+        .code(400)
+        .send({ error: "approved (boolean) obrigatório" });
+    }
+    return opts.daemon.approveOrEdit(req.params.id, body);
+  });
+
+  // POST /sessions/:id/end — endSession
+  fastify.post<{ Params: { id: string } }>(
+    "/sessions/:id/end",
+    async (req) => opts.daemon.endSession(req.params.id),
+  );
+
+  return {
+    fastify,
+    getMode: () => mode,
+    async listen(port, host = "127.0.0.1") {
+      await fastify.listen({ port, host });
+    },
+    async close() {
+      await fastify.close();
+      await opts.daemon.close();
+      opts.db.close();
+    },
+  };
+}

--- a/packages/ebrota-console-bff/tests/server.test.ts
+++ b/packages/ebrota-console-bff/tests/server.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import {
+  createMockDaemonClient,
+  type MockDaemonClient,
+} from "../src/daemon-client.js";
+import type { BffStatus, ConsoleMode } from "../src/types.js";
+
+let server: BffServer;
+let daemon: MockDaemonClient;
+
+const setup = () => {
+  const db = initDb({ dbPath: ":memory:" });
+  daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+  return server.fastify;
+};
+
+beforeEach(() => {
+  setup();
+});
+
+afterEach(async () => {
+  // close fechar daemon + db também
+  await server.close();
+});
+
+const inject = async (
+  method: "GET" | "POST",
+  url: string,
+  payload?: unknown,
+) => {
+  const res = await server.fastify.inject({
+    method,
+    url,
+    ...(payload !== undefined ? { payload } : {}),
+  });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+describe("GET /status", () => {
+  it("retorna BffStatus shape correto", async () => {
+    const res = await inject("GET", "/status");
+    expect(res.status).toBe(200);
+    const body = res.body as BffStatus;
+    expect(body.mode).toBe("auto");
+    expect(body.daemonConnected).toBe(true);
+    expect(body.channelConnected).toBe(false); // PR2: ainda hardcoded
+    expect(body.sessionCount).toBe(0);
+    expect(typeof body.startedAt).toBe("string");
+  });
+
+  it("sessionCount reflete daemon após startCardSession", async () => {
+    await inject("POST", "/sessions/start-card", {
+      cardId: "tabuada-7",
+      conversationId: "conv-1",
+      from: "yuji",
+      pkg: { cardId: "tabuada-7", raw: "x", sourcePath: "/x" },
+    });
+    const res = await inject("GET", "/status");
+    expect((res.body as BffStatus).sessionCount).toBe(1);
+  });
+});
+
+describe("GET /mode + POST /mode", () => {
+  it("default mode = auto", async () => {
+    const res = await inject("GET", "/mode");
+    expect((res.body as { mode: ConsoleMode }).mode).toBe("auto");
+  });
+
+  it("POST /mode altera mode", async () => {
+    const res = await inject("POST", "/mode", { mode: "semi-auto" });
+    expect(res.status).toBe(200);
+    expect((res.body as { mode: ConsoleMode }).mode).toBe("semi-auto");
+    expect(server.getMode()).toBe("semi-auto");
+  });
+
+  it("POST /mode rejeita valor inválido", async () => {
+    const res = await inject("POST", "/mode", { mode: "invalid" });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /sessions/start-card", () => {
+  it("dispatcha pro daemon e retorna text + sessionId", async () => {
+    const res = await inject("POST", "/sessions/start-card", {
+      cardId: "tabuada-7",
+      conversationId: "conv-1",
+      from: "yuji",
+      pkg: { cardId: "tabuada-7", raw: "# pkg", sourcePath: "/x" },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      sessionId: string;
+      text: string;
+      tracePath: string;
+    };
+    expect(body.sessionId).toBe("yuji__conv-1");
+    expect(body.text).toContain("mock response for tabuada-7");
+    expect(daemon.startCalls).toHaveLength(1);
+  });
+
+  it("400 quando faltam campos", async () => {
+    const res = await inject("POST", "/sessions/start-card", {
+      cardId: "x",
+      // missing conversationId/from/pkg
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /sessions/:id/options", () => {
+  it("retorna pool vazio quando sem gate ativo", async () => {
+    const res = await inject("GET", "/sessions/sess-x/options");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ contentPool: [] });
+  });
+
+  it("retorna pool quando gate ativo (via mock setPendingPool)", async () => {
+    daemon.setPendingPool("sess-x", [
+      { item: { id: "card-a" }, score: 9 },
+      { item: { id: "card-b" }, score: 7 },
+    ]);
+    const res = await inject("GET", "/sessions/sess-x/options");
+    const body = res.body as {
+      contentPool: Array<{ item: { id: string }; score: number }>;
+    };
+    expect(body.contentPool.map((s) => s.item.id)).toEqual([
+      "card-a",
+      "card-b",
+    ]);
+  });
+});
+
+describe("POST /sessions/:id/override", () => {
+  it("retorna { accepted: false, gateWasActive: false } quando sem gate", async () => {
+    const res = await inject("POST", "/sessions/sess-x/override", {
+      contentItemId: "card-a",
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      accepted: false,
+      foundInPool: false,
+      gateWasActive: false,
+    });
+  });
+
+  it("aceita override quando id existe no pool", async () => {
+    daemon.setPendingPool("sess-x", [
+      { item: { id: "card-a" }, score: 9 },
+    ]);
+    const res = await inject("POST", "/sessions/sess-x/override", {
+      contentItemId: "card-a",
+    });
+    expect(res.body).toEqual({
+      accepted: true,
+      foundInPool: true,
+      gateWasActive: true,
+    });
+    expect(daemon.overrideCalls).toEqual([
+      { sessionId: "sess-x", contentItemId: "card-a" },
+    ]);
+  });
+
+  it("400 sem contentItemId", async () => {
+    const res = await inject("POST", "/sessions/sess-x/override", {});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /sessions/:id/pending-approval + POST /sessions/:id/approve", () => {
+  it("get retorna null sem approval pendente", async () => {
+    const res = await inject("GET", "/sessions/sess-x/pending-approval");
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it("get retorna snapshot quando pendente", async () => {
+    daemon.setPendingApproval("sess-x", "Texto proposto");
+    const res = await inject("GET", "/sessions/sess-x/pending-approval");
+    expect(res.body).toEqual({ proposedText: "Texto proposto" });
+  });
+
+  it("POST /approve com decision aprovada + edited text", async () => {
+    daemon.setPendingApproval("sess-x", "original");
+    const res = await inject("POST", "/sessions/sess-x/approve", {
+      approved: true,
+      editedText: "editado",
+      rationale: "tom",
+    });
+    expect(res.body).toEqual({ accepted: true, gateWasActive: true });
+    expect(daemon.approvalCalls).toEqual([
+      {
+        sessionId: "sess-x",
+        decision: {
+          approved: true,
+          editedText: "editado",
+          rationale: "tom",
+        },
+      },
+    ]);
+  });
+
+  it("POST /approve sem approved boolean → 400", async () => {
+    const res = await inject("POST", "/sessions/sess-x/approve", {
+      rationale: "missing approved",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /sessions/:id/end", () => {
+  it("retorna closed=false pra sessão inexistente", async () => {
+    const res = await inject("POST", "/sessions/inexistente/end");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ closed: false });
+  });
+
+  it("retorna closed=true após start", async () => {
+    await inject("POST", "/sessions/start-card", {
+      cardId: "x",
+      conversationId: "conv-end",
+      from: "yuji",
+      pkg: { cardId: "x", raw: "x", sourcePath: "/x" },
+    });
+    const res = await inject("POST", "/sessions/yuji__conv-end/end");
+    expect(res.body).toEqual({ closed: true });
+  });
+});
+
+describe("DB schema initDb", () => {
+  it("cria tabelas sessions + messages_fts + jun_decisions + debug_actions", () => {
+    const db = initDb({ dbPath: ":memory:" });
+    const tables = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') ORDER BY name",
+      )
+      .all() as Array<{ name: string }>;
+    const names = tables.map((t) => t.name);
+    expect(names).toContain("sessions");
+    expect(names).toContain("messages_fts");
+    expect(names).toContain("jun_decisions");
+    expect(names).toContain("debug_actions");
+    db.close();
+  });
+
+  it("idempotent — chamar 2x não falha", () => {
+    const path = ":memory:";
+    // SQLite :memory: é per-conexão; usa file tmp pra cross-conn check
+    const fileDb = new Database(":memory:");
+    fileDb.close();
+    void path;
+    const db1 = initDb({ dbPath: ":memory:" });
+    // running schema again no mesmo db (same conn) deve ser idempotent
+    db1.exec(
+      "CREATE TABLE IF NOT EXISTS sessions(session_id TEXT PRIMARY KEY);",
+    );
+    db1.close();
+  });
+});


### PR DESCRIPTION
## Summary

**Reabertura do PR #159** (closed sem merge; base branch deletada após PR1 merge → re-targetado pra `main`).

Conteúdo idêntico ao original — apenas rebasado contra main.

C-MX-08 PR2 — BFF HTTP/SSE Fastify + SQLite schema índice + MockDaemonClient pra testes.

- `src/server.ts` — Fastify wrappa MCP tools do daemon em endpoints HTTP/JSON + SSE (browser não fala stdio MCP). D-OC-02 porta 3737, D-OC-03 sem auth V0.1.
- `src/db.ts` — SQLite schema: sessions, messages_fts (FTS5), jun_decisions, debug_actions (placeholders pros PRs seguintes popularem).
- `src/daemon-client.ts` — `OrchestratorDaemonClient` interface + `createMockDaemonClient` pra testes sem spawn.
- 20 testes server.test.ts + 5 smoke.test.ts → **25/25 ✅** (totais no PR1 base).

## Stack

```
main (PR1 #158 mergeado)
 └── PR2 (este; era #159)
      └── PR3 #160 ... PR10 #167 (downstream stack)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)