### PR TITLE
[fix ops#1055] openai-compat (LLM local) não força mock por keyMissing

### DIFF
--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -15,7 +15,7 @@ import { extractSignals } from "./signal-extractor.js";
 import { applyPostProcessors } from "./post-processor.js";
 import { buildInaugural } from "./inaugural.js";
 import { canSkipDrotaComposition } from "./compose-skip.js";
-import { logDebugEvent, getProviderForStep } from "@ascendimacy/shared";
+import { logDebugEvent, shouldUseMockLlm } from "@ascendimacy/shared";
 
 const server = new McpServer({
   name: "motor-drota",
@@ -354,13 +354,9 @@ server.registerTool(
       };
     }
 
-    // motor#22: provider-aware mock detection.
-    const drotaProvider = getProviderForStep("drota");
-    const drotaKeyMissing = drotaProvider === "anthropic"
-      ? !process.env["ANTHROPIC_API_KEY"]
-      : !process.env["INFOMANIAK_API_KEY"];
-    const useMock =
-      process.env["USE_MOCK_LLM"] === "true" || drotaKeyMissing;
+    // motor#22 + D-3-PROV (ops#1055) follow-up: gate provider-aware via
+    // shared/llm-router.ts. openai-compat (LLM local) não exige API key.
+    const useMock = shouldUseMockLlm("drota");
     // motor#25 (handoff #24 Tarefa 2): split em stable prefix + dynamic body
     // pra prompt caching. STABLE_DROTA_PREFIX (BLOCO 1+4+5) é literalmente
     // idêntico entre calls — Anthropic cache_control: ephemeral funciona.

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -34,7 +34,7 @@ import {
   isParentalProfileMinimal,
   triageForParents,
   logDebugEvent,
-  getProviderForStep,
+  shouldUseMockLlm,
   computeChallengeCost,
   computeTrustRatio,
   deriveOutcomeSignal,
@@ -306,15 +306,10 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   // 2. Triagem parental (Bloco 4 #17, paper §6 camada 2).
   //    Se persona.profile.parental_profile existir E estiver mínimo,
   //    passa topK pelo triageForParents (rule-based ou Haiku).
-  // motor#22: provider-aware mock detection — antes era hardcoded
-  // !ANTHROPIC_API_KEY (legacy pré-router motor#21). Agora checa a key
-  // do provider efetivamente configurado pra este step.
-  const planejadorProvider = getProviderForStep("planejador");
-  const planejadorKeyMissing = planejadorProvider === "anthropic"
-    ? !process.env["ANTHROPIC_API_KEY"]
-    : !process.env["INFOMANIAK_API_KEY"];
-  const useMockLlm =
-    process.env["USE_MOCK_LLM"] === "true" || planejadorKeyMissing;
+  // motor#22 + D-3-PROV (ops#1055) follow-up: gate provider-aware,
+  // openai-compat (LLM local) não exige API key. Helper centralizado
+  // em shared/llm-router.ts pra evitar duplicação com motor-drota.
+  const useMockLlm = shouldUseMockLlm("planejador");
   const parentalProfile = extractParentalProfile(input.persona);
   let triageMode: "rule_based" | "haiku" | "skipped" = "skipped";
   let triageRejectedIds: string[] = [];

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -125,6 +125,30 @@ export function getProviderForStep(step: string): LlmProvider {
 }
 
 /**
+ * Decide se step deve cair em mock-LLM fixture.
+ *
+ * Provider-aware (D-3-PROV ops#1055 follow-up): openai-compat = LLM local
+ * (llama.cpp/vLLM-XPU) e NÃO exige API key — sem essa exceção, o gate
+ * caía no branch legacy (checava INFOMANIAK_API_KEY) e forçava mock
+ * mesmo com llama-server up. Reproduzido em smoke STS 2026-05-24 contra
+ * Qwen3-30B (`signals=[]`, `"Mock: contexto inicial"` em strategicRationale).
+ *
+ * Ordem de precedência:
+ * 1. USE_MOCK_LLM=true → mock (override explícito do operador)
+ * 2. provider=anthropic + sem ANTHROPIC_API_KEY → mock
+ * 3. provider=infomaniak + sem INFOMANIAK_API_KEY → mock
+ * 4. provider=openai-compat → NUNCA mock por key (LLM local, sem API key)
+ */
+export function shouldUseMockLlm(step: string): boolean {
+  if (process.env["USE_MOCK_LLM"] === "true") return true;
+  const provider = getProviderForStep(step);
+  if (provider === "anthropic") return !process.env["ANTHROPIC_API_KEY"];
+  if (provider === "infomaniak") return !process.env["INFOMANIAK_API_KEY"];
+  // openai-compat: LLM local, no key required
+  return false;
+}
+
+/**
  * Resolve model pra um step. Provider-aware:
  * - Se provider=anthropic e env <STEP>_MODEL é Anthropic-style ou ausente → Claude default
  * - Se provider=infomaniak → Infomaniak model name

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -8,6 +8,7 @@ import {
   getModelForStep,
   getMaxTokensForStep,
   shouldEnableThinking,
+  shouldUseMockLlm,
   isReasoningModel,
   DEFAULT_PROVIDERS,
   DEFAULT_MODELS,
@@ -223,6 +224,82 @@ describe("shouldEnableThinking", () => {
     expect(shouldEnableThinking("planejador", "openai-compat", true)).toBe(false);
     expect(shouldEnableThinking("drota", "openai-compat", true)).toBe(false);
     expect(shouldEnableThinking("persona-sim", "openai-compat", false)).toBe(false);
+  });
+});
+
+describe("shouldUseMockLlm (D-3-PROV ops#1055 follow-up)", () => {
+  /** Save + clear all key/provider env so each test starts pristine. */
+  const KEY_ENVS = [
+    "USE_MOCK_LLM",
+    "ANTHROPIC_API_KEY",
+    "INFOMANIAK_API_KEY",
+    "LLM_PROVIDER",
+    "PLANEJADOR_PROVIDER",
+    "DROTA_PROVIDER",
+  ];
+  const savedKeys: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEY_ENVS) {
+      savedKeys[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEY_ENVS) {
+      if (savedKeys[k] === undefined) delete process.env[k];
+      else process.env[k] = savedKeys[k];
+    }
+  });
+
+  it("USE_MOCK_LLM=true força mock independente do provider", () => {
+    process.env["USE_MOCK_LLM"] = "true";
+    process.env["LLM_PROVIDER"] = "openai-compat";
+    expect(shouldUseMockLlm("planejador")).toBe(true);
+  });
+
+  it("provider=anthropic sem ANTHROPIC_API_KEY → mock", () => {
+    process.env["LLM_PROVIDER"] = "anthropic";
+    expect(shouldUseMockLlm("planejador")).toBe(true);
+  });
+
+  it("provider=anthropic com ANTHROPIC_API_KEY → real", () => {
+    process.env["LLM_PROVIDER"] = "anthropic";
+    process.env["ANTHROPIC_API_KEY"] = "sk-test";
+    expect(shouldUseMockLlm("planejador")).toBe(false);
+  });
+
+  it("provider=infomaniak sem INFOMANIAK_API_KEY → mock", () => {
+    process.env["LLM_PROVIDER"] = "infomaniak";
+    expect(shouldUseMockLlm("drota")).toBe(true);
+  });
+
+  it("provider=infomaniak com INFOMANIAK_API_KEY → real", () => {
+    process.env["LLM_PROVIDER"] = "infomaniak";
+    process.env["INFOMANIAK_API_KEY"] = "im-test";
+    expect(shouldUseMockLlm("drota")).toBe(false);
+  });
+
+  it("provider=openai-compat SEM nenhuma API key → real (LLM local)", () => {
+    // Bug raiz reproduzido em smoke STS 2026-05-24: antes desse fix, o
+    // gate caía em else legacy e forçava mock mesmo com llama-server up.
+    process.env["LLM_PROVIDER"] = "openai-compat";
+    expect(shouldUseMockLlm("planejador")).toBe(false);
+    expect(shouldUseMockLlm("drota")).toBe(false);
+  });
+
+  it("provider=openai-compat com USE_MOCK_LLM=true → mock (operador override)", () => {
+    process.env["LLM_PROVIDER"] = "openai-compat";
+    process.env["USE_MOCK_LLM"] = "true";
+    expect(shouldUseMockLlm("planejador")).toBe(true);
+  });
+
+  it("per-step provider override é respeitado", () => {
+    process.env["LLM_PROVIDER"] = "anthropic"; // global
+    process.env["DROTA_PROVIDER"] = "openai-compat"; // override
+    // anthropic gate vs openai-compat gate
+    expect(shouldUseMockLlm("planejador")).toBe(true); // anthropic sem key
+    expect(shouldUseMockLlm("drota")).toBe(false); // openai-compat sem key OK
   });
 });
 


### PR DESCRIPTION
## Summary

D-3-PROV (ops#1055) introduziu \`provider=openai-compat\` no \`llm-router\` mas os mock gates em \`planejador/src/plan.ts\` e \`motor-drota/src/server.ts\` não foram atualizados — ficaram com else legacy checando \`INFOMANIAK_API_KEY\`. Com \`LLM_PROVIDER=openai-compat\` e sem \`INFOMANIAK_API_KEY\`, \`keyMissing=true\` e o pipeline caía em **mock fixtures mesmo com llama-server up**.

## Como reproduziu

Smoke STS 2026-05-24 contra Qwen3-30B-A3B-Instruct-2507 (llama.cpp SYCL na Intel Arc B580, endpoint \`http://localhost:9000/v1\`):

- \`strategicRationale: "Mock: contexto inicial..."\` — fixture planejador
- \`selectionRationale: "Mock: Icebreaker..."\` — fixture drota selector
- \`signals: []\` em todos os turns
- Greeting \"Ryo, bom te conhecer...\" → vem de \`motor-drota/src/inaugural.ts:81\` (fixture)
- **Qwen3-30B nunca foi chamado** apesar de \`--real-llm\` flag no STS e \`LLM_PROVIDER=openai-compat\` no \`.env\`

## Fix

- **\`shared/src/llm-router.ts\`**: novo helper \`shouldUseMockLlm(step)\` com semântica explícita por provider:
  - \`USE_MOCK_LLM=true\` → mock (operador override, sempre vence)
  - \`anthropic\` sem \`ANTHROPIC_API_KEY\` → mock
  - \`infomaniak\` sem \`INFOMANIAK_API_KEY\` → mock
  - \`openai-compat\` → **NUNCA mock por key** (LLM local não exige API key)
- **\`planejador/src/plan.ts\`** e **\`motor-drota/src/server.ts\`**: trocam keyMissing inline pelo helper. Consolida 2 sites duplicados.

## Tests

8 novos em \`shared/tests/llm-router.test.ts\`:

- \`USE_MOCK_LLM=true\` força mock em qualquer provider
- \`anthropic\`/\`infomaniak\` com/sem key (4 testes)
- **\`openai-compat\` sem nenhuma API key → real** (regression test do bug)
- \`openai-compat\` + \`USE_MOCK_LLM=true\` → mock (operador override)
- Per-step provider override (\`DROTA_PROVIDER=openai-compat\` vs global \`LLM_PROVIDER=anthropic\`)

## Verificação

- ✅ \`npm test --workspace shared\` → 649/649
- ✅ \`npm test --workspace planejador\` → 304/304
- ✅ \`npm test --workspace motor-drota\` → 206/206
- ✅ \`npm run build\` clean em todos os 3 workspaces

## Karpathy constraints (CLAUDE.md §0)

- **P3 Surgery** — apenas o gate. Não toquei callsites do callLlm/callHaiku, não refatorei pricing, não mexi em signal-extractor (que tem gate próprio só USE_MOCK_LLM).
- **P4 Verifiable** — alvo: \"smoke STS com LLM_PROVIDER=openai-compat NÃO emite 'Mock:' em strategicRationale\". Regression test em \`shared/tests/llm-router.test.ts\` cobre o caso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)