### PR TITLE
[fix ops#1055] callGateway bypass pra openai-compat → fetch direto (v2)

### DIFF
--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -19,7 +19,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { join, dirname } from "node:path";
 import { createRequire } from "node:module";
-import type { LlmProvider } from "./llm-router.js";
+import {
+  getProviderForStep,
+  getModelForStep,
+  type LlmProvider,
+} from "./llm-router.js";
+import { getLlmTimeoutMs } from "./llm-config.js";
 
 // Tipos espelham llm-gateway/src/types.ts. Mantidos sincronizados manualmente.
 export interface GatewayChatCompletionInput {
@@ -147,12 +152,116 @@ async function getClient(): Promise<Client> {
 }
 
 /**
+ * Bypass do llm-gateway pra `provider=openai-compat` — D-3-PROV (ops#1055).
+ *
+ * O gateway MCP só rotea anthropic/infomaniak (retry/fallback/bucket
+ * coordenado). LLM local (llama.cpp SYCL, vLLM-XPU) não passa pelo
+ * gateway — chamada direta via fetch ao `LLM_LOCAL_ENDPOINT`, sem
+ * retry coordenado, sem fallback cross-provider. Caller usa o mesmo
+ * `callGateway()` agnóstico; o switch é interno aqui.
+ *
+ * Endpoint default: `http://localhost:8080/v1/chat/completions`
+ * Override via env `LLM_LOCAL_ENDPOINT`.
+ *
+ * Pricing: openai-compat = custo 0 USD (LLM local, sem custo de API);
+ * `calculateCostUsd` em llm-config.ts já trata.
+ */
+interface OpenAiChatChoice {
+  message?: { content?: string };
+  finish_reason?: string;
+}
+interface OpenAiChatUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+}
+interface OpenAiChatResponse {
+  choices?: OpenAiChatChoice[];
+  usage?: OpenAiChatUsage;
+  model?: string;
+}
+
+async function callLocalChatCompletion(
+  req: GatewayChatCompletionInput,
+): Promise<GatewayChatCompletionOutput> {
+  const endpoint =
+    process.env["LLM_LOCAL_ENDPOINT"] ??
+    "http://localhost:8080/v1/chat/completions";
+  const model =
+    req.model && req.model.length > 0
+      ? req.model
+      : getModelForStep(req.step, "openai-compat");
+  // cacheableSystemPrefix é prepended pra preservar caching automático
+  // do llama.cpp (prefixos consistentes >1024 tokens cacheiam server-side).
+  const systemContent =
+    (req.cacheableSystemPrefix ?? "") + req.systemPrompt;
+  const body: Record<string, unknown> = {
+    model,
+    messages: [
+      { role: "system", content: systemContent },
+      { role: "user", content: req.userMessage },
+    ],
+  };
+  if (req.maxTokens !== undefined) body["max_tokens"] = req.maxTokens;
+  const timeoutMs = getLlmTimeoutMs(req.step);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const t0 = Date.now();
+  try {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `gateway error: HTTP_${res.status} — ${text.slice(0, 200)}`,
+      );
+    }
+    const parsed = (await res.json()) as OpenAiChatResponse;
+    const choice = parsed.choices?.[0];
+    if (choice === undefined) {
+      throw new Error("gateway error: EMPTY_RESPONSE — no choices in response");
+    }
+    const usage = parsed.usage ?? {};
+    return {
+      content: choice.message?.content ?? "",
+      tokens: {
+        in: usage.prompt_tokens ?? 0,
+        out: usage.completion_tokens ?? 0,
+        reasoning: 0,
+        cacheRead: usage.prompt_tokens_details?.cached_tokens ?? 0,
+        cacheCreation: 0,
+      },
+      provider: "openai-compat",
+      model: parsed.model ?? model,
+      latency_ms: Date.now() - t0,
+      attempt_count: 1,
+      was_fallback: false,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Chama o gateway. Lazy-spawn no primeiro call; reusa o mesmo processo
  * gateway pro resto da vida do processo caller.
+ *
+ * D-3-PROV (ops#1055): se provider efetivo é `openai-compat`, faz bypass
+ * do gateway MCP e chama direto via fetch (LLM local não tem retry/
+ * fallback coordenado — overhead do MCP+bucket é desnecessário).
  */
 export async function callGateway(
   req: GatewayChatCompletionInput,
 ): Promise<GatewayChatCompletionOutput> {
+  const effectiveProvider = req.provider ?? getProviderForStep(req.step);
+  if (effectiveProvider === "openai-compat") {
+    return callLocalChatCompletion(req);
+  }
   const client = await getClient();
   const result = await client.callTool({
     name: "chat_completion",

--- a/shared/tests/gateway-client.test.ts
+++ b/shared/tests/gateway-client.test.ts
@@ -1,0 +1,223 @@
+/**
+ * gateway-client tests — D-3-PROV (ops#1055) bypass pra openai-compat.
+ *
+ * Foco: o switch `callGateway` quando provider=openai-compat → fetch
+ * direto, sem passar pelo MCP gateway. Mockamos `globalThis.fetch` pra
+ * verificar request shape + parsing do response.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+import { callGateway } from "../src/gateway-client.js";
+
+const ORIG_ENV = { ...process.env };
+let fetchMock: Mock;
+
+beforeEach(() => {
+  // Pristine env pros tests deste describe
+  for (const k of [
+    "LLM_LOCAL_ENDPOINT",
+    "LLM_LOCAL_MODEL",
+    "LLM_PROVIDER",
+    "PLANEJADOR_PROVIDER",
+    "PLANEJADOR_MODEL",
+    "DROTA_PROVIDER",
+    "DROTA_MODEL",
+  ]) {
+    delete process.env[k];
+  }
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(ORIG_ENV)) {
+    if (process.env[k] !== v) process.env[k] = v;
+  }
+});
+
+const mockOpenAiResponse = (overrides: Record<string, unknown> = {}) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    choices: [
+      { message: { content: "pong" }, finish_reason: "stop" },
+    ],
+    usage: {
+      prompt_tokens: 12,
+      completion_tokens: 3,
+      total_tokens: 15,
+      prompt_tokens_details: { cached_tokens: 10 },
+    },
+    model: "qwen3-30b",
+    ...overrides,
+  }),
+});
+
+describe("callGateway openai-compat bypass (D-3-PROV)", () => {
+  it("provider=openai-compat → fetch direto, não MCP", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    process.env["LLM_LOCAL_MODEL"] = "qwen3-30b";
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    const out = await callGateway({
+      step: "planejador",
+      provider: "openai-compat",
+      systemPrompt: "You are Brota.",
+      userMessage: "ping",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(out.provider).toBe("openai-compat");
+    expect(out.content).toBe("pong");
+    expect(out.model).toBe("qwen3-30b");
+  });
+
+  it("usa LLM_LOCAL_ENDPOINT e POSTa body OpenAI-compat", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://172.28.160.1:9000/v1/chat/completions";
+    process.env["LLM_LOCAL_MODEL"] = "qwen3-30b";
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      systemPrompt: "system body",
+      userMessage: "user body",
+      maxTokens: 256,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://172.28.160.1:9000/v1/chat/completions");
+    expect(init.method).toBe("POST");
+    expect(
+      (init.headers as Record<string, string>)["Content-Type"],
+    ).toBe("application/json");
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe("qwen3-30b");
+    expect(body.messages).toEqual([
+      { role: "system", content: "system body" },
+      { role: "user", content: "user body" },
+    ]);
+    expect(body.max_tokens).toBe(256);
+  });
+
+  it("cacheableSystemPrefix é prepended em system content", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      cacheableSystemPrefix: "STABLE_PREFIX\n\n",
+      systemPrompt: "DYNAMIC_BODY",
+      userMessage: "go",
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body.messages[0].content).toBe("STABLE_PREFIX\n\nDYNAMIC_BODY");
+  });
+
+  it("tokens extraídos de prompt_tokens + cached_tokens", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    const out = await callGateway({
+      step: "planejador",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    expect(out.tokens.in).toBe(12);
+    expect(out.tokens.out).toBe(3);
+    expect(out.tokens.cacheRead).toBe(10);
+    expect(out.tokens.reasoning).toBe(0);
+    expect(out.was_fallback).toBe(false);
+    expect(out.attempt_count).toBe(1);
+    expect(out.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("HTTP non-2xx → throws com shape gateway error: HTTP_N", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    await expect(
+      callGateway({
+        step: "drota",
+        provider: "openai-compat",
+        model: "qwen3-30b",
+        systemPrompt: "s",
+        userMessage: "u",
+      }),
+    ).rejects.toThrow(/gateway error: HTTP_500/);
+  });
+
+  it("response sem choices → throws EMPTY_RESPONSE", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [], model: "qwen3-30b" }),
+    });
+
+    await expect(
+      callGateway({
+        step: "drota",
+        provider: "openai-compat",
+        model: "qwen3-30b",
+        systemPrompt: "s",
+        userMessage: "u",
+      }),
+    ).rejects.toThrow(/EMPTY_RESPONSE/);
+  });
+
+  it("provider resolvido via env LLM_PROVIDER=openai-compat", async () => {
+    process.env["LLM_PROVIDER"] = "openai-compat";
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    process.env["LLM_LOCAL_MODEL"] = "qwen3-30b";
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    // Não passa provider — vem do env
+    const out = await callGateway({
+      step: "planejador",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(out.provider).toBe("openai-compat");
+  });
+
+  it("endpoint default é localhost:8080 quando LLM_LOCAL_ENDPOINT ausente", async () => {
+    process.env["LLM_LOCAL_MODEL"] = "qwen3-30b";
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    await callGateway({
+      step: "planejador",
+      provider: "openai-compat",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("http://localhost:8080/v1/chat/completions");
+  });
+});


### PR DESCRIPTION
## Summary

Re-aplica #170 contra \`main\` — o merge anterior foi pra base \`fix/openai-compat-mock-gate\` que ficou órfã quando #169 mergeou em main. Cherry-pick limpo do commit original.

Conteúdo idêntico ao #170: \`callGateway()\` em \`shared/src/gateway-client.ts\` detecta \`provider=openai-compat\` e faz \`fetch\` direto pro \`LLM_LOCAL_ENDPOINT\` ao invés de passar pelo MCP gateway (que tem Zod enum estrito \`["anthropic","infomaniak"]\`).

- ✅ 657/657 shared tests passing
- ✅ 8 testes específicos cobrindo o bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)