### PR TITLE
[fix ops#1055] gateway-client: defesa empty content openai-compat

### DIFF
--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -167,7 +167,14 @@ async function getClient(): Promise<Client> {
  * `calculateCostUsd` em llm-config.ts já trata.
  */
 interface OpenAiChatChoice {
-  message?: { content?: string };
+  /**
+   * `message.content` é o canal principal. `reasoning_content` é usado por
+   * llama.cpp quando o chat template injeta thinking mode (Qwen3 instruct
+   * pode cair nesse caminho mesmo não sendo variante reasoning — D-3-PROV
+   * follow-up ops#1055). Defesa: se `content` vier vazio mas houver
+   * `reasoning_content`, usamos esse como fallback antes de propagar "".
+   */
+  message?: { content?: string; reasoning_content?: string };
   finish_reason?: string;
 }
 interface OpenAiChatUsage {
@@ -227,8 +234,34 @@ async function callLocalChatCompletion(
       throw new Error("gateway error: EMPTY_RESPONSE — no choices in response");
     }
     const usage = parsed.usage ?? {};
+    // D-3-PROV ops#1055 follow-up: defesa contra empty content.
+    // Bug reproduzido em smoke STS Qwen3-30B 2026-05-24 (kei turn 2 G2 fail):
+    // materializer recebeu content="" e propagou pra botMessage vazia.
+    // Defesa em camadas:
+    //  1. Se content vazio mas reasoning_content presente → usa reasoning
+    //     (caso edge: chat template thinking=1 detectado em modelo instruct).
+    //  2. Se finish_reason ≠ "stop" OU content final vazio → log warning
+    //     com fingerprint pra debug (não muda comportamento, dá visibilidade).
+    const rawContent = choice.message?.content ?? "";
+    const reasoningContent = choice.message?.reasoning_content ?? "";
+    const content =
+      rawContent.length > 0
+        ? rawContent
+        : reasoningContent.length > 0
+          ? reasoningContent
+          : "";
+    if (content.length === 0 || (choice.finish_reason && choice.finish_reason !== "stop")) {
+      console.warn(
+        `[gateway-client] openai-compat suspicious response: ` +
+          `finish_reason=${choice.finish_reason ?? "?"} ` +
+          `content_len=${rawContent.length} ` +
+          `reasoning_len=${reasoningContent.length} ` +
+          `step=${req.step} ` +
+          `completion_tokens=${usage.completion_tokens ?? 0}`,
+      );
+    }
     return {
-      content: choice.message?.content ?? "",
+      content,
       tokens: {
         in: usage.prompt_tokens ?? 0,
         out: usage.completion_tokens ?? 0,

--- a/shared/tests/gateway-client.test.ts
+++ b/shared/tests/gateway-client.test.ts
@@ -220,4 +220,125 @@ describe("callGateway openai-compat bypass (D-3-PROV)", () => {
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toBe("http://localhost:8080/v1/chat/completions");
   });
+
+  // D-3-PROV ops#1055 follow-up: defesa contra empty content em openai-compat.
+  // Bug reproduzido em smoke STS Qwen3-30B 2026-05-24 (kei G2 fail turn 2).
+
+  it("content vazio + reasoning_content presente → usa reasoning como fallback", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: "",
+              reasoning_content: "tô por aqui quando quiser conversar.",
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 50, completion_tokens: 10, total_tokens: 60 },
+        model: "qwen3-30b",
+      }),
+    });
+
+    const out = await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    expect(out.content).toBe("tô por aqui quando quiser conversar.");
+  });
+
+  it("content vazio sem reasoning_content → retorna string vazia", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          { message: { content: "" }, finish_reason: "stop" },
+        ],
+        usage: { prompt_tokens: 50, completion_tokens: 0, total_tokens: 50 },
+        model: "qwen3-30b",
+      }),
+    });
+
+    const out = await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    // Não muda comportamento (callsite faz fallback) — só não crasha.
+    expect(out.content).toBe("");
+  });
+
+  it("content presente é priorizado sobre reasoning_content", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: "real response",
+              reasoning_content: "deveria ser ignorado",
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 50, completion_tokens: 5, total_tokens: 55 },
+        model: "qwen3-30b",
+      }),
+    });
+
+    const out = await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    expect(out.content).toBe("real response");
+  });
+
+  it("finish_reason=length emite warning mas não crasha", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          { message: { content: "cortado..." }, finish_reason: "length" },
+        ],
+        usage: { prompt_tokens: 50, completion_tokens: 200, total_tokens: 250 },
+        model: "qwen3-30b",
+      }),
+    });
+
+    const out = await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    expect(out.content).toBe("cortado...");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("finish_reason=length"),
+    );
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

- Bug reproduzido em smoke STS Qwen3-30B 2026-05-24 (kei turn 2 G2 fail): `motorTrace.drota.linguisticMaterialization=""`. Materializer recebeu `content=""` do LLM local e propagou empty pra `botMessage`.
- Server log mostrou `thinking = 1` no chat template detectado (Qwen3 Instruct-2507 caiu no caminho de modelo reasoning mesmo não sendo variant). Hipótese: LLM emitiu `reasoning_content` mas `content` vazio.
- 3 lacunas de diagnóstico fixadas: type ignorava `reasoning_content`, `finish_reason` capturado mas não logado, zero observability quando content vinha vazio.

## Mudanças

- `OpenAiChatChoice.message` agora aceita `reasoning_content?: string`
- `callLocalChatCompletion`: fallback content → reasoning_content → ""
- `console.warn` quando `finish_reason ≠ "stop"` OU `content === ""` (fingerprint completo: step, finish_reason, content_len, reasoning_len, completion_tokens)

## Não muda comportamento

- Callsite (`constrained-materializer`) continua recebendo `out.content`. Se vazio mesmo após reasoning fallback, comportamento atual preservado (return `text: ""`).
- Diferença: agora callsite tem chance de receber reasoning como fallback, E temos visibility quando empty acontece.

## Test plan

- [x] `npm test --workspace shared` → 661 passing
- [x] 4 testes novos cobrem: reasoning fallback, empty puro, content priority, finish_reason=length warning
- [ ] Smoke STS pós-merge pra ver se kei turn 2 deixa de fail G2 (e/ou se warning aparece com fingerprint útil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)