### PR TITLE
[feat ops#1122] C-MX-07 PR6 — approve_or_edit + bridge approvalGate (rebase v2)

### DIFF
--- a/orchestrator/src/daemon.ts
+++ b/orchestrator/src/daemon.ts
@@ -107,6 +107,33 @@ export interface OverrideSelectionResult {
   gateWasActive: boolean;
 }
 
+export interface ApprovalDecision {
+  /** True envia (com editedText se presente, senão proposedText original);
+   *  false aborta (não envia outbound). */
+  approved: boolean;
+  /** Se presente, substitui o proposedText antes do envio. */
+  editedText?: string;
+  /** Optional: comentário freeform do operador pra Edit Learner v0
+   *  (DS-04). Persistido em telemetria pelo caller (BFF). */
+  rationale?: string;
+}
+
+export interface SubmitForApprovalOptions {
+  /** Timeout em ms. Após expirar, gate resolve com `{approved: true}`
+   *  (auto-approve fail-safe — não bloqueia outbound em produção). */
+  timeoutMs: number;
+  /** Decisão default em caso de timeout. Default `{approved: true}`. Em
+   *  modo paranoid pode setar `{approved: false}` pra abortar silenciosamente. */
+  defaultDecision?: ApprovalDecision;
+}
+
+export interface ApproveOrEditResult {
+  /** True se gate estava pendente + decision foi aplicada. */
+  accepted: boolean;
+  /** True se sessionId tinha approval gate pendente. */
+  gateWasActive: boolean;
+}
+
 interface ToolCallResult {
   content: Array<{ type: string; text?: string }>;
 }
@@ -134,6 +161,16 @@ export class OrchestratorDaemon {
     {
       contentPool: ScoredContentItem[];
       resolve: (decision: OptionsGateDecision) => void;
+    }
+  >();
+  /** Approvals pendentes per-session — registradas via submitForApproval
+   *  (caller motor-channels bridge ou BFF), resolvidas via approveOrEdit
+   *  MCP tool. proposedText fica acessível pra getPendingApproval. */
+  private pendingApprovals = new Map<
+    string,
+    {
+      proposedText: string;
+      resolve: (decision: ApprovalDecision) => void;
     }
   >();
   private shuttingDown = false;
@@ -195,6 +232,74 @@ export class OrchestratorDaemon {
     if (bucket.events.length > TURN_EVENT_BUFFER_CAP) {
       bucket.events.splice(0, bucket.events.length - TURN_EVENT_BUFFER_CAP);
     }
+  }
+
+  /**
+   * Registra approval pendente pra `sessionId` (S-OD-09). Retorna
+   * Promise que resolve quando approveOrEdit é chamado, ou após timeout
+   * com `defaultDecision` (default `{approved: true}` — fail-safe que
+   * NÃO bloqueia outbound em produção). Caller (bridge ou BFF) await
+   * essa Promise antes de fazer channel.send.
+   *
+   * Se já há approval pendente pra mesma sessionId, sobrescreve (caller
+   * decide política — em geral, último win).
+   */
+  submitForApproval(
+    sessionId: string,
+    proposedText: string,
+    opts: SubmitForApprovalOptions,
+  ): Promise<ApprovalDecision> {
+    const defaultDecision: ApprovalDecision =
+      opts.defaultDecision ?? { approved: true };
+    return new Promise<ApprovalDecision>((resolve) => {
+      const existing = this.pendingApprovals.get(sessionId);
+      if (existing !== undefined) {
+        // Resolve a anterior com default (sem perder caller que estava
+        // aguardando) e sobrescreve com a nova.
+        existing.resolve(defaultDecision);
+      }
+      const timeoutHandle = setTimeout(() => {
+        this.pendingApprovals.delete(sessionId);
+        resolve(defaultDecision);
+      }, opts.timeoutMs);
+      this.pendingApprovals.set(sessionId, {
+        proposedText,
+        resolve: (decision) => {
+          clearTimeout(timeoutHandle);
+          this.pendingApprovals.delete(sessionId);
+          resolve(decision);
+        },
+      });
+    });
+  }
+
+  /**
+   * Snapshot do approval pendente. UI usa pra mostrar o proposedText
+   * antes do operador decidir.
+   */
+  getPendingApproval(
+    sessionId: string,
+  ): { proposedText: string } | undefined {
+    const pending = this.pendingApprovals.get(sessionId);
+    if (pending === undefined) return undefined;
+    return { proposedText: pending.proposedText };
+  }
+
+  /**
+   * Resolve approval pendente com a decisão do operador (S-OD-09).
+   * Caller (BFF do eBrota Console via MCP tool approve_or_edit) chama
+   * isso quando Jun clica Approve/Edit/Reject na UI.
+   */
+  approveOrEdit(
+    sessionId: string,
+    decision: ApprovalDecision,
+  ): ApproveOrEditResult {
+    const pending = this.pendingApprovals.get(sessionId);
+    if (pending === undefined) {
+      return { accepted: false, gateWasActive: false };
+    }
+    pending.resolve(decision);
+    return { accepted: true, gateWasActive: true };
   }
 
   /**
@@ -268,11 +373,17 @@ export class OrchestratorDaemon {
     if (this.shuttingDown || !this.started) return;
     this.shuttingDown = true;
     this.log("[orchestrator-daemon] shutting down");
-    // Resolve gates pendentes sem override pra não deixar runTurn em pé.
+    // Resolve gates/approvals pendentes pra não deixar callers em pé.
     for (const [, pending] of this.pendingGates) {
       pending.resolve({});
     }
     this.pendingGates.clear();
+    // Approvals: shutdown decide approved=false (não envia outbound se
+    // operador não decidiu). Conservador no shutdown.
+    for (const [, pending] of this.pendingApprovals) {
+      pending.resolve({ approved: false });
+    }
+    this.pendingApprovals.clear();
     this.sessions.clear();
     this.turnEvents.clear();
     if (this.clients !== null) {

--- a/orchestrator/src/mcp-server.ts
+++ b/orchestrator/src/mcp-server.ts
@@ -208,5 +208,67 @@ export function createOrchestratorMcpServer(
     },
   );
 
+  server.registerTool(
+    "approve_or_edit",
+    {
+      description:
+        "Resolve approval gate pendente da sessão (operator decision do " +
+        "eBrota Console). decision: { approved, editedText?, rationale? }. " +
+        "Caller (motor-channels bridge ou BFF) tinha registrado approval via " +
+        "submitForApproval e awaiting; essa tool destrava o await. Retorna " +
+        "{ accepted, gateWasActive }.",
+      inputSchema: {
+        sessionId: z.string(),
+        decision: z.object({
+          approved: z.boolean(),
+          editedText: z.string().optional(),
+          rationale: z.string().optional(),
+        }),
+      } as any,
+    },
+    async (input: {
+      sessionId: string;
+      decision: {
+        approved: boolean;
+        editedText?: string;
+        rationale?: string;
+      };
+    }) => {
+      const result = opts.daemon.approveOrEdit(
+        input.sessionId,
+        input.decision,
+      );
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(result) },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "get_pending_approval",
+    {
+      description:
+        "Snapshot do approval pendente (proposedText) sem resolver o gate. " +
+        "UI usa pra renderizar texto antes do operador decidir. Retorna " +
+        "null se sessão não tem approval pendente.",
+      inputSchema: {
+        sessionId: z.string(),
+      } as any,
+    },
+    async (input: { sessionId: string }) => {
+      const pending = opts.daemon.getPendingApproval(input.sessionId);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(pending ?? null),
+          },
+        ],
+      };
+    },
+  );
+
   return server;
 }

--- a/orchestrator/tests/approval.test.ts
+++ b/orchestrator/tests/approval.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createOrchestratorMcpServer } from "../src/mcp-server.js";
+import {
+  OrchestratorDaemon,
+  type ApprovalDecision,
+  type ApproveOrEditResult,
+} from "../src/daemon.js";
+import type { McpClients } from "../src/mcp-clients.js";
+
+const mockClients = (): McpClients =>
+  ({
+    planejador: {} as never,
+    motorDrota: {} as never,
+    motorExecucao: {} as never,
+  }) satisfies McpClients;
+
+const setupDaemon = async () => {
+  const daemon = new OrchestratorDaemon({
+    clientsFactory: async () => mockClients(),
+    clientsDisposer: async () => undefined,
+    log: () => undefined,
+  });
+  await daemon.start();
+  return daemon;
+};
+
+describe("Daemon — submitForApproval + approveOrEdit", () => {
+  it("approveOrEdit em sessão sem approval pendente → gateWasActive=false", async () => {
+    const daemon = await setupDaemon();
+    expect(daemon.approveOrEdit("any", { approved: true })).toEqual({
+      accepted: false,
+      gateWasActive: false,
+    });
+    await daemon.stop();
+  });
+
+  it("submitForApproval resolve com decisão de approveOrEdit", async () => {
+    const daemon = await setupDaemon();
+    const pendingPromise = daemon.submitForApproval(
+      "sess-1",
+      "Texto proposto",
+      { timeoutMs: 5000 },
+    );
+    // approve depois
+    await new Promise<void>((r) => setTimeout(r, 10));
+    const result = daemon.approveOrEdit("sess-1", {
+      approved: true,
+      editedText: "Texto editado",
+      rationale: "Tom mais leve",
+    });
+    expect(result).toEqual({ accepted: true, gateWasActive: true });
+    const decision = await pendingPromise;
+    expect(decision).toEqual({
+      approved: true,
+      editedText: "Texto editado",
+      rationale: "Tom mais leve",
+    });
+    await daemon.stop();
+  });
+
+  it("submitForApproval timeout resolve com defaultDecision (default approved=true)", async () => {
+    const daemon = await setupDaemon();
+    const decision = await daemon.submitForApproval(
+      "sess-timeout",
+      "Texto proposto",
+      { timeoutMs: 30 },
+    );
+    expect(decision).toEqual({ approved: true });
+    await daemon.stop();
+  });
+
+  it("submitForApproval timeout com defaultDecision custom", async () => {
+    const daemon = await setupDaemon();
+    const decision = await daemon.submitForApproval(
+      "sess-paranoid",
+      "Texto proposto",
+      {
+        timeoutMs: 30,
+        defaultDecision: { approved: false, rationale: "no decision" },
+      },
+    );
+    expect(decision).toEqual({ approved: false, rationale: "no decision" });
+    await daemon.stop();
+  });
+
+  it("getPendingApproval retorna proposedText enquanto pendente, undefined depois", async () => {
+    const daemon = await setupDaemon();
+    const p = daemon.submitForApproval("sess-snap", "Hello", {
+      timeoutMs: 5000,
+    });
+    await new Promise<void>((r) => setTimeout(r, 10));
+    expect(daemon.getPendingApproval("sess-snap")).toEqual({
+      proposedText: "Hello",
+    });
+    daemon.approveOrEdit("sess-snap", { approved: true });
+    await p;
+    expect(daemon.getPendingApproval("sess-snap")).toBeUndefined();
+    await daemon.stop();
+  });
+
+  it("submitForApproval sobrescreve approval pendente prévia (último win, antiga resolve com default)", async () => {
+    const daemon = await setupDaemon();
+    const first = daemon.submitForApproval("sess-rep", "Texto 1", {
+      timeoutMs: 5000,
+    });
+    await new Promise<void>((r) => setTimeout(r, 10));
+    const second = daemon.submitForApproval("sess-rep", "Texto 2", {
+      timeoutMs: 5000,
+    });
+    // first resolve com default approved=true
+    const firstDecision = await first;
+    expect(firstDecision).toEqual({ approved: true });
+    // Approve second
+    daemon.approveOrEdit("sess-rep", { approved: false });
+    const secondDecision = await second;
+    expect(secondDecision).toEqual({ approved: false });
+    await daemon.stop();
+  });
+
+  it("stop() resolve approvals pendentes com approved=false (conservador)", async () => {
+    const daemon = await setupDaemon();
+    const p = daemon.submitForApproval("sess-stop", "Hello", {
+      timeoutMs: 5000,
+    });
+    await new Promise<void>((r) => setTimeout(r, 10));
+    await daemon.stop();
+    const decision = await p;
+    expect(decision).toEqual({ approved: false });
+  });
+});
+
+describe("MCP server — approve_or_edit + get_pending_approval E2E", () => {
+  const setupE2E = async () => {
+    const daemon = await setupDaemon();
+    const server = createOrchestratorMcpServer({ daemon });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    const client = new Client(
+      { name: "test", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([server.connect(serverT), client.connect(clientT)]);
+    return { daemon, server, client };
+  };
+
+  it("tools registradas: approve_or_edit + get_pending_approval", async () => {
+    const { client, server, daemon } = await setupE2E();
+    const tools = await client.listTools();
+    const names = tools.tools.map((t) => t.name);
+    expect(names).toContain("approve_or_edit");
+    expect(names).toContain("get_pending_approval");
+    await client.close();
+    await server.close();
+    await daemon.stop();
+  });
+
+  it("approve_or_edit via MCP resolve approval pendente", async () => {
+    const { client, server, daemon } = await setupE2E();
+    const pending = daemon.submitForApproval("sess-mcp", "Hello", {
+      timeoutMs: 5000,
+    });
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    const result = await client.callTool({
+      name: "approve_or_edit",
+      arguments: {
+        sessionId: "sess-mcp",
+        decision: {
+          approved: true,
+          editedText: "Hola",
+          rationale: "spanish demo",
+        },
+      },
+    });
+    const parsed = JSON.parse(
+      (
+        result as {
+          content: Array<{ type: string; text?: string }>;
+        }
+      ).content[0]!.text!,
+    ) as ApproveOrEditResult;
+    expect(parsed).toEqual({ accepted: true, gateWasActive: true });
+
+    const decision = (await pending) as ApprovalDecision;
+    expect(decision.editedText).toBe("Hola");
+
+    await client.close();
+    await server.close();
+    await daemon.stop();
+  });
+
+  it("get_pending_approval via MCP retorna snapshot ou null", async () => {
+    const { client, server, daemon } = await setupE2E();
+    // Sem approval pendente → null
+    const before = await client.callTool({
+      name: "get_pending_approval",
+      arguments: { sessionId: "sess-gp" },
+    });
+    expect(
+      JSON.parse(
+        (
+          before as {
+            content: Array<{ type: string; text?: string }>;
+          }
+        ).content[0]!.text!,
+      ),
+    ).toBeNull();
+
+    // Submit + check snapshot
+    const p = daemon.submitForApproval("sess-gp", "Hello", {
+      timeoutMs: 5000,
+    });
+    await new Promise<void>((r) => setTimeout(r, 10));
+    const after = await client.callTool({
+      name: "get_pending_approval",
+      arguments: { sessionId: "sess-gp" },
+    });
+    expect(
+      JSON.parse(
+        (
+          after as {
+            content: Array<{ type: string; text?: string }>;
+          }
+        ).content[0]!.text!,
+      ),
+    ).toEqual({ proposedText: "Hello" });
+
+    daemon.approveOrEdit("sess-gp", { approved: true });
+    await p;
+    await client.close();
+    await server.close();
+    await daemon.stop();
+  });
+});

--- a/packages/motor-channels/src/orchestrator-bridge.ts
+++ b/packages/motor-channels/src/orchestrator-bridge.ts
@@ -46,6 +46,43 @@ export interface OrchestratorBridge {
   ): Promise<StartCardSessionOutput>;
 }
 
+/**
+ * ApprovalGate — C-MX-07 S-OD-10 (PR6). Hook opcional entre
+ * `bridge.startCardSession` (que devolve proposedText) e `channel.send`.
+ * Em semi-auto mode, operador (Jun via eBrota Console) decide via UI:
+ *  - `approved: true` + sem editedText → envia proposedText original
+ *  - `approved: true` + editedText → envia o texto editado
+ *  - `approved: false` → aborta, NÃO envia outbound
+ *
+ * `resolver` é injetado pelo caller (BFF do eBrota Console em produção,
+ * mock em testes). Pattern Promise-based — caller pode amarrar a um
+ * MCP tool do orchestrator daemon (`approve_or_edit`), a SSE event do
+ * próprio BFF, ou auto-approve em modo headless/testes.
+ */
+export interface ApprovalGateInput {
+  /** Texto materializado pelo motor-drota. */
+  proposedText: string;
+  /** Contexto da carta — UI usa pra renderizar header da pendência. */
+  cardId: CardId;
+  conversationId: ConversationId;
+  from: ChannelAddress;
+}
+
+export interface ApprovalDecision {
+  /** True envia; false aborta sem channel.send. */
+  approved: boolean;
+  /** Substitui proposedText se presente. */
+  editedText?: string;
+  /** Comentário freeform do operador pra Edit Learner v0 (DS-04). */
+  rationale?: string;
+}
+
+export interface ApprovalGate {
+  /** Resolve com decisão do operador. Timeout/fail-safe fica a cargo
+   *  do resolver (caller); bridge só await. */
+  resolver: (input: ApprovalGateInput) => Promise<ApprovalDecision>;
+}
+
 export interface InboundBridgeOptions {
   channel: WhatsAppChannel;
   loader: CardPackageLoader;
@@ -60,6 +97,11 @@ export interface InboundBridgeOptions {
   /** Hook opcional pra erros surgindo de bridge.startCardSession ou
    *  channel.send. Default loga via console.error. */
   onError?: (err: unknown, context: { event: CardActivatedEvent }) => void;
+  /** Gate de aprovação semi-auto (C-MX-07 S-OD-10). Quando undefined,
+   *  bridge funciona em auto mode (envia direto). Quando set, await
+   *  resolver antes de channel.send — operador decide via eBrota
+   *  Console. */
+  approvalGate?: ApprovalGate;
 }
 
 export interface InboundBridge {
@@ -101,6 +143,7 @@ export function createInboundBridge(
     try {
       const pkg = await opts.loader.load(ev.cardId);
       let responseText: string;
+      let cameFromBridge = false;
       if (pkg === null) {
         responseText = fallback;
       } else {
@@ -111,7 +154,29 @@ export function createInboundBridge(
           pkg,
         });
         responseText = result.text;
+        cameFromBridge = true;
       }
+
+      // Approval gate (S-OD-10) — só aplica em resposta vinda do bridge.
+      // cardNotFoundMessage (pkg=null) pula gate: é mensagem de sistema,
+      // não precisa aprovação.
+      if (cameFromBridge && opts.approvalGate !== undefined) {
+        const decision = await opts.approvalGate.resolver({
+          proposedText: responseText,
+          cardId: ev.cardId,
+          conversationId: ev.conversationId,
+          from: ev.from,
+        });
+        if (!decision.approved) {
+          // Operador rejeitou — não envia outbound. Termina silenciosamente;
+          // BFF pode logar a decisão pra telemetry Edit Learner separado.
+          return;
+        }
+        if (decision.editedText !== undefined) {
+          responseText = decision.editedText;
+        }
+      }
+
       await rateLimit.acquire();
       await opts.channel.send(ev.from, responseText);
     } catch (err) {

--- a/packages/motor-channels/tests/orchestrator-bridge.test.ts
+++ b/packages/motor-channels/tests/orchestrator-bridge.test.ts
@@ -271,3 +271,133 @@ describe("createInboundBridge — rate limiting", () => {
     expect(channel.sentMessages).toHaveLength(1);
   });
 });
+
+describe("createInboundBridge — approvalGate (S-OD-10)", () => {
+  it("approved=true envia proposedText original", async () => {
+    const channel = createMockChannel();
+    const loader = createCardPackageLoader({ baseDir: FIXTURES_DIR });
+    const bridge = fakeBridge(() => "Texto motor-drota");
+    const resolver = vi.fn(async () => ({ approved: true }));
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimiter,
+      approvalGate: { resolver },
+    });
+    ib.start();
+    channel.simulateInbound(inbound("card:tabuada-7"));
+    await flush();
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(channel.sentMessages).toEqual([
+      {
+        to: "5511999990000@s.whatsapp.net",
+        text: "Texto motor-drota",
+      },
+    ]);
+  });
+
+  it("approved=true + editedText envia editado", async () => {
+    const channel = createMockChannel();
+    const loader = createCardPackageLoader({ baseDir: FIXTURES_DIR });
+    const bridge = fakeBridge(() => "Texto motor-drota");
+    const resolver = vi.fn(async () => ({
+      approved: true,
+      editedText: "Texto editado por Jun",
+    }));
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimiter,
+      approvalGate: { resolver },
+    });
+    ib.start();
+    channel.simulateInbound(inbound("card:tabuada-7"));
+    await flush();
+    expect(channel.sentMessages[0]!.text).toBe("Texto editado por Jun");
+  });
+
+  it("approved=false aborta (não envia outbound)", async () => {
+    const channel = createMockChannel();
+    const loader = createCardPackageLoader({ baseDir: FIXTURES_DIR });
+    const bridge = fakeBridge(() => "Texto motor-drota");
+    const resolver = vi.fn(async () => ({
+      approved: false,
+      rationale: "Tom errado",
+    }));
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimiter,
+      approvalGate: { resolver },
+    });
+    ib.start();
+    channel.simulateInbound(inbound("card:tabuada-7"));
+    await flush();
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(channel.sentMessages).toEqual([]);
+  });
+
+  it("approvalGate recebe context completo (cardId, conversationId, from)", async () => {
+    const channel = createMockChannel();
+    const loader = createCardPackageLoader({ baseDir: FIXTURES_DIR });
+    const bridge = fakeBridge(() => "Resp");
+    const resolver = vi.fn(async () => ({ approved: true }));
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimiter,
+      approvalGate: { resolver },
+    });
+    ib.start();
+    channel.simulateInbound(inbound("card:tabuada-7"));
+    await flush();
+    const [input] = resolver.mock.calls[0]!;
+    expect(input).toEqual({
+      proposedText: "Resp",
+      cardId: "tabuada-7",
+      conversationId: "conv-bridge-001",
+      from: "5511999990000@s.whatsapp.net",
+    });
+  });
+
+  it("approvalGate NÃO é chamado pra cardNotFoundMessage (pkg=null)", async () => {
+    const channel = createMockChannel();
+    const loader = createCardPackageLoader({ baseDir: FIXTURES_DIR });
+    const bridge = fakeBridge(() => "Resp");
+    const resolver = vi.fn(async () => ({ approved: false }));
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimiter,
+      approvalGate: { resolver },
+    });
+    ib.start();
+    channel.simulateInbound(inbound("card:fantasma-404"));
+    await flush();
+    expect(resolver).not.toHaveBeenCalled();
+    // fallback enviado direto (sem gate)
+    expect(channel.sentMessages[0]!.text).toBe("Carta não encontrada.");
+  });
+
+  it("sem approvalGate, comportamento auto preservado (envia direto)", async () => {
+    const channel = createMockChannel();
+    const loader = createCardPackageLoader({ baseDir: FIXTURES_DIR });
+    const bridge = fakeBridge(() => "Resp auto");
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimiter,
+      // no approvalGate
+    });
+    ib.start();
+    channel.simulateInbound(inbound("card:tabuada-7"));
+    await flush();
+    expect(channel.sentMessages[0]!.text).toBe("Resp auto");
+  });
+});


### PR DESCRIPTION
Rebase de #156 (base original deletado após merge do PR5 #176). Cherry-pick limpo sobre main.

---

## Summary

**PR6 de C-MX-07** — cross-workspace PR fechando o ciclo de intervenção end-to-end. Daemon expõe approval API + MCP tool; motor-channels bridge consome via opcional `approvalGate`.

- **Sub-stories cobertas:** S-OD-09 + S-OD-10 (S-OD-11 wiring fica pra capability C-MX-08 BFF)
- **Stacked em:** #155 PR5
- **Branch:** `sprint4/pr6-c-mx-07-approve-or-edit`
- **Issue:** [ops#1122](https://github.com/ascendimacy/ascendimacy-ops/issues/1122)
- **Workspaces touched:** `orchestrator/` + `packages/motor-channels/`

## Arquitetura

```
[BFF eBrota Console] (futuro)
  │
  ├─ pega event subscribe_turn_state (PR4)
  ├─ mostra UI pra Jun
  └─ chama daemon.approve_or_edit via MCP

[motor-channels createInboundBridge]
  ├─ bridge.startCardSession → proposedText
  ├─ approvalGate.resolver({proposedText, ...}) ← awaits decisão
  │   └─ BFF amarra essa Promise ao approve_or_edit do daemon
  └─ channel.send (ou abort se rejected)

[orchestrator daemon]
  └─ approve_or_edit MCP tool → resolve pendingApprovals Promise
```

Wiring **loose deliberadamente**: bridge tem `ApprovalGate` opaque; daemon tem `approve_or_edit` MCP tool. BFF do eBrota Console (C-MX-08) faz a ponte — resolver chama MCP `daemon.approve_or_edit` ou polling `get_pending_approval`.

## O que entra

### `orchestrator/src/daemon.ts`
- Types: `ApprovalDecision`, `SubmitForApprovalOptions`, `ApproveOrEditResult`
- `pendingApprovals: Map<sessionId, {proposedText, resolve}>`
- `submitForApproval(sessionId, proposedText, {timeoutMs, defaultDecision?})` — retorna Promise; timeout resolve com defaultDecision (default `{approved: true}` fail-safe — não bloqueia outbound em prod)
- `getPendingApproval(sessionId)` — snapshot pra UI
- `approveOrEdit(sessionId, decision)` — resolve pendente; retorna `{accepted, gateWasActive}`
- Sobrescreve approval anterior (último win, antiga resolve com default)
- `stop()` resolve approvals pendentes com `{approved: false}` (conservador)

### `orchestrator/src/mcp-server.ts`
- `approve_or_edit(sessionId, decision)` — BFF chama quando Jun decide
- `get_pending_approval(sessionId)` — snapshot pra UI

### `motor-channels/src/orchestrator-bridge.ts`
- Types: `ApprovalGateInput`, `ApprovalDecision`, `ApprovalGate`
- `InboundBridgeOptions.approvalGate?: ApprovalGate`
- Quando set, await `resolver(input)` após `bridge.startCardSession`:
  - `approved=false` → aborta, **não envia outbound**
  - `approved=true + editedText` → envia editado
  - `approved=true` (sem edit) → envia proposedText original
- approvalGate **PULA** pra `cardNotFoundMessage` (pkg=null) — fallback é sistema

## Decisões tomadas

1. **Default decision = `{approved: true}`** — fail-safe, não bloqueia outbound se BFF/operador não decidir a tempo. Caller pode setar `{approved: false}` em mode paranoid.
2. **`stop()` decide `{approved: false}`** — assimétrico com timeout (que é true). No shutdown, conservador (não envia mensagens parcialmente processadas).
3. **`submitForApproval` sobrescreve approval anterior** — semântica "última vence". Anterior resolve com default decision (não loga erro). Evita dois callers em pé.
4. **Wiring loose entre bridge ↔ daemon** — sem coupling direto. Bridge tem `ApprovalGate` opaque; daemon tem MCP tool. BFF faz a ponte em produção. Mantém separação de workspaces clean.
5. **approvalGate PULA para cardNotFoundMessage** — fallback é mensagem de sistema, não precisa aprovação humana. Evita "carta não encontrada" parecer suspeito pro operador.
6. **`get_pending_approval` tool** além do approve_or_edit — UI pode renderizar texto antes do operador decidir; sem ele, UI dependeria de subscribe_turn_state pra detectar materialization_ready + manter state.
7. **`rationale` field optional em ApprovalDecision** — pra Edit Learner v0 (DS-04 motor). BFF/operator pode passar comentário freeform. Persistência fica pro BFF/telemetry.

## Verificação (alvos P4)

- [x] `npm run build --workspace orchestrator` — exit 0
- [x] `npm run build --workspace packages/motor-channels` — exit 0
- [x] `npm test --workspace orchestrator` — 133/133 verde (10 approval novos)
- [x] `npm test --workspace packages/motor-channels` — 95/95 verde (6 approvalGate novos)
- [x] Daemon submitForApproval resolve via approveOrEdit
- [x] Timeout resolve com defaultDecision
- [x] Sobrescreve approval anterior corretamente
- [x] Bridge: approved=true envia original; +editedText envia editado; approved=false aborta
- [x] Bridge: approvalGate context completo + pula cardNotFoundMessage
- [x] MCP tools E2E

## Próximo (PR7)

**S-OD-12 + S-OD-13 + S-OD-14** — tests integration full + smoke manual contra LLM local + cli daemon entry script wiring. Fecha C-MX-07.

S-OD-11 (wiring entry script bridge ↔ daemon) **fica pra capability futura C-MX-08 BFF** — separação de concerns mantida. PR7 deste fluxo só faz smoke pieces isoladas.

## Test plan

- [ ] Reviewer roda `npm test --workspace orchestrator` → 133/133
- [ ] Reviewer roda `npm test --workspace packages/motor-channels` → 95/95
- [ ] Confirma decisões 1-7 — especialmente (1) fail-safe default, (4) wiring loose, (5) skip pra cardNotFoundMessage
- [ ] (Opcional) Smoke manual: rodar daemon, submeter approval via daemon API direto, resolver via MCP tool, verificar timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Rebased via reset+cherry-pick por Claude Code