### PR TITLE
[feat ops#1122] C-MX-07 PR7 — integration tests + daemon smoke (rebase v2)

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -21,6 +21,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@ascendimacy/motor-channels": "*",
     "@types/js-yaml": "*",
     "@types/node": "*",
     "typescript": "*",

--- a/orchestrator/scripts/daemon-smoke.mjs
+++ b/orchestrator/scripts/daemon-smoke.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Smoke manual do orchestrator daemon — C-MX-07 S-OD-14 (PR7).
+ *
+ * Inicia o daemon como subprocesso stdio, conecta um MCP client, dispatcha
+ * tools básicos pra exercitar o pipeline completo. Útil pra:
+ *  - Validar daemon roda sem deadlock por ~1min (memory leak smoke)
+ *  - Confirmar startCardSession retorna text não-marker
+ *  - Confirmar subscribe_turn_state emite 4 eventos por turn
+ *
+ * NÃO substitui smoke real contra LLM (precisa Anthropic/Infomaniak keys
+ * ou OVMS qwen14b local). Por default usa USE_MOCK_LLM=true pra rodar
+ * offline; sobrescreve setando USE_MOCK_LLM=false antes de invocar.
+ *
+ * USAGE:
+ *   npm run build --workspace orchestrator
+ *   USE_MOCK_LLM=true node orchestrator/scripts/daemon-smoke.mjs
+ *
+ *   # Real LLM local (qwen14b OVMS via host.docker.internal):
+ *   LLM_PROVIDER=local LOCAL_LLM_BASE_URL=http://host.docker.internal:9000/v3 \
+ *     LOCAL_LLM_MODEL=qwen14b USE_MOCK_LLM=false \
+ *     node orchestrator/scripts/daemon-smoke.mjs
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const daemonEntry = resolve(__dirname, "../dist/daemon.js");
+
+const log = (msg) => console.log(`[smoke] ${msg}`);
+
+const parseToolResult = (result) => {
+  const text = result?.content?.[0]?.text ?? "{}";
+  return JSON.parse(text);
+};
+
+const main = async () => {
+  log(`spawning daemon: ${daemonEntry}`);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [daemonEntry],
+    env: { ...process.env },
+  });
+  const client = new Client(
+    { name: "daemon-smoke", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+  log("connected to daemon via stdio MCP");
+
+  const tools = await client.listTools();
+  log(`tools available: ${tools.tools.map((t) => t.name).join(", ")}`);
+
+  log("calling daemon.status...");
+  const status = parseToolResult(
+    await client.callTool({ name: "daemon.status", arguments: {} }),
+  );
+  log(`status: ${JSON.stringify(status)}`);
+
+  log("calling startCardSession (paula-mendes + tabuada-7 pkg)...");
+  const startResult = parseToolResult(
+    await client.callTool({
+      name: "startCardSession",
+      arguments: {
+        cardId: "tabuada-7",
+        conversationId: "smoke-conv-001",
+        from: "smoke-from",
+        pkg: {
+          cardId: "tabuada-7",
+          raw: "# Tabuada do 7\n\n7x1=7, 7x2=14, 7x3=21",
+          sourcePath: "smoke-fixture",
+        },
+        personaId: "paula-mendes",
+      },
+    }),
+  );
+  log(`session=${startResult.sessionId}`);
+  log(
+    `materialized text (first 120 chars):\n  "${startResult.text?.slice(0, 120) ?? "(empty)"}..."`,
+  );
+  if (startResult.text?.includes("[pending-real-impl]")) {
+    log(
+      "⚠️  text contém [pending-real-impl] marker — runTurn pode não ter rodado",
+    );
+  }
+
+  log("polling subscribe_turn_state...");
+  const events = parseToolResult(
+    await client.callTool({
+      name: "subscribe_turn_state",
+      arguments: { sessionId: startResult.sessionId },
+    }),
+  );
+  log(
+    `events: ${events.events?.map((e) => e.type).join(" → ") ?? "(none)"}`,
+  );
+  log(`totalEmitted: ${events.totalEmitted}`);
+
+  log("calling endSession...");
+  const endResult = parseToolResult(
+    await client.callTool({
+      name: "endSession",
+      arguments: { sessionId: startResult.sessionId },
+    }),
+  );
+  log(`endSession: ${JSON.stringify(endResult)}`);
+
+  log("closing client + transport...");
+  await client.close();
+  log("✅ smoke complete");
+};
+
+main().catch((err) => {
+  console.error("[smoke] ❌ failed:", err);
+  process.exit(1);
+});

--- a/orchestrator/tests/integration-motor-channels.test.ts
+++ b/orchestrator/tests/integration-motor-channels.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Integration test C-MX-07 — daemon + motor-channels + trio mocks.
+ * S-OD-13 (PR7).
+ *
+ * Cobre o ciclo end-to-end em processo único (sem stdio): mensagem
+ * `card:<id>` simulada no mock channel → createInboundBridge dispatcha
+ * pro daemon → daemon roda turn com trio mockado → resposta materializada
+ * volta via channel.send. Em semi-auto, approvalGate wireado ao daemon
+ * resolve via approveOrEdit.
+ *
+ * NÃO testa stdio MCP transport (suficientemente coberto por
+ * tests/mcp-server.test.ts via InMemoryTransport). Foco aqui é a
+ * orquestração cross-workspace.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import {
+  createInboundBridge,
+  createMockChannel,
+  createCardPackageLoader,
+  type ApprovalGate,
+  type OrchestratorBridge,
+  type RateLimiter,
+} from "@ascendimacy/motor-channels";
+import { OrchestratorDaemon } from "../src/daemon.js";
+import type { McpClients } from "../src/mcp-clients.js";
+import type {
+  ScoredContentItem,
+  SessionState,
+} from "@ascendimacy/shared";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Reusa fixtures de pacote do motor-channels (não duplica)
+const FIXTURES_DIR = resolve(
+  __dirname,
+  "../../packages/motor-channels/tests/fixtures/pacotes",
+);
+
+const fakeState: SessionState = {
+  sessionId: "stub",
+  trustLevel: 0.3,
+  budgetRemaining: 100,
+  eventLog: [],
+  turn: 0,
+};
+
+const sampleItem: ScoredContentItem = {
+  item: {
+    id: "mock-item-1",
+    type: "curiosity_hook",
+    domain: "linguistics",
+    casel_target: ["SA"],
+    age_range: [0, 99],
+    surprise: 7,
+    verified: true,
+    base_score: 7,
+    fact: "",
+    bridge: "",
+    quest: "",
+    sacrifice_type: "reflect",
+  },
+  score: 7,
+  reasons: ["mock"],
+};
+
+const buildTrio = (drotaResponse: string): McpClients => {
+  const planejador = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            strategicRationale: "mock",
+            contentPool: [sampleItem],
+            contextHints: {},
+          }),
+        },
+      ],
+    }),
+  };
+  const motorDrota = {
+    callTool: async (params: { name: string }) => {
+      if (params.name === "extract_signals") {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ signals: [] }) }],
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              selectedContent: sampleItem,
+              selectionRationale: "mock",
+              linguisticMaterialization: drotaResponse,
+            }),
+          },
+        ],
+      };
+    },
+  };
+  const motorExecucao = {
+    callTool: async (params: { name: string }) => {
+      if (params.name === "get_state") {
+        return {
+          content: [{ type: "text", text: JSON.stringify(fakeState) }],
+        };
+      }
+      if (params.name === "log_event") {
+        return {
+          content: [
+            { type: "text", text: JSON.stringify({ logged: true }) },
+          ],
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              success: true,
+              newState: { ...fakeState, turn: 1 },
+              eventLogged: {
+                timestamp: new Date().toISOString(),
+                type: "playbook_executed",
+                playbookId: "default",
+                data: {},
+              },
+            }),
+          },
+        ],
+      };
+    },
+  };
+  return {
+    planejador: planejador as never,
+    motorDrota: motorDrota as never,
+    motorExecucao: motorExecucao as never,
+  };
+};
+
+const setupIntegration = async (
+  opts: { drotaResponse?: string; semiAutoTimeoutMs?: number } = {},
+) => {
+  const tracesDir = mkdtempSync(join(tmpdir(), "orchestrator-integration-"));
+  const daemon = new OrchestratorDaemon({
+    clientsFactory: async () =>
+      buildTrio(opts.drotaResponse ?? "Resposta motor-drota"),
+    clientsDisposer: async () => undefined,
+    log: () => undefined,
+    now: () => "2026-05-24T13:00:00.000Z",
+    tracesDir,
+  });
+  await daemon.start();
+
+  const channel = createMockChannel();
+  const loader = createCardPackageLoader({ baseDir: FIXTURES_DIR });
+  const passthroughLimit: RateLimiter = { acquire: async () => {} };
+
+  // Bridge backed por daemon.runCardTurn — produção wireia via MCP stdio;
+  // aqui é in-process direct call.
+  const bridge: OrchestratorBridge = {
+    async startCardSession(input) {
+      const result = await daemon.runCardTurn({
+        cardId: input.cardId,
+        conversationId: input.conversationId,
+        from: input.from,
+        pkg: input.pkg,
+        personaId: "paula-mendes",
+        semiAutoTimeoutMs: opts.semiAutoTimeoutMs ?? 0,
+      });
+      return { text: result.text };
+    },
+  };
+
+  return {
+    daemon,
+    channel,
+    loader,
+    bridge,
+    passthroughLimit,
+    cleanup: () => rmSync(tracesDir, { recursive: true, force: true }),
+  };
+};
+
+const flush = async () => {
+  await new Promise<void>((r) => setTimeout(r, 50));
+};
+
+describe("Integration C-MX-07 — daemon + motor-channels (auto mode)", () => {
+  it("inbound card:tabuada-7 → daemon runs turn → channel.send com resposta materializada", async () => {
+    const { daemon, channel, loader, bridge, passthroughLimit, cleanup } =
+      await setupIntegration({ drotaResponse: "Vamos lá Yuji!" });
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimit,
+    });
+    ib.start();
+    channel.simulateInbound({
+      from: "5511aaa@s.whatsapp.net",
+      text: "card:tabuada-7",
+      conversationId: "5511aaa@s.whatsapp.net",
+      timestamp: "2026-05-24T13:00:00.000Z",
+    });
+    await flush();
+    expect(channel.sentMessages).toEqual([
+      {
+        to: "5511aaa@s.whatsapp.net",
+        text: "Vamos lá Yuji!",
+      },
+    ]);
+    expect(daemon.status().sessionCount).toBe(1);
+    await daemon.stop();
+    cleanup();
+  });
+
+  it("daemon turn_events buffer recebe os 4 eventos pós-turn (planning/selection/material/playbook)", async () => {
+    const { daemon, channel, loader, bridge, passthroughLimit, cleanup } =
+      await setupIntegration();
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimit,
+    });
+    ib.start();
+    channel.simulateInbound({
+      from: "5511aaa@s.whatsapp.net",
+      text: "card:tabuada-7",
+      conversationId: "conv-events-integration",
+      timestamp: "2026-05-24T13:00:00.000Z",
+    });
+    await flush();
+    const snap = daemon.subscribeTurnState(
+      "paula-mendes__conv-events-integration",
+      0,
+    );
+    expect(snap.events.map((e) => e.type)).toEqual([
+      "planning_started",
+      "selection_made",
+      "materialization_ready",
+      "playbook_executed",
+    ]);
+    await daemon.stop();
+    cleanup();
+  });
+
+  it("cardNotFoundMessage envia fallback sem disparar daemon", async () => {
+    const { daemon, channel, loader, bridge, passthroughLimit, cleanup } =
+      await setupIntegration();
+    const bridgeSpy = vi.spyOn(bridge, "startCardSession");
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimit,
+    });
+    ib.start();
+    channel.simulateInbound({
+      from: "5511aaa@s.whatsapp.net",
+      text: "card:nao-existe-404",
+      conversationId: "conv-404",
+      timestamp: "2026-05-24T13:00:00.000Z",
+    });
+    await flush();
+    expect(bridgeSpy).not.toHaveBeenCalled();
+    expect(channel.sentMessages[0]!.text).toBe("Carta não encontrada.");
+    expect(daemon.status().sessionCount).toBe(0);
+    await daemon.stop();
+    cleanup();
+  });
+});
+
+describe("Integration C-MX-07 — semi-auto: approvalGate + override", () => {
+  it("approvalGate aprovação edita → channel.send envia editado", async () => {
+    const { daemon, channel, loader, bridge, passthroughLimit, cleanup } =
+      await setupIntegration({ drotaResponse: "Texto motor-drota original" });
+
+    // approvalGate.resolver amarra ao daemon: submete pra approval +
+    // BFF simulado aprova depois.
+    const approvalGate: ApprovalGate = {
+      resolver: (input) =>
+        daemon.submitForApproval(
+          `paula-mendes__${input.conversationId}`,
+          input.proposedText,
+          { timeoutMs: 5000 },
+        ),
+    };
+
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimit,
+      approvalGate,
+    });
+    ib.start();
+
+    channel.simulateInbound({
+      from: "5511aaa@s.whatsapp.net",
+      text: "card:tabuada-7",
+      conversationId: "conv-edit",
+      timestamp: "2026-05-24T13:00:00.000Z",
+    });
+
+    // Aguarda turn rodar + approvalGate registrar
+    await new Promise<void>((r) => setTimeout(r, 60));
+    expect(daemon.getPendingApproval("paula-mendes__conv-edit")).toEqual({
+      proposedText: "Texto motor-drota original",
+    });
+
+    // Simula Jun editando + aprovando via daemon
+    daemon.approveOrEdit("paula-mendes__conv-edit", {
+      approved: true,
+      editedText: "Texto editado pelo Jun",
+      rationale: "Tom mais leve",
+    });
+
+    await flush();
+    expect(channel.sentMessages[0]!.text).toBe("Texto editado pelo Jun");
+    await daemon.stop();
+    cleanup();
+  });
+
+  it("approvalGate rejeição → outbound NÃO enviado", async () => {
+    const { daemon, channel, loader, bridge, passthroughLimit, cleanup } =
+      await setupIntegration();
+
+    const approvalGate: ApprovalGate = {
+      resolver: (input) =>
+        daemon.submitForApproval(
+          `paula-mendes__${input.conversationId}`,
+          input.proposedText,
+          { timeoutMs: 5000 },
+        ),
+    };
+
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimit,
+      approvalGate,
+    });
+    ib.start();
+
+    channel.simulateInbound({
+      from: "5511aaa@s.whatsapp.net",
+      text: "card:tabuada-7",
+      conversationId: "conv-reject",
+      timestamp: "2026-05-24T13:00:00.000Z",
+    });
+
+    await new Promise<void>((r) => setTimeout(r, 60));
+    daemon.approveOrEdit("paula-mendes__conv-reject", {
+      approved: false,
+      rationale: "Tom errado",
+    });
+
+    await flush();
+    expect(channel.sentMessages).toEqual([]);
+    await daemon.stop();
+    cleanup();
+  });
+
+  it("approvalGate timeout fail-safe envia original (defaultDecision approved=true)", async () => {
+    const { daemon, channel, loader, bridge, passthroughLimit, cleanup } =
+      await setupIntegration({ drotaResponse: "Texto auto" });
+
+    const approvalGate: ApprovalGate = {
+      resolver: (input) =>
+        daemon.submitForApproval(
+          `paula-mendes__${input.conversationId}`,
+          input.proposedText,
+          { timeoutMs: 50 },
+        ),
+    };
+
+    const ib = createInboundBridge({
+      channel,
+      loader,
+      bridge,
+      rateLimit: passthroughLimit,
+      approvalGate,
+    });
+    ib.start();
+    channel.simulateInbound({
+      from: "5511aaa@s.whatsapp.net",
+      text: "card:tabuada-7",
+      conversationId: "conv-timeout-approval",
+      timestamp: "2026-05-24T13:00:00.000Z",
+    });
+    // 100ms > 50ms timeout, garante fail-safe disparar
+    await new Promise<void>((r) => setTimeout(r, 120));
+    expect(channel.sentMessages[0]!.text).toBe("Texto auto");
+    await daemon.stop();
+    cleanup();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -7718,9 +7718,11 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "motor": "dist/cli.js"
+        "motor": "dist/cli.js",
+        "motor-daemon": "dist/daemon.js"
       },
       "devDependencies": {
+        "@ascendimacy/motor-channels": "*",
         "@types/js-yaml": "*",
         "@types/node": "*",
         "typescript": "*",


### PR DESCRIPTION
Rebase de #157 (base original deletado após merge do PR6 #177). Cherry-pick limpo sobre main.

Fecha C-MX-07.

---

## Summary

**PR7 fecha C-MX-07** — tests integration cross-workspace daemon ↔ motor-channels + smoke manual script.

- **Sub-stories cobertas:** S-OD-12 + S-OD-13 + S-OD-14
- **Stacked em:** #156 PR6
- **Branch:** `sprint4/pr7-c-mx-07-integration-smoke`
- **Issue:** [ops#1122](https://github.com/ascendimacy/ascendimacy-ops/issues/1122)

## O que entra

### `orchestrator/package.json`
- `devDependencies` += `@ascendimacy/motor-channels` (cross-workspace test only)

### `orchestrator/tests/integration-motor-channels.test.ts` (6 tests, novo)
In-process integration: `createInboundBridge` (motor-channels) backed por `daemon.runCardTurn` (orchestrator). Trio mockado direto no daemon's `clientsFactory`.

Cobertura:
1. inbound `card:tabuada-7` → daemon turn → `channel.send` com texto materializado
2. daemon `turn_events` buffer recebe os 4 eventos pós-turn (planning → selection → materialization → playbook)
3. `cardNotFoundMessage` envia fallback sem disparar daemon (pkg=null)
4. `approvalGate` aprovação com editedText → `channel.send` envia editado
5. `approvalGate` rejeição → outbound NÃO enviado
6. `approvalGate` timeout fail-safe → `defaultDecision approved=true` proceds

Approval gate wireado ao daemon via `submitForApproval`/`approveOrEdit` direct call. BFF futuro do eBrota Console substituirá pelo MCP roundtrip (`approve_or_edit` tool).

### `orchestrator/scripts/daemon-smoke.mjs` (script manual)
- Spawn daemon como subprocesso stdio + connect MCP client
- Dispatch tools básicos: `daemon.status`, `startCardSession`, `subscribe_turn_state`, `endSession`
- Detect `[pending-real-impl]` marker → warning se runTurn não rodou
- Default `USE_MOCK_LLM=true` (offline); override via env vars pra LLM real

Usage docs no script header pra Jun rodar manualmente.

## Decisões tomadas

1. **Integration test in-process** (não stdio) — testa orquestração cross-workspace sem complexidade de spawn. Cobertura stdio já está em `mcp-server.test.ts` via `InMemoryTransport`.
2. **Reusa fixtures de pacote do motor-channels** (`packages/motor-channels/tests/fixtures/pacotes/tabuada-7.md`) em vez de duplicar — single source of truth pros tests.
3. **Approval gate via direct `daemon.submitForApproval` call** (não MCP roundtrip) — simula o que o BFF fará logicamente. Roundtrip MCP do BFF é responsabilidade da C-MX-08.
4. **devDep cross-workspace OK** — orchestrator depende de motor-channels só em testes. Runtime fica decoupled. Lint-friendly.
5. **Smoke script NÃO é executado em CI** — manual artifact pro Jun rodar quando preciso. Pode quebrar se env var faltar; output pretty-printed pra debug.
6. **Daemon smoke é stdio puro** (não in-process) — exercita o transport real que o BFF vai usar em produção. Detecção do marker pega "runTurn não rodou" facilmente.

## Verificação (alvos P4)

- [x] `npm run build --workspace orchestrator` — exit 0
- [x] `npm test --workspace orchestrator` — **139/139 verde** (6 integration novos)
- [x] Integration test: auto mode full flow (card → daemon → channel.send)
- [x] Integration test: turn_events buffer recebe 4 eventos via daemon
- [x] Integration test: cardNotFoundMessage pula daemon
- [x] Integration test: approvalGate edit/reject/timeout cobertos
- [x] Smoke script compila + executável (não rodado em CI)

## Stack C-MX-07 completo

| PR | # | Status |
|---|---|---|
| PR1 | #151 | daemon scaffolding (S-OD-01 + 02) |
| PR2 | #152 | mcp-server real + session lifecycle (S-OD-03 + 04) |
| PR3 | #153 | startCardSession runTurn real (S-OD-05) |
| PR4 | #154 | subscribe_turn_state polling (S-OD-06) |
| PR5 | #155 | list_options + override_selection (S-OD-07 + 08) |
| PR6 | #156 | approve_or_edit + bridge approvalGate (S-OD-09 + 10) |
| **PR7** | **(este)** | integration tests + daemon smoke (S-OD-12 + 13 + 14) |

**S-OD-11** (wiring entry script bridge ↔ daemon real) fica pra C-MX-08 BFF — separação clean de workspaces preservada. Em produção, BFF spawnará daemon via stdio MCP + amarrará approvalGate aos MCP tools.

## Próximo

Capability **C-MX-08 eBrota Console** ([ops#1123](https://github.com/ascendimacy/ascendimacy-ops/issues/1123)) — daemon agora tem todas as MCP tools que o BFF precisa consumir.

## Test plan

- [ ] Reviewer roda `npm test --workspace orchestrator` → 139/139
- [ ] Confirma decisões 1-6 — especialmente (1) in-process vs stdio, (3) direct call vs roundtrip
- [ ] (Opcional, Jun) rodar smoke manual: `USE_MOCK_LLM=true node orchestrator/scripts/daemon-smoke.mjs`
- [ ] (Opcional, Jun) rodar smoke contra LLM local (qwen14b OVMS) com env vars apropriadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Rebased via reset+cherry-pick por Claude Code