### PR TITLE
[fix bug-pl-01] planejador vê extracted_signals + deflection awareness (Sprint 5 PR1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Build shared
         run: npm run build -w shared
 
+      # motor-channels é cross-workspace devDep do orchestrator (integration
+      # test C-MX-07 PR7 importa via @ascendimacy/motor-channels). package.json
+      # aponta pra ./dist via exports, então vitest falha resolver entry sem
+      # build. Build aqui antes dos tests pra desbloquear orchestrator.
+      - name: Build motor-channels
+        run: npm run build -w packages/motor-channels
+
       - name: Run tests
         run: npm test
 

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -236,7 +236,11 @@ export async function runTurn(
   // Captura signals do user message + history tail. Loga signals_extracted
   // event no event_log pra Trigger Evaluator consumir.
   // Read-only — fail-soft, qualquer erro vira signals=[].
+  // BUG-PL-01 Sprint 5: extractedSignals capturado fora do try pra ser
+  // injetado em plan_turn contextHints (planejador precisa ver pra propor
+  // deflection awareness no rationale).
   const tSig = Date.now();
+  let extractedSignals: string[] = [];
   try {
     const signalsResult = await clients.motorDrota.callTool({
       name: "extract_signals",
@@ -259,6 +263,7 @@ export async function runTurn(
       overall_confidence?: number;
     }>(signalsResult);
     if (sig.signals && sig.signals.length > 0) {
+      extractedSignals = sig.signals;
       // Loga event no motor-execucao pra Trigger Evaluator ler na próxima call
       await clients.motorExecucao.callTool({
         name: "log_event",
@@ -286,9 +291,28 @@ export async function runTurn(
   void (Date.now() - tSig); // keep latency hint local — debug log captura via debug-mode
 
   const t1 = Date.now();
+  // BUG-PL-01 Sprint 5: passa extracted_signals em contextHints pro planejador
+  // injetar SINAIS DETECTADOS NO TURNO + bloco DEFLECTION ATIVO no system prompt
+  // quando deflection_thematic/exit_marker_* presentes. Antes, signals só iam
+  // pro event_log e o planejador rodava cego — deflections ignoradas por 3 turns.
+  const planContextHints: Record<string, unknown> = {};
+  if (extractedSignals.length > 0) {
+    planContextHints["extracted_signals"] = extractedSignals;
+    planContextHints["last_user_message"] = message;
+  }
   const planResult = await clients.planejador.callTool({
     name: "plan_turn",
-    arguments: { sessionId, persona, adquirente, inventory, state, incomingMessage: message },
+    arguments: {
+      sessionId,
+      persona,
+      adquirente,
+      inventory,
+      state,
+      incomingMessage: message,
+      ...(Object.keys(planContextHints).length > 0
+        ? { contextHints: planContextHints }
+        : {}),
+    },
   });
   const plan = parseToolText<import("@ascendimacy/shared").PlanTurnOutput>(planResult);
   turnEntries.push({

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -74,9 +74,39 @@ function seedPath(): string | undefined {
  * Exported pra consumo por PoC scripts (ops#1069 follow-up) que precisam
  * reproduzir prompt do planejador sem passar pelo MCP handler completo.
  * Sem mudança de comportamento — só visibility.
+ *
+ * BUG-PL-01 Sprint 5: agora injeta SINAIS DETECTADOS NO TURNO ATUAL
+ * (vindos do caller via `input.contextHints["extracted_signals"]`) +
+ * bloco DEFLECTION ATIVO quando `deflection_thematic` / `exit_marker_*`
+ * estão presentes.
+ *
+ * Antes deste fix, signal-extractor rodava upstream mas o output ficava
+ * só no event_log — planejador nunca via signals, então strategicRationale
+ * + contextHints ignoravam deflections (bot insistia no tema por 3 turns).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-05-bugfix-materializer-content-anchor.md
  */
 export function buildSystemPrompt(input: PlanTurnInput): string {
-  const { persona, state, incomingMessage } = input;
+  const { persona, state, incomingMessage, contextHints } = input;
+
+  const extractedSignals = Array.isArray(contextHints?.["extracted_signals"])
+    ? (contextHints["extracted_signals"] as string[])
+    : [];
+
+  const signalsBlock = extractedSignals.length > 0
+    ? `\nSINAIS DETECTADOS NO TURNO ATUAL: ${extractedSignals.join(", ")}`
+    : "";
+
+  const deflectionActive = extractedSignals.some(
+    (s) =>
+      s === "deflection_thematic" ||
+      s === "exit_marker_implicit" ||
+      s === "exit_marker_explicit",
+  );
+  const deflectionBlock = deflectionActive
+    ? `\n⚠️ DEFLECTION ATIVO: o sujeito desviou do tema anterior. O strategicRationale DEVE reconhecer o desvio e propor tema diferente. NÃO retorne ao tema que o sujeito evitou. Em contextHints, adicione:\n  "avoid": "não retornar ao tema que o sujeito acabou de desviar",\n  "tone": "leve, sem pressão".`
+    : "";
+
   return `Você é o Planejador do motor Ascendimacy. Seu papel é AUXILIAR de compositor:
 o scoring de content items é determinístico (feito no código). Você só emite:
 
@@ -86,7 +116,7 @@ o scoring de content items é determinístico (feito no código). Você só emit
 SUJEITO: ${persona.name}, ${persona.age} anos.
 Perfil: ${JSON.stringify(persona.profile, null, 2)}
 Estado: trust=${state.trustLevel.toFixed(2)}, turn=${state.turn}, budget=${state.budgetRemaining}
-Mensagem: "${incomingMessage}"
+Mensagem: "${incomingMessage}"${signalsBlock}${deflectionBlock}
 
 Detecte a língua do sujeito (ex: 'pt-br', 'pt-br limitado', 'pt-br basico', 'ja', 'en'). Se o perfil indica falante não-nativo (ex: japonês aprendendo pt-br), use 'pt-br limitado'.
 
@@ -430,10 +460,25 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   const gardnerInstruction = buildGardnerInstruction(input);
 
   // 5. Injeta status_gates + casel_focus + gardner meta + triage meta em contextHints.
+  // BUG-PL-01 Sprint 5: upstream hints (extracted_signals etc) têm prioridade.
+  // Spread inicial preserva input.contextHints; LLM rationale e status_gates
+  // layer-by-layer em cima sem sobrescrever silenciosamente.
   const contextHints: Record<string, unknown> = {
+    ...(input.contextHints ?? {}),
     ...rationale.contextHints,
     status_gates: allGates(statusMatrix),
   };
+  // Re-aplica keys upstream pra garantir que rationale.contextHints
+  // (LLM-generated) não sobrescreva sinais do caller.
+  if (input.contextHints?.["extracted_signals"]) {
+    contextHints["extracted_signals"] = input.contextHints["extracted_signals"];
+  }
+  if (input.contextHints?.["last_user_message"]) {
+    contextHints["last_user_message"] = input.contextHints["last_user_message"];
+  }
+  if (input.contextHints?.["recent_turns"]) {
+    contextHints["recent_turns"] = input.contextHints["recent_turns"];
+  }
   if (focusDim) {
     contextHints["casel_focus_dimension"] = focusDim;
     contextHints["casel_focus_targets"] = caselTargets;

--- a/planejador/src/server.ts
+++ b/planejador/src/server.ts
@@ -56,6 +56,10 @@ server.registerTool(
         kidsHelixState: z.record(z.string(), z.unknown()).optional(),
       }),
       incomingMessage: z.string(),
+      // BUG-PL-01 Sprint 5: upstream hints (extracted_signals, last_user_message,
+      // recent_turns) opcionais. Caller passa pra preservar context awareness;
+      // buildSystemPrompt consome `extracted_signals` pra deflection block.
+      contextHints: z.record(z.string(), z.unknown()).optional(),
     } as any,
   },
   async (input: PlanTurnInput) => {

--- a/planejador/tests/plan.test.ts
+++ b/planejador/tests/plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { planTurn } from "../src/plan.js";
+import { planTurn, buildSystemPrompt } from "../src/plan.js";
 
 process.env["USE_MOCK_LLM"] = "true";
 
@@ -299,5 +299,86 @@ describe("planTurn — G-22 pool-builder loop integration (ops#1093)", () => {
     if (anyHasSacrificeReason) {
       expect(anyHasSacrificeReason).toBe(true);
     }
+  });
+});
+
+// ─── BUG-PL-01 Sprint 5: extracted_signals + deflection ───────────────────
+describe("buildSystemPrompt — extracted_signals + deflection (BUG-PL-01)", () => {
+  const baseInput = {
+    sessionId: "test-deflection",
+    persona: mockPersona,
+    adquirente: mockAdquirente,
+    inventory: mockInventory,
+    state: mockState,
+    incomingMessage: "tô melhor falando de tênis",
+  };
+
+  it("signal deflection_thematic → prompt contém aviso DEFLECTION ATIVO", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: {
+        extracted_signals: ["deflection_thematic", "peer_reference"],
+      },
+    });
+    expect(prompt).toContain("SINAIS DETECTADOS NO TURNO ATUAL");
+    expect(prompt).toContain("deflection_thematic");
+    expect(prompt).toContain("DEFLECTION ATIVO");
+    expect(prompt).toContain("não retornar ao tema");
+  });
+
+  it("exit_marker_implicit também ativa deflection block", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: { extracted_signals: ["exit_marker_implicit"] },
+    });
+    expect(prompt).toContain("DEFLECTION ATIVO");
+  });
+
+  it("signals presentes mas sem deflection → não tem bloco DEFLECTION ATIVO", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: {
+        extracted_signals: ["peer_reference", "voluntary_topic_deepening"],
+      },
+    });
+    expect(prompt).toContain("SINAIS DETECTADOS NO TURNO ATUAL");
+    expect(prompt).toContain("peer_reference");
+    expect(prompt).not.toContain("DEFLECTION ATIVO");
+  });
+
+  it("extracted_signals vazio → prompt sem bloco SINAIS DETECTADOS", () => {
+    const prompt = buildSystemPrompt({
+      ...baseInput,
+      contextHints: { extracted_signals: [] },
+    });
+    expect(prompt).not.toContain("SINAIS DETECTADOS");
+    expect(prompt).not.toContain("DEFLECTION ATIVO");
+  });
+
+  it("contextHints undefined → comportamento legado preservado (sem signals)", () => {
+    const prompt = buildSystemPrompt(baseInput);
+    expect(prompt).not.toContain("SINAIS DETECTADOS");
+    expect(prompt).not.toContain("DEFLECTION ATIVO");
+    // Mas o prompt fundamental ainda está presente
+    expect(prompt).toContain("Planejador do motor Ascendimacy");
+  });
+});
+
+describe("planTurn — preserva extracted_signals em contextHints de output (BUG-PL-01)", () => {
+  it("input.contextHints.extracted_signals chega no output.contextHints", async () => {
+    const output = await planTurn({
+      sessionId: "test-signals-preserve",
+      persona: mockPersona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+      contextHints: {
+        extracted_signals: ["deflection_thematic"],
+        last_user_message: "previous msg",
+      },
+    });
+    expect(output.contextHints["extracted_signals"]).toEqual(["deflection_thematic"]);
+    expect(output.contextHints["last_user_message"]).toBe("previous msg");
   });
 });

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -14,6 +14,19 @@ export interface PlanTurnInput {
   inventory: PlaybookIndex[];
   state: SessionState;
   incomingMessage: string;
+  /**
+   * Hints upstream do caller (orchestrator) — preservados na contextHints
+   * de output. Keys atualmente reconhecidas:
+   *  - `extracted_signals: string[]` (motor#25 — signal-extractor output;
+   *    consumido por `buildSystemPrompt` pra deflection awareness no LLM
+   *    rationale, BUG-PL-01).
+   *  - `last_user_message: string` (reservado pra recent_turns awareness).
+   *  - `recent_turns: Array<{role, content}>` (reservado).
+   *
+   * Spread inicial em planTurn faz upstream ter prioridade sobre LLM
+   * rationale — evita override silencioso.
+   */
+  contextHints?: Record<string, unknown>;
 }
 
 export interface PlanTurnOutput {


### PR DESCRIPTION
## Sprint 5 PR1 — re-implementação clean de motor-simplificacao-v1 commit 63423d5 (parte planejador)

### Bug em main

- `signal-extractor` roda upstream e gera signals (`deflection_thematic` etc), logado em event_log
- Mas `plan_turn` NUNCA recebe os signals — planejador ignora completamente
- Resultado: `strategicRationale` propõe Fact mesmo após sujeito desviar; bot insiste no tema por 3 turns
- Reproduzido no STS smoke 2026-05-24 (kei): "Quer dizer, por que você tá me perguntando isso agora?" 3x

### Escopo

**Incluído**: parte BUG-PL-01 do commit 63423d5
**Dropped**: parte BUG-CM-01. Main já tem "Ancoragem obrigatória" + "NUNCA inventa conteúdo" no `STABLE_DROTA_PREFIX` (motor-drota/server.ts:73). Smoke confirma Fact ancorado em Ryo turn 4 ("Sabia que, na Segunda Guerra, os EUA usaram Navajo...").

### Fix

| File | Mudança |
|---|---|
| `shared/src/contracts.ts` | `PlanTurnInput.contextHints?: Record<string, unknown>` |
| `planejador/src/plan.ts` | `buildSystemPrompt` exportado + lê `extracted_signals` + injeta `signalsBlock` + `deflectionBlock` quando `deflection_thematic`/`exit_marker_*` presentes; `planTurn` faz spread inicial de upstream hints com prioridade |
| `planejador/src/server.ts` | zod schema accept `contextHints` opcional |
| `orchestrator/src/orchestrator.ts` | captura `sig.signals` do `extract_signals` call + passa como `contextHints.extracted_signals` + `last_user_message` no `plan_turn` |
| `planejador/tests/plan.test.ts` | +6 tests (5 buildSystemPrompt + 1 planTurn preserve) |

### deflectionBlock (cita no system prompt)

```
⚠️ DEFLECTION ATIVO: o sujeito desviou do tema anterior. O strategicRationale
DEVE reconhecer o desvio e propor tema diferente. NÃO retorne ao tema que o
sujeito evitou. Em contextHints, adicione:
  "avoid": "não retornar ao tema que o sujeito acabou de desviar",
  "tone": "leve, sem pressão".
```

### Test plan

- [x] `npm test --workspace shared` — 661 passing
- [x] `npm test --workspace planejador` — 310 passing (inclui 6 novos)
- [x] `npm test --workspace orchestrator` — 139 passing
- [x] Build clean em todos os 3 workspaces
- [ ] STS smoke kei pós-merge: bot muda de tema no turn seguinte após `deflection_thematic`

### Specs

- `ascendimacy-ops/docs/specs/2026-05-05-bugfix-materializer-content-anchor.md` (referência original)

🤖 Sprint 5 PR1 via Claude Code