### PR TITLE
[feat sprint5#1] StableStateCache + types (foundation)

### DIFF
--- a/shared/src/stable-state-cache.ts
+++ b/shared/src/stable-state-cache.ts
@@ -1,0 +1,123 @@
+/**
+ * Stable State Cache — campos cacheados por sessão pra alimentar
+ * Unified Assessor sem recalcular tudo a cada turn.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §3.6
+ *
+ * Distinção:
+ *   - StableStateFields: recalculados UMA VEZ por sessão (ou via evento explícito)
+ *   - VolatileStateFields: recalculados a cada turn pelo Unified Assessor
+ *
+ * Invalidação de stable: operador online/offline, transição status_matrix,
+ * fim de sessão. Não a cada turn.
+ *
+ * DT-SIM-02: VoiceProfile ainda não existe como tipo canônico em shared/.
+ * Usa stub `Record<string, unknown>` aqui; refina quando voice profiles
+ * entrarem como tipo formal (Sprint 5 #2).
+ *
+ * Sprint 5 #1 — re-implementação clean de feat/motor-simplificacao-v1
+ * commit e27f829 contra main.
+ */
+
+import type { HelixState } from "./helix-state.js";
+import type { StatusMatrix } from "./status-matrix.js";
+import type { SemanticSignal } from "./semantic-signals.js";
+
+/** Jurisdição ativa do sujeito (afeta jurisdiction_respect). */
+export type Jurisdiction = "br" | "jp" | "ch";
+
+/** Engajamento derivado dos signals + mood. */
+export type EngagementLevel = "high" | "medium" | "low" | "disengaging";
+
+/**
+ * Campos estáveis — recalculados UMA VEZ por sessão.
+ * Invalidação só via evento explícito (transição, operador, fim de sessão).
+ */
+export interface StableStateFields {
+  /** ID canônico do sujeito (cross-session via motor#47). */
+  child_id: string;
+  /** 0.0-1.0 — derivado do trust-calculator.ts. */
+  trust_level: number;
+  /** Jurisdição ativa pra constraints de materialização. */
+  jurisdiction_active: Jurisdiction;
+  /** Flags de modificadores (futoko, incident, crisis_flag, etc.). */
+  modifier_flags: string[];
+  /** Operador humano disponível pra escalation. */
+  operator_online: boolean;
+  /**
+   * Voice profile do sujeito (cascade: ClientVoiceProfile → CulturalDefault
+   * → Universal). Estrutura formal pendente (DT-SIM-02). Stub Record por enquanto.
+   */
+  voice_profile: Record<string, unknown>;
+  /** Estado do Double Helix (atualiza só no fim da sessão). */
+  helix_state: HelixState;
+  /** Status matrix brejo/baia/pasto (atualiza só via transição detectada). */
+  status_matrix: StatusMatrix;
+  /** Timestamp do início da sessão (epoch ms). */
+  stable_computed_at: number;
+}
+
+/**
+ * Campos voláteis — recalculados a cada turn pelo Unified Assessor.
+ */
+export interface VolatileStateFields {
+  /** Mood absoluto 1-10 (do AssessmentResult). */
+  mood: number;
+  /** Últimos 3 valores de mood pra detectar drift. */
+  mood_window: number[];
+  /** Engajamento derivado dos signals. */
+  engagement: EngagementLevel;
+  /** Signals do turn atual (capturados pelo Unified Assessor). */
+  signals_last_turn: SemanticSignal[];
+  /** Budget restante (decrementado pelo Pragmatic Selector). */
+  budget_remaining: number;
+  /** Contador do turn atual na sessão. */
+  turn_count: number;
+}
+
+/**
+ * Cache em memória de StableStateFields por child_id.
+ *
+ * Não thread-safe — assume single-process. Cada chamada
+ * createStableStateCache() cria store independente (isolamento em tests).
+ */
+export interface StableStateCache {
+  /** Lê campos estáveis pro child. Retorna null se não cacheado. */
+  get(childId: string): StableStateFields | null;
+  /** Persiste campos estáveis (cria ou atualiza). */
+  set(childId: string, fields: StableStateFields): void;
+  /** Invalida cache pro child (transição detectada, fim de sessão). */
+  invalidate(childId: string): void;
+  /** Invalida cache inteiro (debug, restart). */
+  invalidateAll(): void;
+  /** Retorna idade do cache em ms (Date.now() - stable_computed_at). */
+  age(childId: string): number | null;
+}
+
+/**
+ * Cria instância nova do cache. Map em memória; cada chamada cria store
+ * independente (útil em tests pra isolamento).
+ */
+export function createStableStateCache(): StableStateCache {
+  const store = new Map<string, StableStateFields>();
+
+  return {
+    get(childId: string): StableStateFields | null {
+      return store.get(childId) ?? null;
+    },
+    set(childId: string, fields: StableStateFields): void {
+      store.set(childId, fields);
+    },
+    invalidate(childId: string): void {
+      store.delete(childId);
+    },
+    invalidateAll(): void {
+      store.clear();
+    },
+    age(childId: string): number | null {
+      const fields = store.get(childId);
+      if (!fields) return null;
+      return Date.now() - fields.stable_computed_at;
+    },
+  };
+}

--- a/shared/tests/stable-state-cache.test.ts
+++ b/shared/tests/stable-state-cache.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { createStableStateCache } from "../src/stable-state-cache.js";
+import type { StableStateFields } from "../src/stable-state-cache.js";
+import { initHelix } from "../src/helix-planner.js";
+
+function buildFields(childId: string): StableStateFields {
+  return {
+    child_id: childId,
+    trust_level: 0.5,
+    jurisdiction_active: "jp",
+    modifier_flags: [],
+    operator_online: false,
+    voice_profile: {},
+    helix_state: initHelix(childId),
+    status_matrix: { emotional: "baia" },
+    stable_computed_at: Date.now(),
+  };
+}
+
+describe("StableStateCache", () => {
+  it("get retorna null pra childId não cacheado", () => {
+    const cache = createStableStateCache();
+    expect(cache.get("user-1")).toBeNull();
+  });
+
+  it("set + get roundtrip", () => {
+    const cache = createStableStateCache();
+    const fields = buildFields("user-1");
+    cache.set("user-1", fields);
+    expect(cache.get("user-1")).toEqual(fields);
+  });
+
+  it("isolamento entre child_ids", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", buildFields("user-1"));
+    cache.set("user-2", buildFields("user-2"));
+    expect(cache.get("user-1")?.child_id).toBe("user-1");
+    expect(cache.get("user-2")?.child_id).toBe("user-2");
+  });
+
+  it("invalidate remove entry específica", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", buildFields("user-1"));
+    cache.set("user-2", buildFields("user-2"));
+    cache.invalidate("user-1");
+    expect(cache.get("user-1")).toBeNull();
+    expect(cache.get("user-2")).not.toBeNull();
+  });
+
+  it("invalidateAll limpa cache inteiro", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", buildFields("user-1"));
+    cache.set("user-2", buildFields("user-2"));
+    cache.invalidateAll();
+    expect(cache.get("user-1")).toBeNull();
+    expect(cache.get("user-2")).toBeNull();
+  });
+
+  it("age retorna ms desde stable_computed_at", () => {
+    const cache = createStableStateCache();
+    const past = Date.now() - 5000;
+    cache.set("user-1", { ...buildFields("user-1"), stable_computed_at: past });
+    const age = cache.age("user-1");
+    expect(age).not.toBeNull();
+    expect(age!).toBeGreaterThanOrEqual(5000);
+  });
+
+  it("age retorna null pra child sem cache", () => {
+    const cache = createStableStateCache();
+    expect(cache.age("user-1")).toBeNull();
+  });
+
+  it("set sobrescreve idempotentemente", () => {
+    const cache = createStableStateCache();
+    cache.set("user-1", { ...buildFields("user-1"), trust_level: 0.3 });
+    cache.set("user-1", { ...buildFields("user-1"), trust_level: 0.8 });
+    expect(cache.get("user-1")?.trust_level).toBe(0.8);
+  });
+
+  it("instâncias separadas não compartilham state", () => {
+    const cache1 = createStableStateCache();
+    const cache2 = createStableStateCache();
+    cache1.set("user-1", buildFields("user-1"));
+    expect(cache2.get("user-1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Sprint 5 #1 — re-implementação clean de feat/motor-simplificacao-v1 commit e27f829

Foundation pra Sprint 5. Isolado, sem deps. Próximos PRs (Unified Assessor #4, Pragmatic Selector #5, etc) consomem o cache.

### Adicionado

`shared/src/stable-state-cache.ts` (120 linhas):
- `StableStateFields`: child_id, trust_level, jurisdiction_active, modifier_flags, operator_online, voice_profile (stub DT-SIM-02), helix_state, status_matrix, stable_computed_at
- `VolatileStateFields`: mood, mood_window, engagement, signals_last_turn, budget_remaining, turn_count
- `Jurisdiction` (br|jp|ch), `EngagementLevel` (high|medium|low|disengaging)
- `StableStateCache` API: get/set/invalidate/invalidateAll/age
- `createStableStateCache()` factory; store independente por instância

`shared/tests/stable-state-cache.test.ts` (9 tests):
- smoke + roundtrip + invalidação + age

### Distinção stable vs volatile

| Stable (cached) | Volatile (recalc per turn) |
|---|---|
| trust_level | mood |
| jurisdiction | engagement |
| modifier_flags | signals_last_turn |
| voice_profile | budget_remaining |
| helix_state | turn_count |
| status_matrix | mood_window |

Invalidação stable: transição status_matrix, operador online/offline, fim de sessão.

### Test plan

- [x] `npm test --workspace shared` — 670/670 passing
- [x] Build clean

### Spec

`ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §3.6`

🤖 Sprint 5 #1 via Claude Code