### PR TITLE
[feat sprint5#2] Voice Profiles YAML + Inaugural Template Resolver

### DIFF
--- a/motor-drota/src/inaugural-template.ts
+++ b/motor-drota/src/inaugural-template.ts
@@ -1,0 +1,259 @@
+/**
+ * Inaugural Template Resolver — apresentação do bot na primeira sessão.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5.5
+ *
+ * Cascade fallback:
+ *   1. ClientVoiceProfile (override por família) → mais específico
+ *   2. CulturalDefaultProfile (ja.yaml, br-pt.yaml, _neutral.yaml)
+ *   3. UniversalTemplate (built-in fallback hardcoded)
+ *
+ * Slots resolvidos:
+ *   - greeting (texto da saudação)
+ *   - subject_name_form (nome do sujeito + honorífico)
+ *   - purpose (1-2 frases sobre o que vão fazer)
+ *   - non_evaluation_clause (obrigatória — "não é teste")
+ *   - exit_right (sempre presente — como sair)
+ *   - confirmation_invite (ancorado em interesse se disponível)
+ *
+ * DT-SIM-06: voice_profile + cultural_default ainda são YAMLs sem loader
+ * canônico em runtime. Esta função aceita os dois como `Record<string, unknown>`
+ * (ja parsed via js-yaml externamente). Refatora quando profile-loader real
+ * entrar.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface InauguralChild {
+  /** Nome do sujeito como deve aparecer (sem honorífico por padrão JP). */
+  name: string;
+  /** Honorific override (se família configurou diferente do default). */
+  honorific?: string;
+  /** Idade — usada pra calibração de tom (não exposta no template). */
+  age?: number;
+  /** Interesse principal pra ancorar confirmation_invite. */
+  topInterest?: string;
+}
+
+export interface InauguralResolveInput {
+  /** Voice profile parseado (ClientVoiceProfile). Pode ser null. */
+  voiceProfile?: Record<string, unknown> | null;
+  /** Cultural default parseado (ja.yaml, _neutral.yaml). Pode ser null. */
+  culturalDefault?: Record<string, unknown> | null;
+  /** Dados da criança/sujeito. */
+  child: InauguralChild;
+  /** Número da sessão (1=inaugural, 2+=recorrente). */
+  sessionNumber: number;
+  /** Modo joint? (templates de dyad ficam pra v1). */
+  isJoint?: boolean;
+  /** Nome do parceiro (se joint). */
+  jointPartnerName?: string;
+}
+
+export interface InauguralResolveOutput {
+  /** Texto completo pronto pra Bridge. */
+  text: string;
+  /** Template resolvido (cascade source). */
+  template_used:
+    | "inaugural_solo_jp"
+    | "inaugural_solo_br"
+    | "inaugural_recorrente"
+    | "inaugural_universal_fallback";
+  /** Cláusula de não-avaliação presente? (acceptance criterion). */
+  non_evaluation_clause_present: boolean;
+  /** Direito de saída presente? (acceptance criterion). */
+  exit_right_present: boolean;
+  /** Source da cascade ("client_override" | "cultural_default" | "universal"). */
+  cascade_source: "client_override" | "cultural_default" | "universal";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Universal fallback (built-in PT-BR — funciona sem nenhum YAML)
+// ─────────────────────────────────────────────────────────────────────────
+
+const UNIVERSAL_FALLBACK = {
+  greeting: "Oi",
+  purpose:
+    "Estou aqui pra pensar coisas com você. Não dou respostas — falo junto.",
+  non_evaluation_clause: "Isso não é prova nem avaliação.",
+  exit_right: "Se quiser parar, é só falar.",
+  confirmation_invite_default: "O que tá rolando aí?",
+  confirmation_invite_template: "Hoje quer falar sobre {interest}?",
+};
+
+const UNIVERSAL_RECORRENTE = {
+  template: "Olá de novo, {name}. Pegando de onde paramos?",
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function getNested(
+  obj: Record<string, unknown> | null | undefined,
+  path: string[],
+): unknown {
+  if (!obj) return undefined;
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (cur && typeof cur === "object" && key in cur) {
+      cur = (cur as Record<string, unknown>)[key];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function buildSubjectNameForm(child: InauguralChild): string {
+  const honorific = child.honorific && child.honorific !== "bare_name"
+    ? `-${child.honorific}`
+    : "";
+  return `${child.name}${honorific}`;
+}
+
+function fillTemplate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  let out = template;
+  for (const [k, v] of Object.entries(vars)) {
+    out = out.replace(new RegExp(`\\{${k}\\}`, "g"), v);
+  }
+  return out;
+}
+
+/** Resolve campo via cascade: client → cultural → universal fallback. */
+function resolveField(
+  path: string[],
+  client: Record<string, unknown> | null | undefined,
+  cultural: Record<string, unknown> | null | undefined,
+  fallback: string,
+): { value: string; source: "client_override" | "cultural_default" | "universal" } {
+  const fromClient = asString(getNested(client, path));
+  if (fromClient) return { value: fromClient, source: "client_override" };
+  const fromCultural = asString(getNested(cultural, path));
+  if (fromCultural) return { value: fromCultural, source: "cultural_default" };
+  return { value: fallback, source: "universal" };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve template inaugural via cascade. Sempre retorna texto válido.
+ *
+ * sessionNumber > 1 → template recorrente (curto, referencia sessão anterior).
+ * sessionNumber = 1 → template completo com greeting + purpose + non_eval +
+ * exit_right + confirmation_invite.
+ */
+export function resolveInauguralTemplate(
+  input: InauguralResolveInput,
+): InauguralResolveOutput {
+  // Sessão recorrente — template curto
+  if (input.sessionNumber > 1) {
+    const recorrenteOverride = asString(
+      getNested(input.voiceProfile, ["client_overrides", "recorrente_template"]),
+    );
+    const template = recorrenteOverride ?? UNIVERSAL_RECORRENTE.template;
+    return {
+      text: fillTemplate(template, {
+        name: buildSubjectNameForm(input.child),
+      }),
+      template_used: "inaugural_recorrente",
+      non_evaluation_clause_present: false, // recorrente não precisa
+      exit_right_present: false,
+      cascade_source: recorrenteOverride ? "client_override" : "universal",
+    };
+  }
+
+  // Sessão 1 — template completo
+  const subjectNameForm = buildSubjectNameForm(input.child);
+
+  const greetingPath = ["inaugural", "greeting"];
+  const purposePath = ["inaugural", "purpose"];
+  const nonEvalPath = ["inaugural", "non_evaluation_clause"];
+  const exitRightPath = ["inaugural", "exit_right"];
+  const inviteDefaultPath = ["inaugural", "confirmation_invite_default"];
+  const inviteTemplatePath = ["inaugural", "confirmation_invite_template"];
+
+  const greeting = resolveField(
+    greetingPath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.greeting,
+  );
+  const purpose = resolveField(
+    purposePath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.purpose,
+  );
+  const nonEval = resolveField(
+    nonEvalPath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.non_evaluation_clause,
+  );
+  const exitRight = resolveField(
+    exitRightPath,
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.exit_right,
+  );
+
+  // Confirmation invite: usa template se interesse disponível, default se não
+  let invite: string;
+  if (input.child.topInterest) {
+    const tmpl = resolveField(
+      inviteTemplatePath,
+      input.voiceProfile,
+      input.culturalDefault,
+      UNIVERSAL_FALLBACK.confirmation_invite_template,
+    );
+    invite = fillTemplate(tmpl.value, { interest: input.child.topInterest });
+  } else {
+    const def = resolveField(
+      inviteDefaultPath,
+      input.voiceProfile,
+      input.culturalDefault,
+      UNIVERSAL_FALLBACK.confirmation_invite_default,
+    );
+    invite = def.value;
+  }
+
+  // Compose final text
+  const greetingLine = `${greeting.value}, ${subjectNameForm}.`;
+  const text = [greetingLine, purpose.value, nonEval.value, exitRight.value, invite]
+    .filter((s) => s && s.trim().length > 0)
+    .join(" ");
+
+  // Cascade source: pega o mais específico que contribuiu
+  const sources = [greeting.source, purpose.source, nonEval.source, exitRight.source];
+  let cascadeSource: "client_override" | "cultural_default" | "universal" = "universal";
+  if (sources.includes("client_override")) cascadeSource = "client_override";
+  else if (sources.includes("cultural_default")) cascadeSource = "cultural_default";
+
+  // Decide template label baseado no language do cultural default
+  let templateUsed: InauguralResolveOutput["template_used"] = "inaugural_universal_fallback";
+  if (cascadeSource !== "universal") {
+    const lang = asString(getNested(input.culturalDefault, ["language"]));
+    if (lang === "ja") templateUsed = "inaugural_solo_jp";
+    else if (lang === "pt") templateUsed = "inaugural_solo_br";
+  }
+
+  return {
+    text: text.trim(),
+    template_used: templateUsed,
+    non_evaluation_clause_present: nonEval.value.length > 0,
+    exit_right_present: exitRight.value.length > 0,
+    cascade_source: cascadeSource,
+  };
+}

--- a/motor-drota/tests/inaugural-template.test.ts
+++ b/motor-drota/tests/inaugural-template.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import { resolveInauguralTemplate } from "../src/inaugural-template.js";
+
+const JA_CULTURAL = {
+  language: "ja",
+  inaugural: {
+    greeting: "こんにちは",
+    purpose: "僕はあなたと一緒に何かを考える相手だよ。",
+    non_evaluation_clause: "これはテストじゃないよ。",
+    exit_right: "「もういい」って言えば、いつでも終われるよ。",
+    confirmation_invite_default: "今日は何が気になってる?",
+    confirmation_invite_template: "今日、{interest}について話したい?",
+  },
+};
+
+const PT_CULTURAL = {
+  language: "pt",
+  inaugural: {
+    greeting: "Oi",
+    purpose: "Estou aqui pra pensar coisas com você.",
+    non_evaluation_clause: "Isso não é prova nem avaliação.",
+    exit_right: "Se quiser parar, é só falar.",
+    confirmation_invite_default: "O que tá rolando aí?",
+    confirmation_invite_template: "Hoje quer falar sobre {interest}?",
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sessão 1 — template completo
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — sessão 1 cultural JP", () => {
+  it("retorna texto JP com todos os slots", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("こんにちは");
+    expect(r.text).toContain("Ryo");
+    expect(r.text).toContain("これはテストじゃないよ");
+    expect(r.text).toContain("もういい");
+    expect(r.template_used).toBe("inaugural_solo_jp");
+    expect(r.non_evaluation_clause_present).toBe(true);
+    expect(r.exit_right_present).toBe(true);
+    expect(r.cascade_source).toBe("cultural_default");
+  });
+
+  it("usa interest no confirmation_invite quando disponível", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo", topInterest: "Dragon Ball" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Dragon Ball");
+  });
+
+  it("usa default invite quando interest ausente", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("気になってる");
+  });
+
+  it("honorific bare_name → sem sufixo", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo", honorific: "bare_name" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Ryo.");
+    expect(r.text).not.toContain("Ryo-");
+  });
+
+  it("honorific kun → sufixo aplicado", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo", honorific: "kun" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Ryo-kun");
+  });
+});
+
+describe("resolveInauguralTemplate — sessão 1 cultural PT", () => {
+  it("retorna texto PT-BR com todos os slots", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: PT_CULTURAL,
+      child: { name: "Saki" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Oi");
+    expect(r.text).toContain("Saki");
+    expect(r.text).toContain("não é prova");
+    expect(r.template_used).toBe("inaugural_solo_br");
+    expect(r.non_evaluation_clause_present).toBe(true);
+    expect(r.exit_right_present).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Cascade override (ClientVoiceProfile)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — cascade ClientVoiceProfile sobrescreve", () => {
+  it("client_override.inaugural.purpose vence cultural", () => {
+    const client = {
+      inaugural: {
+        purpose: "Custom purpose desta família.",
+      },
+    };
+    const r = resolveInauguralTemplate({
+      voiceProfile: client,
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Custom purpose desta família");
+    expect(r.text).not.toContain("僕はあなた"); // cultural purpose NÃO usado
+    expect(r.cascade_source).toBe("client_override");
+  });
+
+  it("client parcial → fallback cultural pros campos não cobertos", () => {
+    const client = { inaugural: { greeting: "Olá!" } }; // só override greeting
+    const r = resolveInauguralTemplate({
+      voiceProfile: client,
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Olá!"); // do client
+    expect(r.text).toContain("もういい"); // do cultural (exit_right)
+    expect(r.cascade_source).toBe("client_override");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Universal fallback (sem voice profile nem cultural)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — universal fallback", () => {
+  it("sem profile nem cultural → texto built-in PT-BR funciona", () => {
+    const r = resolveInauguralTemplate({
+      child: { name: "Test" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toContain("Test");
+    expect(r.text.length).toBeGreaterThan(20);
+    expect(r.template_used).toBe("inaugural_universal_fallback");
+    expect(r.non_evaluation_clause_present).toBe(true);
+    expect(r.exit_right_present).toBe(true);
+    expect(r.cascade_source).toBe("universal");
+  });
+
+  it("cultural null + voice null → fallback hardcoded sempre disponível", () => {
+    const r = resolveInauguralTemplate({
+      voiceProfile: null,
+      culturalDefault: null,
+      child: { name: "X" },
+      sessionNumber: 1,
+    });
+    expect(r.text).toBeTruthy();
+    expect(r.exit_right_present).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sessão recorrente (sessionNumber > 1)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveInauguralTemplate — sessão recorrente", () => {
+  it("sessionNumber=2 → template recorrente curto", () => {
+    const r = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 2,
+    });
+    expect(r.template_used).toBe("inaugural_recorrente");
+    expect(r.text).toContain("Ryo");
+    // Recorrente não precisa de non_eval/exit (já apresentados na sessão 1)
+    expect(r.non_evaluation_clause_present).toBe(false);
+    expect(r.exit_right_present).toBe(false);
+  });
+
+  it("sessionNumber=10 também usa recorrente", () => {
+    const r = resolveInauguralTemplate({
+      child: { name: "Kei" },
+      sessionNumber: 10,
+    });
+    expect(r.template_used).toBe("inaugural_recorrente");
+    expect(r.text).toContain("Kei");
+  });
+
+  it("client_override.recorrente_template vence universal", () => {
+    const client = {
+      client_overrides: { recorrente_template: "Custom: {name}, vamos lá!" },
+    };
+    const r = resolveInauguralTemplate({
+      voiceProfile: client,
+      child: { name: "Ryo" },
+      sessionNumber: 3,
+    });
+    expect(r.text).toBe("Custom: Ryo, vamos lá!");
+    expect(r.cascade_source).toBe("client_override");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Acceptance criteria do spec §11
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("acceptance criteria — non_eval + exit_right bilíngue", () => {
+  it("PT + JP ambos têm non_eval + exit_right (sessão 1)", () => {
+    const ja = resolveInauguralTemplate({
+      culturalDefault: JA_CULTURAL,
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    const pt = resolveInauguralTemplate({
+      culturalDefault: PT_CULTURAL,
+      child: { name: "Saki" },
+      sessionNumber: 1,
+    });
+    expect(ja.non_evaluation_clause_present).toBe(true);
+    expect(ja.exit_right_present).toBe(true);
+    expect(pt.non_evaluation_clause_present).toBe(true);
+    expect(pt.exit_right_present).toBe(true);
+  });
+});

--- a/shared/voice/cultural-defaults/_neutral.yaml
+++ b/shared/voice/cultural-defaults/_neutral.yaml
@@ -1,0 +1,31 @@
+# Cultural Defaults — Neutral fallback (PT-BR plain)
+#
+# Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5.5
+#
+# Universal fallback quando ClientVoiceProfile + CulturalDefault específico
+# (ja.yaml, br-pt.yaml) ausentes. Tom direto, sem decoração cultural.
+
+cultural_default_provenance: universal_neutral
+language: pt
+locale: pt-BR
+
+inaugural:
+  greeting: "Oi"
+  greeting_with_name_format: "{greeting}, {name}."
+  purpose: |
+    Estou aqui pra pensar coisas com você. Não sou quem dá respostas — sou quem fala junto.
+  non_evaluation_clause: "Isso não é prova nem avaliação."
+  exit_right: "Se quiser parar, é só falar. Sem problema nenhum."
+  confirmation_invite_template: "Hoje, quer falar sobre {interest}?"
+  confirmation_invite_default: "O que tá rolando aí?"
+
+pulso:
+  type: plain
+  enabled: false
+  tie_threshold: 0.05
+  rng_seed_strategy: deterministic_session
+  vocabulary: []
+
+honorifics:
+  default_form: bare_name
+  available_options: [bare_name]

--- a/shared/voice/cultural-defaults/ja.yaml
+++ b/shared/voice/cultural-defaults/ja.yaml
@@ -1,0 +1,60 @@
+# Cultural Defaults — Japonês (JP)
+#
+# Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5.5
+# + 2026-04-26-pulso-spec-v0.md (omikuji v0)
+#
+# Status: v0 — pendente revisão Yuji/Yuko ANTES do piloto Nagareyama.
+# cultural_default_provenance: "claude_ai_v0_pending_family_anchor"
+#
+# Quando Yuji/Yuko revisarem, atualizar provenance para "family_anchor".
+
+cultural_default_provenance: claude_ai_v0_pending_family_anchor
+language: ja
+locale: ja-JP
+
+# ─── Inaugural template (turn 0 primeira sessão) ─────────────────────
+# Spec §5.5 — slots mínimos pro piloto Nagareyama.
+inaugural:
+  greeting: "こんにちは"
+  # subject_name_form é resolvido em runtime (sem honorífico por padrão JP;
+  # família revisa). Esta é apenas a forma de saudação.
+  greeting_with_name_format: "{greeting}、{name}。"
+
+  # Propósito (1-2 frases) — claude_ai_v0; family_anchor revisará tom.
+  purpose: |
+    僕はあなたと一緒に何かを考える相手だよ。
+    答えを教える人じゃなくて、一緒に気になることを話す相手。
+
+  # Cláusula de não-avaliação (obrigatória — não é teste).
+  non_evaluation_clause: "これはテストじゃないよ。"
+
+  # Direito de saída (sempre presente).
+  exit_right: "「もういい」って言えば、いつでも終われるよ。"
+
+  # Convite pra começar (ancorado em interesse — slot dinâmico {interest}).
+  confirmation_invite_template: "今日、{interest}について話したい?"
+  confirmation_invite_default: "今日は何が気になってる?"
+
+# ─── Pulso vocabulário cultural (omikuji v0) ─────────────────────────
+# Spec 2026-04-26-pulso-spec-v0.md DA-PULSO-03: 7 níveis (drop 半吉).
+pulso:
+  type: omikuji
+  enabled: true
+  tie_threshold: 0.05
+  rng_seed_strategy: deterministic_session
+  vocabulary:
+    - { symbol: "大吉", translation: "fortuna grande", weight: 1 }
+    - { symbol: "吉", translation: "fortuna boa", weight: 2 }
+    - { symbol: "中吉", translation: "fortuna média", weight: 3 }
+    - { symbol: "小吉", translation: "fortuna pequena", weight: 2 }
+    - { symbol: "末吉", translation: "fortuna distante", weight: 2 }
+    - { symbol: "凶", translation: "azar", weight: 1 }
+    - { symbol: "大凶", translation: "azar grande", weight: 1 }
+
+# ─── Honorific defaults ──────────────────────────────────────────────
+# Família revisa: padrão é SEM honorífico (familiaridade desejada).
+honorifics:
+  default_form: bare_name
+  available_options: [bare_name, kun, chan, san]
+  # Aviso: usar honorífico errado em JP é violação social leve; defer
+  # à família.

--- a/shared/voice/profiles/kids-jp.voice-profile.yaml
+++ b/shared/voice/profiles/kids-jp.voice-profile.yaml
@@ -1,0 +1,36 @@
+# Voice Profile — Kids JP
+#
+# Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §6.2
+# Cascade: ClientVoiceProfile (este) → CulturalDefault (ja.yaml) → Universal (_neutral.yaml)
+
+profile_id: kids-jp
+language: ja
+cultural_default_ref: shared/voice/cultural-defaults/ja.yaml
+
+# ─── Materializer config (DS-09) ─────────────────────────────────────
+# DT-SIM-05: spec mencionou "qwen" como default; v0 usa step "drota"
+# existente (Kimi K2.5 via Infomaniak). Refator pra ler model daqui
+# quando voice profile ganhar tipo formal.
+materializer:
+  step: drota
+  max_tokens: 300
+  temperature: 0.7
+
+# ─── Assessor config (DS-08) ─────────────────────────────────────────
+assessor:
+  step: unified-assessor
+  max_tokens: 256
+  temperature: 0.1
+
+# ─── Pulso config (motor#33, DA-PULSO-01..05) ────────────────────────
+pulso:
+  enabled: true
+  type: omikuji
+  tie_threshold: 0.05
+  rng_seed_strategy: deterministic_session
+  vocabulary_ref: shared/voice/cultural-defaults/ja.yaml#pulso
+
+# ─── Cliente-specific overrides (família Yuji+Yuko revisa) ───────────
+client_overrides:
+  honorific: bare_name # família escolhe; default JP é sem honorífico
+  inaugural_purpose_override: null # null = usa do cultural default


### PR DESCRIPTION
Sprint 5 #2 — re-implementação clean de feat/motor-simplificacao-v1 commits e4dec2b + 8665d72 + 7d277ad.

## Adicionado
- `shared/voice/profiles/kids-jp.voice-profile.yaml` — client overrides
- `shared/voice/cultural-defaults/ja.yaml` — JP defaults
- `shared/voice/cultural-defaults/_neutral.yaml` — universal fallback
- `motor-drota/src/inaugural-template.ts` (259 linhas) — Cascade resolver ClientVoice→Cultural→Universal
- `motor-drota/tests/inaugural-template.test.ts` (231 linhas, 14 tests)

## Validação
- 220/220 motor-drota tests passing
- Build clean

🤖 Sprint 5 #2 via Claude Code