### PR TITLE
[feat sprint5#3] Qwen3 thinking OFF default no openai-compat client

### DIFF
--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -211,6 +211,15 @@ async function callLocalChatCompletion(
     ],
   };
   if (req.maxTokens !== undefined) body["max_tokens"] = req.maxTokens;
+  // Sprint 5 #3: Qwen3 family ativa hybrid thinking por default, drenando
+  // 500-2000 tokens em raciocínio antes do conteúdo — infla latência e
+  // consome max_tokens. Desativar via chat_template_kwargs.enable_thinking
+  // (mecanismo oficial do Qwen3 chat template).
+  // Modelos sem suporte (Qwen2.5, Claude via Meridian, Gemma3) ignoram
+  // silenciosamente. Override via LOCAL_LLM_THINKING=true se quiser ativo.
+  body["chat_template_kwargs"] = {
+    enable_thinking: process.env["LOCAL_LLM_THINKING"] === "true",
+  };
   const timeoutMs = getLlmTimeoutMs(req.step);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);

--- a/shared/tests/gateway-client.test.ts
+++ b/shared/tests/gateway-client.test.ts
@@ -341,4 +341,41 @@ describe("callGateway openai-compat bypass (D-3-PROV)", () => {
     );
     warnSpy.mockRestore();
   });
+
+  // Sprint 5 #3: Qwen3 thinking OFF default
+  it("body inclui chat_template_kwargs.enable_thinking=false por default", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    delete process.env["LOCAL_LLM_THINKING"];
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body.chat_template_kwargs).toEqual({ enable_thinking: false });
+  });
+
+  it("LOCAL_LLM_THINKING=true → enable_thinking=true", async () => {
+    process.env["LLM_LOCAL_ENDPOINT"] = "http://localhost:9000/v1/chat/completions";
+    process.env["LOCAL_LLM_THINKING"] = "true";
+    fetchMock.mockResolvedValueOnce(mockOpenAiResponse());
+
+    await callGateway({
+      step: "drota",
+      provider: "openai-compat",
+      model: "qwen3-30b",
+      systemPrompt: "s",
+      userMessage: "u",
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body.chat_template_kwargs).toEqual({ enable_thinking: true });
+  });
 });


### PR DESCRIPTION
Sprint 5 #3 — re-implementação clean de feat/motor-simplificacao-v1 commit 2e5e691.

## Bug
Qwen3 family ativa hybrid thinking por default, drena 500-2000 tokens reasoning antes do content. Possível causa raiz do empty content investigado em #172.

## Fix
body.chat_template_kwargs.enable_thinking=false por default.
Override via LOCAL_LLM_THINKING=true. Modelos sem suporte ignoram silenciosamente.

## Tests
2 novos casos. 14/14 gateway-client + 672/672 shared.

🤖 Sprint 5 #3 via Claude Code