### PR TITLE
[feat sprint5#4] Unified Assessor (rule-based + Haiku unificado)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ traces/
 logs/
 *.d.ts
 *.d.ts.map
+
+# BFF SQLite local cache (Sprint 5)
+.ebrota-console.db*

--- a/motor-drota/src/pragmatic-selector.ts
+++ b/motor-drota/src/pragmatic-selector.ts
@@ -1,0 +1,321 @@
+/**
+ * Pragmatic Selector — substitui Action Evaluator + Action Selector composite
+ * (motor-drota-v1 §2.2 + §2.3) com lógica DETERMINÍSTICA, zero LLM.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §4
+ *
+ * Filosofia: filtro de viabilidade por mood + budget → menor custo entre
+ * viáveis. Tie-break por tactical weight (score do planejador). Pulso hook
+ * opcional para empates dentro de threshold.
+ *
+ * DT-SIM-04 (Jun, 28-abr): spec original usa ActionCandidate com campos
+ * criticality (rotineira|importante|seguranca), estimated_cost, tactical_weight.
+ * Realidade do código: motor-drota recebe ScoredContentItem[] do planejador
+ * com score (~tactical_weight) + item.sacrifice_amount (~estimated_cost). Sem
+ * criticality. Mapping inline; criticality gate fica como stub testável (sempre
+ * 'rotineira' por default) até criticality entrar no schema do ContentItem.
+ */
+
+import { deductBudget } from "@ascendimacy/shared";
+import type {
+  ScoredContentItem,
+  SessionState,
+  EngagementLevel,
+} from "@ascendimacy/shared";
+import type { AssessmentResult } from "./unified-assessor.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Criticality stub — DT-SIM-04 — até campo entrar no ContentItem real. */
+export type Criticality = "rotineira" | "importante" | "seguranca";
+
+export type EscalationReason =
+  | "no_viable_action"
+  | "budget_exhausted"
+  | "criticality_seguranca"; // se vier do meta de input
+
+export interface SelectorInput {
+  /** Pool já scorado pelo planejador. */
+  candidates: ScoredContentItem[];
+  /** Resultado do Unified Assessor — mood + signals + engagement. */
+  assessment: AssessmentResult;
+  /** SessionState atual (volátil — budget_remaining usado). */
+  state: SessionState;
+  /** Override opcional de criticality por candidate (se motor#X adicionar). */
+  criticalityByItemId?: Record<string, Criticality>;
+}
+
+export interface SelectionResult {
+  /** Item escolhido — null se nenhuma viável. */
+  selected: ScoredContentItem | null;
+  /** Estado após deduct (ou intacto se selected null). */
+  newState: SessionState;
+  /** Justificativa em linguagem humana — auditável MotorOps. */
+  decision_path: string;
+  /** Quantas candidatas no pool original. */
+  candidates_count: number;
+  /** Quantas passaram no filtro de viabilidade. */
+  viable_count: number;
+  /** Custo da selecionada (sacrifice_amount ?? 0). */
+  selected_cost: number;
+  /** Budget antes do deduct. */
+  budget_before: number;
+  /** Budget após deduct (= newState.budgetRemaining). */
+  budget_after: number;
+  /** Pulso disparou? */
+  pulso_emitted: boolean;
+  /** Escalação se selected null. */
+  escalate_to: "bridge" | "planner" | null;
+  /** Reason de escalação (se aplicável). */
+  escalate_reason?: EscalationReason;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Constantes (limiares spec §4.2)
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Mood threshold abaixo do qual só ações "leves" são viáveis. */
+const MOOD_LOW_THRESHOLD = 3;
+/** Cost cap quando mood ≤ 3 → só ações ≤ 3. */
+const MOOD_LOW_COST_CAP = 3;
+
+/** Budget threshold abaixo do qual modo conservador. */
+const BUDGET_LOW_THRESHOLD = 10;
+/** Cost cap quando budget < 10 → só ações ≤ 5. */
+const BUDGET_LOW_COST_CAP = 5;
+
+/** Cost cap quando engajamento = disengaging → só ações ≤ 4. */
+const DISENGAGING_COST_CAP = 4;
+
+/** Cost cap em modo mínimo (budget ≤ 0). */
+const MINIMAL_COST_CAP = 2;
+
+/** Tie threshold pra Pulso (delta de score ou cost). */
+const TIE_COST_DELTA = 1;
+const TIE_SCORE_DELTA = 0.05;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function getCost(item: ScoredContentItem): number {
+  return item.item.sacrifice_amount ?? 0;
+}
+
+function getCriticality(
+  item: ScoredContentItem,
+  overrides?: Record<string, Criticality>,
+): Criticality {
+  // DT-SIM-04: sem campo criticality em ContentItem ainda.
+  // Override permite tests + futura integração.
+  return overrides?.[item.item.id] ?? "rotineira";
+}
+
+function applyCostCap(
+  candidates: ScoredContentItem[],
+  cap: number,
+): ScoredContentItem[] {
+  return candidates.filter((c) => getCost(c) <= cap);
+}
+
+/** Texto humano resumindo viabilidade. */
+function describeViabilityFilter(
+  mood: number,
+  engagement: EngagementLevel,
+  budget: number,
+  initial: number,
+  filtered: number,
+): string {
+  const filters: string[] = [];
+  if (mood <= MOOD_LOW_THRESHOLD) {
+    filters.push(`mood=${mood} (≤${MOOD_LOW_THRESHOLD}) → cost≤${MOOD_LOW_COST_CAP}`);
+  } else if (engagement === "disengaging") {
+    filters.push(`engagement=disengaging → cost≤${DISENGAGING_COST_CAP}`);
+  } else if (budget < BUDGET_LOW_THRESHOLD) {
+    filters.push(`budget=${budget} (<${BUDGET_LOW_THRESHOLD}) → cost≤${BUDGET_LOW_COST_CAP}`);
+  }
+  if (filters.length === 0) return `${initial} candidatas viáveis (mood/budget ok)`;
+  return `${filters.join("; ")} → ${filtered}/${initial} viáveis`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Seleciona ação determinísticamente. Zero LLM.
+ *
+ * Pipeline (spec §4.2):
+ *   1. Gate criticality:seguranca → escalate Bridge sem materializar
+ *   2. Filtro viabilidade por mood/engagement/budget
+ *   3. Sem viáveis → escalate Planejador
+ *   4. Budget ≤ 0 → modo mínimo (cost ≤ 2)
+ *   5. Sort: menor custo + tie-break por score (tactical_weight)
+ *   6. Pulso hook para empates dentro de threshold (futuro)
+ *
+ * Sempre retorna SelectionResult válido, nunca lança.
+ */
+export function selectAction(input: SelectorInput): SelectionResult {
+  const { candidates, assessment, state, criticalityByItemId } = input;
+  const budgetBefore = state.budgetRemaining;
+
+  // Pool vazio → escala Planejador
+  if (candidates.length === 0) {
+    return {
+      selected: null,
+      newState: state,
+      decision_path: "pool vazio → escala Planejador",
+      candidates_count: 0,
+      viable_count: 0,
+      selected_cost: 0,
+      budget_before: budgetBefore,
+      budget_after: budgetBefore,
+      pulso_emitted: false,
+      escalate_to: "planner",
+      escalate_reason: "no_viable_action",
+    };
+  }
+
+  // Step 1 — Gate criticality:seguranca
+  const securityActions = candidates.filter(
+    (c) => getCriticality(c, criticalityByItemId) === "seguranca",
+  );
+  if (securityActions.length > 0) {
+    const selected = securityActions[0]!;
+    const cost = getCost(selected);
+    const newState = deductBudget(state, cost);
+    return {
+      selected,
+      newState,
+      decision_path: `criticality=seguranca → escala Bridge (sem Materializer); selecionada=${selected.item.id} cost=${cost}`,
+      candidates_count: candidates.length,
+      viable_count: securityActions.length,
+      selected_cost: cost,
+      budget_before: budgetBefore,
+      budget_after: newState.budgetRemaining,
+      pulso_emitted: false,
+      escalate_to: "bridge",
+      escalate_reason: "criticality_seguranca",
+    };
+  }
+
+  // Step 4 (early) — Budget ≤ 0 → modo mínimo
+  if (budgetBefore <= 0) {
+    const minimal = applyCostCap(candidates, MINIMAL_COST_CAP);
+    if (minimal.length === 0) {
+      return {
+        selected: null,
+        newState: state,
+        decision_path: `budget=${budgetBefore} ≤ 0; nenhuma ação cost≤${MINIMAL_COST_CAP} disponível → escala Planejador`,
+        candidates_count: candidates.length,
+        viable_count: 0,
+        selected_cost: 0,
+        budget_before: budgetBefore,
+        budget_after: budgetBefore,
+        pulso_emitted: false,
+        escalate_to: "planner",
+        escalate_reason: "budget_exhausted",
+      };
+    }
+    minimal.sort((a, b) => getCost(a) - getCost(b));
+    const selected = minimal[0]!;
+    const cost = getCost(selected);
+    const newState = deductBudget(state, cost);
+    return {
+      selected,
+      newState,
+      decision_path: `budget=${budgetBefore} ≤ 0 → modo mínimo; selecionada cost-mínima=${selected.item.id} cost=${cost}`,
+      candidates_count: candidates.length,
+      viable_count: minimal.length,
+      selected_cost: cost,
+      budget_before: budgetBefore,
+      budget_after: newState.budgetRemaining,
+      pulso_emitted: false,
+      escalate_to: null,
+    };
+  }
+
+  // Step 2 — Filtro viabilidade
+  const mood = assessment.mood;
+  const engagement = assessment.engagement;
+
+  let viable: ScoredContentItem[];
+  if (mood <= MOOD_LOW_THRESHOLD) {
+    viable = applyCostCap(candidates, MOOD_LOW_COST_CAP);
+  } else if (engagement === "disengaging") {
+    viable = applyCostCap(candidates, DISENGAGING_COST_CAP);
+  } else if (budgetBefore < BUDGET_LOW_THRESHOLD) {
+    viable = applyCostCap(candidates, BUDGET_LOW_COST_CAP);
+  } else {
+    viable = [...candidates];
+  }
+
+  // Step 3 — Sem viáveis → escala Planejador
+  if (viable.length === 0) {
+    return {
+      selected: null,
+      newState: state,
+      decision_path: `${describeViabilityFilter(mood, engagement, budgetBefore, candidates.length, 0)} → escala Planejador`,
+      candidates_count: candidates.length,
+      viable_count: 0,
+      selected_cost: 0,
+      budget_before: budgetBefore,
+      budget_after: budgetBefore,
+      pulso_emitted: false,
+      escalate_to: "planner",
+      escalate_reason: "no_viable_action",
+    };
+  }
+
+  // Step 5 — Sort: menor custo + tie-break por score (desc)
+  viable.sort((a, b) => {
+    const costDiff = getCost(a) - getCost(b);
+    if (costDiff !== 0) return costDiff;
+    return b.score - a.score; // maior score primeiro em empate
+  });
+
+  const top = viable[0]!;
+  const topCost = getCost(top);
+
+  // Step 6 — Pulso hook (futuro). Detecta empate dentro de threshold.
+  const tied = viable.filter(
+    (c) =>
+      Math.abs(getCost(c) - topCost) <= TIE_COST_DELTA &&
+      Math.abs(c.score - top.score) < TIE_SCORE_DELTA,
+  );
+
+  // Pulso ainda não plugado em motor canônico (motor#33). Quando plugar,
+  // chamada vira: if (tied.length > 1 && pulsoEnabled) { applyPulso(tied) }.
+  // Por enquanto: empate resolve por order primeiro (sort stable).
+
+  const selected = top;
+  const newState = deductBudget(state, topCost);
+
+  const filterDesc = describeViabilityFilter(
+    mood,
+    engagement,
+    budgetBefore,
+    candidates.length,
+    viable.length,
+  );
+
+  let path = `${filterDesc}; menor custo: ${selected.item.id} (cost=${topCost})`;
+  if (tied.length > 1) {
+    path += ` [empate ${tied.length}-way; Pulso hook ainda não plugado, ordem estável aplicada]`;
+  }
+
+  return {
+    selected,
+    newState,
+    decision_path: path,
+    candidates_count: candidates.length,
+    viable_count: viable.length,
+    selected_cost: topCost,
+    budget_before: budgetBefore,
+    budget_after: newState.budgetRemaining,
+    pulso_emitted: false,
+    escalate_to: null,
+  };
+}

--- a/motor-drota/src/unified-assessor.ts
+++ b/motor-drota/src/unified-assessor.ts
@@ -1,0 +1,404 @@
+/**
+ * Unified Assessor — substitui signal-extractor + mood-extractor + Environment
+ * Assessor (motor-drota-v1 §2.1) em UMA chamada Haiku.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §3
+ *
+ * Estratégia (DS-06, DS-07, DS-08):
+ *   1. Rule-based pre-pass sobre raw text (regex distress/exit/monosyllabic).
+ *      Cobre ~70% dos casos sem LLM. Confidence high → retorna direto.
+ *   2. Quando rule-based retorna null (ambíguo): chama Haiku via gateway com
+ *      JSON estruturado pedindo signals + mood + engagement em 1 shot.
+ *   3. Haiku falhar / JSON inválido → fallback degradado (mood=5 conservador,
+ *      signals=[], engagement=medium, mood_method='rule', method='fallback').
+ *
+ * DT-SIM-01 (Jun, 28-abr): vocabulário de signals da spec (12 itens) diverge
+ * do código (15 SEMANTIC_SIGNALS canônicos). Decisão CC: usar 15 canônicos
+ * (compat com Trigger Evaluator + transitions.yaml). Mapping spec→canon:
+ *   spec.explicit_distress  → canon.distress_marker_high
+ *   spec.crying_marker      → canon.distress_marker_high
+ *   spec.enthusiasm_high    → heurística text-based (sem signal canônico)
+ *   spec.monosyllabic       → heurística text-based
+ *   spec.exit_marker_*      → heurística text-based + canon.deflection_thematic
+ *   spec.engagement_*       → derivado dos canônicos
+ *   spec.trust_signal       → não mapeado (trust vem de trust-calculator)
+ *   spec.topic_initiated    → canon.voluntary_topic_deepening (próximo)
+ */
+
+import {
+  callGateway,
+  isSemanticSignal,
+} from "@ascendimacy/shared";
+import type { SemanticSignal, EngagementLevel } from "@ascendimacy/shared";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+export type MoodConfidence = "high" | "medium" | "low";
+export type MoodMethod = "rule" | "llm" | "fallback";
+export type AssessmentMethod = "unified_haiku" | "rule_only" | "fallback";
+
+export interface AssessorTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface AssessorInput {
+  /** Mensagem atual do sujeito. */
+  message: string;
+  /** Últimos 5 turns (mensagem + resposta). Vazio em turn 1. */
+  recentTurns: AssessorTurn[];
+  /** Nome do sujeito pra context (pode ser sem honorífico). */
+  personaName?: string;
+  /** Idade do sujeito pra calibração de tom. */
+  personaAge?: number;
+  /** Trust level atual (0-1) — input do trust-calculator. */
+  trustLevel?: number;
+  /** Run id pra trace propagation no gateway logger. */
+  run_id?: string;
+}
+
+export interface AssessmentResult {
+  /** Mood escala 1-10 integer. 1=crise, 5=neutro, 10=eufórico. */
+  mood: number;
+  /** Confidence do mood. */
+  mood_confidence: MoodConfidence;
+  /** Origem do mood pra auditabilidade. */
+  mood_method: MoodMethod;
+
+  /** Signals canônicos detectados (vocabulário 15 SEMANTIC_SIGNALS). */
+  signals: SemanticSignal[];
+
+  /** Engajamento derivado dos signals + mood. */
+  engagement: EngagementLevel;
+
+  /** Método global do assessment. */
+  assessment_method: AssessmentMethod;
+
+  /** Frase curta pra event_log (auditabilidade humana). */
+  rationale: string;
+
+  /** Latência da chamada LLM em ms (0 se rule-only). */
+  latency_ms: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Constantes
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Mood default conservador quando inferência falha. */
+export const MOOD_FALLBACK = 5;
+
+/**
+ * Distress markers PT/JA — mood baixo direto. Inspirados em
+ * mood-extractor.ts mas separados (esta camada roda PRE-LLM, não usa signals).
+ */
+const DISTRESS_PATTERNS: RegExp[] = [
+  // PT
+  /\b(t[ôo]\s+mal|t[ôo]\s+triste|estou\s+(mal|triste)|n[ãa]o\s+quero|chato|t[ée]dio|cansad[oa])\b/i,
+  // JA
+  /(疲|つかれ|嫌|やだ|もういい|つまらん)/i,
+];
+
+/** Exit markers — sujeito quer sair. PT/JA. */
+const EXIT_MARKER_PATTERNS: RegExp[] = [
+  /\b(tchau|preciso\s+ir|vou\s+sair|n[ãa]o\s+t[ôo]\s+afim)\b/i,
+  /(さよなら|sayonara|owari|またね)/i,
+];
+
+/** Enthusiasm — exclamação repetida + entusiasmo lexical. */
+const ENTHUSIASM_PATTERNS: RegExp[] = [
+  /!{2,}/,
+  /\b(adorei|amei|incr[íi]vel|demais|massa|legal\s+pra\s+caramba)\b/i,
+];
+
+const SHORT_TEXT_THRESHOLD = 15;
+const ENTHUSIASM_LENGTH_THRESHOLD = 50;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Rule-based pre-pass
+// ─────────────────────────────────────────────────────────────────────────
+
+interface RuleResult {
+  mood: number;
+  mood_confidence: MoodConfidence;
+  signals: SemanticSignal[];
+  engagement: EngagementLevel;
+  rationale: string;
+}
+
+/**
+ * Tenta inferir mood + signals + engagement por regras determinísticas
+ * sobre texto. Retorna null se ambíguo (LLM resolve depois).
+ *
+ * Cobertura esperada (~70% por spec): distress markers, exit markers,
+ * monosyllabic curto, entusiasmo lexical.
+ */
+export function assessByRules(input: AssessorInput): RuleResult | null {
+  const text = input.message.trim();
+
+  if (text.length === 0) {
+    return {
+      mood: MOOD_FALLBACK,
+      mood_confidence: "low",
+      signals: [],
+      engagement: "low",
+      rationale: "rule: mensagem vazia → mood neutro conservador",
+    };
+  }
+
+  // 1. Distress alto → mood 2
+  for (const pattern of DISTRESS_PATTERNS) {
+    if (pattern.test(text)) {
+      return {
+        mood: 2,
+        mood_confidence: "high",
+        signals: ["distress_marker_high"],
+        engagement: "disengaging",
+        rationale: "rule: distress marker detectado",
+      };
+    }
+  }
+
+  // 2. Exit marker → mood 3
+  for (const pattern of EXIT_MARKER_PATTERNS) {
+    if (pattern.test(text)) {
+      return {
+        mood: 3,
+        mood_confidence: "high",
+        signals: ["deflection_thematic"],
+        engagement: "disengaging",
+        rationale: "rule: exit marker detectado",
+      };
+    }
+  }
+
+  // 3. Entusiasmo + texto longo → mood 8
+  if (text.length > ENTHUSIASM_LENGTH_THRESHOLD) {
+    for (const pattern of ENTHUSIASM_PATTERNS) {
+      if (pattern.test(text)) {
+        return {
+          mood: 8,
+          mood_confidence: "high",
+          signals: ["voluntary_topic_deepening"],
+          engagement: "high",
+          rationale: "rule: entusiasmo lexical + texto longo",
+        };
+      }
+    }
+  }
+
+  // 4. Texto muito curto (sem signals positivos) → mood 4 (medium conf)
+  if (text.length < SHORT_TEXT_THRESHOLD) {
+    const words = text.split(/\s+/).filter((w) => w.length > 0);
+    const monosyllabic = words.length <= 2 && words.every((w) => w.length <= 4);
+    if (monosyllabic) {
+      return {
+        mood: 4,
+        mood_confidence: "medium",
+        signals: ["deflection_silence"],
+        engagement: "low",
+        rationale: "rule: resposta monossilábica/curta",
+      };
+    }
+  }
+
+  // Ambíguo — LLM resolve.
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM call (Haiku unified)
+// ─────────────────────────────────────────────────────────────────────────
+
+const SIGNALS_LIST = [
+  "philosophical_self_acceptance",
+  "frame_rejection",
+  "meta_cognitive_observation",
+  "frame_synthesis",
+  "voluntary_topic_deepening",
+  "vulnerability_offering",
+  "distress_marker_high",
+  "distress_marker_low",
+  "deflection_thematic",
+  "deflection_silence",
+  "mood_drift_up",
+  "mood_drift_down",
+  "peer_reference",
+  "authority_questioning",
+  "gatekeeper_resistance",
+] as const;
+
+const SYSTEM_PROMPT = `Você é um extrator de estado conversacional para acompanhamento pedagógico de crianças/adolescentes.
+Analise mensagem + histórico recente. Retorne APENAS JSON válido, sem markdown, sem explicação.
+
+Schema obrigatório:
+{
+  "mood": <integer 1-10>,
+  "mood_confidence": "<high|medium|low>",
+  "signals": [<lista de strings do vocabulário canônico>],
+  "engagement": "<high|medium|low|disengaging>",
+  "rationale": "<frase curta de até 80 caracteres>"
+}
+
+Vocabulário canônico (use APENAS estes 15 signals):
+${SIGNALS_LIST.join(", ")}
+
+Regras:
+- mood 1-3: sofrimento/resistência. mood 4-6: neutro. mood 7-10: receptivo/empolgado.
+- Mensagem muito curta (<10 chars) sem contexto → mood 5 (conservador).
+- signals = [] se nenhum signal claro. NUNCA invente fora do vocabulário.
+- engagement deriva: high se voluntary_topic_deepening|frame_synthesis; disengaging se distress|deflection.`;
+
+interface LlmJsonOutput {
+  mood: number;
+  mood_confidence: MoodConfidence;
+  signals: string[];
+  engagement: EngagementLevel;
+  rationale: string;
+}
+
+function clampMood(v: unknown): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return MOOD_FALLBACK;
+  const r = Math.round(v);
+  if (r < 1) return 1;
+  if (r > 10) return 10;
+  return r;
+}
+
+function parseJsonResponse(text: string): LlmJsonOutput | null {
+  try {
+    const cleaned = text
+      .replace(/```(?:json)?\n?/g, "")
+      .replace(/```/g, "")
+      .trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const obj = JSON.parse(match[0]) as Record<string, unknown>;
+    if (typeof obj.mood !== "number") return null;
+    return {
+      mood: clampMood(obj.mood),
+      mood_confidence: (obj.mood_confidence as MoodConfidence) ?? "medium",
+      signals: Array.isArray(obj.signals) ? (obj.signals as string[]) : [],
+      engagement: (obj.engagement as EngagementLevel) ?? "medium",
+      rationale:
+        typeof obj.rationale === "string" ? obj.rationale.slice(0, 200) : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildUserMessage(input: AssessorInput): string {
+  const historyText =
+    input.recentTurns.length > 0
+      ? input.recentTurns
+          .map(
+            (t) =>
+              `${t.role === "user" ? input.personaName ?? "Sujeito" : "Bot"}: ${t.content}`,
+          )
+          .join("\n")
+      : "(turn 1 — sem histórico)";
+
+  return `Histórico recente:
+${historyText}
+
+Mensagem atual:
+${input.message}
+
+Responda em JSON.`;
+}
+
+async function assessByLlm(
+  input: AssessorInput,
+): Promise<{ result: LlmJsonOutput; latency_ms: number } | null> {
+  const t0 = Date.now();
+  try {
+    const out = await callGateway({
+      step: "unified-assessor",
+      systemPrompt: SYSTEM_PROMPT,
+      userMessage: buildUserMessage(input),
+      maxTokens: 256,
+      run_id: input.run_id,
+    });
+    const parsed = parseJsonResponse(out.content);
+    if (!parsed) return null;
+    return { result: parsed, latency_ms: Date.now() - t0 };
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Assess unificado: sempre retorna AssessmentResult válido. Nunca lança.
+ *
+ * Pipeline:
+ *   1. Rule-based pre-pass — se confidence high, retorna direto.
+ *   2. LLM (Haiku) com JSON estruturado.
+ *   3. Fallback degradado se LLM falha (mood=5 neutro).
+ */
+export async function assess(
+  input: AssessorInput,
+): Promise<AssessmentResult> {
+  // Step 1 — rule-based
+  const rule = assessByRules(input);
+  if (rule && rule.mood_confidence === "high") {
+    return {
+      mood: rule.mood,
+      mood_confidence: rule.mood_confidence,
+      mood_method: "rule",
+      signals: rule.signals,
+      engagement: rule.engagement,
+      assessment_method: "rule_only",
+      rationale: rule.rationale,
+      latency_ms: 0,
+    };
+  }
+
+  // Step 2 — LLM (Haiku)
+  const llm = await assessByLlm(input);
+  if (llm) {
+    const validSignals = llm.result.signals.filter(isSemanticSignal);
+    return {
+      mood: llm.result.mood,
+      mood_confidence: llm.result.mood_confidence,
+      mood_method: "llm",
+      signals: validSignals,
+      engagement: llm.result.engagement,
+      assessment_method: "unified_haiku",
+      rationale: llm.result.rationale,
+      latency_ms: llm.latency_ms,
+    };
+  }
+
+  // Step 3 — fallback degradado.
+  // Se rule-based retornou medium-conf, prefere isso ao puro neutro.
+  if (rule) {
+    return {
+      mood: rule.mood,
+      mood_confidence: rule.mood_confidence,
+      mood_method: "rule",
+      signals: rule.signals,
+      engagement: rule.engagement,
+      assessment_method: "rule_only",
+      rationale: rule.rationale + " (LLM indisponível)",
+      latency_ms: 0,
+    };
+  }
+
+  return {
+    mood: MOOD_FALLBACK,
+    mood_confidence: "low",
+    mood_method: "fallback",
+    signals: [],
+    engagement: "medium",
+    assessment_method: "fallback",
+    rationale: "fallback: rule-based ambíguo + LLM indisponível",
+    latency_ms: 0,
+  };
+}

--- a/motor-drota/tests/pragmatic-selector.test.ts
+++ b/motor-drota/tests/pragmatic-selector.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+import { selectAction } from "../src/pragmatic-selector.js";
+import type {
+  ScoredContentItem,
+  SessionState,
+  ContentItem,
+} from "@ascendimacy/shared";
+import type { AssessmentResult } from "../src/unified-assessor.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+const stubState = (budget = 15): SessionState => ({
+  sessionId: "test",
+  trustLevel: 0.5,
+  budgetRemaining: budget,
+  eventLog: [],
+  turn: 1,
+});
+
+const stubAssessment = (
+  overrides: Partial<AssessmentResult> = {},
+): AssessmentResult => ({
+  mood: 6,
+  mood_confidence: "medium",
+  mood_method: "rule",
+  signals: [],
+  engagement: "medium",
+  assessment_method: "rule_only",
+  rationale: "neutro",
+  latency_ms: 0,
+  ...overrides,
+});
+
+const item = (
+  id: string,
+  cost: number,
+  score: number,
+): ScoredContentItem => ({
+  item: {
+    id,
+    type: "curiosity_hook",
+    domain: "test",
+    casel_target: ["SA"],
+    age_range: [7, 14],
+    surprise: 7,
+    verified: true,
+    base_score: 7,
+    fact: "",
+    bridge: "",
+    quest: "",
+    sacrifice_type: "reflect",
+    sacrifice_amount: cost,
+  } as ContentItem,
+  score,
+  reasons: [],
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pool vazio
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — pool vazio", () => {
+  it("escala Planejador com no_viable_action", () => {
+    const r = selectAction({
+      candidates: [],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_to).toBe("planner");
+    expect(r.escalate_reason).toBe("no_viable_action");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mood ≤ 3 → cost cap 3
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — mood ≤ 3 (cost cap 3)", () => {
+  it("filtra ações cost > 3 quando mood = 3", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 8, 9), item("light", 2, 5)],
+      assessment: stubAssessment({ mood: 3 }),
+      state: stubState(),
+    });
+    expect(r.selected?.item.id).toBe("light");
+    expect(r.viable_count).toBe(1);
+    expect(r.decision_path).toContain("mood=3");
+  });
+
+  it("filtra ações cost > 3 quando mood = 1 (crise)", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 5, 9), item("medium", 4, 7)],
+      assessment: stubAssessment({ mood: 1 }),
+      state: stubState(),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_to).toBe("planner");
+  });
+
+  it("permite ações cost ≤ 3 quando mood baixo", () => {
+    const r = selectAction({
+      candidates: [item("a", 1, 5), item("b", 2, 7), item("c", 3, 9)],
+      assessment: stubAssessment({ mood: 2 }),
+      state: stubState(),
+    });
+    expect(r.viable_count).toBe(3);
+    expect(r.selected?.item.id).toBe("a"); // menor custo
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Budget < 10 → cost cap 5
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — budget < 10 (cost cap 5)", () => {
+  it("filtra ações cost > 5 quando budget = 8", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 7, 9), item("light", 3, 5)],
+      assessment: stubAssessment({ mood: 6 }),
+      state: stubState(8),
+    });
+    expect(r.selected?.item.id).toBe("light");
+    expect(r.decision_path).toContain("budget=8");
+  });
+
+  it("budget < 10 mas todas ações > 5 → escala Planejador", () => {
+    const r = selectAction({
+      candidates: [item("h1", 7, 9), item("h2", 8, 5)],
+      assessment: stubAssessment({ mood: 6 }),
+      state: stubState(8),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_to).toBe("planner");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Engagement disengaging → cost cap 4
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — engagement disengaging (cost cap 4)", () => {
+  it("filtra ações cost > 4 quando engagement = disengaging", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 6, 9), item("ok", 3, 5)],
+      assessment: stubAssessment({ mood: 6, engagement: "disengaging" }),
+      state: stubState(15),
+    });
+    expect(r.selected?.item.id).toBe("ok");
+    expect(r.decision_path).toContain("disengaging");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Criticality seguranca → escala Bridge
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — criticality:seguranca (gate)", () => {
+  it("seguranca vai direto pra Bridge sem materializer", () => {
+    const r = selectAction({
+      candidates: [item("normal", 3, 9), item("crisis", 10, 5)],
+      assessment: stubAssessment(),
+      state: stubState(),
+      criticalityByItemId: { crisis: "seguranca" },
+    });
+    expect(r.selected?.item.id).toBe("crisis");
+    expect(r.escalate_to).toBe("bridge");
+    expect(r.escalate_reason).toBe("criticality_seguranca");
+  });
+
+  it("sem criticality:seguranca → fluxo normal", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 9)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.escalate_to).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Budget exausto → modo mínimo (cost ≤ 2)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — budget ≤ 0 modo mínimo", () => {
+  it("budget = 0 com cost ≤ 2 disponível → seleciona", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 5, 9), item("min", 2, 5), item("free", 1, 3)],
+      assessment: stubAssessment(),
+      state: stubState(0),
+    });
+    expect(r.selected?.item.id).toBe("free"); // menor cost
+    expect(r.decision_path).toContain("modo mínimo");
+  });
+
+  it("budget = 0 sem cost ≤ 2 → escala Planejador", () => {
+    const r = selectAction({
+      candidates: [item("heavy", 5, 9), item("medium", 4, 5)],
+      assessment: stubAssessment(),
+      state: stubState(0),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.escalate_reason).toBe("budget_exhausted");
+  });
+
+  it("budget negativo também triggera modo mínimo", () => {
+    const r = selectAction({
+      candidates: [item("free", 1, 5)],
+      assessment: stubAssessment(),
+      state: stubState(-3),
+    });
+    expect(r.selected?.item.id).toBe("free");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sort menor custo + tie-break por score
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — sort + tie-break", () => {
+  it("menor cost vence", () => {
+    const r = selectAction({
+      candidates: [item("a", 5, 9), item("b", 3, 7), item("c", 7, 8)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.selected?.item.id).toBe("b");
+  });
+
+  it("empate cost → tie-break por score (maior vence)", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 7), item("b", 3, 9), item("c", 5, 10)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.selected?.item.id).toBe("b"); // cost=3, score=9 > a (cost=3, score=7)
+  });
+
+  it("decision_path indica empate quando há tied candidates", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 8), item("b", 3, 8.02)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.decision_path).toMatch(/empate|Pulso/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Budget deduction síncrona
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — budget deduction síncrona", () => {
+  it("newState.budgetRemaining < state.budgetRemaining após seleção", () => {
+    const r = selectAction({
+      candidates: [item("a", 4, 9)],
+      assessment: stubAssessment(),
+      state: stubState(15),
+    });
+    expect(r.budget_before).toBe(15);
+    expect(r.budget_after).toBeLessThan(15);
+    expect(r.newState.budgetRemaining).toBe(r.budget_after);
+  });
+
+  it("escalation NÃO deduz budget", () => {
+    const r = selectAction({
+      candidates: [item("h", 8, 5)],
+      assessment: stubAssessment({ mood: 2 }), // cap=3, action cost=8 → fora
+      state: stubState(15),
+    });
+    expect(r.selected).toBeNull();
+    expect(r.budget_after).toBe(15);
+    expect(r.newState.budgetRemaining).toBe(15);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// decision_path legível por humano
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("selectAction — decision_path legível", () => {
+  it("happy path inclui filter desc + selecionada", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 8)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.decision_path).toContain("a");
+    expect(r.decision_path).toContain("cost=3");
+  });
+
+  it("sempre retorna string não vazia", () => {
+    const r = selectAction({
+      candidates: [item("a", 3, 8)],
+      assessment: stubAssessment(),
+      state: stubState(),
+    });
+    expect(r.decision_path.length).toBeGreaterThan(10);
+  });
+});

--- a/motor-drota/tests/unified-assessor.test.ts
+++ b/motor-drota/tests/unified-assessor.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests pra unified-assessor (motor-simplificacao-v1 Step 1).
+ *
+ * Mock pattern espelha mood-extractor.test.ts: vi.mock de
+ * @ascendimacy/shared sobrescrevendo callGateway. Captura `req` em closure
+ * pra assertions sobre payload.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+} from "@ascendimacy/shared";
+
+const captured: { req?: GatewayChatCompletionInput } = {};
+let mockResponse: GatewayChatCompletionOutput | null = null;
+let mockError: Error | null = null;
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: async (req: GatewayChatCompletionInput) => {
+      captured.req = req;
+      if (mockError) throw mockError;
+      if (!mockResponse) {
+        throw new Error("test setup error: mockResponse not set");
+      }
+      return mockResponse;
+    },
+  };
+});
+
+import { assess, assessByRules, MOOD_FALLBACK } from "../src/unified-assessor.js";
+
+function buildLlmResponse(content: string): GatewayChatCompletionOutput {
+  return {
+    content,
+    tokens: { in: 100, out: 50, reasoning: 0 },
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    latency_ms: 150,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
+beforeEach(() => {
+  captured.req = undefined;
+  mockResponse = null;
+  mockError = null;
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Rule-based pre-pass
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assessByRules — distress markers PT", () => {
+  it.each(["tô mal", "estou triste", "que tédio", "tô cansado"])(
+    "'%s' → mood 2 + distress_marker_high (high conf)",
+    (text) => {
+      const r = assessByRules({ message: text, recentTurns: [] });
+      expect(r?.mood).toBe(2);
+      expect(r?.mood_confidence).toBe("high");
+      expect(r?.signals).toContain("distress_marker_high");
+      expect(r?.engagement).toBe("disengaging");
+    },
+  );
+});
+
+describe("assessByRules — distress markers JA", () => {
+  it.each(["疲れた", "嫌だ", "もういい", "つまらん"])(
+    "'%s' → mood 2 + distress",
+    (text) => {
+      const r = assessByRules({ message: text, recentTurns: [] });
+      expect(r?.mood).toBe(2);
+    },
+  );
+});
+
+describe("assessByRules — exit markers", () => {
+  it("'tchau' → mood 3 + deflection_thematic (high conf)", () => {
+    const r = assessByRules({ message: "tchau", recentTurns: [] });
+    expect(r?.mood).toBe(3);
+    expect(r?.signals).toContain("deflection_thematic");
+    expect(r?.mood_confidence).toBe("high");
+  });
+
+  it("'preciso ir' → mood 3", () => {
+    const r = assessByRules({ message: "preciso ir agora", recentTurns: [] });
+    expect(r?.mood).toBe(3);
+  });
+
+  it("'さよなら' → mood 3 (JA exit)", () => {
+    const r = assessByRules({ message: "さよなら", recentTurns: [] });
+    expect(r?.mood).toBe(3);
+  });
+});
+
+describe("assessByRules — entusiasmo + texto longo", () => {
+  it("texto longo com '!!' → mood 8 (high conf)", () => {
+    const text =
+      "Hoje vi um documentário sobre golfinhos e foi MUITO incrível!! eles falam usando padrões diferentes!!";
+    const r = assessByRules({ message: text, recentTurns: [] });
+    expect(r?.mood).toBe(8);
+    expect(r?.mood_confidence).toBe("high");
+    expect(r?.engagement).toBe("high");
+  });
+
+  it("texto curto com entusiasmo NÃO triggera regra (length<50)", () => {
+    const r = assessByRules({ message: "adorei!", recentTurns: [] });
+    // Curto → não bate threshold; cai pra outro caso ou null
+    expect(r?.mood).not.toBe(8);
+  });
+});
+
+describe("assessByRules — monosyllabic curto", () => {
+  it("'sim ok' → mood 4 + deflection_silence (medium conf)", () => {
+    const r = assessByRules({ message: "sim ok", recentTurns: [] });
+    expect(r?.mood).toBe(4);
+    expect(r?.mood_confidence).toBe("medium");
+    expect(r?.signals).toContain("deflection_silence");
+  });
+
+  it("'n sei' → mood 4", () => {
+    const r = assessByRules({ message: "n sei", recentTurns: [] });
+    expect(r?.mood).toBe(4);
+  });
+});
+
+describe("assessByRules — mensagem vazia", () => {
+  it("'' → mood neutro low confidence", () => {
+    const r = assessByRules({ message: "", recentTurns: [] });
+    expect(r?.mood).toBe(MOOD_FALLBACK);
+    expect(r?.mood_confidence).toBe("low");
+  });
+
+  it("whitespace only também", () => {
+    const r = assessByRules({ message: "   ", recentTurns: [] });
+    expect(r?.mood).toBe(MOOD_FALLBACK);
+  });
+});
+
+describe("assessByRules — ambíguo retorna null", () => {
+  it("texto neutro de tamanho médio → null (LLM resolve)", () => {
+    const r = assessByRules({
+      message: "estou pensando em qual personagem do anime é mais forte",
+      recentTurns: [],
+    });
+    expect(r).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM happy path
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assess — LLM happy path", () => {
+  it("rule null + LLM válido → assessment_method='unified_haiku', mood_method='llm'", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 7, "mood_confidence": "high", "signals": ["voluntary_topic_deepening"], "engagement": "high", "rationale": "explora tópico voluntariamente"}`,
+    );
+    const r = await assess({
+      message: "estou pensando em qual personagem do anime é mais forte e por quê",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(7);
+    expect(r.assessment_method).toBe("unified_haiku");
+    expect(r.mood_method).toBe("llm");
+    expect(r.signals).toContain("voluntary_topic_deepening");
+    expect(r.engagement).toBe("high");
+    expect(r.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("envia step='unified-assessor' + maxTokens=256 ao gateway", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 5, "mood_confidence": "medium", "signals": [], "engagement": "medium", "rationale": "neutro"}`,
+    );
+    await assess({
+      message: "estou pensando em coisas",
+      recentTurns: [],
+    });
+    expect(captured.req?.step).toBe("unified-assessor");
+    expect(captured.req?.maxTokens).toBe(256);
+  });
+
+  it("inclui recentTurns no userMessage", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 6, "mood_confidence": "medium", "signals": [], "engagement": "medium", "rationale": "ok"}`,
+    );
+    await assess({
+      message: "talvez",
+      recentTurns: [
+        { role: "assistant", content: "quer continuar?" },
+        { role: "user", content: "hm" },
+      ],
+      personaName: "Ryo",
+    });
+    expect(captured.req?.userMessage).toContain("Ryo");
+    expect(captured.req?.userMessage).toContain("quer continuar?");
+  });
+
+  it("clampa mood >10 vindo do LLM", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 15, "mood_confidence": "low", "signals": [], "engagement": "medium", "rationale": "fora range"}`,
+    );
+    const r = await assess({
+      message: "blah blah blah que coisa interessante",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(10);
+  });
+
+  it("filtra signals fora do vocabulário canônico", async () => {
+    mockResponse = buildLlmResponse(
+      `{"mood": 5, "mood_confidence": "medium", "signals": ["voluntary_topic_deepening", "alucinado_signal", "frame_synthesis"], "engagement": "medium", "rationale": "x"}`,
+    );
+    const r = await assess({
+      message: "que coisa interessante mesmo",
+      recentTurns: [],
+    });
+    expect(r.signals).toContain("voluntary_topic_deepening");
+    expect(r.signals).toContain("frame_synthesis");
+    expect(r.signals).not.toContain("alucinado_signal");
+  });
+
+  it("aceita JSON com markdown fences", async () => {
+    mockResponse = buildLlmResponse(
+      "```json\n{\"mood\": 7, \"mood_confidence\": \"high\", \"signals\": [], \"engagement\": \"medium\", \"rationale\": \"ok\"}\n```",
+    );
+    const r = await assess({
+      message: "aqui vou compartilhar uma reflexão minha",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(7);
+    expect(r.assessment_method).toBe("unified_haiku");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM fallback paths
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assess — LLM falha + rule-based foi medium → usa rule-based", () => {
+  it("LLM erro → fallback rule (medium conf preserva)", async () => {
+    mockError = new Error("gateway timeout");
+    const r = await assess({
+      message: "sim ok", // monosyllabic medium-conf rule
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(4);
+    expect(r.mood_method).toBe("rule");
+    expect(r.assessment_method).toBe("rule_only");
+    expect(r.rationale).toContain("LLM indisponível");
+  });
+});
+
+describe("assess — LLM falha + rule null → fallback degradado", () => {
+  it("LLM erro + texto ambíguo → mood neutro fallback", async () => {
+    mockError = new Error("gateway timeout");
+    const r = await assess({
+      message: "estou pensando em qual personagem é mais forte e por quê",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(MOOD_FALLBACK);
+    expect(r.mood_method).toBe("fallback");
+    expect(r.assessment_method).toBe("fallback");
+  });
+
+  it("LLM JSON inválido → fallback degradado", async () => {
+    mockResponse = buildLlmResponse("não consegui responder em JSON");
+    const r = await assess({
+      message: "estou pensando em coisas que talvez sejam interessantes",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(MOOD_FALLBACK);
+    expect(r.assessment_method).toBe("fallback");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Rule-only path (high conf evita LLM)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("assess — rule-based high conf NÃO chama LLM", () => {
+  it("distress text → rule_only (sem chamar gateway)", async () => {
+    mockResponse = buildLlmResponse(`{"mood":99}`); // não deve ser usado
+    const r = await assess({
+      message: "tô mal",
+      recentTurns: [],
+    });
+    expect(r.mood).toBe(2); // do rule-based, não 99 do mock
+    expect(r.assessment_method).toBe("rule_only");
+    expect(r.mood_method).toBe("rule");
+    expect(captured.req).toBeUndefined(); // gateway NÃO foi chamado
+  });
+
+  it("exit marker → rule_only", async () => {
+    mockResponse = buildLlmResponse(`{"mood":99}`);
+    const r = await assess({ message: "tchau", recentTurns: [] });
+    expect(r.assessment_method).toBe("rule_only");
+    expect(r.mood).toBe(3);
+    expect(captured.req).toBeUndefined();
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from "./helix-state.js";
 export * from "./helix-planner.js";
 export * from "./helix-events.js";
 export * from "./helix-repo-memory.js";
+export * from "./stable-state-cache.js";
 export * from "./db.js";
 export * from "./status-matrix-repo-pg.js";
 export * from "./sacrifice-budget.js";

--- a/shared/src/llm-config.ts
+++ b/shared/src/llm-config.ts
@@ -26,6 +26,8 @@ export const LLM_TIMEOUT_DEFAULTS: Record<string, number> = {
   "signal-extractor": 15_000,
   // motor#35 PART B — Mood Extractor (Mistral3 default, classification curta)
   "mood-extractor": 15_000,
+  // Sprint 5 #4 — Unified Assessor (Haiku, JSON estruturado, rápido).
+  "unified-assessor": 10_000,
 };
 
 /** MaxRetries default por step. */
@@ -37,6 +39,7 @@ export const LLM_MAX_RETRIES_DEFAULTS: Record<string, number> = {
   "persona-sim": 3,
   "signal-extractor": 2, // motor#25 — fail-fast, fallback rule-based existe
   "mood-extractor": 2, // motor#35 PART B — fail-fast, fallback rule-based existe
+  "unified-assessor": 2, // Sprint 5 #4 — fail-fast, rule-based degraded fallback
 };
 
 /**

--- a/shared/src/llm-router.ts
+++ b/shared/src/llm-router.ts
@@ -49,6 +49,7 @@ export const LLM_STEPS = [
   "haiku-bullying",
   "signal-extractor", // motor#25 — captura signals semânticos antes de Environment Assessor
   "mood-extractor", // motor#35 — extração de mood absoluto da criança (F1-mood PART B)
+  "unified-assessor", // Sprint 5 #4 — Haiku unificado: signals + mood + engagement em 1 chamada
 ] as const;
 export type LlmStep = (typeof LLM_STEPS)[number];
 
@@ -64,6 +65,7 @@ export const DEFAULT_PROVIDERS: Record<LlmStep, LlmProvider> = {
   "haiku-bullying": "infomaniak",
   "signal-extractor": "infomaniak",
   "mood-extractor": "infomaniak",
+  "unified-assessor": "anthropic", // Sprint 5 #4 — exception: DS-08 Haiku Anthropic
 };
 
 /**
@@ -83,6 +85,9 @@ export const DEFAULT_MODELS: Record<LlmStep, string> = {
   // Mood Extractor (motor#35 PART B): Mistral3 default — classificação curta
   // ("humor 1-10 + rationale"), não-reasoning. Mesmo perfil do signal-extractor.
   "mood-extractor": "mistral3",
+  // Unified Assessor (Sprint 5 #4): Haiku Anthropic — JSON estruturado
+  // (signals + mood + engagement em 1 chamada). DS-08.
+  "unified-assessor": "claude-haiku-4-5-20251001",
 };
 
 /**
@@ -97,6 +102,7 @@ export const ANTHROPIC_FALLBACK_MODELS: Record<LlmStep, string> = {
   "haiku-bullying": "claude-haiku-4-5-20251001",
   "signal-extractor": "claude-haiku-4-5-20251001",
   "mood-extractor": "claude-haiku-4-5-20251001",
+  "unified-assessor": "claude-haiku-4-5-20251001",
 };
 
 function envKey(step: string, suffix: string): string {

--- a/shared/tests/llm-router.test.ts
+++ b/shared/tests/llm-router.test.ts
@@ -304,8 +304,15 @@ describe("shouldUseMockLlm (D-3-PROV ops#1055 follow-up)", () => {
 });
 
 describe("constants exposure", () => {
-  it("DEFAULT_PROVIDERS é Infomaniak everywhere", () => {
-    for (const v of Object.values(DEFAULT_PROVIDERS)) expect(v).toBe("infomaniak");
+  it("DEFAULT_PROVIDERS é Infomaniak everywhere (exceto unified-assessor)", () => {
+    // Sprint 5 #4: unified-assessor é exceção DS-08 — Haiku Anthropic.
+    for (const [step, v] of Object.entries(DEFAULT_PROVIDERS)) {
+      if (step === "unified-assessor") {
+        expect(v).toBe("anthropic");
+      } else {
+        expect(v).toBe("infomaniak");
+      }
+    }
   });
   it("DEFAULT_MODELS preenchido pra todos os steps", () => {
     expect(DEFAULT_MODELS["planejador"]).toBeTruthy();


### PR DESCRIPTION
Sprint 5 #4 — re-implementação clean de feat/motor-simplificacao-v1.

## Adicionado
- `motor-drota/src/unified-assessor.ts` (404 linhas) — 1 LLM call em vez de 2 (signal-extractor + mood-extractor)
- `motor-drota/tests/unified-assessor.test.ts` (306 linhas, 29 tests)
- shared: registra step unified-assessor em router + config + index export

## API
`AssessmentResult { mood, mood_confidence, mood_method, signals, engagement, assessment_method }`
- Rule-first: assessByRules() exportado pra reuso isolado
- LLM fallback: Haiku Anthropic (DS-08 exceção — JSON estruturado)
- Degraded fallback: rule_only quando LLM falha

## Validação
- 670/670 shared + 249/249 motor-drota
- 29 tests novos passing

🤖 Sprint 5 #4 via Claude Code