### PR TITLE
[feat sprint5#7] trace-schema v0.3.4 (snapshots simplificado)

### DIFF
--- a/shared/src/trace-schema.ts
+++ b/shared/src/trace-schema.ts
@@ -109,6 +109,37 @@ export interface TurnTrace {
   parseFailure?: boolean;
   /** Razão (parse_failure | json_invalid_after_extract). */
   parseFailureReason?: string;
+
+  // ─── v0.3.4 (Sprint 5) — motor-simplificacao Steps 1-5 (feature flag) ───
+  /** Snapshot do Unified Assessor (Step 1/Sprint 5 #4). Preenchido só com flag on. */
+  assessmentSnapshot?: {
+    mood: number;
+    mood_method: "rule" | "llm" | "fallback";
+    mood_confidence: "high" | "medium" | "low";
+    signals: string[];
+    engagement: "high" | "medium" | "low" | "disengaging";
+    model_used?: string;
+    latency_ms: number;
+  };
+  /** Snapshot do Pragmatic Selector (Step 2/Sprint 5 #5). Preenchido só com flag on. */
+  selectionSnapshot?: {
+    decision_path: string;
+    candidates_count: number;
+    viable_count: number;
+    selected_id: string;
+    selected_cost: number;
+    budget_before: number;
+    budget_after: number;
+    pulso_emitted?: boolean;
+  };
+  /** Snapshot do Constrained Materializer (Step 3/Sprint 5 #6). Preenchido só com flag on. */
+  materializationSnapshot?: {
+    model_used: string;
+    fallback_triggered: boolean;
+    latency_ms: number;
+    token_count: number;
+    sanitization_applied?: boolean;
+  };
 }
 
 export interface SessionTrace {


### PR DESCRIPTION
Sprint 5 #7 — stacked sobre #187.

3 campos opcionais em TurnTrace pra trace do pipeline simplificado:
- assessmentSnapshot
- selectionSnapshot  
- materializationSnapshot

Backward compat preservada (todos opcionais).

🤖 Sprint 5 #7