### PR TITLE
[feat sprint5#10] Contextual priority — orchestrator passa last_user_message

### DIFF
--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -422,7 +422,13 @@ export async function runTurn(
       state,
       persona,
       strategicRationale: plan.strategicRationale,
-      contextHints: plan.contextHints,
+      // Sprint 5 #10: injeta last_user_message em contextHints pra
+      // contextual priority — Constrained Materializer (USE_SIMPLIFIED_PIPELINE)
+      // engata tema do sujeito; sem isso, materializer não vê msg incoming.
+      contextHints: {
+        ...(plan.contextHints ?? {}),
+        last_user_message: message,
+      },
       instruction_addition: drotaInstructionAddition,
     },
   });


### PR DESCRIPTION
Sprint 5 #10 — stacked sobre #189. Orchestrator passa last_user_message em contextHints pro Constrained Materializer engatar tema do sujeito.

Resto das mudanças (materializer + server incomingMessage wire) já vieram com #6 + #8.

🤖 Sprint 5 #10