### PR TITLE
[feat sprint5#6 v2] Constrained Materializer (rebase pós-merge cascade)

### DIFF
--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -1,0 +1,339 @@
+/**
+ * Constrained Materializer — substitui Linguistic Materializer + Post-Processor
+ * F1-F5 (motor-drota-v1 §2.4 + §2.5) com constraints embutidas no system prompt.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-04-28-motor-simplificacao-llm-spec-v1.md §5
+ *
+ * Filosofia (DS-03, DS-05):
+ *   - Constraints de segurança ficam no system prompt (não em filtros separados)
+ *   - Modelo retorna FALLBACK: <texto seguro> quando seria forçado a violar
+ *   - SEM loop de re-tentativa — fallback é o output (não falha)
+ *   - sanitizeMaterialization mantida como camada final defensiva
+ *
+ * DT-SIM-05 (Jun, 28-abr): voice_profile.materializer.model proposto na spec
+ * (default "qwen") usa string que não está no LlmStep enum atual. Solução v0:
+ * usar step "drota" existente (que já roteia para Kimi via Infomaniak por
+ * default e respeita override per-callsite via DROTA_PROVIDER/DROTA_MODEL env).
+ * Quando voice profile ganhar tipo formal (DT-SIM-02), refatorar pra ler
+ * model dali.
+ */
+
+import { callGateway } from "@ascendimacy/shared";
+import type { ScoredContentItem, EngagementLevel } from "@ascendimacy/shared";
+import { sanitizeMaterialization } from "./select.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface MaterializerContext {
+  /** Item selecionado pelo Pragmatic Selector. */
+  action: ScoredContentItem;
+  /** Nome do sujeito (forma adequada — sem honorífico por padrão JP). */
+  subjectNameForm: string;
+  /** Mood atual 1-10. */
+  mood: number;
+  /** Engajamento. */
+  engagement: EngagementLevel;
+  /** Turno atual da sessão. */
+  turnCount: number;
+  /** Budget remaining após deduct (do SelectionResult). */
+  budgetRemaining: number;
+  /** Jurisdição ativa pra constraints. */
+  jurisdictionActive: "br" | "jp" | "ch";
+  /** Run id pra trace. */
+  run_id?: string;
+  /** Override do step LLM (default "drota"). DT-SIM-05. */
+  llmStep?: string;
+  /** Max tokens (default 300 — Kids respostas curtas). */
+  maxTokens?: number;
+  /** Última mensagem do sujeito — necessária pra "prioridade contextual". */
+  incomingMessage?: string;
+  /** motor#69 H4: Helix phase ("solo" / "retrieval" / "boss"). */
+  helixPhase?: "solo" | "retrieval" | "boss";
+  /** motor#69 H4: dim CASEL ativa do meta-ciclo Helix. */
+  caselFocusDim?: string;
+  /** motor#69 H4: dim CASEL anterior (retrieval) — só se phase != solo. */
+  caselRetrievalDim?: string;
+  /**
+   * 2026-05-05 (sts-realista): janela curta de history (últimos 3 pares
+   * user/assistant). Motor é semi-stateless: estratégia (helix, status,
+   * gardner) vem de state; awareness conversacional vem daqui pra evitar
+   * loops + permitir continuidade temática. NÃO vai pro PREFIX cacheável —
+   * é dinâmico turn-a-turn, fica em userMessage.
+   */
+  recentTurns?: Array<{ role: "user" | "assistant"; content: string }>;
+  /**
+   * 2026-05-07 Phase 2 memory (#476): bloco de perfil acumulado pré-formatado
+   * por profile-store. Vazio = primeira sessão / perfil indisponível. Vai pro
+   * userMessage (varia por persona, raro hit cross-persona).
+   */
+  personaProfileBlock?: string;
+}
+
+export interface MaterializationResult {
+  /** Texto final pronto pra Bridge (já sanitizado). */
+  text: string;
+  /** Modelo usado (provedor:nome). */
+  model_used: string;
+  /** True se LLM retornou FALLBACK: prefix (constraint violado em prompt). */
+  fallback_triggered: boolean;
+  /** Latência da chamada LLM em ms. */
+  latency_ms: number;
+  /** Token count estimado (out tokens). */
+  token_count: number;
+  /** True se sanitizeMaterialization removeu palavras (defensiva final). */
+  sanitization_applied: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Prompts (Kids — perfil neutro-respeitoso JP/BR)
+//
+// Step 8 do handoff vLLM: separação STABLE_MATERIALIZER_PREFIX (cacheável)
+// vs userMessage (dinâmico) pra prefix caching funcionar.
+// vLLM faz hash do system message; campos volatéis lá quebram cache hit.
+// ─────────────────────────────────────────────────────────────────────────
+
+const FALLBACK_PREFIX = "FALLBACK:";
+
+/**
+ * Prefixo IMUTÁVEL na sessão — vai pra cacheableSystemPrefix.
+ * Inclui contrato de voz + regras condicionais (texto fixo) + constraints
+ * de segurança. Nada que muda turn-a-turn.
+ */
+export const STABLE_MATERIALIZER_PREFIX = `/no_think
+Você é um acompanhante pedagógico de crianças. Seu nome não importa — você é uma voz, não um personagem.
+
+CONTRATO DE VOZ (obrigatório, sem exceção):
+- Tom: neutro-respeitoso. Zero infantilização.
+- Zero diminutivos não-solicitados.
+- Zero elogios automáticos. PROIBIDO usar (mesmo prefixados em meio à frase): "que legal!", "legal!", "incrível!", "muito bem!", "ótimo!", "isso é ótimo", "parece legal", "parece divertido", "que bonitinho!", "Que bom!", "isso é bom para…".
+- Zero jargão pedagógico ("dimensão", "CASEL", "Dreyfus", "score", "playbook").
+- Zero falsa simetria. PROIBIDO dizer "eu também", "tô X também", "também adoro/curto/treino/jogo X". Você não tem hobbies, gostos, treino próprio — você acompanha o sujeito.
+- Zero terapia-esqueléstica ("como você está se sentindo com isso?").
+- Zero "Como posso te ajudar?" — você não é assistente genérico.
+
+ANTI-LOOP (importante, sob risco de soar artificial):
+- Se o sujeito repete a mesma resposta entre turns (ex: "tô treinando tênis" 3x seguidas), NÃO insista no mesmo enquadramento. Reconheça brevemente (1 cláusula) e MUDE o ângulo: pergunte sobre algo adjacente, ou recue ("ok, tô por aqui quando quiser").
+- Não escale com elogios cumulativos ("legal!" → "muito legal!" → "que demais!") — isso soa falso e o contrato proíbe.
+- Se o sujeito desviou de um tema (mudou de assunto explicitamente), NÃO retorne a esse tema na mesma resposta. O contextHints.avoid indica o tema a evitar — respeite-o literalmente.
+
+CONTEÚDO PEDAGÓGICO (regra obrigatória):
+O Fact abaixo FOI SELECIONADO para este sujeito neste momento. Você DEVE
+usá-lo — a questão é COMO, não SE.
+
+Regra de ancoragem:
+1. Reconheça o tema do sujeito em 1 frase curta (sem elogio, sem eco excessivo).
+2. Introduza o Fact com uma ponte NATURAL ao que ele disse.
+   - Se o tema do sujeito conecta diretamente ao Domínio → traga o Fact diretamente.
+   - Se o tema do sujeito não conecta diretamente → use o Fact como ângulo lateral.
+     Exemplo: sujeito falou de tênis, Fact é sobre golfinhos com nome → bridge:
+     "Golfinhos chamam uns aos outros pelo nome. Quando você tá em jogo, como
+     chama a atenção do parceiro?"
+3. Bridge e Quest entram DEPOIS do Fact, reformulados dentro do contexto do sujeito.
+4. Exceção única: se o sujeito enviou sinal EXPLÍCITO de saída ("tchau", "preciso ir",
+   "para") OU se o Fact exigiria violar CONSTRAINTS DE SEGURANÇA → ignore o Fact e
+   reconheça brevemente a saída ou retorne FALLBACK.
+
+NUNCA gere resposta genérica ignorando o Fact. Se não encontrar ângulo, crie um.
+
+REGRAS CONDICIONAIS (texto fixo; aplicar conforme situação dinâmica abaixo):
+- Se mood ≤ 3 → SEM perguntas abertas. Apenas reconhecimento factual curto.
+- Se engagement = disengaging → 1 frase, tom leve, sem pressão.
+- Se turn ≤ 3 → 1-2 frases (turn inicial). Prioridade contextual acima vale duplo.
+- Se turn > 3 → pode expandir conforme engajamento, mas sem prolixidade.
+- Se MENSAGEM DO SUJEITO está marcada como vazia/vaga (turn inaugural, "oi", mensagem ≤ 3 palavras sem tema) → NÃO use Fact/Bridge/Quest. Abra com apresentação curta do que vão fazer juntos + 1 pergunta sobre o sujeito.
+- Se HELIX_PHASE = boss (Double Helix integrador) → quest/desafio integra os DOIS domínios CASEL (CASEL_FOCUS_DIM + CASEL_RETRIEVAL_DIM) numa única atividade concreta, não em quests separadas. Ex: SOC ativo + SA retrieval → "como sua autoconsciência muda quando está com outras pessoas?" (não duas perguntas).
+- Se HELIX_PHASE = retrieval → mencionar CASEL_RETRIEVAL_DIM sutilmente como ponte (re-visita), sem forçar.
+
+CONSTRAINTS DE SEGURANÇA (violação = retornar FALLBACK):
+- NUNCA induza o sujeito a compartilhar dados sensíveis (localização, escola, informações de terceiros).
+- NUNCA mencione dados de outros sujeitos por nome.
+- NUNCA contradiga restrições de jurisdição ativa.
+- Se a ação especificada exige violar qualquer constraint acima:
+  retorne EXATAMENTE: ${FALLBACK_PREFIX} <reconhecimento neutro de 1 frase sem conteúdo da ação>
+
+INSTRUÇÕES FINAIS:
+Retorne apenas o texto a ser enviado ao sujeito. Sem explicação, sem metadados, sem markdown.
+Se retornar FALLBACK, use exatamente o formato acima.`;
+
+/**
+ * userMessage — DINÂMICO turn-a-turn. Inclui SUJEITO/MOOD/ENGAJAMENTO/TURN/
+ * BUDGET/AÇÃO. NÃO vai pro cacheableSystemPrefix — varia a cada turn.
+ */
+function buildUserMessage(ctx: MaterializerContext): string {
+  const fact = (ctx.action.item as { fact?: string }).fact ?? "(sem fact)";
+  const bridge = (ctx.action.item as { bridge?: string }).bridge ?? "(sem bridge)";
+  const quest = (ctx.action.item as { quest?: string }).quest ?? "(sem quest)";
+
+  const incoming = ctx.incomingMessage?.trim() ?? "";
+  const subjectBlock = incoming.length > 0
+    ? `MENSAGEM DO SUJEITO (use como tema, se houver):\n"${incoming}"`
+    : `MENSAGEM DO SUJEITO: (vazia / vaga — não há tema concreto pra puxar)`;
+
+  // motor#69 H4: helix block (omit quando phase=undefined / fora do helix path).
+  const helixBlock = ctx.helixPhase
+    ? `\nHELIX_PHASE: ${ctx.helixPhase}${ctx.caselFocusDim ? ` | CASEL_FOCUS_DIM: ${ctx.caselFocusDim}` : ""}${ctx.caselRetrievalDim ? ` | CASEL_RETRIEVAL_DIM: ${ctx.caselRetrievalDim}` : ""}\n`
+    : "";
+
+  // 2026-05-05 (sts-realista): janela curta de history pra anti-loop awareness.
+  // Excluímos o turn atual do sujeito (já está em subjectBlock).
+  const turns = ctx.recentTurns ?? [];
+  const tail = turns.slice(-6); // último ~3 pares
+  const botRecent = tail.filter((t) => t.role === "assistant").slice(-3);
+  const userRecent = tail.filter((t) => t.role === "user").slice(-3);
+  const formatLines = (arr: typeof botRecent): string =>
+    arr.length === 0
+      ? "(nenhum)"
+      : arr.map((t, i) => `[${i + 1}] "${t.content.slice(0, 240).replace(/\n/g, " ")}"`).join("\n");
+  const historyBlock = tail.length > 0
+    ? `
+
+VOCÊ JÁ DISSE (não repita verbatim — varie ângulo, vocabulário, abertura):
+${formatLines(botRecent)}
+
+SUJEITO JÁ DISSE (continue o que está em aberto, não recomece zero):
+${formatLines(userRecent)}`
+    : "";
+
+  // 2026-05-07 Nível A: profile NÃO entra mais no userMessage — vai pro
+  // cacheableSystemPrefix em materialize(). Aqui apenas garantimos que
+  // o resto do dynamic body fica intacto.
+
+  return `SUJEITO: ${ctx.subjectNameForm}
+MOOD: ${ctx.mood}/10 | ENGAJAMENTO: ${ctx.engagement} | TURN: ${ctx.turnCount}
+BUDGET: ${ctx.budgetRemaining}
+JURISDIÇÃO: ${ctx.jurisdictionActive}
+${helixBlock}
+${subjectBlock}${historyBlock}
+
+AÇÃO LATENTE (use só se houver ponte natural com a mensagem do sujeito acima):
+- ID: ${ctx.action.item.id}
+- Tipo: ${ctx.action.item.type}
+- Domínio: ${ctx.action.item.domain}
+- Fact: ${fact}
+- Bridge: ${bridge}
+- Quest: ${quest}
+
+Aplique a PRIORIDADE CONTEXTUAL do contrato. Se houver ponte → traga Fact/Bridge/Quest dentro do tema do sujeito. Se não houver tema/ponte → reconheça e abra com 1 pergunta sobre o que ele trouxe (ou como ele está, se mensagem vazia). Respeite contrato de voz + regras condicionais. ANTI-LOOP: se algo da sua lista "VOCÊ JÁ DISSE" está sendo replicado mentalmente, MUDE de ângulo agora.`;
+}
+
+/**
+ * 2026-05-07 Otimização #2: max_tokens adaptativo.
+ *
+ * Heurística:
+ *  - mood ≤ 3 OU engagement=disengaging → 200 (apenas reconhecimento factual)
+ *  - turnCount ≤ 3 → 350 (rapport curto)
+ *  - engagement=high E turnCount ≥ 4 → 600 (deepening permite expansão)
+ *  - default → 400
+ *
+ * Reduz gen time em ~30-50% nos turns "duros" mantendo headroom em turns ricos.
+ */
+function adaptiveMaxTokens(
+  turnCount: number,
+  engagement: EngagementLevel,
+  mood: number,
+): number {
+  if (mood <= 3 || engagement === "disengaging") return 200;
+  if (turnCount <= 3) return 350;
+  if (engagement === "high") return 600;
+  return 400;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Materializa o texto final. Sempre retorna MaterializationResult válido,
+ * nunca lança.
+ *
+ * Pipeline:
+ *   1. STABLE_MATERIALIZER_PREFIX (cacheável) + userMessage (dinâmico)
+ *   2. callGateway(step="drota") — vLLM prefix caching opera sobre prefix
+ *   3. Parse output: se começar com FALLBACK:, extrai texto seguro
+ *   4. sanitizeMaterialization defensiva final (FORBIDDEN_WORDS)
+ *
+ * Em caso de erro do LLM: retorna texto fallback hardcoded conservador.
+ */
+export async function materialize(
+  ctx: MaterializerContext,
+): Promise<MaterializationResult> {
+  const t0 = Date.now();
+  const userMessage = buildUserMessage(ctx);
+  if (process.env["ASC_DEBUG_MATERIALIZER"] === "true") {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[materialize] turn=${ctx.turnCount} recentTurns=${(ctx.recentTurns ?? []).length} userMsgLen=${userMessage.length}\n--- USER MSG START ---\n${userMessage}\n--- USER MSG END ---`,
+    );
+  }
+
+  let rawText: string;
+  let modelUsed = "unknown";
+  let outTokens = 0;
+
+  try {
+    // 2026-05-07 Nível A (#476 Phase 2): profile vai pro cacheableSystemPrefix
+    // pra cache hit cross-turn dentro da sessão (profile constante por 6 turns
+    // entre compressões). llama-server prefix caching pega automaticamente.
+    const profileBlock = (ctx.personaProfileBlock ?? "").trim();
+    const cacheablePrefix =
+      profileBlock.length > 0
+        ? `${STABLE_MATERIALIZER_PREFIX}\n\n${profileBlock}`
+        : STABLE_MATERIALIZER_PREFIX;
+
+    const out = await callGateway({
+      step: ctx.llmStep ?? "drota",
+      // systemPrompt vazio: tudo fixo está em cacheableSystemPrefix.
+      // Preserva prefix caching no vLLM (Step 8 do handoff).
+      systemPrompt: "",
+      cacheableSystemPrefix: cacheablePrefix,
+      userMessage,
+      // 2026-05-05 (sts-realista): turn 1-3 mantém 300 (rapport curto).
+      // turn 4+ permite 600 — abre espaço pra profundidade quando há contexto
+      // estabelecido. Override explícito via ctx.maxTokens vence a heurística.
+      // 2026-05-07 Otimização #2: max_tokens adaptativo por engagement+mood.
+      // Rationale: turns "duros" (mood baixo, disengaging) merecem reconhecimento
+      // curto (~200), não monólogo. Receptivo/deepening permite expansão.
+      // Override explícito via ctx.maxTokens vence.
+      maxTokens: ctx.maxTokens ?? adaptiveMaxTokens(ctx.turnCount, ctx.engagement, ctx.mood),
+      run_id: ctx.run_id,
+    });
+    rawText = out.content;
+    modelUsed = `${out.provider}:${out.model}`;
+    outTokens = out.tokens.out;
+  } catch {
+    // LLM error → texto neutro fallback hardcoded
+    return {
+      text: "Tô por aqui. Quando quiser me contar mais, conta.",
+      model_used: "fallback_hardcoded",
+      fallback_triggered: true,
+      latency_ms: Date.now() - t0,
+      token_count: 0,
+      sanitization_applied: false,
+    };
+  }
+
+  // Detect FALLBACK: prefix
+  const fallbackTriggered = rawText.trimStart().startsWith(FALLBACK_PREFIX);
+  let textBeforeSanitize: string;
+  if (fallbackTriggered) {
+    const idx = rawText.indexOf(FALLBACK_PREFIX);
+    textBeforeSanitize = rawText.slice(idx + FALLBACK_PREFIX.length).trim();
+  } else {
+    textBeforeSanitize = rawText.trim();
+  }
+
+  // Sanitização defensiva final
+  const sanitized = sanitizeMaterialization(textBeforeSanitize);
+  const sanitizationApplied = sanitized !== textBeforeSanitize;
+
+  return {
+    text: sanitized,
+    model_used: modelUsed,
+    fallback_triggered: fallbackTriggered,
+    latency_ms: Date.now() - t0,
+    token_count: outTokens,
+    sanitization_applied: sanitizationApplied,
+  };
+}

--- a/motor-drota/tests/constrained-materializer.test.ts
+++ b/motor-drota/tests/constrained-materializer.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+  ScoredContentItem,
+  ContentItem,
+} from "@ascendimacy/shared";
+
+const captured: { req?: GatewayChatCompletionInput } = {};
+let mockResponse: GatewayChatCompletionOutput | null = null;
+let mockError: Error | null = null;
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: async (req: GatewayChatCompletionInput) => {
+      captured.req = req;
+      if (mockError) throw mockError;
+      if (!mockResponse) {
+        throw new Error("test setup error: mockResponse not set");
+      }
+      return mockResponse;
+    },
+  };
+});
+
+import { materialize } from "../src/constrained-materializer.js";
+import type { MaterializerContext } from "../src/constrained-materializer.js";
+
+const buildLlmResponse = (content: string): GatewayChatCompletionOutput => ({
+  content,
+  tokens: { in: 100, out: 50, reasoning: 0 },
+  provider: "infomaniak",
+  model: "moonshotai/Kimi-K2.5",
+  latency_ms: 150,
+  attempt_count: 1,
+  was_fallback: false,
+});
+
+const stubItem = (id = "test-action"): ScoredContentItem => ({
+  item: {
+    id,
+    type: "curiosity_hook",
+    domain: "biology",
+    casel_target: ["SA"],
+    age_range: [7, 14],
+    surprise: 7,
+    verified: true,
+    base_score: 7,
+    fact: "Os golfinhos têm nomes próprios.",
+    bridge: "Que som você teria como nome?",
+    quest: "Pensa num apelido pra você.",
+    sacrifice_type: "reflect",
+    sacrifice_amount: 3,
+  } as ContentItem,
+  score: 8,
+  reasons: [],
+});
+
+const stubCtx = (overrides: Partial<MaterializerContext> = {}): MaterializerContext => ({
+  action: stubItem(),
+  subjectNameForm: "Ryo",
+  mood: 6,
+  engagement: "medium",
+  turnCount: 2,
+  budgetRemaining: 12,
+  jurisdictionActive: "jp",
+  ...overrides,
+});
+
+beforeEach(() => {
+  captured.req = undefined;
+  mockResponse = null;
+  mockError = null;
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Happy path
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — happy path", () => {
+  it("LLM válido → text limpo, fallback_triggered=false", async () => {
+    mockResponse = buildLlmResponse("Que som você teria como nome?");
+    const r = await materialize(stubCtx());
+    expect(r.text).toBe("Que som você teria como nome?");
+    expect(r.fallback_triggered).toBe(false);
+    expect(r.model_used).toContain("Kimi");
+  });
+
+  it("envia step='drota' por default", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx());
+    expect(captured.req?.step).toBe("drota");
+  });
+
+  it("override de step funciona", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ llmStep: "persona-sim" }));
+    expect(captured.req?.step).toBe("persona-sim");
+  });
+
+  it("userMessage inclui slots dinâmicos (post-Step 8 refactor)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ subjectNameForm: "Kei", mood: 4 }));
+    // Step 8: campos dinâmicos vão pro userMessage (não systemPrompt) pra
+    // preservar prefix caching no vLLM.
+    const user = captured.req?.userMessage ?? "";
+    expect(user).toContain("Kei");
+    expect(user).toContain("MOOD: 4/10");
+  });
+
+  it("cacheableSystemPrefix é STABLE_MATERIALIZER_PREFIX (cache hit pro vLLM)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx());
+    const prefix = captured.req?.cacheableSystemPrefix ?? "";
+    expect(prefix.length).toBeGreaterThan(100);
+    expect(prefix).toContain("CONTRATO DE VOZ");
+    expect(prefix).toContain("CONSTRAINTS DE SEGURANÇA");
+    expect(prefix).toContain("REGRAS CONDICIONAIS");
+  });
+
+  it("systemPrompt vazio (tudo fixo está em cacheableSystemPrefix)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx());
+    expect(captured.req?.systemPrompt).toBe("");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// FALLBACK: prefix handling
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — FALLBACK: prefix", () => {
+  it("LLM retorna 'FALLBACK: ...' → fallback_triggered=true e texto extraído", async () => {
+    mockResponse = buildLlmResponse(
+      "FALLBACK: Estou aqui. Conta quando quiser.",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(true);
+    expect(r.text).toBe("Estou aqui. Conta quando quiser.");
+  });
+
+  it("FALLBACK com whitespace inicial", async () => {
+    mockResponse = buildLlmResponse(
+      "  FALLBACK: Texto seguro.  ",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(true);
+    expect(r.text).toBe("Texto seguro.");
+  });
+
+  it("texto SEM prefix FALLBACK → fallback_triggered=false", async () => {
+    mockResponse = buildLlmResponse(
+      "Resposta normal sem fallback prefix.",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sanitização defensiva final (FORBIDDEN_WORDS)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — sanitização final", () => {
+  it("FORBIDDEN_WORDS no output → sanitization_applied=true e palavras removidas", async () => {
+    mockResponse = buildLlmResponse(
+      "Vou usar o playbook pra você.",
+    );
+    const r = await materialize(stubCtx());
+    expect(r.sanitization_applied).toBe(true);
+    expect(r.text).not.toContain("playbook");
+  });
+
+  it("output limpo → sanitization_applied=false", async () => {
+    mockResponse = buildLlmResponse("Texto normal sem termo proibido.");
+    const r = await materialize(stubCtx());
+    expect(r.sanitization_applied).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mood baixo / engagement disengaging — guidance no prompt
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — regras condicionais sempre no cacheableSystemPrefix", () => {
+  // Step 8: regras condicionais ficam SEMPRE no prefix como texto fixo
+  // ("Se mood ≤ 3 → ..."). Aplicação em runtime depende do mood/engajamento
+  // que LLM lê no userMessage. Cache hit preservado.
+  it("'SEM perguntas abertas' no prefix (regra mood ≤ 3 fixa)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ mood: 2 }));
+    expect(captured.req?.cacheableSystemPrefix).toContain("SEM perguntas abertas");
+  });
+
+  it("'1 frase, tom leve' no prefix (regra disengaging fixa)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ engagement: "disengaging" }));
+    expect(captured.req?.cacheableSystemPrefix).toContain("1 frase, tom leve");
+  });
+
+  it("'turn inicial' no prefix (regra turn ≤ 3 fixa)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ turnCount: 1 }));
+    expect(captured.req?.cacheableSystemPrefix).toContain("turn inicial");
+  });
+
+  it("MOOD value vai pro userMessage (LLM aplica regra fixa do prefix)", async () => {
+    mockResponse = buildLlmResponse("ok");
+    await materialize(stubCtx({ mood: 2, engagement: "disengaging", turnCount: 1 }));
+    expect(captured.req?.userMessage).toContain("MOOD: 2");
+    expect(captured.req?.userMessage).toContain("ENGAJAMENTO: disengaging");
+    expect(captured.req?.userMessage).toContain("TURN: 1");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM error → fallback hardcoded
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — LLM error fallback", () => {
+  it("erro do gateway → texto fallback hardcoded + model_used='fallback_hardcoded'", async () => {
+    mockError = new Error("gateway timeout");
+    const r = await materialize(stubCtx());
+    expect(r.fallback_triggered).toBe(true);
+    expect(r.model_used).toBe("fallback_hardcoded");
+    expect(r.text.length).toBeGreaterThan(0);
+    expect(r.text).not.toContain("playbook"); // forbidden words check
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Latência + token count
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("materialize — metadata", () => {
+  it("latency_ms registrado", async () => {
+    mockResponse = buildLlmResponse("ok");
+    const r = await materialize(stubCtx());
+    expect(r.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("token_count vem do gateway tokens.out", async () => {
+    mockResponse = buildLlmResponse("ok");
+    const r = await materialize(stubCtx());
+    expect(r.token_count).toBe(50); // do mock
+  });
+});
+
+// ─── 2026-05-05 (bugfix-materializer-content-anchor) ────────────────────────
+describe("STABLE_MATERIALIZER_PREFIX — content anchor + deflection", () => {
+  it("contém 'CONTEÚDO PEDAGÓGICO' e ordena Fact como obrigatório", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("CONTEÚDO PEDAGÓGICO");
+    expect(STABLE_MATERIALIZER_PREFIX).toContain(
+      "FOI SELECIONADO para este sujeito",
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("a questão é COMO, não SE");
+  });
+
+  it("não contém mais 'POSSIBILIDADE LATENTE'", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).not.toContain("POSSIBILIDADE LATENTE");
+  });
+
+  it("ANTI-LOOP inclui constraint de não retornar a tema desviado", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("desviou de um tema");
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("contextHints.avoid");
+  });
+
+  it("REGRAS CONDICIONAIS incluem turn inaugural sem tema → não usar Fact", async () => {
+    const { STABLE_MATERIALIZER_PREFIX } = await import(
+      "../src/constrained-materializer.js"
+    );
+    expect(STABLE_MATERIALIZER_PREFIX).toContain("turn inaugural");
+    expect(STABLE_MATERIALIZER_PREFIX).toContain(
+      "NÃO use Fact/Bridge/Quest",
+    );
+  });
+});


### PR DESCRIPTION
Rebase de #187 (base original deletada após merge cascade incompleto). Cherry-pick limpo sobre main.

Adiciona motor-drota/src/constrained-materializer.ts (204 linhas) + tests (221 linhas, 22 tests). Inclui prefix caching refactor (#9).

🤖 Rebased via reset+cherry-pick