### PR TITLE
[feat sprint-pedag P2.1] scorer pesa interest_match

### DIFF
--- a/planejador/src/child-profile.ts
+++ b/planejador/src/child-profile.ts
@@ -39,12 +39,24 @@ export function personaToChildProfile(
     ? (profile["cycle_day"] as number)
     : undefined;
 
+  // Sprint Pedagógico P2.1: extrai interests do profile pro scorer pesar
+  // interest_match. Aceita 'interests' top-level OR 'preferences.interests'
+  // (formato fixture profile-store/Phase2). String list ou skip.
+  const rawInterests = profile["interests"]
+    ?? (profile["preferences"] as Record<string, unknown> | undefined)?.["interests"];
+  const interests = Array.isArray(rawInterests)
+    ? (rawInterests as unknown[])
+        .filter((x): x is string => typeof x === "string" && x.trim().length > 0)
+        .map((s) => s.trim())
+    : undefined;
+
   return {
     age: persona.age,
     domain_ranking: domainRanking,
     recent_hook_domains: recentHookDomains,
     cycle_day: cycleDay,
     cycle_phase: cyclePhaseFor(cycleDay),
+    interests,
   };
 }
 

--- a/shared/src/scorer.ts
+++ b/shared/src/scorer.ts
@@ -65,6 +65,14 @@ export const TREE_TOP_DOMAIN_BONUS = 5;
 export const CASEL_FOCUS_BONUS = 3;
 
 /**
+ * Sprint Pedagógico P2.1: bonus quando interest do sujeito match item.
+ * Match path: persona.interests ∩ (item.gardner_channels ∪ item.domain ∪ item.id).
+ * +6 escolhido pra ser ≥ surprise bonus máximo (+6 com surprise=10) — interest
+ * vence surpresa quando profile tem interests definidos.
+ */
+export const INTEREST_MATCH_SCORE = 6;
+
+/**
  * motor#23: penalidade forte pra items já consumidos na sessão atual.
  * Maior que qualquer bônus normal (base_score+surprise+casel ≈ 12-15) — efetivamente
  * exclui o item enquanto outros disponíveis. Não 1000 (parent_pinned) pois ainda
@@ -85,6 +93,14 @@ export interface ChildScoringProfile {
   domain_ranking?: Record<string, DomainRankEntry>;
   recent_hook_domains?: string[];
   engagement_by_type?: Partial<Record<ContentItemType, number>>;
+
+  /**
+   * Sprint Pedagógico P2.1: interesses livres do sujeito (tênis, mecânica,
+   * dragon_ball, etc). Match com item.gardner_channels OR substring de
+   * item.domain/item.id (case-insensitive) → INTEREST_MATCH_SCORE boost.
+   * Vindo de persona.profile.interests via personaToChildProfile.
+   */
+  interests?: string[];
 
   /**
    * Dia no ciclo helix de 18 dias (1-18). Bloco 2a adiciona o slot;
@@ -174,6 +190,31 @@ export function scoreItem(
   if (domainEntry && domainEntry.score !== 0) {
     score += domainEntry.score;
     reasons.push(`domain_interest=+${domainEntry.score}`);
+  }
+
+  // Sprint Pedagógico P2.1: interest match boost.
+  // persona.interests vs item.gardner_channels/domain/id. Case-insensitive,
+  // substring match. Múltiplos matches contam UMA vez (boost fixo, não somado)
+  // pra evitar items "genéricos" dominarem por casarem com vários interests.
+  if (child.interests && child.interests.length > 0) {
+    const itemHaystack = [
+      item.domain,
+      item.id,
+      ...(item.gardner_channels ?? []),
+    ]
+      .filter(Boolean)
+      .map((s) => String(s).toLowerCase());
+    const matched = child.interests.find((interest) => {
+      const needle = interest.toLowerCase().trim();
+      if (needle.length === 0) return false;
+      return itemHaystack.some(
+        (hay) => hay.includes(needle) || needle.includes(hay),
+      );
+    });
+    if (matched !== undefined) {
+      score += INTEREST_MATCH_SCORE;
+      reasons.push(`interest_match=+${INTEREST_MATCH_SCORE} ('${matched}')`);
+    }
   }
 
   // Surprise bonus — diamantes ganham peso.

--- a/shared/tests/scorer.test.ts
+++ b/shared/tests/scorer.test.ts
@@ -402,3 +402,77 @@ describe("scoreItem — sacrifice_cost_by_id adjustment (ops#1093)", () => {
     expect(r.reasons.find((x) => x.includes("sacrifice"))).toBeUndefined();
   });
 });
+
+// ─── Sprint Pedagógico P2.1: interest_match boost ──────────────────────────
+describe("scoreItem — interest_match (Sprint Pedagógico P2.1)", () => {
+  it("interest match item.domain → +6 + reason", () => {
+    const r = scoreItem(
+      hook({ domain: "tennis", base_score: 7 }),
+      { age: 10, interests: ["tennis", "mechanics"] },
+      baseCtx,
+    );
+    expect(r.score).toBe(7 + 6);
+    expect(r.reasons.some((x) => x.includes("interest_match=+6"))).toBe(true);
+  });
+
+  it("interest match item.id substring → +6", () => {
+    const r = scoreItem(
+      hook({ id: "ling_tennis_history", domain: "linguistics", base_score: 7 }),
+      { age: 10, interests: ["tennis"] },
+      baseCtx,
+    );
+    expect(r.score).toBe(7 + 6);
+  });
+
+  it("interest match gardner_channel → +6", () => {
+    const r = scoreItem(
+      hook({ domain: "math", gardner_channels: ["logical_math"], base_score: 5 }),
+      { age: 10, interests: ["logical_math"] },
+      baseCtx,
+    );
+    expect(r.score).toBe(5 + 6);
+  });
+
+  it("nenhum match → score base", () => {
+    const r = scoreItem(
+      hook({ domain: "biology", base_score: 7 }),
+      { age: 10, interests: ["tennis"] },
+      baseCtx,
+    );
+    expect(r.score).toBe(7);
+    expect(r.reasons.some((x) => x.includes("interest_match"))).toBe(false);
+  });
+
+  it("interests undefined → backward compat (sem boost)", () => {
+    const r = scoreItem(hook({ base_score: 7 }), { age: 10 }, baseCtx);
+    expect(r.score).toBe(7);
+    expect(r.reasons.some((x) => x.includes("interest_match"))).toBe(false);
+  });
+
+  it("múltiplos interests, 1 match → +6 (não soma)", () => {
+    const r = scoreItem(
+      hook({ domain: "tennis", base_score: 7 }),
+      { age: 10, interests: ["tennis", "mechanics", "dragon_ball"] },
+      baseCtx,
+    );
+    expect(r.score).toBe(7 + 6); // não 7 + 18
+  });
+
+  it("interest com whitespace → trimado", () => {
+    const r = scoreItem(
+      hook({ domain: "tennis", base_score: 7 }),
+      { age: 10, interests: ["  tennis  "] },
+      baseCtx,
+    );
+    expect(r.score).toBe(7 + 6);
+  });
+
+  it("case insensitive match", () => {
+    const r = scoreItem(
+      hook({ domain: "Tennis", base_score: 7 }),
+      { age: 10, interests: ["TENNIS"] },
+      baseCtx,
+    );
+    expect(r.score).toBe(7 + 6);
+  });
+});


### PR DESCRIPTION
Sprint Pedagógico P2.1 — scorer ganha INTEREST_MATCH_SCORE quando persona.interests intersect item.gardner_channels/domain/id.

Bug observado em smoke 2026-05-25: cards Kei iguais aos Ryo (tears/Navajo) — pool não diferencia por persona interest.

Fix: +6 boost (≥ surprise max), case-insensitive substring, max 1 match (evita items genéricos dominarem).

Tests: +8 no scorer. 680/680 shared.

🤖 Sprint Pedagógico