### PR TITLE
[feat] BFF /rescan endpoint + fs.watch auto-rescan

### DIFF
--- a/packages/ebrota-console-bff/src/cli.ts
+++ b/packages/ebrota-console-bff/src/cli.ts
@@ -73,6 +73,7 @@ const server = createBffServer({
   db,
   initialMode,
   logger: true,
+  tracesDir,
 });
 
 // Scan traces ANTES de listen (idempotente; ok mesmo se dir não existe).

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -37,8 +37,10 @@ import {
 import {
   listSessionLibrary,
   readSessionTrace,
+  scanTraces,
   type SessionLibraryFilters,
 } from "./traces-scanner.js";
+import { existsSync, watch as fsWatch, type FSWatcher } from "node:fs";
 import {
   createDebugEventsStore,
   recordDebugAction,
@@ -71,6 +73,13 @@ export interface CreateBffServerOptions {
    *  Default http://localhost:5173 (vite). PR9 deploy serviria o
    *  build estático no próprio BFF. */
   uiBaseUrl?: string;
+  /**
+   * Diretório de traces — se fornecido, habilita:
+   *  - POST /rescan endpoint (manual trigger)
+   *  - fs.watch auto-rescan quando novo .json é criado (debounced 1s)
+   * Default: undefined → endpoint retorna 503, sem watcher.
+   */
+  tracesDir?: string;
 }
 
 export interface BffServer {
@@ -519,6 +528,42 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
     }),
   );
 
+  // POST /rescan — re-indexa o tracesDir (manual trigger).
+  // Útil quando STS roda em outro processo e deposita novos traces;
+  // o BFF normalmente só scaneia no startup.
+  fastify.post("/rescan", async (_req, reply) => {
+    if (!opts.tracesDir) {
+      return reply
+        .code(503)
+        .send({ error: "tracesDir não configurado — rescan indisponível" });
+    }
+    const result = await scanTraces({
+      tracesDir: opts.tracesDir,
+      db: opts.db,
+      log: () => {},
+    });
+    return result;
+  });
+
+  // fs.watch auto-rescan — debounce 1s pra agregar bursts.
+  // Watcher só sobe se tracesDir existir; ausente vira no-op silencioso.
+  let watcher: FSWatcher | null = null;
+  let watchDebounce: NodeJS.Timeout | null = null;
+  if (opts.tracesDir && existsSync(opts.tracesDir)) {
+    watcher = fsWatch(opts.tracesDir, { recursive: true }, (_event, filename) => {
+      if (!filename || !filename.toString().endsWith(".json")) return;
+      if (watchDebounce) clearTimeout(watchDebounce);
+      watchDebounce = setTimeout(() => {
+        watchDebounce = null;
+        void scanTraces({
+          tracesDir: opts.tracesDir!,
+          db: opts.db,
+          log: () => {},
+        });
+      }, 1000);
+    });
+  }
+
   return {
     fastify,
     getMode: () => mode,
@@ -527,6 +572,14 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       await fastify.listen({ port, host });
     },
     async close() {
+      if (watchDebounce) {
+        clearTimeout(watchDebounce);
+        watchDebounce = null;
+      }
+      if (watcher) {
+        watcher.close();
+        watcher = null;
+      }
       await fastify.close();
       await opts.daemon.close();
       opts.db.close();

--- a/packages/ebrota-console-bff/tests/server-rescan.test.ts
+++ b/packages/ebrota-console-bff/tests/server-rescan.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import {
+  createMockDaemonClient,
+  type MockDaemonClient,
+} from "../src/daemon-client.js";
+import { listSessionLibrary } from "../src/traces-scanner.js";
+
+let server: BffServer;
+let daemon: MockDaemonClient;
+let db: DatabaseType;
+let tmpRoot: string;
+
+const writeTrace = (
+  subdir: string,
+  trace: Record<string, unknown>,
+): string => {
+  const dir = join(tmpRoot, subdir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "trace.json");
+  writeFileSync(path, JSON.stringify(trace));
+  return path;
+};
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  daemon = createMockDaemonClient();
+  tmpRoot = mkdtempSync(join(tmpdir(), "server-rescan-"));
+});
+
+afterEach(async () => {
+  await server.close();
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const inject = async (method: "GET" | "POST", url: string) => {
+  const res = await server.fastify.inject({ method, url });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as Record<string, unknown>) : null,
+  };
+};
+
+describe("POST /rescan", () => {
+  it("503 quando tracesDir não configurado", async () => {
+    server = createBffServer({ daemon, db, logger: false });
+    const res = await inject("POST", "/rescan");
+    expect(res.status).toBe(503);
+    expect((res.body as { error: string }).error).toMatch(/tracesDir/);
+  });
+
+  it("indexa novos traces que apareceram após startup", async () => {
+    server = createBffServer({ daemon, db, logger: false, tracesDir: tmpRoot });
+
+    // Estado inicial: zero sessions indexadas
+    expect(listSessionLibrary(db)).toHaveLength(0);
+
+    // STS deposita trace novo enquanto BFF roda
+    writeTrace("session-novo", {
+      sessionId: "kei__novo",
+      persona: "kei",
+      startedAt: "2026-05-25T10:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 0,
+          incomingMessage: "card:test",
+          finalResponse: "ok",
+        },
+      ],
+    });
+
+    const res = await inject("POST", "/rescan");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      sessionsIndexed: number;
+      filesScanned: number;
+    };
+    expect(body.sessionsIndexed).toBe(1);
+    expect(body.filesScanned).toBe(1);
+
+    const sessions = listSessionLibrary(db);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sessionId).toBe("kei__novo");
+  });
+});
+
+describe("fs.watch auto-rescan", () => {
+  it("re-indexa após novo .json aparecer no tracesDir (debounced)", async () => {
+    server = createBffServer({ daemon, db, logger: false, tracesDir: tmpRoot });
+    expect(listSessionLibrary(db)).toHaveLength(0);
+
+    writeTrace("watched", {
+      sessionId: "yuji__watched",
+      persona: "yuji",
+      startedAt: "2026-05-25T11:00:00.000Z",
+      turns: [{ turnNumber: 0, finalResponse: "auto" }],
+    });
+
+    // Espera o debounce (1s) + margem pro scan async terminar
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const sessions = listSessionLibrary(db);
+    expect(sessions.length).toBeGreaterThanOrEqual(1);
+    expect(sessions.some((s) => s.sessionId === "yuji__watched")).toBe(true);
+  });
+
+  it("tracesDir inexistente não derruba o server (no-op)", async () => {
+    const missingDir = join(tmpRoot, "does-not-exist");
+    server = createBffServer({
+      daemon,
+      db,
+      logger: false,
+      tracesDir: missingDir,
+    });
+    // Endpoint ainda responde — scanTraces lida com dir ausente
+    const res = await inject("POST", "/rescan");
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- Novo `POST /rescan` re-indexa `tracesDir` sob demanda (retorna `ScanResult`)
- `fs.watch` recursivo, debounced 1s, auto-indexa qualquer `.json` novo
- `503` quando `tracesDir` ausente (mantém compat com testes/headless)
- Cleanup do watcher + timer no `close()`

Resolve o gap descoberto durante a smoke pós-Sprint Pedagógico: traces depositados pelo STS depois do startup do BFF ficavam invisíveis no Console até reinício manual. Agora aparece automático.

## Test plan
- [x] `tests/server-rescan.test.ts` — 4 tests: 503 sem tracesDir, rescan manual, fs.watch debounced, dir ausente no-op
- [x] BFF suite: 101 passing (97 → 101)
- [ ] Manual: smoke rodando em background — após PR mergeada, verificar que novas conversas Ryo/Kei aparecem sem `bff restart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)