### PR TITLE
[feat] Subject Knowledge Fase 1 — schema + parental_profile expand

### DIFF
--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -71,6 +71,67 @@ CREATE TABLE IF NOT EXISTS debug_actions (
 );
 CREATE INDEX IF NOT EXISTS idx_debug_actions_session
   ON debug_actions(session_id);
+
+-- Subject Knowledge — fundação pedagógica eBrota (spec 2026-05-25, Fase 1).
+-- Cross-session ledger por sujeito. Append-only. Schema-only nesta fase —
+-- writers (Discovery, Boundary, ConceptLedger, RecallCheck) entregues em
+-- Fases 2/3/5.
+CREATE TABLE IF NOT EXISTS subject_knowledge (
+  id            TEXT PRIMARY KEY,
+  subject_id    TEXT NOT NULL,
+  type          TEXT NOT NULL CHECK(type IN (
+    'interest', 'value', 'need', 'discovery',
+    'boundary_event', 'presented_concept',
+    'recall_check_attempt', 'vertical_affinity_signal'
+  )),
+  source        TEXT NOT NULL CHECK(source IN (
+    'self_declared', 'parent_claimed', 'motor_inferred'
+  )),
+  confidence    REAL NOT NULL,
+  confirmed_at  TEXT,
+  alignment     TEXT NOT NULL DEFAULT 'unknown' CHECK(alignment IN (
+    'aligned', 'neutral', 'divergent', 'unknown'
+  )),
+  payload_json  TEXT NOT NULL,
+  turn_ref      TEXT NOT NULL,
+  session_id    TEXT NOT NULL,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_sk_subject_type
+  ON subject_knowledge(subject_id, type);
+CREATE INDEX IF NOT EXISTS idx_sk_session
+  ON subject_knowledge(session_id);
+CREATE INDEX IF NOT EXISTS idx_sk_created_at
+  ON subject_knowledge(created_at);
+
+-- Sujeito-proposto materializado por subject_id. Derivado de
+-- parental_profile.aspirations + complementos clássicos. Versionado.
+CREATE TABLE IF NOT EXISTS subject_proposed (
+  subject_id            TEXT PRIMARY KEY,
+  version               INTEGER NOT NULL DEFAULT 1,
+  axes_active           TEXT NOT NULL,
+  complements_per_axis  TEXT NOT NULL,
+  reasoning_log         TEXT NOT NULL,
+  ratified_at           TEXT,
+  last_modified_at      TEXT NOT NULL
+);
+
+-- Sinais de afinidade com verticais (eixos/tradições) — pista pra flashes
+-- culturais e pra sugestões de ajuste no sujeito-proposto.
+CREATE TABLE IF NOT EXISTS vertical_affinity_signals (
+  id              TEXT PRIMARY KEY,
+  subject_id      TEXT NOT NULL,
+  vertical_kind   TEXT NOT NULL CHECK(vertical_kind IN ('axis', 'lineage')),
+  vertical_id     TEXT NOT NULL,
+  score_affinity  REAL NOT NULL,
+  evidence_count  INTEGER NOT NULL DEFAULT 1,
+  last_seen_at    TEXT NOT NULL,
+  in_base         INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_vas_subject
+  ON vertical_affinity_signals(subject_id);
+CREATE INDEX IF NOT EXISTS idx_vas_score
+  ON vertical_affinity_signals(score_affinity);
 `;
 
 export interface InitDbOptions {

--- a/packages/ebrota-console-bff/tests/db-subject-knowledge.test.ts
+++ b/packages/ebrota-console-bff/tests/db-subject-knowledge.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests do schema Subject Knowledge no BFF SQLite (spec 2026-05-25 Fase 1).
+ * Valida que as 3 tabelas novas criam, indexam, e aceitam payload válido.
+ *
+ * Writers e endpoints entregues em Fases 2/3/5/6 — aqui é só schema.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+let db: DatabaseType;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+});
+
+afterEach(() => {
+  db.close();
+});
+
+const tableExists = (name: string): boolean => {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+    .get(name) as { name: string } | undefined;
+  return row !== undefined;
+};
+
+const indexExists = (name: string): boolean => {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name=?")
+    .get(name) as { name: string } | undefined;
+  return row !== undefined;
+};
+
+describe("subject_knowledge schema", () => {
+  it("cria tabela com colunas e índices esperados", () => {
+    expect(tableExists("subject_knowledge")).toBe(true);
+    expect(indexExists("idx_sk_subject_type")).toBe(true);
+    expect(indexExists("idx_sk_session")).toBe(true);
+    expect(indexExists("idx_sk_created_at")).toBe(true);
+  });
+
+  it("aceita insert de interest discovery", () => {
+    db.prepare(
+      `INSERT INTO subject_knowledge (
+        id, subject_id, type, source, confidence, alignment,
+        payload_json, turn_ref, session_id
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "sk-1",
+      "ryo",
+      "interest",
+      "self_declared",
+      0.95,
+      "unknown",
+      JSON.stringify({ kind: "interest", label: "Dragon Ball", intensity: "high" }),
+      "sess1__turn0",
+      "sess1",
+    );
+    const row = db
+      .prepare("SELECT * FROM subject_knowledge WHERE id=?")
+      .get("sk-1") as { type: string; payload_json: string };
+    expect(row.type).toBe("interest");
+    const payload = JSON.parse(row.payload_json);
+    expect(payload.label).toBe("Dragon Ball");
+  });
+
+  it("aceita boundary_event com severity_band", () => {
+    db.prepare(
+      `INSERT INTO subject_knowledge (
+        id, subject_id, type, source, confidence,
+        payload_json, turn_ref, session_id
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "sk-2",
+      "ryo",
+      "boundary_event",
+      "motor_inferred",
+      0.85,
+      JSON.stringify({
+        kind: "boundary_event",
+        signal_type: "deflection_thematic",
+        topic_category: "tema_escolar_recente",
+        intensity: "mid",
+        motor_response: "muda_tema",
+        severity_band: "routine",
+      }),
+      "sess1__turn3",
+      "sess1",
+    );
+    const row = db
+      .prepare("SELECT payload_json FROM subject_knowledge WHERE id=?")
+      .get("sk-2") as { payload_json: string };
+    const p = JSON.parse(row.payload_json);
+    expect(p.severity_band).toBe("routine");
+    expect(p.topic_category).toBe("tema_escolar_recente");
+  });
+
+  it("rejeita type inválido", () => {
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO subject_knowledge (
+            id, subject_id, type, source, confidence,
+            payload_json, turn_ref, session_id
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "sk-bad",
+          "ryo",
+          "fake_type",
+          "self_declared",
+          0.5,
+          "{}",
+          "t",
+          "s",
+        ),
+    ).toThrow();
+  });
+
+  it("rejeita source inválido", () => {
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO subject_knowledge (
+            id, subject_id, type, source, confidence,
+            payload_json, turn_ref, session_id
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "sk-bad",
+          "ryo",
+          "interest",
+          "made_up",
+          0.5,
+          "{}",
+          "t",
+          "s",
+        ),
+    ).toThrow();
+  });
+});
+
+describe("subject_proposed schema", () => {
+  it("cria tabela", () => {
+    expect(tableExists("subject_proposed")).toBe(true);
+  });
+
+  it("aceita upsert de proposed", () => {
+    db.prepare(
+      `INSERT INTO subject_proposed (
+        subject_id, version, axes_active, complements_per_axis,
+        reasoning_log, ratified_at, last_modified_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "ryo",
+      1,
+      JSON.stringify([3, 4, 7]),
+      JSON.stringify({ 3: ["andreia", "yuki"], 4: ["shoshin"], 7: ["hesed"] }),
+      JSON.stringify({
+        3: "autoconfiança pedida + complemento bushido por afinidade",
+        4: "balanço autoconfiança via shoshin (zen)",
+        7: "empatia pedida + hesed (hebraica)",
+      }),
+      null,
+      new Date().toISOString(),
+    );
+    const row = db
+      .prepare("SELECT * FROM subject_proposed WHERE subject_id=?")
+      .get("ryo") as { version: number; axes_active: string };
+    expect(row.version).toBe(1);
+    expect(JSON.parse(row.axes_active)).toEqual([3, 4, 7]);
+  });
+});
+
+describe("vertical_affinity_signals schema", () => {
+  it("cria tabela com índices", () => {
+    expect(tableExists("vertical_affinity_signals")).toBe(true);
+    expect(indexExists("idx_vas_subject")).toBe(true);
+    expect(indexExists("idx_vas_score")).toBe(true);
+  });
+
+  it("aceita inserts e ordena por score", () => {
+    db.prepare(
+      `INSERT INTO vertical_affinity_signals (
+        id, subject_id, vertical_kind, vertical_id,
+        score_affinity, evidence_count, last_seen_at, in_base
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("vas-1", "ryo", "lineage", "estoica", 0.7, 3, "2026-05-25", 0);
+    db.prepare(
+      `INSERT INTO vertical_affinity_signals (
+        id, subject_id, vertical_kind, vertical_id,
+        score_affinity, evidence_count, last_seen_at, in_base
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("vas-2", "ryo", "axis", "6", 0.5, 2, "2026-05-25", 0);
+
+    const rows = db
+      .prepare(
+        "SELECT vertical_id FROM vertical_affinity_signals WHERE subject_id=? ORDER BY score_affinity DESC",
+      )
+      .all("ryo") as Array<{ vertical_id: string }>;
+    expect(rows.map((r) => r.vertical_id)).toEqual(["estoica", "6"]);
+  });
+
+  it("rejeita vertical_kind inválido", () => {
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO vertical_affinity_signals (
+            id, subject_id, vertical_kind, vertical_id,
+            score_affinity, last_seen_at
+          ) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("vas-x", "ryo", "wrong", "abc", 0.5, "2026-05-25"),
+    ).toThrow();
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -21,6 +21,7 @@ export * from "./status-matrix-repo-pg.js";
 export * from "./sacrifice-budget.js";
 export * from "./mixins/with-gardner-program.js";
 export * from "./parental-profile.js";
+export * from "./subject-knowledge.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/parental-profile.ts
+++ b/shared/src/parental-profile.ts
@@ -74,6 +74,34 @@ export type ParentDecisionProfile =
   | "decider_risk_averse"
   | "decider_permissive";
 
+/**
+ * Sujeito-proposto = ideal explícito do programa pedagógico.
+ *
+ * Spec: 2026-05-25-subject-knowledge-bridge.md §3.2.
+ * Separado de parental_perception (que descreve "o que pai vê") —
+ * aspirations é "para onde o programa caminha".
+ */
+export interface ParentalAspirations {
+  /** Traços-alvo declarados livremente pelos pais. */
+  proposed_traits?: string[];
+  /** Virtudes-alvo ancoradas no catálogo de eixos clássicos (axis_id 1..12). */
+  proposed_virtues?: Array<{ axis: number; note?: string }>;
+  /** Competências aplicadas declaradas. */
+  proposed_competencies?: string[];
+}
+
+/**
+ * Filtro cultural — pais podem bloquear tradições inteiras do catálogo.
+ * Validador deve alertar se bloqueio reduz algum eixo a <2 alternativas.
+ */
+export interface CulturalFilter {
+  allowed_lineages?: string[];
+  blocked_lineages?: string[];
+}
+
+/** Configuração de cadência de flashes culturais (verticais fora da base). */
+export type FlashesSetting = "off" | "occasional" | "frequent";
+
 export interface ParentalProfile {
   id: string;
   role: "primary" | "secondary";
@@ -85,6 +113,22 @@ export interface ParentalProfile {
   parental_perception?: ParentalPerception;
   /** Valor opcional: minutos desde onboarding; serve pra re-onboarding trimestral. */
   onboarding_completed_at?: string;
+
+  // --- Subject Knowledge fundação (spec 2026-05-25, fase 1 opcional) ---
+  /** Norte do programa: ideal estruturado pra onde o sujeito caminha. */
+  aspirations?: ParentalAspirations;
+  /** Necessidades latentes percebidas pelos pais (não exigem confirm do filho —
+   * motor endereça obliquamente via ponte tripla). */
+  latent_needs?: string[];
+  /** Interesses que os pais acham que o filho tem — PRECISAM ser confirmados
+   * pelo filho em conversa antes do scorer ativar boost. */
+  parent_claimed_interests?: string[];
+  /** Filtro de tradições clássicas para complementos do sujeito-proposto. */
+  cultural_filter?: CulturalFilter;
+  /** Cadência de flashes culturais (verticais fora da base). Default 'occasional'. */
+  flashes_setting?: FlashesSetting;
+  /** Budget de checagens de recall por sessão. 0..2, default 1. */
+  recall_check_budget_per_session?: number;
 }
 
 /** `true` se o perfil tem o mínimo pra Milestone 1 (§9 doc). */

--- a/shared/src/subject-knowledge.ts
+++ b/shared/src/subject-knowledge.ts
@@ -1,0 +1,155 @@
+/**
+ * Subject Knowledge — fundação pedagógica eBrota.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-subject-knowledge-bridge.md
+ *
+ * Fase 1: tipos de domínio. Tabelas SQL em ebrota-console-bff/src/db.ts.
+ * Writers/algoritmos em fases posteriores.
+ *
+ * Princípio organizador: produto navega o gap entre sujeito-real (descoberto
+ * via conversa) e sujeito-proposto (ideal parental + complementos clássicos).
+ */
+
+/**
+ * Tipos de evento que populam o ledger cross-session do sujeito.
+ *
+ * - interest/value/need/discovery: alimentam o sujeito-real
+ * - boundary_event: sinaliza o que o motor evitou (insumo parental)
+ * - presented_concept: Fact materializado (+1pt no eixo tocado)
+ * - recall_check_attempt: checagem ativa da IA (+5pt se positive)
+ * - vertical_affinity_signal: pista de interesse fora da base (candidato a flash)
+ */
+export type SubjectKnowledgeType =
+  | "interest"
+  | "value"
+  | "need"
+  | "discovery"
+  | "boundary_event"
+  | "presented_concept"
+  | "recall_check_attempt"
+  | "vertical_affinity_signal";
+
+export type SubjectKnowledgeSource =
+  | "self_declared"
+  | "parent_claimed"
+  | "motor_inferred";
+
+export type SubjectKnowledgeAlignment =
+  | "aligned"
+  | "neutral"
+  | "divergent"
+  | "unknown";
+
+export interface SubjectKnowledgeEntry {
+  id: string;
+  subject_id: string;
+  type: SubjectKnowledgeType;
+  source: SubjectKnowledgeSource;
+  confidence: number;
+  /** turn_ref quando foi confirmado; null = pendente (caso parent_claimed sem confirmação). */
+  confirmed_at: string | null;
+  alignment: SubjectKnowledgeAlignment;
+  /** Estrutura específica por type; ver spec §3.1.1 ou helpers abaixo. */
+  payload: SubjectKnowledgePayload;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+}
+
+export type SubjectKnowledgePayload =
+  | InterestPayload
+  | ValuePayload
+  | NeedPayload
+  | DiscoveryPayload
+  | BoundaryEventPayload
+  | PresentedConceptPayload
+  | RecallCheckAttemptPayload
+  | VerticalAffinitySignalPayload;
+
+export interface InterestPayload {
+  kind: "interest";
+  label: string;
+  evidence_phrase?: string;
+  intensity?: "low" | "mid" | "high";
+}
+
+export interface ValuePayload {
+  kind: "value";
+  label: string;
+  evidence_phrase?: string;
+}
+
+export interface NeedPayload {
+  kind: "need";
+  label: string;
+  reported_by_parent?: boolean;
+}
+
+export interface DiscoveryPayload {
+  kind: "discovery";
+  label: string;
+  detail?: string;
+}
+
+export interface BoundaryEventPayload {
+  kind: "boundary_event";
+  signal_type:
+    | "deflection_thematic"
+    | "gatekeeper_resistance"
+    | "frame_rejection"
+    | "distress_marker_low"
+    | "distress_marker_high"
+    | "exit_marker_implicit"
+    | "exit_marker_explicit"
+    | "mood_drift_down";
+  /** Categoria abstraída — NÃO conteúdo literal. Privacidade do sujeito. */
+  topic_category: string;
+  intensity: "low" | "mid" | "high";
+  motor_response: "muda_tema" | "suaviza" | "recua_total" | "outro";
+  severity_band: "routine" | "clinical_signal";
+}
+
+export interface PresentedConceptPayload {
+  kind: "presented_concept";
+  concept_id: string;
+  keywords: string[];
+  /** "tradicao/complemento" — ex: "estoica/dicotomia_controle" */
+  lineage_anchor: string;
+  /** 1..12 do catálogo de eixos */
+  axis_id: number;
+  family: "carater" | "disposicao" | "cognicao_si";
+  points: 1;
+}
+
+export interface RecallCheckAttemptPayload {
+  kind: "recall_check_attempt";
+  concept_id_referenced: string;
+  framing_used: string;
+  result: "positive" | "negative" | "ambiguous";
+  points_awarded: 0 | 5;
+}
+
+export interface VerticalAffinitySignalPayload {
+  kind: "vertical_affinity_signal";
+  vertical_kind: "axis" | "lineage";
+  vertical_id: string;
+  score_affinity: number;
+}
+
+/**
+ * Sujeito-proposto materializado: ideal parental + complementos clássicos
+ * escolhidos do catálogo de lineage. Versionado — muda quando pais ajustam.
+ */
+export interface SubjectProposed {
+  subject_id: string;
+  version: number;
+  /** IDs dos eixos do catálogo (1..12) ativos no programa. */
+  axes_active: number[];
+  /** Por eixo, lista de complement_ids (do catálogo) ativos. */
+  complements_per_axis: Record<number, string[]>;
+  /** Explicação por eixo: por que esses complementos foram propostos. */
+  reasoning_log: Record<number, string>;
+  /** ISO timestamp quando os pais ratificaram explicitamente. null = pendente. */
+  ratified_at: string | null;
+  last_modified_at: string;
+}

--- a/shared/tests/parental-profile-aspirations.test.ts
+++ b/shared/tests/parental-profile-aspirations.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests dos campos opcionais Subject Knowledge spec 2026-05-25 Fase 1.
+ * Garante que campos novos não quebram fixtures existentes — adoção gradual.
+ */
+import { describe, it, expect } from "vitest";
+import { isParentalProfileMinimal } from "../src/parental-profile.js";
+import type {
+  ParentalProfile,
+  ParentalAspirations,
+  CulturalFilter,
+  FlashesSetting,
+} from "../src/parental-profile.js";
+
+const baseMinimal: ParentalProfile = {
+  id: "yuji",
+  role: "primary",
+  decision_profile: "consultative_risk_averse",
+  family_values: { principles: ["esforço"] },
+  forbidden_zones: [{ topic: "x", reason: "y" }],
+  budget_constraints: {},
+  parental_availability: {},
+};
+
+describe("ParentalProfile — Subject Knowledge fields (opcionais)", () => {
+  it("perfil minimal sem campos novos continua válido", () => {
+    expect(isParentalProfileMinimal(baseMinimal)).toBe(true);
+  });
+
+  it("aceita aspirations completas sem afetar minimal", () => {
+    const aspirations: ParentalAspirations = {
+      proposed_traits: ["autoconfiança", "empatia"],
+      proposed_virtues: [
+        { axis: 3, note: "coragem civil" },
+        { axis: 7 },
+      ],
+      proposed_competencies: ["responsabilidade acadêmica"],
+    };
+    const p: ParentalProfile = { ...baseMinimal, aspirations };
+    expect(isParentalProfileMinimal(p)).toBe(true);
+    expect(p.aspirations?.proposed_virtues?.[0].axis).toBe(3);
+  });
+
+  it("aceita latent_needs e parent_claimed_interests distintos", () => {
+    const p: ParentalProfile = {
+      ...baseMinimal,
+      latent_needs: ["abertura emocional"],
+      parent_claimed_interests: ["Pokemon"],
+    };
+    expect(p.latent_needs).toHaveLength(1);
+    expect(p.parent_claimed_interests).toEqual(["Pokemon"]);
+  });
+
+  it("cultural_filter aceita allowed/blocked", () => {
+    const culturalFilter: CulturalFilter = {
+      allowed_lineages: ["aristotelica", "estoica", "bushido", "zen"],
+      blocked_lineages: [],
+    };
+    const p: ParentalProfile = { ...baseMinimal, cultural_filter: culturalFilter };
+    expect(p.cultural_filter?.allowed_lineages).toContain("estoica");
+  });
+
+  it("flashes_setting aceita as 3 variantes", () => {
+    const variants: FlashesSetting[] = ["off", "occasional", "frequent"];
+    for (const v of variants) {
+      const p: ParentalProfile = { ...baseMinimal, flashes_setting: v };
+      expect(p.flashes_setting).toBe(v);
+    }
+  });
+
+  it("recall_check_budget_per_session aceita 0..2", () => {
+    for (const n of [0, 1, 2]) {
+      const p: ParentalProfile = {
+        ...baseMinimal,
+        recall_check_budget_per_session: n,
+      };
+      expect(p.recall_check_budget_per_session).toBe(n);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fase 1 da [spec Subject Knowledge + Bridge Tutor Clássico](https://github.com/ascendimacy/ascendimacy-ops/blob/docs/c-mx-07-c-mx-08-specs/docs/specs/2026-05-25-subject-knowledge-bridge.md) — fundação de dados pra navegar o gap entre sujeito-real e sujeito-proposto.

**Zero mudança comportamental.** Writers/algoritmos virão em Fases 2-7. Tudo o que muda agora: tipos TS + 3 tabelas SQLite + 6 campos opcionais no \`ParentalProfile\`.

### Tipos TS novos (\`shared/src/subject-knowledge.ts\`)
- \`SubjectKnowledgeType\`: 8 variantes (interest/value/need/discovery/boundary_event/presented_concept/recall_check_attempt/vertical_affinity_signal)
- \`SubjectKnowledgeEntry\` com payload tagged por type
- \`SubjectProposed\` (norte pedagógico versionado)

### Campos novos em \`ParentalProfile\` (todos opcionais)
- \`aspirations\` (proposed_traits/virtues/competencies) — separado de \`parental_perception\`
- \`latent_needs[]\` (não exigem confirmação do filho)
- \`parent_claimed_interests[]\` (precisam confirmação antes de boost no scorer)
- \`cultural_filter\` (allowed/blocked lineages)
- \`flashes_setting\` (off/occasional/frequent)
- \`recall_check_budget_per_session\` (0..2)

### 3 tabelas novas no BFF SQLite
- \`subject_knowledge\` (append-only ledger cross-session com CHECK constraints + 3 índices)
- \`subject_proposed\` (1 por sujeito, versionado)
- \`vertical_affinity_signals\` (candidatos a flash, indexado por score)

## Test plan
- [x] \`shared/tests/parental-profile-aspirations.test.ts\` — 6 tests (campos opcionais não quebram \`isParentalProfileMinimal\`)
- [x] \`packages/ebrota-console-bff/tests/db-subject-knowledge.test.ts\` — 10 tests (tabelas criam, índices existem, CHECK constraints funcionam, inserts/queries OK)
- [x] Suite total: 1.412 passing, zero regressão (shared 686 / motor 298 / planejador 321 / bff 107)
- [x] Build verde em 4 workspaces

## Próximos passos
- Fase 2: \`DiscoveryWriter\` + \`BoundaryEventWriter\` (popula as tabelas)
- Fase 3: \`InauguralTemplate\` contract + \`ConceptLedgerWriter\`
- Fase 4: Catálogo de eixos YAML (12 eixos × ~48 complementos)

Ajustes on-the-fly: schema é extensivo via migration aditiva; campos opcionais permitem evolução sem breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)