### PR TITLE
[feat] Subject Knowledge Fase 4 — catálogo lineage YAML (12 eixos × 48 complementos)

### DIFF
--- a/motor-drota/data/lineage-catalog.yaml
+++ b/motor-drota/data/lineage-catalog.yaml
@@ -1,0 +1,432 @@
+# Lineage Catalog v1 — vocabulário fechado de tradições clássicas
+#
+# Spec: ascendimacy-ops/docs/specs/2026-05-25-subject-knowledge-bridge.md §2
+# Estrutura: 3 famílias × 4 eixos = 12 eixos, com ~48 complementos plurais
+# de 9 tradições.
+#
+# Princípio de redundância (validado no loader):
+#   cada eixo precisa ≥3 complementos de tradições distintas
+#   pra honrar opt-in parental sem coerção mascarada.
+#
+# Editar com cuidado: este arquivo é fundação pedagógica.
+
+version: 1
+
+axes:
+  # ─── Família CARÁTER (virtudes cardinais) ────────────────────────
+
+  - id: 1
+    family: carater
+    name: Prudência / Sabedoria-prática
+    balances:
+      - impulsividade
+      - dogmatismo
+      - perfeccionismo_paralisante
+      - regra_cega
+    complements:
+      - id: phronesis
+        lineage: aristotelica
+        axis_id: 1
+        short_definition: >-
+          sabedoria prática — discernir o agir certo aqui-agora,
+          não regra geral
+        youth_example: >-
+          "qual o tipo de jogada que cabe NESTE momento, não em todos?"
+      - id: dicotomia_controle
+        lineage: estoica
+        axis_id: 1
+        short_definition: >-
+          distinguir o que está sob mim do que não está; agir só
+          onde tenho controle
+        youth_example: '"isso que te chateou — depende de você ou não?"'
+        shared_with_axes: [12]
+      - id: wu_wei
+        lineage: taoista
+        axis_id: 1
+        short_definition: >-
+          ação-sem-forçar; saber quando esperar e quando agir
+        youth_example: '"às vezes a melhor jogada é não jogada"'
+      - id: da_xue_reflexao
+        lineage: confucionista
+        axis_id: 1
+        short_definition: >-
+          reflexão sistemática antes da ação
+          ("investigar coisas para conhecer")
+        youth_example: '"antes de responder no grupo, o que você sabe de fato?"'
+
+  - id: 2
+    family: carater
+    name: Justiça / Equanimidade
+    balances:
+      - favoritismo
+      - partidarização
+      - indiferença
+      - retribuição_vingativa
+    complements:
+      - id: justica_aristotelica
+        lineage: aristotelica
+        axis_id: 2
+        short_definition: >-
+          dar a cada um o que lhe é devido conforme proporção
+        youth_example: '"no time, o esforço de cada um conta como?"'
+      - id: mishpat
+        lineage: hebraica
+        axis_id: 2
+        short_definition: >-
+          justiça como fidelidade ao bem-do-outro, não só regra
+        youth_example: '"amigo errado merece o quê de você?"'
+      - id: ren_li
+        lineage: confucionista
+        axis_id: 2
+        short_definition: >-
+          humanidade-em-ritual — tratamento adequado a cada relação
+        youth_example: '"como você se dirige a um professor vs um colega?"'
+      - id: equanimidade_estoica
+        lineage: estoica
+        axis_id: 2
+        short_definition: >-
+          não dar peso desigual a si vs aos outros nos cálculos morais
+        youth_example: '"se fosse outra pessoa fazendo isso, você acharia ok?"'
+
+  - id: 3
+    family: carater
+    name: Fortaleza / Coragem
+    balances:
+      - timidez
+      - conformismo
+      - evitamento_de_confronto
+      - fuga_de_responsabilidade
+    complements:
+      - id: andreia
+        lineage: paideia
+        axis_id: 3
+        short_definition: >-
+          coragem grega — enfrentar perigo ou desconforto justo
+        youth_example: '"tem coisa que você não diz por medo? qual?"'
+      - id: yuki
+        lineage: bushido
+        axis_id: 3
+        short_definition: >-
+          coragem em ato — não recuar quando o certo é avançar
+        youth_example: '"naquele momento, o que você queria ter feito?"'
+      - id: hupomone_cristã
+        lineage: cristã
+        axis_id: 3
+        short_definition: >-
+          suportar sob pressão sem ceder ao mal — coragem-de-permanecer
+        youth_example: >-
+          "quando o grupo fez X, você continuou no que acreditava
+          ou foi com?"
+      - id: parresia
+        lineage: paideia
+        axis_id: 3
+        short_definition: >-
+          falar a verdade mesmo em desvantagem social
+        youth_example: '"tem coisa que precisava ser dita e você engoliu?"'
+        shared_with_axes: [9]
+
+  - id: 4
+    family: carater
+    name: Temperança / Medida
+    balances:
+      - excesso
+      - busca_de_prazer_rapido
+      - perda_de_medida_em_vitoria_ou_derrota
+    complements:
+      - id: sophrosyne
+        lineage: paideia
+        axis_id: 4
+        short_definition: >-
+          autocontrole equilibrado — "saúde da alma"
+        youth_example: '"quando você quer muito X, o que acontece com Y?"'
+      - id: enkrateia
+        lineage: aristotelica
+        axis_id: 4
+        short_definition: >-
+          domínio de si frente ao impulso
+        youth_example: '"deu vontade de respondar — você respondeu? por quê?"'
+      - id: shoshin
+        lineage: zen
+        axis_id: 4
+        short_definition: >-
+          mente-de-iniciante — não inflar pelo que já se sabe
+        youth_example: '"depois que você acertou aquilo, ficou difícil treinar como?"'
+        shared_with_axes: [10]
+      - id: mochizoku
+        lineage: bushido
+        axis_id: 4
+        short_definition: >-
+          suficiência — saber a hora de parar
+        youth_example: '"tem hora que você sabe que é bastante? como você sente?"'
+
+  # ─── Família DISPOSIÇÃO (afetivo-existencial-relacional) ──────────
+
+  - id: 5
+    family: disposicao
+    name: Confiança / Fé-em-sentido
+    balances:
+      - niilismo
+      - paralisia_existencial
+      - ceticismo_defensivo
+    complements:
+      - id: emunah
+        lineage: hebraica
+        axis_id: 5
+        short_definition: >-
+          confiança fiel — lealdade no vínculo apesar da dúvida
+        youth_example: '"no que você ainda aposta mesmo sem ver garantia?"'
+      - id: pistis_cristã
+        lineage: cristã
+        axis_id: 5
+        short_definition: >-
+          fé como adesão a um sentido maior, não certeza
+        youth_example: '"tem coisa que você acredita mesmo sem provar?"'
+      - id: assentir_estoico
+        lineage: estoica
+        axis_id: 5
+        short_definition: >-
+          dar consentimento ativo ao real, não submissão passiva
+        youth_example: >-
+          "o que aconteceu — você briga com isso ou aceita pra
+          trabalhar com?"
+      - id: xin_confucionista
+        lineage: confucionista
+        axis_id: 5
+        short_definition: >-
+          confiabilidade — ser alguém em quem se pode confiar
+        youth_example: '"as pessoas podem contar com você no quê?"'
+
+  - id: 6
+    family: disposicao
+    name: Esperança / Persistência ativa
+    balances:
+      - desanimo
+      - vitimização
+      - abandono_em_meio_ao_processo
+    complements:
+      - id: gaman
+        lineage: bushido
+        axis_id: 6
+        short_definition: >-
+          suportar com dignidade enquanto se age, não passivo
+        youth_example: '"quando ficou difícil, você continuou como?"'
+      - id: hupomone_persistencia
+        lineage: cristã
+        axis_id: 6
+        short_definition: >-
+          paciência ativa — ficar com o que ainda não amadureceu
+        youth_example: '"você esperou alguma coisa por muito tempo? como foi?"'
+      - id: amor_fati
+        lineage: estoica
+        axis_id: 6
+        short_definition: >-
+          amar o que se passa — transformar em material de crescimento
+        youth_example: '"essa coisa chata — o que ela te ensinou?"'
+      - id: tikvah
+        lineage: hebraica
+        axis_id: 6
+        short_definition: >-
+          esperança como ato de manter o fio aberto pro futuro
+        youth_example: '"quando você imagina daqui um ano, o que aparece?"'
+
+  - id: 7
+    family: disposicao
+    name: Compaixão / Vínculo
+    balances:
+      - competitividade_isolada
+      - frieza
+      - indiferença_ao_outro
+    complements:
+      - id: agape
+        lineage: cristã
+        axis_id: 7
+        short_definition: >-
+          amor que quer o bem do outro independente de retorno
+        youth_example: '"tem alguém em quem você pensa sem esperar nada?"'
+      - id: hesed
+        lineage: hebraica
+        axis_id: 7
+        short_definition: >-
+          gentileza-em-ato — compromisso amoroso com vínculo
+        youth_example: '"como você mostra que se importa sem dizer?"'
+      - id: ren
+        lineage: confucionista
+        axis_id: 7
+        short_definition: >-
+          humanidade-no-trato — sentir o que o outro sente
+        youth_example: '"o que o outro tava sentindo ali? você conseguiu pegar?"'
+      - id: karuna
+        lineage: zen
+        axis_id: 7
+        short_definition: >-
+          compaixão como reconhecer sofrimento e querer mitigar
+        youth_example: '"quando alguém tá mal, o que você faz?"'
+
+  - id: 8
+    family: disposicao
+    name: Gratidão / Reverência
+    balances:
+      - direito_adquirido
+      - cinismo
+      - achatamento_simbolico
+    complements:
+      - id: eucharistia
+        lineage: cristã
+        axis_id: 8
+        short_definition: >-
+          gratidão-em-celebração — reconhecer o dado
+        youth_example: '"o que te chegou hoje que você não pediu?"'
+      - id: xiao
+        lineage: confucionista
+        axis_id: 8
+        short_definition: >-
+          piedade filial — dever amoroso pra com quem nos formou
+        youth_example: '"o que você deve a quem te criou? como mostra?"'
+      - id: prosoche_estoica
+        lineage: estoica
+        axis_id: 8
+        short_definition: >-
+          atenção plena ao que está acontecendo agora como dom
+        youth_example: '"o que tá acontecendo agora que você nem notava?"'
+      - id: kansha
+        lineage: zen
+        axis_id: 8
+        short_definition: >-
+          gratidão como prática de ver-com-clareza
+        youth_example: '"feche os olhos. o que tem aí que merece atenção?"'
+
+  # ─── Família COGNIÇÃO-DE-SI (meta-cognitivo, agência) ────────────
+
+  - id: 9
+    family: cognicao_si
+    name: Veracidade / Honestidade
+    balances:
+      - conveniencia_social
+      - mascara
+      - conflito_avoidance_habitual
+    complements:
+      - id: parresia_veracidade
+        lineage: paideia
+        axis_id: 9
+        short_definition: >-
+          falar a verdade mesmo em desvantagem social
+        youth_example: '"tem coisa que você sabia e não falou?"'
+      - id: makoto
+        lineage: bushido
+        axis_id: 9
+        short_definition: >-
+          sinceridade-de-coração — alinhamento entre dentro e fora
+        youth_example: '"você fica diferente dependendo de quem tá perto?"'
+      - id: aletheia
+        lineage: paideia
+        axis_id: 9
+        short_definition: >-
+          verdade como des-velamento — ver o que estava encoberto
+        youth_example: '"tem coisa que você não queria ver e agora vê?"'
+      - id: emet
+        lineage: hebraica
+        axis_id: 9
+        short_definition: >-
+          verdade como solidez e fidelidade no longo prazo
+        youth_example: '"o que você fala continua de pé daqui um ano?"'
+
+  - id: 10
+    family: cognicao_si
+    name: Curiosidade / Mente-aberta
+    balances:
+      - dogmatismo
+      - fechamento
+      - falsa_certeza_adolescente
+    complements:
+      - id: shoshin_curiosidade
+        lineage: zen
+        axis_id: 10
+        short_definition: >-
+          mente-de-iniciante — olhar como se fosse a primeira vez
+        youth_example: '"essa coisa que você já conhece — o que ainda não sabe dela?"'
+      - id: thaumazein
+        lineage: paideia
+        axis_id: 10
+        short_definition: >-
+          espanto filosófico — admirar como início da pergunta
+        youth_example: '"quando foi a última vez que você ficou surpreso de verdade?"'
+      - id: aprender_aristotelico
+        lineage: aristotelica
+        axis_id: 10
+        short_definition: >-
+          desejo natural de saber — "todos os homens querem saber"
+        youth_example: '"o que você quer entender e ninguém te explica?"'
+      - id: wu_zhi_taoista
+        lineage: taoista
+        axis_id: 10
+        short_definition: >-
+          reconhecer o não-saber como abertura, não falha
+        youth_example: '"tem coisa que você não sabe e isso é bom?"'
+
+  - id: 11
+    family: cognicao_si
+    name: Autoconhecimento / Intrapessoal
+    balances:
+      - autoengano
+      - alienação
+      - identidade_emprestada_do_grupo
+    complements:
+      - id: gnothi_seauton
+        lineage: paideia
+        axis_id: 11
+        short_definition: >-
+          "conhece-te a ti mesmo" — máxima délfica
+        youth_example: '"o que você sabe de você que ninguém mais sabe?"'
+      - id: examen_estoico
+        lineage: estoica
+        axis_id: 11
+        short_definition: >-
+          exame regular do dia — o que fiz, o que poderia ter feito
+        youth_example: '"olhando o dia de hoje, onde você acha que pisou na bola?"'
+      - id: mokuso
+        lineage: bushido
+        axis_id: 11
+        short_definition: >-
+          introspecção silenciosa antes da ação
+        youth_example: '"antes de responder o grupo, você parou pra pensar?"'
+      - id: lev_hebraico
+        lineage: hebraica
+        axis_id: 11
+        short_definition: >-
+          "coração" como sede integrada de pensar+sentir+querer;
+          conhecer o próprio lev
+        youth_example: '"o que seu coração quer mesmo aqui? não o que parece bonito"'
+
+  - id: 12
+    family: cognicao_si
+    name: Responsabilidade / Agência
+    balances:
+      - externalismo
+      - vitimização
+      - dependencia
+      - desresponsabilização_adolescente
+    complements:
+      - id: dicotomia_controle_responsabilidade
+        lineage: estoica
+        axis_id: 12
+        short_definition: >-
+          identificar o que é meu agir e assumir; descartar o resto
+        youth_example: '"isso que aconteceu — qual a parte sua?"'
+      - id: giri
+        lineage: bushido
+        axis_id: 12
+        short_definition: >-
+          dever moral devido por vínculo, assumido sem reclamação
+        youth_example: '"você prometeu — agora?"'
+      - id: kavod
+        lineage: hebraica
+        axis_id: 12
+        short_definition: >-
+          honra pessoal como responsabilidade por carregar nome/vínculo
+        youth_example: '"o que você não faria porque te diminui?"'
+      - id: proairesis
+        lineage: aristotelica
+        axis_id: 12
+        short_definition: >-
+          escolha deliberada — distinguir o que escolho do que acontece comigo
+        youth_example: '"isso foi escolha sua ou foi você sendo levado?"'

--- a/motor-drota/package.json
+++ b/motor-drota/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/server.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "postbuild": "mkdir -p dist/prompts && cp src/prompts/*.txt dist/prompts/",
+    "postbuild": "mkdir -p dist/prompts && cp src/prompts/*.txt dist/prompts/ && mkdir -p dist/data && cp data/*.yaml dist/data/",
     "test": "vitest run",
     "start": "node dist/server.js",
     "clean": "rm -rf dist"
@@ -14,6 +14,8 @@
   "dependencies": {
     "@ascendimacy/shared": "*",
     "@modelcontextprotocol/sdk": "^1.10.2",
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/motor-drota/src/lineage-catalog-loader.ts
+++ b/motor-drota/src/lineage-catalog-loader.ts
@@ -1,0 +1,96 @@
+/**
+ * Loader do Lineage Catalog YAML — motor-drota.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-subject-knowledge-bridge.md §2.
+ *
+ * Carrega motor-drota/data/lineage-catalog.yaml, valida estrutura,
+ * disponibiliza API para consulta (filtrada por cultural_filter parental).
+ *
+ * Falha hard se validação produz qualquer issue de nível "error" — não
+ * deixa o sistema rodar com catálogo inconsistente que viole redundância
+ * mínima por eixo (≥3 tradições distintas).
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+import {
+  validateLineageCatalog,
+  type LineageCatalog,
+  type LineageCatalogValidationIssue,
+} from "@ascendimacy/shared";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Path default do catálogo YAML; sobe da pasta dist/ até motor-drota/data/. */
+export const DEFAULT_CATALOG_PATH = join(
+  __dirname,
+  "..",
+  "data",
+  "lineage-catalog.yaml",
+);
+
+export interface LoadCatalogOptions {
+  /** Override do path (útil em tests). Default: motor-drota/data/lineage-catalog.yaml */
+  path?: string;
+  /** Se true (default), throw em issues de nível "error". Se false, retorna catálogo + issues. */
+  strict?: boolean;
+}
+
+export interface LoadCatalogResult {
+  catalog: LineageCatalog;
+  issues: LineageCatalogValidationIssue[];
+}
+
+/**
+ * Carrega e valida o catálogo. Em strict mode (default), lança erro
+ * se qualquer issue de nível "error" for encontrado.
+ */
+export function loadLineageCatalog(opts: LoadCatalogOptions = {}): LoadCatalogResult {
+  const path = opts.path ?? DEFAULT_CATALOG_PATH;
+  const strict = opts.strict ?? true;
+
+  const raw = readFileSync(path, "utf-8");
+  const parsed = yaml.load(raw);
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`lineage-catalog: YAML root inválido em ${path}`);
+  }
+  const catalog = parsed as LineageCatalog;
+  if (!Array.isArray(catalog.axes)) {
+    throw new Error(`lineage-catalog: campo 'axes' obrigatório (array) em ${path}`);
+  }
+
+  const issues = validateLineageCatalog(catalog);
+  if (strict) {
+    const errors = issues.filter((i) => i.level === "error");
+    if (errors.length > 0) {
+      const summary = errors
+        .map((i) => `  [${i.code}] ${i.message}`)
+        .join("\n");
+      throw new Error(
+        `lineage-catalog: ${errors.length} erro(s) de validação:\n${summary}`,
+      );
+    }
+  }
+
+  return { catalog, issues };
+}
+
+/**
+ * Singleton lazy — primeira chamada carrega; subsequentes retornam cache.
+ * Reset via resetCatalogCache() em testes.
+ */
+let cachedCatalog: LineageCatalog | undefined;
+
+export function getCatalog(): LineageCatalog {
+  if (cachedCatalog === undefined) {
+    cachedCatalog = loadLineageCatalog().catalog;
+  }
+  return cachedCatalog;
+}
+
+export function resetCatalogCache(): void {
+  cachedCatalog = undefined;
+}

--- a/motor-drota/tests/lineage-catalog-loader.test.ts
+++ b/motor-drota/tests/lineage-catalog-loader.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests do loader do Lineage Catalog (spec 2026-05-25 Fase 4).
+ * Cobre: parsing, validação estrutural, redundância por eixo, filtros culturais.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { dump as yamlDump } from "js-yaml";
+import {
+  loadLineageCatalog,
+  getCatalog,
+  resetCatalogCache,
+  DEFAULT_CATALOG_PATH,
+} from "../src/lineage-catalog-loader.js";
+import {
+  getComplementsForAxis,
+  getAxis,
+  getComplement,
+  LINEAGE_TRADITIONS,
+  validateLineageCatalog,
+  type LineageCatalog,
+} from "@ascendimacy/shared";
+
+beforeEach(() => {
+  resetCatalogCache();
+});
+
+describe("loadLineageCatalog — default path (catálogo v1)", () => {
+  it("carrega motor-drota/data/lineage-catalog.yaml sem erros", () => {
+    const result = loadLineageCatalog();
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors).toEqual([]);
+  });
+
+  it("contém exatamente 12 eixos", () => {
+    const { catalog } = loadLineageCatalog();
+    expect(catalog.axes).toHaveLength(12);
+  });
+
+  it("cada eixo tem ≥3 complementos de tradições distintas (redundância opt-in)", () => {
+    const { catalog } = loadLineageCatalog();
+    for (const axis of catalog.axes) {
+      const traditions = new Set(axis.complements.map((c) => c.lineage));
+      expect(traditions.size).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("famílias mapeiam corretamente: 1-4 carater, 5-8 disposicao, 9-12 cognicao_si", () => {
+    const { catalog } = loadLineageCatalog();
+    for (const axis of catalog.axes) {
+      if (axis.id <= 4) expect(axis.family).toBe("carater");
+      else if (axis.id <= 8) expect(axis.family).toBe("disposicao");
+      else expect(axis.family).toBe("cognicao_si");
+    }
+  });
+
+  it("todas as tradições usadas estão no vocabulário fechado", () => {
+    const { catalog } = loadLineageCatalog();
+    for (const axis of catalog.axes) {
+      for (const c of axis.complements) {
+        expect(LINEAGE_TRADITIONS).toContain(c.lineage);
+      }
+    }
+  });
+
+  it("axis_id em cada complement bate com axis_id do eixo pai", () => {
+    const { catalog } = loadLineageCatalog();
+    for (const axis of catalog.axes) {
+      for (const c of axis.complements) {
+        expect(c.axis_id).toBe(axis.id);
+      }
+    }
+  });
+
+  it("DEFAULT_CATALOG_PATH aponta pra arquivo existente", () => {
+    expect(DEFAULT_CATALOG_PATH).toMatch(/lineage-catalog\.yaml$/);
+  });
+});
+
+describe("getCatalog — singleton cache", () => {
+  it("retorna a mesma instância nas chamadas subsequentes", () => {
+    const c1 = getCatalog();
+    const c2 = getCatalog();
+    expect(c1).toBe(c2);
+  });
+
+  it("resetCatalogCache força recarga", () => {
+    const c1 = getCatalog();
+    resetCatalogCache();
+    const c2 = getCatalog();
+    expect(c1).not.toBe(c2);
+    expect(c1.axes).toHaveLength(c2.axes.length);
+  });
+});
+
+describe("getAxis / getComplement / getComplementsForAxis (helpers)", () => {
+  it("getAxis encontra eixo por ID", () => {
+    const cat = getCatalog();
+    const axis3 = getAxis(cat, 3);
+    expect(axis3?.name).toMatch(/Fortaleza/);
+  });
+
+  it("getComplement encontra complement em qualquer eixo", () => {
+    const cat = getCatalog();
+    const phronesis = getComplement(cat, "phronesis");
+    expect(phronesis?.lineage).toBe("aristotelica");
+    expect(phronesis?.axis_id).toBe(1);
+  });
+
+  it("getComplementsForAxis filtra por allowed_lineages", () => {
+    const cat = getCatalog();
+    const filtered = getComplementsForAxis(cat, 4, {
+      allowed: ["zen", "estoica"],
+    });
+    expect(filtered.every((c) => c.lineage === "zen" || c.lineage === "estoica")).toBe(true);
+    expect(filtered.length).toBeGreaterThan(0);
+  });
+
+  it("getComplementsForAxis filtra por blocked_lineages", () => {
+    const cat = getCatalog();
+    const all = getComplementsForAxis(cat, 7);
+    const blocked = getComplementsForAxis(cat, 7, { blocked: ["cristã"] });
+    expect(blocked.length).toBe(all.length - 1);
+    expect(blocked.every((c) => c.lineage !== "cristã")).toBe(true);
+  });
+
+  it("sem filtro retorna todos os complements do eixo", () => {
+    const cat = getCatalog();
+    const all = getComplementsForAxis(cat, 1);
+    expect(all.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("validateLineageCatalog — detecção de issues", () => {
+  it("detecta eixo com tradições insuficientes (redundância <3)", () => {
+    const bad: LineageCatalog = {
+      version: 1,
+      axes: Array.from({ length: 12 }, (_, i) => ({
+        id: i + 1,
+        family: i < 4 ? "carater" : i < 8 ? "disposicao" : "cognicao_si",
+        name: `Eixo ${i + 1}`,
+        balances: [],
+        complements: [
+          { id: `a${i}`, lineage: "estoica", axis_id: i + 1, short_definition: "x", youth_example: "y" },
+          { id: `b${i}`, lineage: "estoica", axis_id: i + 1, short_definition: "x", youth_example: "y" },
+        ],
+      })),
+    };
+    const issues = validateLineageCatalog(bad);
+    const redundancyIssues = issues.filter((i) => i.code === "axis_redundancy_insufficient");
+    expect(redundancyIssues.length).toBe(12);
+  });
+
+  it("detecta axis_id duplicado", () => {
+    const bad: LineageCatalog = {
+      version: 1,
+      axes: [
+        {
+          id: 1,
+          family: "carater",
+          name: "A",
+          balances: [],
+          complements: [
+            { id: "x1", lineage: "estoica", axis_id: 1, short_definition: "x", youth_example: "y" },
+            { id: "x2", lineage: "zen", axis_id: 1, short_definition: "x", youth_example: "y" },
+            { id: "x3", lineage: "paideia", axis_id: 1, short_definition: "x", youth_example: "y" },
+          ],
+        },
+        {
+          id: 1,
+          family: "carater",
+          name: "A dup",
+          balances: [],
+          complements: [
+            { id: "y1", lineage: "estoica", axis_id: 1, short_definition: "x", youth_example: "y" },
+            { id: "y2", lineage: "zen", axis_id: 1, short_definition: "x", youth_example: "y" },
+            { id: "y3", lineage: "paideia", axis_id: 1, short_definition: "x", youth_example: "y" },
+          ],
+        },
+      ],
+    };
+    const issues = validateLineageCatalog(bad);
+    expect(issues.some((i) => i.code === "axis_id_duplicate")).toBe(true);
+  });
+
+  it("warning quando family não bate com mapeamento esperado por axis_id", () => {
+    const bad: LineageCatalog = {
+      version: 1,
+      axes: Array.from({ length: 12 }, (_, i) => ({
+        id: i + 1,
+        family: "carater" as const, // todos como carater — eixos 5..12 vão warning
+        name: `Eixo ${i + 1}`,
+        balances: [],
+        complements: [
+          { id: `${i}a`, lineage: "estoica", axis_id: i + 1, short_definition: "x", youth_example: "y" },
+          { id: `${i}b`, lineage: "zen", axis_id: i + 1, short_definition: "x", youth_example: "y" },
+          { id: `${i}c`, lineage: "paideia", axis_id: i + 1, short_definition: "x", youth_example: "y" },
+        ],
+      })),
+    };
+    const issues = validateLineageCatalog(bad);
+    const warnings = issues.filter((i) => i.code === "axis_family_unexpected");
+    expect(warnings.length).toBe(8);
+  });
+});
+
+describe("loadLineageCatalog — strict mode + erros", () => {
+  it("strict (default) lança erro quando catálogo é inválido", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "lineage-bad-"));
+    const path = join(tmp, "bad-catalog.yaml");
+    const badCat = {
+      version: 1,
+      axes: [
+        {
+          id: 1, family: "carater", name: "x", balances: [],
+          complements: [
+            { id: "a", lineage: "estoica", axis_id: 1, short_definition: "x", youth_example: "y" },
+          ],
+        },
+      ],
+    };
+    writeFileSync(path, yamlDump(badCat));
+    expect(() => loadLineageCatalog({ path })).toThrow(/erro\(s\) de validação/);
+  });
+
+  it("strict=false retorna catálogo + issues mesmo com erros", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "lineage-bad-"));
+    const path = join(tmp, "bad-catalog.yaml");
+    const badCat = {
+      version: 1,
+      axes: [
+        {
+          id: 1, family: "carater", name: "x", balances: [],
+          complements: [
+            { id: "a", lineage: "estoica", axis_id: 1, short_definition: "x", youth_example: "y" },
+          ],
+        },
+      ],
+    };
+    writeFileSync(path, yamlDump(badCat));
+    const { catalog, issues } = loadLineageCatalog({ path, strict: false });
+    expect(catalog.axes).toHaveLength(1);
+    expect(issues.some((i) => i.level === "error")).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,8 @@
       "dependencies": {
         "@ascendimacy/shared": "*",
         "@modelcontextprotocol/sdk": "^1.10.2",
+        "@types/js-yaml": "^4.0.9",
+        "js-yaml": "^4.1.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -2191,7 +2193,6 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -21,6 +21,7 @@ export * from "./status-matrix-repo-pg.js";
 export * from "./sacrifice-budget.js";
 export * from "./mixins/with-gardner-program.js";
 export * from "./parental-profile.js";
+export * from "./lineage-catalog.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/lineage-catalog.ts
+++ b/shared/src/lineage-catalog.ts
@@ -1,0 +1,234 @@
+/**
+ * Lineage Catalog — vocabulário fechado de tradições clássicas usado
+ * pelo Tutor para compor o sujeito-proposto via ponte tripla.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-subject-knowledge-bridge.md §2.
+ *
+ * Tipos canônicos cross-workspace. Loader + YAML em motor-drota/.
+ *
+ * Princípio de redundância (auditado na validação):
+ *   cada eixo (1..12) deve ter ≥3 complementos de tradições distintas
+ *   pra honrar opt-in parental sem cair em coerção mascarada.
+ */
+
+/** Vocabulário fechado das 9 tradições disponíveis na v1. */
+export type LineageTradition =
+  | "aristotelica"
+  | "paideia"
+  | "estoica"
+  | "bushido"
+  | "zen"
+  | "cristã"
+  | "hebraica"
+  | "confucionista"
+  | "taoista";
+
+export const LINEAGE_TRADITIONS: readonly LineageTradition[] = [
+  "aristotelica",
+  "paideia",
+  "estoica",
+  "bushido",
+  "zen",
+  "cristã",
+  "hebraica",
+  "confucionista",
+  "taoista",
+] as const;
+
+/** Famílias do catálogo (3 famílias × 4 eixos = 12 eixos). */
+export type CatalogFamily = "carater" | "disposicao" | "cognicao_si";
+
+export const CATALOG_FAMILIES: readonly CatalogFamily[] = [
+  "carater",
+  "disposicao",
+  "cognicao_si",
+] as const;
+
+/**
+ * Um complemento clássico = elemento atômico do catálogo.
+ *
+ * id é único globalmente (ex: "phronesis"); appears em apenas um eixo
+ * (exceto raros casos de overlap intencional documentados no campo
+ * shared_with_axes).
+ */
+export interface LineageComplement {
+  id: string;
+  lineage: LineageTradition;
+  /** 1..12 do catálogo */
+  axis_id: number;
+  /** Definição-resumo (1-2 linhas). */
+  short_definition: string;
+  /** Exemplo aplicado ao desenvolvimento infantil/adolescente. */
+  youth_example: string;
+  /** Eixos secundários onde o conceito também se aplica (uso raro). */
+  shared_with_axes?: number[];
+}
+
+export interface LineageAxis {
+  id: number;
+  family: CatalogFamily;
+  name: string;
+  /** O que esse eixo balanceia / corrige. */
+  balances: string[];
+  complements: LineageComplement[];
+}
+
+export interface LineageCatalog {
+  version: number;
+  axes: LineageAxis[];
+}
+
+/**
+ * Resultado da validação estrutural — usado tanto no loader quanto
+ * em testes/ferramentas.
+ */
+export interface LineageCatalogValidationIssue {
+  level: "error" | "warning";
+  code: string;
+  message: string;
+  axis_id?: number;
+  complement_id?: string;
+}
+
+export function validateLineageCatalog(
+  cat: LineageCatalog,
+): LineageCatalogValidationIssue[] {
+  const issues: LineageCatalogValidationIssue[] = [];
+  const seenComplementIds = new Set<string>();
+  const seenAxisIds = new Set<number>();
+
+  if (cat.axes.length !== 12) {
+    issues.push({
+      level: "error",
+      code: "axis_count_mismatch",
+      message: `esperado 12 eixos, encontrei ${cat.axes.length}`,
+    });
+  }
+
+  for (const axis of cat.axes) {
+    if (axis.id < 1 || axis.id > 12) {
+      issues.push({
+        level: "error",
+        code: "axis_id_out_of_range",
+        message: `axis_id ${axis.id} fora de 1..12`,
+        axis_id: axis.id,
+      });
+    }
+    if (seenAxisIds.has(axis.id)) {
+      issues.push({
+        level: "error",
+        code: "axis_id_duplicate",
+        message: `axis_id ${axis.id} duplicado`,
+        axis_id: axis.id,
+      });
+    }
+    seenAxisIds.add(axis.id);
+    if (!CATALOG_FAMILIES.includes(axis.family)) {
+      issues.push({
+        level: "error",
+        code: "axis_family_invalid",
+        message: `family '${axis.family}' inválida`,
+        axis_id: axis.id,
+      });
+    }
+
+    // Redundância por eixo: ≥3 tradições distintas
+    const traditionsInAxis = new Set(axis.complements.map((c) => c.lineage));
+    if (traditionsInAxis.size < 3) {
+      issues.push({
+        level: "error",
+        code: "axis_redundancy_insufficient",
+        message: `eixo ${axis.id} tem só ${traditionsInAxis.size} tradição(ões) — mínimo 3 pra honrar opt-in`,
+        axis_id: axis.id,
+      });
+    }
+
+    for (const c of axis.complements) {
+      if (c.axis_id !== axis.id) {
+        issues.push({
+          level: "error",
+          code: "complement_axis_mismatch",
+          message: `complemento '${c.id}' declara axis_id=${c.axis_id} mas está dentro do eixo ${axis.id}`,
+          axis_id: axis.id,
+          complement_id: c.id,
+        });
+      }
+      if (!LINEAGE_TRADITIONS.includes(c.lineage)) {
+        issues.push({
+          level: "error",
+          code: "complement_lineage_invalid",
+          message: `complemento '${c.id}' usa tradição '${c.lineage}' fora do vocabulário`,
+          axis_id: axis.id,
+          complement_id: c.id,
+        });
+      }
+      if (seenComplementIds.has(c.id) && c.shared_with_axes === undefined) {
+        issues.push({
+          level: "error",
+          code: "complement_id_duplicate",
+          message: `complemento '${c.id}' duplicado e sem shared_with_axes`,
+          axis_id: axis.id,
+          complement_id: c.id,
+        });
+      }
+      seenComplementIds.add(c.id);
+    }
+
+    // família esperada por eixo (spec §2)
+    const expectedFamily = expectedFamilyForAxis(axis.id);
+    if (expectedFamily !== null && axis.family !== expectedFamily) {
+      issues.push({
+        level: "warning",
+        code: "axis_family_unexpected",
+        message: `eixo ${axis.id} esperado family '${expectedFamily}', got '${axis.family}'`,
+        axis_id: axis.id,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/** Mapeamento spec §2: eixos 1-4 Caráter, 5-8 Disposição, 9-12 Cognição-de-si. */
+export function expectedFamilyForAxis(axisId: number): CatalogFamily | null {
+  if (axisId >= 1 && axisId <= 4) return "carater";
+  if (axisId >= 5 && axisId <= 8) return "disposicao";
+  if (axisId >= 9 && axisId <= 12) return "cognicao_si";
+  return null;
+}
+
+/** Filtra complementos de um eixo segundo allowed/blocked do filtro cultural parental. */
+export function getComplementsForAxis(
+  cat: LineageCatalog,
+  axisId: number,
+  filter?: { allowed?: LineageTradition[]; blocked?: LineageTradition[] },
+): LineageComplement[] {
+  const axis = cat.axes.find((a) => a.id === axisId);
+  if (!axis) return [];
+  const allowed = filter?.allowed;
+  const blocked = filter?.blocked ?? [];
+  return axis.complements.filter((c) => {
+    if (blocked.includes(c.lineage)) return false;
+    if (allowed !== undefined && allowed.length > 0 && !allowed.includes(c.lineage)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/** Encontra um eixo por ID. */
+export function getAxis(cat: LineageCatalog, axisId: number): LineageAxis | undefined {
+  return cat.axes.find((a) => a.id === axisId);
+}
+
+/** Encontra um complemento por ID (procura em todos os eixos). */
+export function getComplement(
+  cat: LineageCatalog,
+  complementId: string,
+): LineageComplement | undefined {
+  for (const axis of cat.axes) {
+    const c = axis.complements.find((x) => x.id === complementId);
+    if (c) return c;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
Fase 4 da [spec Subject Knowledge + Bridge Tutor Clássico](https://github.com/ascendimacy/ascendimacy-ops/blob/docs/c-mx-07-c-mx-08-specs/docs/specs/2026-05-25-subject-knowledge-bridge.md). **Independente da F1** — pode mergear em qualquer ordem.

Materializa o catálogo clássico como dados estruturados (YAML) com loader + validator + API. Zero impacto comportamental — Fases 5/7 vão consumir.

### Conteúdo do catálogo
- **3 famílias × 4 eixos = 12 eixos:**
  - Caráter: Prudência · Justiça · Fortaleza · Temperança
  - Disposição: Confiança · Esperança · Compaixão · Gratidão
  - Cognição-de-si: Veracidade · Curiosidade · Autoconhecimento · Responsabilidade
- **48 complementos plurais** de 9 tradições (aristotélica, paideia, estoica, bushido, zen, cristã, hebraica, confucionista, taoísta)
- Cada eixo cobre **≥3 tradições distintas** (auditoria opt-in formalizada no validator)

### API
\`\`\`ts
import { loadLineageCatalog, getCatalog } from "@ascendimacy/motor-drota/...";
import { getComplementsForAxis, getAxis, getComplement } from "@ascendimacy/shared";

const cat = getCatalog();
const compls = getComplementsForAxis(cat, 4, { blocked: ["cristã"] });
\`\`\`

### Validator
Detecta 7 códigos de issue (error/warning). Strict mode (default) **lança erro** se redundância <3 tradições/eixo, axis_id duplicado, tradição fora do vocabulário, etc.

## Test plan
- [x] \`motor-drota/tests/lineage-catalog-loader.test.ts\` — 19 tests cobrindo: parsing, 12 eixos, ≥3 tradições/eixo, mapeamento de famílias, filtros culturais (allowed/blocked), detecção de catálogo inválido, strict vs non-strict
- [x] Build verde
- [x] Suite: motor 317 (+19), shared 680, planejador 321 — zero regressão

## Próximos passos
- Fase 5 vai consumir este catálogo no scorer multi-dim + RecallCheckEvaluator
- Fase 7 vai consumir nos flashes culturais por interesse vertical
- Conteúdos pedagógicos (content_seeds) vão ganhar tags \`axis_id\`, \`lineage_anchor\`, \`family\` em Fase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)