### PR TITLE
[feat] Subject Knowledge Fase 2 — Discovery+Boundary writers + pipeline

### DIFF
--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -20,6 +20,11 @@ import type {
   EvaluateAndSelectInput,
   EvaluateAndSelectOutput,
   ScoredContentItem,
+  SubjectKnowledgeEntry,
+} from "@ascendimacy/shared";
+import {
+  extractDiscoveries,
+  extractBoundaryEvents,
 } from "@ascendimacy/shared";
 
 import { assess } from "./unified-assessor.js";
@@ -62,6 +67,40 @@ export async function handleSimplifiedPipeline(
     engagement: assessment.engagement,
   };
 
+  // ── Subject Knowledge Fase 2: writers extraem eventos do turn ──
+  const turnRef = `${input.sessionId}__turn_${input.state.turn}`;
+  const subjectKnowledgeEvents: SubjectKnowledgeEntry[] = [];
+  // 1. Descobertas (interest/value/need) — só da fala do sujeito.
+  subjectKnowledgeEvents.push(
+    ...extractDiscoveries({
+      subjectId: input.persona.id,
+      sessionId: input.sessionId,
+      turnRef,
+      lastUserMessage,
+      signals: assessment.signals,
+      mood: assessment.mood,
+    }),
+  );
+  // 2. Boundary events — registra recuo quando signals indicam.
+  // topicCategory v1: extraído do avoid[] do plan ou marcado como
+  // indefinido. Abstração mais sofisticada vem em fase futura.
+  const avoid = input.contextHints?.["avoid"];
+  const topicCategory =
+    Array.isArray(avoid) && avoid.length > 0
+      ? String(avoid[0])
+      : typeof avoid === "string"
+      ? avoid
+      : "indefinido";
+  subjectKnowledgeEvents.push(
+    ...extractBoundaryEvents({
+      subjectId: input.persona.id,
+      sessionId: input.sessionId,
+      turnRef,
+      signals: assessment.signals,
+      topicCategory,
+    }),
+  );
+
   // 2. Pragmatic Selector — determinístico, zero LLM.
   const selectionResult = selectAction({
     candidates: ranked,
@@ -94,6 +133,7 @@ export async function handleSimplifiedPipeline(
       selectionRationale: selectionResult.decision_path,
       linguisticMaterialization: "Me conta o que está passando na sua cabeça.",
       assessment: assessmentForOutput,
+      subjectKnowledgeEvents,
       ...(selectionResult.escalate_reason
         ? { skipReason: selectionResult.escalate_reason }
         : {}),
@@ -129,6 +169,7 @@ export async function handleSimplifiedPipeline(
       selectionRationale: selectionResult.decision_path,
       linguisticMaterialization: inauguralResult.text,
       assessment: assessmentForOutput,
+      subjectKnowledgeEvents,
     };
   }
 
@@ -153,6 +194,7 @@ export async function handleSimplifiedPipeline(
     selectionRationale: selectionResult.decision_path,
     linguisticMaterialization: matResult.text,
     assessment: assessmentForOutput,
+    subjectKnowledgeEvents,
     ...(matResult.fallback_triggered
       ? { skipReason: "materializer_fallback" }
       : {}),

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -49,6 +49,11 @@ import {
   summarizePersonas,
   getPersonaEvolution,
 } from "./analytics.js";
+import {
+  listSubjectDiscoveries,
+  listBoundaryEvents,
+  summarizeBoundariesByCategory,
+} from "./subject-knowledge-repo.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -467,6 +472,51 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   fastify.post<{ Params: { id: string } }>(
     "/sessions/:id/end",
     async (req) => opts.daemon.endSession(req.params.id),
+  );
+
+  // ── Subject Knowledge endpoints (Fase 2) ─────────────────────────
+  // GET /subjects/:id/discoveries — interest/value/need/discovery
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { type?: string; session?: string; limit?: string };
+  }>("/subjects/:id/discoveries", async (req) => {
+    const limit = req.query.limit ? parseInt(req.query.limit, 10) : undefined;
+    const type =
+      req.query.type === "interest" ||
+      req.query.type === "value" ||
+      req.query.type === "need" ||
+      req.query.type === "discovery"
+        ? req.query.type
+        : undefined;
+    return {
+      discoveries: listSubjectDiscoveries(opts.db, req.params.id, {
+        ...(type ? { type } : {}),
+        ...(req.query.session ? { sessionId: req.query.session } : {}),
+        ...(limit ? { limit } : {}),
+      }),
+    };
+  });
+
+  // GET /subjects/:id/boundaries — boundary_events crus
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { session?: string; limit?: string };
+  }>("/subjects/:id/boundaries", async (req) => {
+    const limit = req.query.limit ? parseInt(req.query.limit, 10) : undefined;
+    return {
+      boundaries: listBoundaryEvents(opts.db, req.params.id, {
+        ...(req.query.session ? { sessionId: req.query.session } : {}),
+        ...(limit ? { limit } : {}),
+      }),
+    };
+  });
+
+  // GET /subjects/:id/boundaries/summary — agregação por topic_category
+  fastify.get<{ Params: { id: string } }>(
+    "/subjects/:id/boundaries/summary",
+    async (req) => ({
+      summary: summarizeBoundariesByCategory(opts.db, req.params.id),
+    }),
   );
 
   return {

--- a/packages/ebrota-console-bff/src/subject-knowledge-repo.ts
+++ b/packages/ebrota-console-bff/src/subject-knowledge-repo.ts
@@ -1,0 +1,147 @@
+/**
+ * Subject Knowledge Repository — queries do ledger cross-session.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-subject-knowledge-bridge.md §4.
+ * Fase 2: read-only views agregadas pros endpoints REST.
+ */
+
+import type { Database as DatabaseType } from "better-sqlite3";
+import type {
+  SubjectKnowledgeEntry,
+  SubjectKnowledgeType,
+} from "@ascendimacy/shared";
+
+interface SkRow {
+  id: string;
+  subject_id: string;
+  type: string;
+  source: string;
+  confidence: number;
+  confirmed_at: string | null;
+  alignment: string;
+  payload_json: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+}
+
+function rowToEntry(row: SkRow): SubjectKnowledgeEntry {
+  return {
+    id: row.id,
+    subject_id: row.subject_id,
+    type: row.type as SubjectKnowledgeType,
+    source: row.source as SubjectKnowledgeEntry["source"],
+    confidence: row.confidence,
+    confirmed_at: row.confirmed_at,
+    alignment: row.alignment as SubjectKnowledgeEntry["alignment"],
+    payload: JSON.parse(row.payload_json),
+    turn_ref: row.turn_ref,
+    session_id: row.session_id,
+    created_at: row.created_at,
+  };
+}
+
+export interface ListOptions {
+  /** Limita ao tipo (default: todos). */
+  type?: SubjectKnowledgeType;
+  /** Filtra por session_id (útil pra debug). */
+  sessionId?: string;
+  /** Limite (default 200). */
+  limit?: number;
+}
+
+/**
+ * Lista discoveries (interest/value/need/discovery) de um sujeito,
+ * ordenadas por created_at desc. Boundary_events e checks ficam de fora —
+ * use listBoundaryEvents() pra esses.
+ */
+export function listSubjectDiscoveries(
+  db: DatabaseType,
+  subjectId: string,
+  opts: ListOptions = {},
+): SubjectKnowledgeEntry[] {
+  const limit = opts.limit ?? 200;
+  const types = opts.type
+    ? [opts.type]
+    : ["interest", "value", "need", "discovery"];
+  const placeholders = types.map(() => "?").join(",");
+  const params: unknown[] = [subjectId, ...types];
+  let sql = `
+    SELECT * FROM subject_knowledge
+    WHERE subject_id = ? AND type IN (${placeholders})
+  `;
+  if (opts.sessionId) {
+    sql += " AND session_id = ?";
+    params.push(opts.sessionId);
+  }
+  sql += " ORDER BY created_at DESC LIMIT ?";
+  params.push(limit);
+  const rows = db.prepare(sql).all(...params) as SkRow[];
+  return rows.map(rowToEntry);
+}
+
+/**
+ * Lista boundary_events de um sujeito. Inclui agregação simples por
+ * topic_category (count) — insumo pro Console UI parental destacar
+ * padrões recorrentes ("Ryo evitou tema X 3x esta semana").
+ */
+export function listBoundaryEvents(
+  db: DatabaseType,
+  subjectId: string,
+  opts: ListOptions = {},
+): SubjectKnowledgeEntry[] {
+  const limit = opts.limit ?? 200;
+  const params: unknown[] = [subjectId];
+  let sql = `
+    SELECT * FROM subject_knowledge
+    WHERE subject_id = ? AND type = 'boundary_event'
+  `;
+  if (opts.sessionId) {
+    sql += " AND session_id = ?";
+    params.push(opts.sessionId);
+  }
+  sql += " ORDER BY created_at DESC LIMIT ?";
+  params.push(limit);
+  const rows = db.prepare(sql).all(...params) as SkRow[];
+  return rows.map(rowToEntry);
+}
+
+export interface BoundaryCategorySummary {
+  topic_category: string;
+  count: number;
+  high_intensity_count: number;
+  last_seen_at: string;
+}
+
+/**
+ * Agregado por topic_category pros sinais clínicos. Quando count >= 3
+ * num mesmo topic (ou high_intensity_count >= 1), Console deve destacar.
+ */
+export function summarizeBoundariesByCategory(
+  db: DatabaseType,
+  subjectId: string,
+): BoundaryCategorySummary[] {
+  const sql = `
+    SELECT
+      json_extract(payload_json, '$.topic_category') AS topic_category,
+      COUNT(*) AS count,
+      SUM(CASE WHEN json_extract(payload_json, '$.intensity') = 'high' THEN 1 ELSE 0 END) AS high_intensity_count,
+      MAX(created_at) AS last_seen_at
+    FROM subject_knowledge
+    WHERE subject_id = ? AND type = 'boundary_event'
+    GROUP BY topic_category
+    ORDER BY count DESC, last_seen_at DESC
+  `;
+  const rows = db.prepare(sql).all(subjectId) as Array<{
+    topic_category: string;
+    count: number;
+    high_intensity_count: number;
+    last_seen_at: string;
+  }>;
+  return rows.map((r) => ({
+    topic_category: r.topic_category ?? "indefinido",
+    count: r.count,
+    high_intensity_count: r.high_intensity_count,
+    last_seen_at: r.last_seen_at,
+  }));
+}

--- a/packages/ebrota-console-bff/src/traces-scanner.ts
+++ b/packages/ebrota-console-bff/src/traces-scanner.ts
@@ -48,6 +48,13 @@ interface RawTraceTurn {
   /** STS schema alias for finalResponse. */
   botMessage?: string;
   timestamp?: string;
+  /**
+   * Subject Knowledge Fase 2: eventos emitidos pelos writers no motor.
+   * Quando presente, scanner insere em subject_knowledge table.
+   * Pode estar no nível do turn (preferido) ou em motorTrace.drota.subjectKnowledgeEvents.
+   */
+  subjectKnowledgeEvents?: unknown[];
+  motorTrace?: { drota?: { subjectKnowledgeEvents?: unknown[] } };
 }
 
 interface RawTrace {
@@ -126,6 +133,20 @@ const UPSERT_SESSION_SQL = `
     trace_path = excluded.trace_path
 `;
 
+const DELETE_SK_BY_SESSION_SQL = `
+  DELETE FROM subject_knowledge WHERE session_id = @sessionId
+`;
+
+const INSERT_SK_SQL = `
+  INSERT INTO subject_knowledge (
+    id, subject_id, type, source, confidence, confirmed_at,
+    alignment, payload_json, turn_ref, session_id, created_at
+  ) VALUES (
+    @id, @subject_id, @type, @source, @confidence, @confirmed_at,
+    @alignment, @payload_json, @turn_ref, @session_id, @created_at
+  )
+`;
+
 const DELETE_FTS_BY_SESSION_SQL = `
   DELETE FROM messages_fts WHERE session_id = @sessionId
 `;
@@ -190,6 +211,44 @@ const indexTrace = (
 
   // Re-populate FTS pra essa sessão (delete-then-insert pra idempotência)
   db.prepare(DELETE_FTS_BY_SESSION_SQL).run({ sessionId });
+
+  // Re-populate subject_knowledge events da sessão (idempotente).
+  // Fase 2: motor emite eventos via simplified-pipeline output; scanner
+  // procura no turn ou em turn.motorTrace.drota.
+  db.prepare(DELETE_SK_BY_SESSION_SQL).run({ sessionId });
+  const insertSk = db.prepare(INSERT_SK_SQL);
+  for (const turn of turns) {
+    const events =
+      (turn.subjectKnowledgeEvents as unknown[] | undefined) ??
+      (turn.motorTrace?.drota?.subjectKnowledgeEvents as unknown[] | undefined) ??
+      [];
+    for (const raw of events) {
+      const ev = raw as Record<string, unknown>;
+      if (
+        typeof ev.id !== "string" ||
+        typeof ev.subject_id !== "string" ||
+        typeof ev.type !== "string"
+      )
+        continue;
+      try {
+        insertSk.run({
+          id: ev.id,
+          subject_id: ev.subject_id,
+          type: ev.type,
+          source: ev.source ?? "motor_inferred",
+          confidence: typeof ev.confidence === "number" ? ev.confidence : 0.5,
+          confirmed_at: ev.confirmed_at ?? null,
+          alignment: ev.alignment ?? "unknown",
+          payload_json: JSON.stringify(ev.payload ?? {}),
+          turn_ref: ev.turn_ref ?? `${sessionId}__turn_${turn.turnNumber ?? 0}`,
+          session_id: sessionId,
+          created_at: ev.created_at ?? new Date().toISOString(),
+        });
+      } catch {
+        // ignora linha inválida (CHECK constraint), não derruba scan
+      }
+    }
+  }
 
   let messagesIndexed = 0;
   const insertFts = db.prepare(INSERT_FTS_SQL);

--- a/packages/ebrota-console-bff/tests/subject-knowledge-pipeline.test.ts
+++ b/packages/ebrota-console-bff/tests/subject-knowledge-pipeline.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests end-to-end Fase 2: trace com subjectKnowledgeEvents →
+ * scanner indexa → repo retorna via API.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { scanTraces } from "../src/traces-scanner.js";
+import {
+  listSubjectDiscoveries,
+  listBoundaryEvents,
+  summarizeBoundariesByCategory,
+} from "../src/subject-knowledge-repo.js";
+import {
+  createBffServer,
+  type BffServer,
+} from "../src/server.js";
+import {
+  createMockDaemonClient,
+  type MockDaemonClient,
+} from "../src/daemon-client.js";
+
+let db: DatabaseType;
+let tmpRoot: string;
+let server: BffServer;
+let daemon: MockDaemonClient;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+  tmpRoot = mkdtempSync(join(tmpdir(), "sk-pipeline-"));
+});
+
+afterEach(async () => {
+  await server.close();
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const writeTrace = (subdir: string, trace: Record<string, unknown>): string => {
+  const dir = join(tmpRoot, subdir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "trace.json");
+  writeFileSync(path, JSON.stringify(trace));
+  return path;
+};
+
+const fakeInterestEvent = (sessionId: string, turnRef: string, label: string) => ({
+  id: `sk-ev-${turnRef}-${label}`,
+  subject_id: "ryo",
+  type: "interest",
+  source: "self_declared",
+  confidence: 0.85,
+  confirmed_at: turnRef,
+  alignment: "unknown",
+  payload: { kind: "interest", label, intensity: "mid" },
+  turn_ref: turnRef,
+  session_id: sessionId,
+  created_at: "2026-05-25T10:00:00.000Z",
+});
+
+const fakeBoundaryEvent = (
+  sessionId: string,
+  turnRef: string,
+  signalType: string,
+  topicCategory: string,
+  intensity = "mid",
+) => ({
+  id: `sk-bd-${turnRef}-${signalType}`,
+  subject_id: "ryo",
+  type: "boundary_event",
+  source: "motor_inferred",
+  confidence: 0.85,
+  confirmed_at: null,
+  alignment: "unknown",
+  payload: {
+    kind: "boundary_event",
+    signal_type: signalType,
+    topic_category: topicCategory,
+    intensity,
+    motor_response: "muda_tema",
+    severity_band: "routine",
+  },
+  turn_ref: turnRef,
+  session_id: sessionId,
+  created_at: "2026-05-25T10:00:00.000Z",
+});
+
+describe("scanner indexa subjectKnowledgeEvents do trace", () => {
+  it("lê eventos no nível do turn", async () => {
+    writeTrace("s1", {
+      sessionId: "ryo__sess-1",
+      persona: "ryo",
+      startedAt: "2026-05-25T10:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 1,
+          incomingMessage: "eu gosto de tênis",
+          finalResponse: "legal",
+          subjectKnowledgeEvents: [
+            fakeInterestEvent("ryo__sess-1", "ryo__sess-1__turn_1", "tênis"),
+          ],
+        },
+      ],
+    });
+
+    const result = await scanTraces({ tracesDir: tmpRoot, db });
+    expect(result.sessionsIndexed).toBe(1);
+
+    const discoveries = listSubjectDiscoveries(db, "ryo");
+    expect(discoveries).toHaveLength(1);
+    expect(discoveries[0].type).toBe("interest");
+    if (discoveries[0].payload.kind === "interest") {
+      expect(discoveries[0].payload.label).toBe("tênis");
+    }
+  });
+
+  it("lê eventos do fallback motorTrace.drota.subjectKnowledgeEvents", async () => {
+    writeTrace("s2", {
+      sessionId: "ryo__sess-2",
+      persona: "ryo",
+      startedAt: "2026-05-25T10:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 1,
+          incomingMessage: "x",
+          finalResponse: "y",
+          motorTrace: {
+            drota: {
+              subjectKnowledgeEvents: [
+                fakeInterestEvent("ryo__sess-2", "ryo__sess-2__turn_1", "anime"),
+              ],
+            },
+          },
+        },
+      ],
+    });
+    await scanTraces({ tracesDir: tmpRoot, db });
+    const discoveries = listSubjectDiscoveries(db, "ryo");
+    expect(discoveries).toHaveLength(1);
+  });
+
+  it("re-scan substitui events (idempotência)", async () => {
+    writeTrace("s3", {
+      sessionId: "ryo__sess-3",
+      persona: "ryo",
+      startedAt: "2026-05-25T10:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 1,
+          incomingMessage: "x",
+          finalResponse: "y",
+          subjectKnowledgeEvents: [
+            fakeInterestEvent("ryo__sess-3", "ryo__sess-3__turn_1", "skate"),
+          ],
+        },
+      ],
+    });
+    await scanTraces({ tracesDir: tmpRoot, db });
+    await scanTraces({ tracesDir: tmpRoot, db });
+    const discoveries = listSubjectDiscoveries(db, "ryo");
+    expect(discoveries).toHaveLength(1);
+  });
+
+  it("ignora linhas inválidas sem derrubar scan", async () => {
+    writeTrace("s4", {
+      sessionId: "ryo__sess-4",
+      persona: "ryo",
+      startedAt: "2026-05-25T10:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 1,
+          incomingMessage: "x",
+          finalResponse: "y",
+          subjectKnowledgeEvents: [
+            { type: "fake_type", subject_id: "ryo" }, // inválido — falta id, CHECK falha
+            fakeInterestEvent("ryo__sess-4", "ryo__sess-4__turn_1", "ok"),
+          ],
+        },
+      ],
+    });
+    const result = await scanTraces({ tracesDir: tmpRoot, db });
+    expect(result.errors).toHaveLength(0);
+    const discoveries = listSubjectDiscoveries(db, "ryo");
+    expect(discoveries).toHaveLength(1); // só o válido
+  });
+});
+
+describe("BFF endpoints /subjects/:id/...", () => {
+  beforeEach(() => {
+    // popula direto
+    writeTrace("ep", {
+      sessionId: "ryo__sess-ep",
+      persona: "ryo",
+      startedAt: "2026-05-25T10:00:00.000Z",
+      turns: [
+        {
+          turnNumber: 1,
+          incomingMessage: "eu gosto de tênis e anime",
+          finalResponse: "ok",
+          subjectKnowledgeEvents: [
+            fakeInterestEvent("ryo__sess-ep", "ryo__sess-ep__turn_1", "tênis"),
+            fakeInterestEvent("ryo__sess-ep", "ryo__sess-ep__turn_1", "anime"),
+          ],
+        },
+        {
+          turnNumber: 3,
+          incomingMessage: "não quero falar disso",
+          finalResponse: "ok",
+          subjectKnowledgeEvents: [
+            fakeBoundaryEvent(
+              "ryo__sess-ep",
+              "ryo__sess-ep__turn_3",
+              "deflection_thematic",
+              "tema_escolar",
+            ),
+          ],
+        },
+        {
+          turnNumber: 5,
+          incomingMessage: "não",
+          finalResponse: "ok",
+          subjectKnowledgeEvents: [
+            fakeBoundaryEvent(
+              "ryo__sess-ep",
+              "ryo__sess-ep__turn_5",
+              "deflection_thematic",
+              "tema_escolar",
+              "high",
+            ),
+          ],
+        },
+      ],
+    });
+    return scanTraces({ tracesDir: tmpRoot, db });
+  });
+
+  const inject = async (url: string) => {
+    const res = await server.fastify.inject({ method: "GET", url });
+    return {
+      status: res.statusCode,
+      body: JSON.parse(res.body) as Record<string, unknown>,
+    };
+  };
+
+  it("GET /subjects/ryo/discoveries retorna interests", async () => {
+    const res = await inject("/subjects/ryo/discoveries");
+    expect(res.status).toBe(200);
+    const list = res.body.discoveries as Array<{ type: string }>;
+    expect(list.length).toBe(2);
+    expect(list.every((d) => d.type === "interest")).toBe(true);
+  });
+
+  it("GET /subjects/ryo/discoveries?type=interest filtra", async () => {
+    const res = await inject("/subjects/ryo/discoveries?type=interest");
+    expect(res.status).toBe(200);
+    const list = res.body.discoveries as Array<unknown>;
+    expect(list.length).toBe(2);
+  });
+
+  it("GET /subjects/ryo/boundaries retorna boundary_events", async () => {
+    const res = await inject("/subjects/ryo/boundaries");
+    expect(res.status).toBe(200);
+    const list = res.body.boundaries as Array<{ type: string }>;
+    expect(list.length).toBe(2);
+    expect(list.every((b) => b.type === "boundary_event")).toBe(true);
+  });
+
+  it("GET /subjects/ryo/boundaries/summary agrega por topic_category", async () => {
+    const res = await inject("/subjects/ryo/boundaries/summary");
+    expect(res.status).toBe(200);
+    const list = res.body.summary as Array<{
+      topic_category: string;
+      count: number;
+      high_intensity_count: number;
+    }>;
+    expect(list).toHaveLength(1);
+    expect(list[0].topic_category).toBe("tema_escolar");
+    expect(list[0].count).toBe(2);
+    expect(list[0].high_intensity_count).toBe(1);
+  });
+
+  it("listSubjectDiscoveries filtra por sessionId", () => {
+    const list = listSubjectDiscoveries(db, "ryo", {
+      sessionId: "ryo__sess-ep",
+    });
+    expect(list.length).toBe(2);
+    const empty = listSubjectDiscoveries(db, "ryo", {
+      sessionId: "ryo__nada",
+    });
+    expect(empty).toHaveLength(0);
+  });
+
+  it("summarizeBoundariesByCategory retorna array vazio se zero events", () => {
+    const summary = summarizeBoundariesByCategory(db, "kei");
+    expect(summary).toEqual([]);
+  });
+});

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -98,6 +98,13 @@ export interface EvaluateAndSelectOutput {
     signals: string[];
     engagement: "high" | "medium" | "low" | "disengaging";
   };
+  /**
+   * Subject Knowledge Fase 2: eventos extraídos pelos writers
+   * (DiscoveryWriter + BoundaryEventWriter) durante este turn.
+   * Escritos no trace pra BFF scanner indexar em subject_knowledge.
+   * Undefined no fluxo antigo (backward compat).
+   */
+  subjectKnowledgeEvents?: import("./subject-knowledge.js").SubjectKnowledgeEntry[];
 }
 
 export interface ExecutePlaybookInput {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -22,6 +22,7 @@ export * from "./sacrifice-budget.js";
 export * from "./mixins/with-gardner-program.js";
 export * from "./parental-profile.js";
 export * from "./subject-knowledge.js";
+export * from "./subject-knowledge-writers.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/subject-knowledge-writers.ts
+++ b/shared/src/subject-knowledge-writers.ts
@@ -1,0 +1,289 @@
+/**
+ * DiscoveryWriter + BoundaryEventWriter — extraction logic.
+ *
+ * Spec: 2026-05-25-subject-knowledge-bridge.md §4.2 e §4.3.
+ *
+ * Pure functions: recebem contexto do turn + signals, retornam
+ * SubjectKnowledgeEntry[] prontos pra inclusão no trace JSON.
+ * Persistência fica a cargo do BFF scanner (lê trace → upserta SQLite).
+ *
+ * Fase 2: heurística regex/keyword (v1). Fase 5+ pode evoluir pra
+ * embeddings / LLM-as-judge.
+ */
+
+import type {
+  SubjectKnowledgeEntry,
+  SubjectKnowledgeAlignment,
+} from "./subject-knowledge.js";
+
+// ─────────────────────────────────────────────────────────────────
+// DiscoveryWriter — interest / value / need / discovery
+// ─────────────────────────────────────────────────────────────────
+
+export interface DiscoveryWriterInput {
+  /** ID do sujeito (persona_id na v1). */
+  subjectId: string;
+  /** ID da sessão atual. */
+  sessionId: string;
+  /** Turn ref no formato sessionId__turn_N. */
+  turnRef: string;
+  /** Última mensagem da persona. */
+  lastUserMessage: string;
+  /** Signals já extraídos pelo assessor (informativo). */
+  signals?: string[];
+  /** Mood opcional pra calibrar confidence. */
+  mood?: number;
+}
+
+const INTEREST_PATTERNS: Array<{ re: RegExp; intensity: "low" | "mid" | "high" }> = [
+  // Português
+  { re: /\b(?:eu\s+)?(?:adoro|amo)\s+([^.,;!?\n]+)/i, intensity: "high" },
+  { re: /\b(?:eu\s+)?gosto\s+(?:muito\s+)?de\s+([^.,;!?\n]+)/i, intensity: "mid" },
+  { re: /\bsou\s+(?:muito\s+)?(?:fã|f[aã]\s+declarado)\s+de\s+([^.,;!?\n]+)/i, intensity: "high" },
+  { re: /\bcurto\s+([^.,;!?\n]+)/i, intensity: "mid" },
+  { re: /\b(?:meu|minha)\s+favorito\s+(?:é|eh)\s+([^.,;!?\n]+)/i, intensity: "high" },
+  { re: /\binteresso?\s+(?:por|em)\s+([^.,;!?\n]+)/i, intensity: "mid" },
+];
+
+const VALUE_PATTERNS: Array<{ re: RegExp; label_extract: (m: RegExpMatchArray) => string }> = [
+  { re: /\bacho\s+(?:que\s+)?([^.,;!?\n]+\s+(?:é|eh|importa|conta|vale))/i, label_extract: (m) => m[1].trim() },
+  { re: /\bpra\s+mim\s+(?:o\s+)?(?:que\s+)?(?:mais\s+)?importa\s+(?:é|eh)?\s*([^.,;!?\n]+)/i, label_extract: (m) => m[1].trim() },
+];
+
+const NEED_PATTERNS: Array<{ re: RegExp }> = [
+  { re: /\bqueria\s+(?:muito\s+)?(?:que|poder)\s+[^.,;!?\n]+/i },
+  { re: /\bprecisava\s+(?:muito\s+)?([^.,;!?\n]+)/i },
+];
+
+/**
+ * Extrai descobertas (interest/value/need/discovery) da última mensagem
+ * da persona. Usa heurística regex em pt-BR. Não chama LLM.
+ *
+ * Retorna array vazio se nada novo detectado — caller filtra duplicatas
+ * cross-turn antes de persistir (responsabilidade do scanner BFF).
+ */
+export function extractDiscoveries(
+  input: DiscoveryWriterInput,
+): SubjectKnowledgeEntry[] {
+  const out: SubjectKnowledgeEntry[] = [];
+  const msg = input.lastUserMessage.trim();
+  if (msg.length === 0) return out;
+
+  // Interests
+  for (const pat of INTEREST_PATTERNS) {
+    const m = msg.match(pat.re);
+    if (m && m[1]) {
+      const label = m[1].trim().replace(/[.,;!?]+$/, "");
+      if (label.length === 0 || label.length > 80) continue;
+      out.push(
+        makeEntry({
+          subjectId: input.subjectId,
+          sessionId: input.sessionId,
+          turnRef: input.turnRef,
+          type: "interest",
+          source: "self_declared",
+          confidence: pat.intensity === "high" ? 0.9 : 0.7,
+          payload: {
+            kind: "interest",
+            label,
+            evidence_phrase: msg.slice(0, 200),
+            intensity: pat.intensity,
+          },
+        }),
+      );
+    }
+  }
+
+  // Values
+  for (const pat of VALUE_PATTERNS) {
+    const m = msg.match(pat.re);
+    if (m) {
+      const label = pat.label_extract(m).replace(/[.,;!?]+$/, "");
+      if (label.length === 0 || label.length > 100) continue;
+      out.push(
+        makeEntry({
+          subjectId: input.subjectId,
+          sessionId: input.sessionId,
+          turnRef: input.turnRef,
+          type: "value",
+          source: "self_declared",
+          confidence: 0.55,
+          payload: {
+            kind: "value",
+            label,
+            evidence_phrase: msg.slice(0, 200),
+          },
+        }),
+      );
+    }
+  }
+
+  // Needs
+  for (const pat of NEED_PATTERNS) {
+    const m = msg.match(pat.re);
+    if (m) {
+      const label = (m[1] ?? m[0]).trim().replace(/[.,;!?]+$/, "");
+      if (label.length === 0 || label.length > 100) continue;
+      out.push(
+        makeEntry({
+          subjectId: input.subjectId,
+          sessionId: input.sessionId,
+          turnRef: input.turnRef,
+          type: "need",
+          source: "self_declared",
+          confidence: 0.5,
+          payload: {
+            kind: "need",
+            label,
+          },
+        }),
+      );
+    }
+  }
+
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// BoundaryEventWriter — registra boundary respeitada
+// ─────────────────────────────────────────────────────────────────
+
+export type BoundarySignalType =
+  | "deflection_thematic"
+  | "gatekeeper_resistance"
+  | "frame_rejection"
+  | "distress_marker_low"
+  | "distress_marker_high"
+  | "exit_marker_implicit"
+  | "exit_marker_explicit"
+  | "mood_drift_down";
+
+const BOUNDARY_SIGNAL_SET: ReadonlySet<string> = new Set<BoundarySignalType>([
+  "deflection_thematic",
+  "gatekeeper_resistance",
+  "frame_rejection",
+  "distress_marker_low",
+  "distress_marker_high",
+  "exit_marker_implicit",
+  "exit_marker_explicit",
+  "mood_drift_down",
+]);
+
+export interface BoundaryEventWriterInput {
+  subjectId: string;
+  sessionId: string;
+  turnRef: string;
+  /** Signals do assessor — apenas os boundary_* são processados. */
+  signals: string[];
+  /** Tema/categoria abstraída do turn corrente (não conteúdo literal).
+   * Caller é responsável pela abstração — se vazio, fica "indefinido".
+   */
+  topicCategory?: string;
+  /** Como o motor respondeu. */
+  motorResponse?: "muda_tema" | "suaviza" | "recua_total" | "outro";
+}
+
+/**
+ * Extrai boundary_events do turn atual baseado nos signals do assessor.
+ *
+ * v1: severity_band sempre 'routine'. Detecção de 'clinical_signal'
+ * (padrão recorrente) fica a cargo do scanner BFF / view agregada,
+ * que tem acesso ao histórico cross-session.
+ */
+export function extractBoundaryEvents(
+  input: BoundaryEventWriterInput,
+): SubjectKnowledgeEntry[] {
+  const out: SubjectKnowledgeEntry[] = [];
+  for (const signalRaw of input.signals) {
+    if (!BOUNDARY_SIGNAL_SET.has(signalRaw)) continue;
+    const signalType = signalRaw as BoundarySignalType;
+    const intensity = signalIntensity(signalType);
+    const motorResponse = input.motorResponse ?? inferMotorResponse(signalType);
+    out.push(
+      makeEntry({
+        subjectId: input.subjectId,
+        sessionId: input.sessionId,
+        turnRef: input.turnRef,
+        type: "boundary_event",
+        source: "motor_inferred",
+        confidence: 0.85,
+        alignment: "unknown",
+        payload: {
+          kind: "boundary_event",
+          signal_type: signalType,
+          topic_category: input.topicCategory ?? "indefinido",
+          intensity,
+          motor_response: motorResponse,
+          severity_band: "routine",
+        },
+      }),
+    );
+  }
+  return out;
+}
+
+function signalIntensity(s: BoundarySignalType): "low" | "mid" | "high" {
+  switch (s) {
+    case "distress_marker_high":
+    case "exit_marker_explicit":
+      return "high";
+    case "distress_marker_low":
+    case "frame_rejection":
+    case "deflection_thematic":
+      return "mid";
+    default:
+      return "low";
+  }
+}
+
+function inferMotorResponse(
+  s: BoundarySignalType,
+): "muda_tema" | "suaviza" | "recua_total" | "outro" {
+  switch (s) {
+    case "exit_marker_explicit":
+    case "distress_marker_high":
+      return "recua_total";
+    case "deflection_thematic":
+      return "muda_tema";
+    case "gatekeeper_resistance":
+    case "frame_rejection":
+      return "suaviza";
+    default:
+      return "outro";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+interface MakeEntryInput {
+  subjectId: string;
+  sessionId: string;
+  turnRef: string;
+  type: SubjectKnowledgeEntry["type"];
+  source: SubjectKnowledgeEntry["source"];
+  confidence: number;
+  alignment?: SubjectKnowledgeAlignment;
+  payload: SubjectKnowledgeEntry["payload"];
+}
+
+function makeEntry(i: MakeEntryInput): SubjectKnowledgeEntry {
+  return {
+    id: `sk-${i.subjectId}-${i.turnRef}-${i.type}-${randomTag()}`,
+    subject_id: i.subjectId,
+    type: i.type,
+    source: i.source,
+    confidence: i.confidence,
+    confirmed_at: i.source === "self_declared" ? i.turnRef : null,
+    alignment: i.alignment ?? "unknown",
+    payload: i.payload,
+    turn_ref: i.turnRef,
+    session_id: i.sessionId,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function randomTag(): string {
+  return Math.random().toString(36).slice(2, 8);
+}

--- a/shared/tests/subject-knowledge-writers.test.ts
+++ b/shared/tests/subject-knowledge-writers.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests DiscoveryWriter + BoundaryEventWriter (spec 2026-05-25 Fase 2).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  extractDiscoveries,
+  extractBoundaryEvents,
+} from "../src/subject-knowledge-writers.js";
+
+const baseDiscoveryInput = {
+  subjectId: "ryo",
+  sessionId: "sess-1",
+  turnRef: "sess-1__turn_2",
+};
+
+describe("extractDiscoveries — interests", () => {
+  it("detecta 'eu gosto de X' como interest mid", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "eu gosto de tênis e anime",
+    });
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    const interest = out.find((e) => e.type === "interest");
+    expect(interest).toBeDefined();
+    if (interest && interest.payload.kind === "interest") {
+      expect(interest.payload.label).toContain("tênis");
+      expect(interest.payload.intensity).toBe("mid");
+    }
+  });
+
+  it("detecta 'adoro X' como interest high", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "adoro Dragon Ball",
+    });
+    const interest = out.find((e) => e.type === "interest");
+    expect(interest).toBeDefined();
+    if (interest && interest.payload.kind === "interest") {
+      expect(interest.payload.label).toContain("Dragon Ball");
+      expect(interest.payload.intensity).toBe("high");
+    }
+  });
+
+  it("detecta 'sou fã de X' como interest high", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "sou fã declarado de skate",
+    });
+    const interest = out.find((e) => e.type === "interest");
+    expect(interest).toBeDefined();
+  });
+
+  it("não emite interest pra mensagem neutra", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "hoje fui na escola, voltei e jantei",
+    });
+    expect(out.filter((e) => e.type === "interest")).toHaveLength(0);
+  });
+
+  it("não emite nada pra mensagem vazia", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "",
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it("entries têm source=self_declared e confirmed_at=turnRef", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "eu gosto de matemática",
+    });
+    for (const e of out) {
+      expect(e.source).toBe("self_declared");
+      expect(e.confirmed_at).toBe(baseDiscoveryInput.turnRef);
+    }
+  });
+});
+
+describe("extractDiscoveries — values", () => {
+  it("detecta 'pra mim importa X'", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "pra mim importa amizade verdadeira mais que nota boa",
+    });
+    const v = out.find((e) => e.type === "value");
+    expect(v).toBeDefined();
+    if (v && v.payload.kind === "value") {
+      expect(v.payload.label.toLowerCase()).toContain("amizade");
+    }
+  });
+});
+
+describe("extractDiscoveries — needs", () => {
+  it("detecta 'queria muito ...' como need", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "queria muito poder dormir mais",
+    });
+    const n = out.find((e) => e.type === "need");
+    expect(n).toBeDefined();
+  });
+
+  it("detecta 'precisava de X'", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "precisava de paz pra estudar",
+    });
+    const n = out.find((e) => e.type === "need");
+    expect(n).toBeDefined();
+  });
+});
+
+const baseBoundaryInput = {
+  subjectId: "ryo",
+  sessionId: "sess-1",
+  turnRef: "sess-1__turn_3",
+};
+
+describe("extractBoundaryEvents", () => {
+  it("emite boundary_event pra deflection_thematic", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: ["deflection_thematic"],
+      topicCategory: "tema_escolar_recente",
+    });
+    expect(out).toHaveLength(1);
+    const e = out[0];
+    expect(e.type).toBe("boundary_event");
+    expect(e.source).toBe("motor_inferred");
+    if (e.payload.kind === "boundary_event") {
+      expect(e.payload.signal_type).toBe("deflection_thematic");
+      expect(e.payload.topic_category).toBe("tema_escolar_recente");
+      expect(e.payload.motor_response).toBe("muda_tema");
+      expect(e.payload.severity_band).toBe("routine");
+      expect(e.payload.intensity).toBe("mid");
+    }
+  });
+
+  it("mapeia distress_marker_high → motor_response=recua_total + intensity=high", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: ["distress_marker_high"],
+    });
+    const e = out[0];
+    if (e.payload.kind === "boundary_event") {
+      expect(e.payload.motor_response).toBe("recua_total");
+      expect(e.payload.intensity).toBe("high");
+    }
+  });
+
+  it("mapeia exit_marker_explicit → recua_total", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: ["exit_marker_explicit"],
+    });
+    if (out[0].payload.kind === "boundary_event") {
+      expect(out[0].payload.motor_response).toBe("recua_total");
+    }
+  });
+
+  it("mapeia gatekeeper_resistance → suaviza", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: ["gatekeeper_resistance"],
+    });
+    if (out[0].payload.kind === "boundary_event") {
+      expect(out[0].payload.motor_response).toBe("suaviza");
+    }
+  });
+
+  it("ignora signals que não são boundaries (ex: frame_synthesis)", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: ["frame_synthesis", "mood_drift_up"],
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it("emite multiple events quando há multiple boundary signals", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: [
+        "deflection_thematic",
+        "gatekeeper_resistance",
+        "mood_drift_down",
+      ],
+      topicCategory: "tema_X",
+    });
+    expect(out).toHaveLength(3);
+    for (const e of out) {
+      expect(e.type).toBe("boundary_event");
+    }
+  });
+
+  it("topicCategory ausente vira 'indefinido'", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: ["deflection_thematic"],
+    });
+    if (out[0].payload.kind === "boundary_event") {
+      expect(out[0].payload.topic_category).toBe("indefinido");
+    }
+  });
+
+  it("respeita motorResponse override do caller", () => {
+    const out = extractBoundaryEvents({
+      ...baseBoundaryInput,
+      signals: ["deflection_thematic"],
+      motorResponse: "outro",
+    });
+    if (out[0].payload.kind === "boundary_event") {
+      expect(out[0].payload.motor_response).toBe("outro");
+    }
+  });
+});
+
+describe("entry IDs", () => {
+  it("são únicos entre múltiplas extrações no mesmo turn", () => {
+    const out = extractDiscoveries({
+      ...baseDiscoveryInput,
+      lastUserMessage: "eu gosto de tênis e gosto de anime e adoro Dragon Ball",
+    });
+    const ids = out.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
## Summary
Fase 2 da [spec](https://github.com/ascendimacy/ascendimacy-ops/blob/docs/c-mx-07-c-mx-08-specs/docs/specs/2026-05-25-subject-knowledge-bridge.md). **Base = #205 (Fase 1)** — mergear F1 primeiro.

Writers + pipeline trace→SQLite + endpoints REST.

### Writers (pure functions em \`shared/\`)
\`\`\`ts
extractDiscoveries({ subjectId, sessionId, turnRef, lastUserMessage, signals, mood })
  → SubjectKnowledgeEntry[] de tipo interest/value/need
extractBoundaryEvents({ subjectId, sessionId, turnRef, signals, topicCategory })
  → SubjectKnowledgeEntry[] de tipo boundary_event
\`\`\`

Heurística v1 (regex pt-BR):
- **Interests**: "eu gosto de X" (mid) · "adoro X" (high) · "sou fã" (high) · "favorito" (high)
- **Values**: "pra mim importa X" · "acho que X importa"
- **Needs**: "queria muito" · "precisava de"
- **Boundaries**: 8 signal_types do assessor → mapeados pra motor_response (muda_tema/suaviza/recua_total)

### Pipeline
Motor (\`simplified-pipeline-handler.ts\`) chama writers após \`assess()\` e emite eventos em \`EvaluateAndSelectOutput.subjectKnowledgeEvents\`. BFF scanner lê do trace JSON (campo \`turn.subjectKnowledgeEvents\` ou fallback \`turn.motorTrace.drota.subjectKnowledgeEvents\`) e popula \`subject_knowledge\` table. Idempotente: re-scan substitui events da sessão.

### Endpoints REST novos
- \`GET /subjects/:id/discoveries?type=interest&session=X&limit=50\`
- \`GET /subjects/:id/boundaries?session=X\`
- \`GET /subjects/:id/boundaries/summary\` — agregado por \`topic_category\` com \`count\` + \`high_intensity_count\` (insumo Console UI)

## Test plan
- [x] \`shared/tests/subject-knowledge-writers.test.ts\` — 18 tests (regex patterns, mapeamentos signals→motor_response, IDs únicos)
- [x] \`packages/ebrota-console-bff/tests/subject-knowledge-pipeline.test.ts\` — 10 tests end-to-end (trace → scanner → repo → endpoints)
- [x] Build verde
- [x] Suite: shared 704 (+18) · bff 117 (+10) · motor 298 · planejador 321 — zero regressão

## Próximo passo após merge
Bridge/STS precisam incluir \`subjectKnowledgeEvents\` no trace JSON que escrevem (motor já emite no output). Fase 3 (Inaugural+Ledger) é o próximo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)