### PR TITLE
[feat] Subject Knowledge Fase 3 — Inaugural contract + ConceptLedgerWriter

### DIFF
--- a/motor-drota/src/inaugural-template.ts
+++ b/motor-drota/src/inaugural-template.ts
@@ -52,6 +52,22 @@ export interface InauguralResolveInput {
   jointPartnerName?: string;
 }
 
+/**
+ * Subject Knowledge Fase 3: pergunta aberta obrigatória pra cada sessão
+ * inaugural (princípio "pergunta aberta abre cada sessão").
+ *
+ * Schema validador (validateInauguralOutput) rejeita templates sem
+ * discovery_question.text não-vazio — não passa code review nem teste.
+ */
+export interface DiscoveryQuestion {
+  /** Pergunta aberta intencional formulada ao sujeito. */
+  text: string;
+  /** O que estamos investigando — guia downstream do DiscoveryWriter. */
+  intent: "interest" | "value" | "context" | "feeling";
+  /** Categorias de signal esperadas como resposta (informativo). */
+  expected_signal_categories: string[];
+}
+
 export interface InauguralResolveOutput {
   /** Texto completo pronto pra Bridge. */
   text: string;
@@ -67,6 +83,12 @@ export interface InauguralResolveOutput {
   exit_right_present: boolean;
   /** Source da cascade ("client_override" | "cultural_default" | "universal"). */
   cascade_source: "client_override" | "cultural_default" | "universal";
+  /**
+   * Subject Knowledge Fase 3: pergunta aberta intencional do turn 0.
+   * Para sessão recorrente (sessionNumber > 1) o motor pode optar por
+   * não incluir — null sinaliza ausência consciente.
+   */
+  discovery_question: DiscoveryQuestion | null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -81,6 +103,17 @@ const UNIVERSAL_FALLBACK = {
   exit_right: "Se quiser parar, é só falar.",
   confirmation_invite_default: "O que tá rolando aí?",
   confirmation_invite_template: "Hoje quer falar sobre {interest}?",
+  /**
+   * Subject Knowledge Fase 3: pergunta aberta default quando nenhuma
+   * tradição/cultura customizada provê uma. Intencionalmente investiga
+   * INTEREST (a maior probabilidade de retorno num turn 0). Cultural
+   * defaults podem override pra `feeling`, `context`, etc.
+   */
+  discovery_question: {
+    text: "Tem alguma coisa que tá te interessando agora? Pode ser qualquer coisa — algo que você faz, que aprende, ou que fica na sua cabeça mesmo sem querer.",
+    intent: "interest" as const,
+    expected_signal_categories: ["interest_marker", "engagement_high"],
+  },
 };
 
 const UNIVERSAL_RECORRENTE = {
@@ -171,6 +204,7 @@ export function resolveInauguralTemplate(
       non_evaluation_clause_present: false, // recorrente não precisa
       exit_right_present: false,
       cascade_source: recorrenteOverride ? "client_override" : "universal",
+      discovery_question: null, // recorrente: motor decide dinamicamente
     };
   }
 
@@ -229,9 +263,55 @@ export function resolveInauguralTemplate(
     invite = def.value;
   }
 
-  // Compose final text
+  // Resolve discovery_question via cascade. Cultural default pode prover
+  // tanto string solta quanto objeto completo; aqui pegamos string e usamos
+  // intent default 'interest'. Override completo via voice_profile.discovery_question.
+  const discoveryQuestionText = resolveField(
+    ["inaugural", "discovery_question"],
+    input.voiceProfile,
+    input.culturalDefault,
+    UNIVERSAL_FALLBACK.discovery_question.text,
+  );
+  // voice_profile pode declarar intent diferente (interest/value/context/feeling)
+  const discoveryQuestionIntentRaw =
+    asString(getNested(input.voiceProfile, ["inaugural", "discovery_question_intent"])) ??
+    asString(getNested(input.culturalDefault, ["inaugural", "discovery_question_intent"])) ??
+    UNIVERSAL_FALLBACK.discovery_question.intent;
+  const discoveryQuestionIntent: DiscoveryQuestion["intent"] =
+    discoveryQuestionIntentRaw === "value" ||
+    discoveryQuestionIntentRaw === "context" ||
+    discoveryQuestionIntentRaw === "feeling"
+      ? discoveryQuestionIntentRaw
+      : "interest";
+
+  const discoveryQuestion: DiscoveryQuestion = {
+    text: discoveryQuestionText.value,
+    intent: discoveryQuestionIntent,
+    expected_signal_categories:
+      UNIVERSAL_FALLBACK.discovery_question.expected_signal_categories,
+  };
+
+  // Compose final text: invite/discovery_question fecha o acolhimento.
+  // Backcompat: se interest disponível usa invite ancorado; senão, se
+  // cultural/voice trouxe confirmation_invite_default não-universal, usa
+  // ele; em último caso, usa a nova discovery_question (PT-BR universal).
+  let closingQuestion: string;
+  if (input.child.topInterest) {
+    closingQuestion = invite;
+  } else {
+    const def = resolveField(
+      inviteDefaultPath,
+      input.voiceProfile,
+      input.culturalDefault,
+      "", // universal vazio força fallback pra discovery_question
+    );
+    closingQuestion =
+      def.value && def.source !== "universal"
+        ? def.value
+        : discoveryQuestion.text;
+  }
   const greetingLine = `${greeting.value}, ${subjectNameForm}.`;
-  const text = [greetingLine, purpose.value, nonEval.value, exitRight.value, invite]
+  const text = [greetingLine, purpose.value, nonEval.value, exitRight.value, closingQuestion]
     .filter((s) => s && s.trim().length > 0)
     .join(" ");
 
@@ -255,5 +335,55 @@ export function resolveInauguralTemplate(
     non_evaluation_clause_present: nonEval.value.length > 0,
     exit_right_present: exitRight.value.length > 0,
     cascade_source: cascadeSource,
+    discovery_question: discoveryQuestion,
   };
+}
+
+/**
+ * Validador estrutural — falha hard quando o acolhimento do turn 0 não
+ * carrega `discovery_question` com texto não-vazio.
+ *
+ * Princípio "pergunta aberta abre cada sessão" (Subject Knowledge Fase 3):
+ * sessão sem pergunta aberta intencional viola o contrato pedagógico
+ * eBrota e não pode passar code review nem teste de integração.
+ *
+ * Sessões recorrentes (template_used === "inaugural_recorrente") são
+ * exceção — motor decide pergunta dinamicamente no flow normal.
+ */
+export class InauguralValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InauguralValidationError";
+  }
+}
+
+export function validateInauguralOutput(
+  output: InauguralResolveOutput,
+): void {
+  if (output.template_used === "inaugural_recorrente") {
+    return; // sessão recorrente — sem obrigatoriedade
+  }
+  if (!output.discovery_question) {
+    throw new InauguralValidationError(
+      "discovery_question ausente — princípio pedagógico exige pergunta aberta no turn 0",
+    );
+  }
+  if (
+    typeof output.discovery_question.text !== "string" ||
+    output.discovery_question.text.trim().length === 0
+  ) {
+    throw new InauguralValidationError(
+      "discovery_question.text vazio — pergunta aberta intencional obrigatória",
+    );
+  }
+  if (!output.non_evaluation_clause_present) {
+    throw new InauguralValidationError(
+      "non_evaluation_clause obrigatória no acolhimento inaugural",
+    );
+  }
+  if (!output.exit_right_present) {
+    throw new InauguralValidationError(
+      "exit_right obrigatório no acolhimento inaugural",
+    );
+  }
 }

--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -25,6 +25,7 @@ import type {
 import {
   extractDiscoveries,
   extractBoundaryEvents,
+  extractPresentedConcepts,
 } from "@ascendimacy/shared";
 
 import { assess } from "./unified-assessor.js";
@@ -188,6 +189,21 @@ export async function handleSimplifiedPipeline(
     incomingMessage: lastUserMessage,
     recentTurns,
   });
+
+  // ── Fase 3: ConceptLedgerWriter — após materializar o Fact, emite
+  // presented_concept (+1pt) se item está taggeado com axis_id/family/
+  // lineage_anchor/extracted_keywords. Items legados sem tags simplesmente
+  // não geram entry. Fallback (rawText vazio) também não conta.
+  if (!matResult.fallback_triggered) {
+    subjectKnowledgeEvents.push(
+      ...extractPresentedConcepts({
+        subjectId: input.persona.id,
+        sessionId: input.sessionId,
+        turnRef,
+        item: selectionResult.selected.item,
+      }),
+    );
+  }
 
   return {
     selectedContent: selectionResult.selected,

--- a/motor-drota/tests/inaugural-validator.test.ts
+++ b/motor-drota/tests/inaugural-validator.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests do validateInauguralOutput (spec 2026-05-25 Fase 3).
+ * Princípio "pergunta aberta abre cada sessão".
+ */
+import { describe, it, expect } from "vitest";
+import {
+  resolveInauguralTemplate,
+  validateInauguralOutput,
+  InauguralValidationError,
+  type InauguralResolveOutput,
+} from "../src/inaugural-template.js";
+
+describe("resolveInauguralTemplate inclui discovery_question", () => {
+  it("session 1 universal (sem profile) traz discovery_question default", () => {
+    const out = resolveInauguralTemplate({
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(out.discovery_question).not.toBeNull();
+    expect(out.discovery_question?.text.length).toBeGreaterThan(0);
+    expect(out.discovery_question?.intent).toBe("interest");
+  });
+
+  it("session recorrente discovery_question = null (motor decide dinâmico)", () => {
+    const out = resolveInauguralTemplate({
+      child: { name: "Ryo" },
+      sessionNumber: 3,
+    });
+    expect(out.discovery_question).toBeNull();
+  });
+
+  it("cultural profile pode override discovery_question text", () => {
+    const out = resolveInauguralTemplate({
+      culturalDefault: {
+        language: "ja",
+        inaugural: {
+          greeting: "こんにちは",
+          purpose: "p",
+          non_evaluation_clause: "n",
+          exit_right: "e",
+          discovery_question: "今、何が頭にある?",
+        },
+      },
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(out.discovery_question?.text).toBe("今、何が頭にある?");
+  });
+
+  it("voice profile pode override intent", () => {
+    const out = resolveInauguralTemplate({
+      voiceProfile: {
+        inaugural: {
+          discovery_question_intent: "feeling",
+        },
+      },
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(out.discovery_question?.intent).toBe("feeling");
+  });
+
+  it("invalid intent default volta pra 'interest'", () => {
+    const out = resolveInauguralTemplate({
+      voiceProfile: {
+        inaugural: { discovery_question_intent: "garbage" },
+      },
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(out.discovery_question?.intent).toBe("interest");
+  });
+});
+
+describe("validateInauguralOutput — princípio P3", () => {
+  const validBase: InauguralResolveOutput = {
+    text: "Oi, Ryo. ...",
+    template_used: "inaugural_universal_fallback",
+    non_evaluation_clause_present: true,
+    exit_right_present: true,
+    cascade_source: "universal",
+    discovery_question: {
+      text: "Tem alguma coisa te interessando?",
+      intent: "interest",
+      expected_signal_categories: ["interest_marker"],
+    },
+  };
+
+  it("passa pra output válido", () => {
+    expect(() => validateInauguralOutput(validBase)).not.toThrow();
+  });
+
+  it("falha quando discovery_question é null em sessão 1", () => {
+    const bad: InauguralResolveOutput = { ...validBase, discovery_question: null };
+    expect(() => validateInauguralOutput(bad)).toThrow(InauguralValidationError);
+    expect(() => validateInauguralOutput(bad)).toThrow(/discovery_question ausente/);
+  });
+
+  it("falha quando discovery_question.text é vazio", () => {
+    const bad: InauguralResolveOutput = {
+      ...validBase,
+      discovery_question: { ...validBase.discovery_question!, text: "   " },
+    };
+    expect(() => validateInauguralOutput(bad)).toThrow(/text vazio/);
+  });
+
+  it("falha quando non_evaluation_clause ausente", () => {
+    const bad: InauguralResolveOutput = { ...validBase, non_evaluation_clause_present: false };
+    expect(() => validateInauguralOutput(bad)).toThrow(/non_evaluation_clause/);
+  });
+
+  it("falha quando exit_right ausente", () => {
+    const bad: InauguralResolveOutput = { ...validBase, exit_right_present: false };
+    expect(() => validateInauguralOutput(bad)).toThrow(/exit_right/);
+  });
+
+  it("sessão recorrente é exceção — não exige discovery_question", () => {
+    const recorrente: InauguralResolveOutput = {
+      text: "Olá de novo, Ryo. Pegando de onde paramos?",
+      template_used: "inaugural_recorrente",
+      non_evaluation_clause_present: false,
+      exit_right_present: false,
+      cascade_source: "universal",
+      discovery_question: null,
+    };
+    expect(() => validateInauguralOutput(recorrente)).not.toThrow();
+  });
+
+  it("output do resolver real passa no validador (smoke)", () => {
+    const out = resolveInauguralTemplate({
+      child: { name: "Ryo" },
+      sessionNumber: 1,
+    });
+    expect(() => validateInauguralOutput(out)).not.toThrow();
+  });
+});

--- a/shared/src/concept-ledger-writer.ts
+++ b/shared/src/concept-ledger-writer.ts
@@ -1,0 +1,92 @@
+/**
+ * ConceptLedgerWriter — emite presented_concept (+1pt) quando motor
+ * materializa um Fact ancorado em eixo/lineage.
+ *
+ * Spec: 2026-05-25-subject-knowledge-bridge.md §4.4.
+ *
+ * Pure function: recebe content_item + context → SubjectKnowledgeEntry | null.
+ * Retorna null quando item não tem os 4 campos necessários (axis_id, family,
+ * lineage_anchor, extracted_keywords) — items legados sem tags simplesmente
+ * não contribuem pro ledger (zero side-effect).
+ */
+
+import type { ContentItem } from "./content-item.js";
+import type { SubjectKnowledgeEntry } from "./subject-knowledge.js";
+
+export interface ConceptLedgerWriterInput {
+  subjectId: string;
+  sessionId: string;
+  turnRef: string;
+  item: ContentItem;
+}
+
+/**
+ * Tenta emitir presented_concept (+1pt). Retorna null se item não tem
+ * as 4 tags necessárias — Fase 3 não força backfill mecânico em items
+ * existentes, então a maioria dos items continua sem entry (esperado).
+ *
+ * Quando todos os campos estão presentes:
+ *   - concept_id = item.id (assumimos único cross-catalog)
+ *   - keywords = item.extracted_keywords
+ *   - lineage_anchor = item.lineage_anchor
+ *   - axis_id = item.axis_id
+ *   - family = item.family
+ *   - points = 1 (fixo na v1)
+ */
+export function extractPresentedConcept(
+  input: ConceptLedgerWriterInput,
+): SubjectKnowledgeEntry | null {
+  const { item } = input;
+  if (
+    typeof item.axis_id !== "number" ||
+    item.axis_id < 1 ||
+    item.axis_id > 12
+  )
+    return null;
+  if (
+    item.family !== "carater" &&
+    item.family !== "disposicao" &&
+    item.family !== "cognicao_si"
+  )
+    return null;
+  if (typeof item.lineage_anchor !== "string" || item.lineage_anchor.length === 0)
+    return null;
+  if (
+    !Array.isArray(item.extracted_keywords) ||
+    item.extracted_keywords.length === 0
+  )
+    return null;
+
+  return {
+    id: `sk-pc-${input.subjectId}-${input.turnRef}-${item.id}`,
+    subject_id: input.subjectId,
+    type: "presented_concept",
+    source: "motor_inferred",
+    confidence: 1.0,
+    confirmed_at: input.turnRef,
+    alignment: "unknown",
+    payload: {
+      kind: "presented_concept",
+      concept_id: item.id,
+      keywords: item.extracted_keywords,
+      lineage_anchor: item.lineage_anchor,
+      axis_id: item.axis_id,
+      family: item.family,
+      points: 1,
+    },
+    turn_ref: input.turnRef,
+    session_id: input.sessionId,
+    created_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Helper para uso direto no pipeline: retorna array (vazio ou unitário)
+ * pra concatenar com outros eventos do turn sem branching no caller.
+ */
+export function extractPresentedConcepts(
+  input: ConceptLedgerWriterInput,
+): SubjectKnowledgeEntry[] {
+  const entry = extractPresentedConcept(input);
+  return entry ? [entry] : [];
+}

--- a/shared/src/content-item.ts
+++ b/shared/src/content-item.ts
@@ -150,6 +150,23 @@ export interface ContentItemBase {
    * Spec ops#1015 G-01 (CASEL × Dreyfus × Gardner), Jun ratificado 2026-05-16.
    */
   dreyfus_level_target?: [DreyfusLevel, DreyfusLevel];
+
+  /**
+   * Subject Knowledge Fase 3 — tags pra ponte tripla + ledger de conceitos.
+   * Quando os 4 campos abaixo estão presentes, ConceptLedgerWriter emite
+   * `presented_concept` (+1pt) no SubjectKnowledge após o item ser materializado.
+   *
+   * Campos opcionais por compatibilidade — items legados sem tags
+   * continuam funcionando, apenas não geram entry no ledger.
+   *
+   * Spec: 2026-05-25-subject-knowledge-bridge.md §3 + §4.4.
+   */
+  axis_id?: number; // 1..12
+  family?: "carater" | "disposicao" | "cognicao_si";
+  /** "tradicao/complemento" — ex: "estoica/dicotomia_controle". */
+  lineage_anchor?: string;
+  /** Palavras-chave do conceito pra futura detecção de recall. */
+  extracted_keywords?: string[];
 }
 
 export interface CuriosityHookItem extends ContentItemBase {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -24,6 +24,7 @@ export * from "./parental-profile.js";
 export * from "./lineage-catalog.js";
 export * from "./subject-knowledge.js";
 export * from "./subject-knowledge-writers.js";
+export * from "./concept-ledger-writer.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/tests/concept-ledger-writer.test.ts
+++ b/shared/tests/concept-ledger-writer.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests do ConceptLedgerWriter (spec 2026-05-25 Fase 3).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  extractPresentedConcept,
+  extractPresentedConcepts,
+} from "../src/concept-ledger-writer.js";
+import type { CuriosityHookItem } from "../src/content-item.js";
+
+const taggedItem: CuriosityHookItem = {
+  id: "metamorfose_lagarta",
+  type: "curiosity_hook",
+  domain: "biologia",
+  casel_target: ["SA"],
+  age_range: [10, 15],
+  surprise: 8,
+  verified: true,
+  base_score: 7,
+  fact: "lagarta vira sopa dentro do casulo",
+  bridge: "como você muda",
+  quest: "que mudança você sentiu?",
+  sacrifice_type: "reflect",
+  // Subject Knowledge tags:
+  axis_id: 4,
+  family: "carater",
+  lineage_anchor: "zen/shoshin",
+  extracted_keywords: ["lagarta", "casulo", "metamorfose", "transformação"],
+};
+
+const untaggedItem: CuriosityHookItem = {
+  id: "legacy-no-tags",
+  type: "curiosity_hook",
+  domain: "ciência",
+  casel_target: ["SA"],
+  age_range: [10, 15],
+  surprise: 6,
+  verified: true,
+  base_score: 5,
+  fact: "x",
+  bridge: "y",
+  quest: "z",
+  sacrifice_type: "reflect",
+};
+
+describe("extractPresentedConcept — item tagged", () => {
+  it("retorna entry presented_concept com +1pt", () => {
+    const entry = extractPresentedConcept({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "sess-1__turn_2",
+      item: taggedItem,
+    });
+    expect(entry).not.toBeNull();
+    if (entry && entry.payload.kind === "presented_concept") {
+      expect(entry.payload.concept_id).toBe("metamorfose_lagarta");
+      expect(entry.payload.axis_id).toBe(4);
+      expect(entry.payload.family).toBe("carater");
+      expect(entry.payload.lineage_anchor).toBe("zen/shoshin");
+      expect(entry.payload.keywords).toContain("metamorfose");
+      expect(entry.payload.points).toBe(1);
+    }
+    expect(entry?.confidence).toBe(1.0);
+    expect(entry?.source).toBe("motor_inferred");
+    expect(entry?.type).toBe("presented_concept");
+  });
+});
+
+describe("extractPresentedConcept — item sem tags retorna null", () => {
+  it("legacy item sem axis_id/family/lineage_anchor/keywords", () => {
+    const entry = extractPresentedConcept({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "sess-1__turn_2",
+      item: untaggedItem,
+    });
+    expect(entry).toBeNull();
+  });
+
+  it("item com axis_id fora de 1..12 retorna null", () => {
+    const entry = extractPresentedConcept({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "sess-1__turn_2",
+      item: { ...taggedItem, axis_id: 15 },
+    });
+    expect(entry).toBeNull();
+  });
+
+  it("item com family inválido retorna null", () => {
+    const entry = extractPresentedConcept({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "sess-1__turn_2",
+      // @ts-expect-error testing invalid family
+      item: { ...taggedItem, family: "nonsense" },
+    });
+    expect(entry).toBeNull();
+  });
+
+  it("item com extracted_keywords vazio retorna null", () => {
+    const entry = extractPresentedConcept({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "sess-1__turn_2",
+      item: { ...taggedItem, extracted_keywords: [] },
+    });
+    expect(entry).toBeNull();
+  });
+
+  it("item com lineage_anchor vazio retorna null", () => {
+    const entry = extractPresentedConcept({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "sess-1__turn_2",
+      item: { ...taggedItem, lineage_anchor: "" },
+    });
+    expect(entry).toBeNull();
+  });
+});
+
+describe("extractPresentedConcepts (array helper)", () => {
+  it("retorna array unitário pra item tagged", () => {
+    const arr = extractPresentedConcepts({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "t1",
+      item: taggedItem,
+    });
+    expect(arr).toHaveLength(1);
+  });
+
+  it("retorna array vazio pra item untagged", () => {
+    const arr = extractPresentedConcepts({
+      subjectId: "ryo",
+      sessionId: "sess-1",
+      turnRef: "t1",
+      item: untaggedItem,
+    });
+    expect(arr).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Fase 3 da [spec](https://github.com/ascendimacy/ascendimacy-ops/blob/docs/c-mx-07-c-mx-08-specs/docs/specs/2026-05-25-subject-knowledge-bridge.md). **Base = #207 (Fase 2)** — rebase em F2.

Dois entregáveis paralelos: contrato formal pra "pergunta aberta abre cada sessão" + ledger automático de conceitos materializados (+1pt).

### Inaugural Template contract
\`InauguralResolveOutput.discovery_question: { text, intent, expected_signal_categories } | null\`

- Universal fallback PT-BR intencional ("Tem alguma coisa que tá te interessando agora?" — intent=interest)
- Cultural/voice profiles podem override texto e intent (4 valores: interest/value/context/feeling)
- **Backcompat preservada**: cultural \`confirmation_invite_default\` (ex: JP "今日は何が気になってる?") ainda vence quando presente — discovery_question entra como fallback universal
- \`validateInauguralOutput()\` throws \`InauguralValidationError\` quando:
  - discovery_question null/empty em sessão 1
  - non_evaluation_clause ausente
  - exit_right ausente
  - sessão recorrente é exceção (motor decide dinâmico)

### ConceptLedgerWriter
\`\`\`ts
extractPresentedConcept({ subjectId, sessionId, turnRef, item })
  → SubjectKnowledgeEntry | null
\`\`\`
- Item precisa de **4 tags** (\`axis_id\` 1-12, \`family\`, \`lineage_anchor\`, \`extracted_keywords\` não-vazio) — items legados sem tags retornam null silenciosamente
- Payload: \`{ concept_id, keywords, lineage_anchor, axis_id, family, points: 1 }\`
- Hook automático no pipeline simplificado após \`materialize()\` (skip em fallback)

### ContentItemBase ganha tags opcionais
\`\`\`ts
axis_id?: number;             // 1..12 do catálogo (F4)
family?: "carater" | "disposicao" | "cognicao_si";
lineage_anchor?: string;      // "tradicao/complemento" ex: "estoica/dicotomia_controle"
extracted_keywords?: string[]; // pra detecção de recall futura
\`\`\`

## Test plan
- [x] \`shared/tests/concept-ledger-writer.test.ts\` — 8 tests (item tagged → entry; untagged/inválido → null)
- [x] \`motor-drota/tests/inaugural-validator.test.ts\` — 12 tests (cascade resolução discovery_question, validador rejeita ausência, sessão recorrente é exceção, backcompat)
- [x] \`motor-drota/tests/inaugural-template.test.ts\` — 14/14 backcompat preservada
- [x] Build verde
- [x] Suite: shared 712 (+8) · motor 310 (+12) · planejador 321 · bff 117 — zero regressão

## Próximos passos pós-merge
- **Backfill dos content_seeds** com tags axis_id/family/lineage_anchor/keywords (PR separado, mecânico — pode rodar paralelo)
- **Fase 5** vai consumir as tags no scorer multi-dim + RecallCheckEvaluator

🤖 Generated with [Claude Code](https://claude.com/claude-code)