### PR TITLE
[chore] Subject Knowledge — backfill mecânico de tags nos content seeds

### DIFF
--- a/content/hooks/seed.json
+++ b/content/hooks/seed.json
@@ -26,6 +26,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "palavras",
+      "diferentes",
+      "inuit",
+      "ártico",
+      "salvar"
     ]
   },
   {
@@ -50,6 +60,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "números",
+      "justo",
+      "pirahã",
+      "amazônia",
+      "brasileira"
     ]
   },
   {
@@ -81,6 +101,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "silêncio",
+      "pesado",
+      "bonito",
+      "quantos",
+      "japonês"
     ]
   },
   {
@@ -114,6 +144,16 @@
     "dreyfus_level_target": [
       "apprentice",
       "practitioner"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "gregos",
+      "antigos",
+      "tinham",
+      "palavras",
+      "paixão"
     ]
   },
   {
@@ -138,6 +178,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "comunicar",
+      "difícil",
+      "gomera",
+      "espanha",
+      "pessoas"
     ]
   },
   {
@@ -162,6 +212,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "palavra",
+      "idioma",
+      "nenhum",
+      "emoção",
+      "palavras"
     ]
   },
   {
@@ -186,6 +246,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "frase",
+      "dizer",
+      "alguém",
+      "fofoca",
+      "contaram"
     ]
   },
   {
@@ -217,6 +287,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "corações",
+      "polvo",
+      "bombeiam",
+      "sangue",
+      "guelras"
     ]
   },
   {
@@ -246,6 +326,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "árvores",
+      "vizinhas",
+      "perigo",
+      "avisa",
+      "alguém"
     ]
   },
   {
@@ -279,6 +369,16 @@
     "dreyfus_level_target": [
       "apprentice",
       "practitioner"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "assovio",
+      "golfinhos",
+      "golfinho",
+      "único",
+      "chamam"
     ]
   },
   {
@@ -303,6 +403,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "espelho",
+      "elefantes",
+      "pessoa",
+      "reconhecem",
+      "espécies"
     ]
   },
   {
@@ -334,6 +444,16 @@
     "dreyfus_level_target": [
       "apprentice",
       "practitioner"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "formiga",
+      "grupo",
+      "velha",
+      "sente",
+      "morrer"
     ]
   },
   {
@@ -358,6 +478,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "casulo",
+      "dentro",
+      "lagarta",
+      "dissolve",
+      "completamente"
     ]
   },
   {
@@ -382,6 +512,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 4,
+    "family": "carater",
+    "lineage_anchor": "paideia/sophrosyne",
+    "extracted_keywords": [
+      "rancor",
+      "corvos",
+      "guardam",
+      "soltar",
+      "reconhecem"
     ]
   },
   {
@@ -413,6 +553,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "intestino",
+      "barriga",
+      "decisão",
+      "milhões",
+      "neurônios"
     ]
   },
   {
@@ -437,6 +587,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "raiva",
+      "alegria",
+      "choro",
+      "lágrimas",
+      "tristeza"
     ]
   },
   {
@@ -461,6 +621,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "olhando",
+      "olhos",
+      "conversa",
+      "pessoas",
+      "conversam"
     ]
   },
   {
@@ -485,6 +655,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 4,
+    "family": "carater",
+    "lineage_anchor": "paideia/sophrosyne",
+    "extracted_keywords": [
+      "sorrir",
+      "sorriso",
+      "corpo",
+      "felicidade",
+      "franzir"
     ]
   },
   {
@@ -509,6 +689,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 4,
+    "family": "carater",
+    "lineage_anchor": "paideia/sophrosyne",
+    "extracted_keywords": [
+      "respiração",
+      "automático",
+      "única",
+      "função",
+      "autônoma"
     ]
   },
   {
@@ -533,6 +723,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "cérebro",
+      "quais",
+      "habilidades",
+      "manter",
+      "adolescência"
     ]
   },
   {
@@ -557,6 +757,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "estrela",
+      "feito",
+      "átomo",
+      "corpo",
+      "fabricado"
     ]
   },
   {
@@ -581,6 +791,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "tempo",
+      "rápido",
+      "minuto",
+      "passa",
+      "devagar"
     ]
   },
   {
@@ -610,6 +830,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "comportamento",
+      "observar",
+      "atenção",
+      "alguém",
+      "pessoa"
     ]
   },
   {
@@ -634,6 +864,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "borboleta",
+      "palavra",
+      "bater",
+      "brasil",
+      "teoricamente"
     ]
   },
   {
@@ -658,6 +898,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 10,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/thaumazein",
+    "extracted_keywords": [
+      "profundo",
+      "everest",
+      "ponto",
+      "fundo",
+      "oceano"
     ]
   },
   {
@@ -682,6 +932,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 10,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/thaumazein",
+    "extracted_keywords": [
+      "exército",
+      "islândia",
+      "nenhum",
+      "soldados",
+      "pacífico"
     ]
   },
   {
@@ -706,6 +966,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 10,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/thaumazein",
+    "extracted_keywords": [
+      "felicidade",
+      "butão",
+      "interna",
+      "bruta",
+      "governo"
     ]
   },
   {
@@ -730,6 +1000,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 10,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/thaumazein",
+    "extracted_keywords": [
+      "produz",
+      "fitoplâncton",
+      "amazônia",
+      "oxigênio",
+      "mundo"
     ]
   },
   {
@@ -754,6 +1034,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 10,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/thaumazein",
+    "extracted_keywords": [
+      "melhor",
+      "finlândia",
+      "escola",
+      "começa",
+      "dever"
     ]
   },
   {
@@ -778,6 +1068,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 2,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/justica_aristotelica",
+    "extracted_keywords": [
+      "guerra",
+      "inimigos",
+      "futebol",
+      "mundial",
+      "soldados"
     ]
   },
   {
@@ -802,6 +1102,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 2,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/justica_aristotelica",
+    "extracted_keywords": [
+      "disse",
+      "decisão",
+      "segundos",
+      "parks",
+      "planejou"
     ]
   },
   {
@@ -826,6 +1136,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 2,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/justica_aristotelica",
+    "extracted_keywords": [
+      "poesia",
+      "samurais",
+      "obrigados",
+      "escrever",
+      "guerreiro"
     ]
   },
   {
@@ -857,6 +1177,16 @@
     "dreyfus_level_target": [
       "apprentice",
       "practitioner"
+    ],
+    "axis_id": 2,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/justica_aristotelica",
+    "extracted_keywords": [
+      "mandela",
+      "carcereiro",
+      "carregar",
+      "preso",
+      "convidou"
     ]
   },
   {
@@ -881,6 +1211,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 2,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/justica_aristotelica",
+    "extracted_keywords": [
+      "tinham",
+      "vikings",
+      "parlamento",
+      "althing",
+      "desde"
     ]
   },
   {
@@ -905,6 +1245,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 2,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/justica_aristotelica",
+    "extracted_keywords": [
+      "espada",
+      "durou",
+      "genghis",
+      "destruiu",
+      "impérios"
     ]
   },
   {
@@ -937,6 +1287,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 4,
+    "family": "carater",
+    "lineage_anchor": "paideia/sophrosyne",
+    "extracted_keywords": [
+      "esperar",
+      "teste",
+      "marshmallow",
+      "stanford",
+      "crianças"
     ]
   },
   {
@@ -961,6 +1321,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "alguém",
+      "pessoas",
+      "assistiram",
+      "kitty",
+      "genovese"
     ]
   },
   {
@@ -985,6 +1355,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "amizades",
+      "reais",
+      "pessoas",
+      "ligariam",
+      "sumisse"
     ]
   },
   {
@@ -1009,6 +1389,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "alguém",
+      "cérebro",
+      "bonito",
+      "automaticamente",
+      "assume"
     ]
   },
   {
@@ -1033,6 +1423,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "corpo",
+      "curvatura",
+      "japão",
+      "profundidade",
+      "mostra"
     ]
   },
   {
@@ -1057,6 +1457,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "etiópia",
+      "maior",
+      "cultura",
+      "mostra",
+      "família"
     ]
   },
   {
@@ -1081,6 +1491,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "dança",
+      "emoção",
+      "maori",
+      "guerra",
+      "expressão"
     ]
   },
   {
@@ -1111,6 +1531,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "pausa",
+      "melhores",
+      "ideias",
+      "suécia",
+      "obrigatória"
     ]
   },
   {
@@ -1135,6 +1565,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "festa",
+      "primeiro",
+      "alguém",
+      "gargalhar",
+      "navajo"
     ]
   },
   {
@@ -1159,6 +1599,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "amigos",
+      "matemática",
+      "estatisticamente",
+      "insegurança",
+      "chama"
     ]
   },
   {
@@ -1183,6 +1633,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "gentileza",
+      "pessoa",
+      "ajuda",
+      "frente",
+      "rodadas"
     ]
   },
   {
@@ -1207,6 +1667,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 3,
+    "family": "carater",
+    "lineage_anchor": "paideia/andreia",
+    "extracted_keywords": [
+      "pedra",
+      "sísifo",
+      "encontrar",
+      "processo",
+      "condenado"
     ]
   },
   {
@@ -1239,6 +1709,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 3,
+    "family": "carater",
+    "lineage_anchor": "paideia/andreia",
+    "extracted_keywords": [
+      "rachadura",
+      "japão",
+      "tigela",
+      "quebra",
+      "reparam"
     ]
   },
   {
@@ -1270,6 +1750,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 3,
+    "family": "carater",
+    "lineage_anchor": "paideia/andreia",
+    "extracted_keywords": [
+      "acreditar",
+      "renascimento",
+      "cultura",
+      "fênix",
+      "existe"
     ]
   },
   {
@@ -1294,6 +1784,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 3,
+    "family": "carater",
+    "lineage_anchor": "paideia/andreia",
+    "extracted_keywords": [
+      "sabedoria",
+      "poderoso",
+      "vikings",
+      "arrancou",
+      "próprio"
     ]
   },
   {
@@ -1318,6 +1818,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 3,
+    "family": "carater",
+    "lineage_anchor": "paideia/andreia",
+    "extracted_keywords": [
+      "pediu",
+      "curiosidade",
+      "mitologia",
+      "japonesa",
+      "izanagi"
     ]
   },
   {
@@ -1342,6 +1852,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 3,
+    "family": "carater",
+    "lineage_anchor": "paideia/andreia",
+    "extracted_keywords": [
+      "anansi",
+      "histórias",
+      "precisa",
+      "forte",
+      "esperto"
     ]
   },
   {
@@ -1366,6 +1886,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 3,
+    "family": "carater",
+    "lineage_anchor": "paideia/andreia",
+    "extracted_keywords": [
+      "polinésia",
+      "achou",
+      "curto",
+      "demais",
+      "laçou"
     ]
   },
   {
@@ -1390,6 +1920,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "regra",
+      "religião",
+      "mundo",
+      "cristianismo",
+      "próximo"
     ]
   },
   {
@@ -1420,6 +1960,16 @@
     "dreyfus_level_target": [
       "apprentice",
       "practitioner"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "xícara",
+      "aluno",
+      "cheio",
+      "professor",
+      "encheu"
     ]
   },
   {
@@ -1444,6 +1994,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "parte",
+      "elefante",
+      "parábola",
+      "cegos",
+      "tocam"
     ]
   },
   {
@@ -1468,6 +2028,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "mundo",
+      "incompleto",
+      "colocar",
+      "judaísmo",
+      "tikkun"
     ]
   },
   {
@@ -1492,6 +2062,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "decisão",
+      "gerações",
+      "tataranetos",
+      "haudenosaunee",
+      "iroqueses"
     ]
   },
   {
@@ -1516,6 +2096,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "círculo",
+      "pintado",
+      "pincelada",
+      "perfeito",
+      "abertura"
     ]
   },
   {
@@ -1540,6 +2130,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "branco",
+      "dentro",
+      "preto",
+      "ponto",
+      "yin-yang"
     ]
   },
   {
@@ -1564,6 +2164,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "coisa",
+      "começo",
+      "ouroboros",
+      "serpente",
+      "engole"
     ]
   },
   {
@@ -1588,6 +2198,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "ocidente",
+      "china",
+      "óbvio",
+      "branco",
+      "pureza"
     ]
   },
   {
@@ -1612,6 +2232,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "brigar",
+      "guerra",
+      "vencer",
+      "maior",
+      "achava"
     ]
   },
   {
@@ -1636,6 +2266,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "perde",
+      "espartanos",
+      "seguraram",
+      "persas",
+      "termópilas"
     ]
   },
   {
@@ -1660,6 +2300,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "guerra",
+      "idioma",
+      "tentaram",
+      "virou",
+      "usaram"
     ]
   },
   {
@@ -1684,6 +2334,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 4,
+    "family": "carater",
+    "lineage_anchor": "paideia/sophrosyne",
+    "extracted_keywords": [
+      "império",
+      "mundo",
+      "precisa",
+      "gandhi",
+      "derrotou"
     ]
   },
   {
@@ -1708,6 +2368,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "humano",
+      "alguém",
+      "médicos",
+      "militares",
+      "obrigados"
     ]
   },
   {
@@ -1732,6 +2402,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 4,
+    "family": "carater",
+    "lineage_anchor": "paideia/sophrosyne",
+    "extracted_keywords": [
+      "fracassou",
+      "nintendo",
+      "fracasso",
+      "começou",
+      "fazendo"
     ]
   },
   {
@@ -1756,6 +2436,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "sistema",
+      "virou",
+      "defeito",
+      "método",
+      "produto"
     ]
   },
   {
@@ -1780,6 +2470,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "post-it",
+      "fracasso",
+      "fraca",
+      "olhar",
+      "ângulo"
     ]
   },
   {
@@ -1804,6 +2504,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "alguém",
+      "patagonia",
+      "publicou",
+      "anúncio",
+      "black"
     ]
   },
   {
@@ -1828,6 +2538,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "problema",
+      "qualquer",
+      "parar",
+      "fábrica",
+      "corda"
     ]
   },
   {
@@ -1852,6 +2572,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "feitos",
+      "carbono",
+      "diferença",
+      "resultado",
+      "oposto"
     ]
   },
   {
@@ -1876,6 +2606,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 11,
+    "family": "cognicao_si",
+    "lineage_anchor": "paideia/gnothi_seauton",
+    "extracted_keywords": [
+      "anomalia",
+      "diferente",
+      "exatamente",
+      "mundo",
+      "única"
     ]
   },
   {
@@ -1900,6 +2640,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 4,
+    "family": "carater",
+    "lineage_anchor": "paideia/sophrosyne",
+    "extracted_keywords": [
+      "ferrugem",
+      "raiva",
+      "reação",
+      "química",
+      "oxidação"
     ]
   },
   {
@@ -1924,6 +2674,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "catalisador",
+      "acontecer",
+      "acelera",
+      "reação",
+      "química"
     ]
   },
   {
@@ -1948,6 +2708,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "regras",
+      "criaria",
+      "seria",
+      "filósofo",
+      "rawls"
     ]
   },
   {
@@ -1972,6 +2742,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "ninguém",
+      "mundo",
+      "campo",
+      "cuida",
+      "pasto"
     ]
   },
   {
@@ -1996,6 +2776,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "prazo",
+      "longo",
+      "dilema",
+      "trair",
+      "cooperar"
     ]
   },
   {
@@ -2020,6 +2810,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "radical",
+      "mundo",
+      "normal",
+      "errado",
+      "janela"
     ]
   },
   {
@@ -2044,6 +2844,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "mariposa",
+      "pequeno",
+      "travar",
+      "primeiro",
+      "computador"
     ]
   },
   {
@@ -2068,6 +2878,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "dados",
+      "família",
+      "amigos",
+      "contratação",
+      "amazon"
     ]
   },
   {
@@ -2092,6 +2912,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "disse",
+      "desfazer",
+      "inventado",
+      "disso",
+      "computador"
     ]
   },
   {
@@ -2116,6 +2946,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 7,
+    "family": "disposicao",
+    "lineage_anchor": "hebraica/hesed",
+    "extracted_keywords": [
+      "graça",
+      "linux",
+      "servidores",
+      "mundo",
+      "supercomputadores"
     ]
   },
   {
@@ -2140,6 +2980,16 @@
     "dreyfus_level_target": [
       "novice",
       "apprentice"
+    ],
+    "axis_id": 1,
+    "family": "carater",
+    "lineage_anchor": "aristotelica/phronesis",
+    "extracted_keywords": [
+      "resolver",
+      "problema",
+      "recursão",
+      "problemas",
+      "chegar"
     ]
   }
 ]

--- a/scripts/backfill-subject-knowledge-tags.mjs
+++ b/scripts/backfill-subject-knowledge-tags.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Backfill mecânico das tags Subject Knowledge nos content seeds.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-subject-knowledge-bridge.md §3, §4.4
+ *
+ * Adiciona axis_id, family, lineage_anchor, extracted_keywords pra cada
+ * item de content/hooks/seed.json que não tenha — habilitando o
+ * ConceptLedgerWriter (+1pt) e o scorer multi-dim (bonus combinatorial).
+ *
+ * Heurística v1:
+ *  - casel_target → axis_id (lookup)
+ *  - axis_id → family (1-4=carater, 5-8=disposicao, 9-12=cognicao_si)
+ *  - domain → lineage_anchor (default por área cultural)
+ *  - extracted_keywords: top palavras-chave do fact (>4 chars, sem stopwords)
+ *
+ * Idempotente: items que já têm axis_id são pulados.
+ *
+ * Uso:
+ *   node scripts/backfill-subject-knowledge-tags.mjs [path/to/seed.json]
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DEFAULT_SEED_PATH = path.join(REPO_ROOT, "content/hooks/seed.json");
+
+// CASEL → axis_id (mapeamento conservador)
+// SA self-awareness  → autoconhecimento (11)
+// SM self-management → temperança (4)
+// SOC social-aware   → compaixão (7)
+// REL relationships  → compaixão (7)
+// DM decision-making → prudência (1)
+const CASEL_TO_AXIS = {
+  SA: 11,
+  SM: 4,
+  SOC: 7,
+  REL: 7,
+  DM: 1,
+};
+
+// Override por domain quando casel é ambíguo (escolhe axis mais alinhado
+// à natureza do conteúdo, não só ao CASEL).
+const DOMAIN_AXIS_OVERRIDE = {
+  philosophy: 1, // Prudência
+  history: 2, // Justiça
+  myth: 3, // Fortaleza
+  mythology: 3,
+  ethics: 2,
+  arts: 10, // Curiosidade
+  music: 7, // Compaixão
+  art: 10,
+  geography: 10,
+  nature: 10,
+};
+
+// Family from axis_id
+function familyForAxis(axisId) {
+  if (axisId >= 1 && axisId <= 4) return "carater";
+  if (axisId >= 5 && axisId <= 8) return "disposicao";
+  if (axisId >= 9 && axisId <= 12) return "cognicao_si";
+  return undefined;
+}
+
+// Default lineage_anchor por axis_id (escolha conservadora; usuário pode
+// refinar item-a-item depois). Cada eixo aponta pra um complemento de
+// tradição plural — não tendencia uma só tradição.
+const DEFAULT_LINEAGE_PER_AXIS = {
+  1: "aristotelica/phronesis",
+  2: "aristotelica/justica_aristotelica",
+  3: "paideia/andreia",
+  4: "paideia/sophrosyne",
+  5: "estoica/assentir_estoico",
+  6: "estoica/amor_fati",
+  7: "hebraica/hesed",
+  8: "estoica/prosoche_estoica",
+  9: "paideia/aletheia",
+  10: "paideia/thaumazein",
+  11: "paideia/gnothi_seauton",
+  12: "estoica/dicotomia_controle_responsabilidade",
+};
+
+// Stopwords PT-BR + EN (usados em facts) pra filtrar do keyword extraction
+const STOPWORDS = new Set([
+  "para", "como", "mais", "menos", "esse", "essa", "isso", "esses", "essas",
+  "este", "esta", "isto", "estes", "estas", "aquele", "aquela", "aquilo",
+  "depois", "antes", "agora", "ainda", "muito", "pouco", "todos", "todas",
+  "nada", "nunca", "sempre", "porque", "quando", "onde", "qual", "quem",
+  "também", "tambem", "então", "entao", "assim", "outro", "outra", "outros",
+  "outras", "mesmo", "mesma", "mesmos", "mesmas", "cada", "tudo", "toda",
+  "the", "this", "that", "with", "from", "have", "they", "their", "them",
+  "into", "what", "when", "where", "which", "while", "would", "could",
+  "should", "about", "after", "before", "than",
+  // grammar particles
+  "uma", "umas", "uns", "dos", "das", "nos", "nas", "nem", "pra", "por",
+  "sem", "sob", "sobre", "entre", "contra", "ate", "até", "ja", "já", "vai",
+  "ser", "tem", "tens", "estar", "está", "estão", "foram", "foi", "era",
+  "são", "sao", "fica", "ficar", "ficou", "ficam",
+]);
+
+function extractKeywords(item) {
+  // Junta fact + bridge + quest (se existir) pra ter mais sinal
+  const text = [item.fact, item.bridge, item.quest]
+    .filter((x) => typeof x === "string")
+    .join(" ");
+
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 4 && !STOPWORDS.has(t));
+
+  // Frequency-ranked, top 5 únicos
+  const freq = new Map();
+  for (const t of tokens) {
+    freq.set(t, (freq.get(t) ?? 0) + 1);
+  }
+  const sorted = [...freq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([w]) => w);
+
+  return sorted.slice(0, 5);
+}
+
+function inferTags(item) {
+  // axis_id: domain override > casel mapping > fallback
+  let axisId = DOMAIN_AXIS_OVERRIDE[item.domain];
+  if (axisId === undefined) {
+    const firstCasel = Array.isArray(item.casel_target) ? item.casel_target[0] : undefined;
+    if (firstCasel && CASEL_TO_AXIS[firstCasel] !== undefined) {
+      axisId = CASEL_TO_AXIS[firstCasel];
+    }
+  }
+  if (axisId === undefined) return null; // skip: não foi possível inferir
+
+  const family = familyForAxis(axisId);
+  const lineage = DEFAULT_LINEAGE_PER_AXIS[axisId];
+  const keywords = extractKeywords(item);
+  if (keywords.length === 0) return null;
+
+  return {
+    axis_id: axisId,
+    family,
+    lineage_anchor: lineage,
+    extracted_keywords: keywords,
+  };
+}
+
+function main() {
+  const seedPath = path.resolve(process.argv[2] ?? DEFAULT_SEED_PATH);
+
+  if (!fs.existsSync(seedPath)) {
+    console.error(`[backfill] seed not found: ${seedPath}`);
+    process.exit(2);
+  }
+
+  const raw = fs.readFileSync(seedPath, "utf8");
+  const items = JSON.parse(raw);
+  if (!Array.isArray(items)) {
+    console.error("[backfill] seed root must be an array");
+    process.exit(2);
+  }
+
+  let backfilled = 0;
+  let skipped = 0;
+  let unable = 0;
+  const familyBreakdown = { carater: 0, disposicao: 0, cognicao_si: 0 };
+
+  for (const item of items) {
+    if (item.axis_id !== undefined) {
+      skipped += 1;
+      continue;
+    }
+    const tags = inferTags(item);
+    if (tags === null) {
+      unable += 1;
+      continue;
+    }
+    item.axis_id = tags.axis_id;
+    item.family = tags.family;
+    item.lineage_anchor = tags.lineage_anchor;
+    item.extracted_keywords = tags.extracted_keywords;
+    backfilled += 1;
+    familyBreakdown[tags.family] = (familyBreakdown[tags.family] ?? 0) + 1;
+  }
+
+  fs.writeFileSync(seedPath, JSON.stringify(items, null, 2) + "\n", "utf8");
+
+  console.log(`[backfill] seed: ${seedPath}`);
+  console.log(`[backfill] total items: ${items.length}`);
+  console.log(`[backfill] backfilled: ${backfilled}`);
+  console.log(`[backfill] skipped (already tagged): ${skipped}`);
+  console.log(`[backfill] unable (no casel/no domain match): ${unable}`);
+  console.log(`[backfill] family breakdown:`);
+  for (const [fam, count] of Object.entries(familyBreakdown)) {
+    console.log(`           ${fam}: ${count}`);
+  }
+}
+
+main();

--- a/shared/tests/seed-tags-backfill.test.ts
+++ b/shared/tests/seed-tags-backfill.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests do backfill Subject Knowledge no content/hooks/seed.json.
+ * Garante que TODOS os items podem gerar presented_concept via
+ * ConceptLedgerWriter — pré-condição para o ledger funcionar em produção.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { extractPresentedConcept } from "../src/concept-ledger-writer.js";
+import type { ContentItem } from "../src/content-item.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SEED_PATH = join(__dirname, "..", "..", "content", "hooks", "seed.json");
+
+const items = JSON.parse(readFileSync(SEED_PATH, "utf8")) as ContentItem[];
+
+describe("content/hooks/seed.json — Subject Knowledge backfill", () => {
+  it("loaded items > 0", () => {
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it("100% dos items têm axis_id (1..12)", () => {
+    const without = items.filter((i) => typeof i.axis_id !== "number");
+    expect(without.map((i) => i.id)).toEqual([]);
+    for (const item of items) {
+      expect(item.axis_id).toBeGreaterThanOrEqual(1);
+      expect(item.axis_id).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it("100% dos items têm family válida", () => {
+    for (const item of items) {
+      expect(["carater", "disposicao", "cognicao_si"]).toContain(item.family);
+    }
+  });
+
+  it("family bate com axis_id (1-4=carater, 5-8=disposicao, 9-12=cognicao_si)", () => {
+    for (const item of items) {
+      if (item.axis_id! >= 1 && item.axis_id! <= 4) expect(item.family).toBe("carater");
+      else if (item.axis_id! >= 5 && item.axis_id! <= 8) expect(item.family).toBe("disposicao");
+      else expect(item.family).toBe("cognicao_si");
+    }
+  });
+
+  it("100% têm lineage_anchor formato tradicao/complemento", () => {
+    for (const item of items) {
+      expect(typeof item.lineage_anchor).toBe("string");
+      expect(item.lineage_anchor).toMatch(/^[a-zA-Záâãéêíóôõúç_-]+\/[a-zA-Z_]+$/);
+    }
+  });
+
+  it("100% têm extracted_keywords não-vazio", () => {
+    for (const item of items) {
+      expect(Array.isArray(item.extracted_keywords)).toBe(true);
+      expect(item.extracted_keywords!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("ConceptLedgerWriter gera entry para 100% dos items", () => {
+    let missed = 0;
+    for (const item of items) {
+      const entry = extractPresentedConcept({
+        subjectId: "test",
+        sessionId: "s",
+        turnRef: "s__t",
+        item,
+      });
+      if (entry === null) missed += 1;
+    }
+    expect(missed).toBe(0);
+  });
+
+  it("distribuição razoável entre famílias (cada uma >= 10%)", () => {
+    const dist = { carater: 0, disposicao: 0, cognicao_si: 0 };
+    for (const item of items) {
+      dist[item.family!] = (dist[item.family!] ?? 0) + 1;
+    }
+    const total = items.length;
+    expect(dist.carater / total).toBeGreaterThanOrEqual(0.1);
+    expect(dist.disposicao / total).toBeGreaterThanOrEqual(0.1);
+    expect(dist.cognicao_si / total).toBeGreaterThanOrEqual(0.1);
+  });
+});


### PR DESCRIPTION
## Summary
Habilita o ConceptLedgerWriter e o scorer multi-dim combinatorial pra **todos os 85 items** dos seeds. Sem este backfill, todos retornam null silenciosamente (design F3) — o bonus combinatorial nunca dispara em produção.

### Heurística do script (idempotente)
- **\`axis_id\`** via domain override + CASEL mapping (1..12)
- **\`family\`** derivado: 1-4 carater, 5-8 disposicao, 9-12 cognicao_si
- **\`lineage_anchor\`** default plural por axis (mistura paideia/aristotelica/estoica/hebraica)
- **\`extracted_keywords\`**: top 5 do fact+bridge+quest (>4 chars, sem stopwords)

### Resultado
- **85/85 items taggeados (100%)**
- Distribuição: caráter 36 (42%) · disposição 21 (25%) · cognição-de-si 28 (33%)

### Refinamento futuro
- Curadoria pedagógica item-a-item pode refinar lineage_anchor por contexto cultural específico
- Script é idempotente — re-execução pula items já taggeados

## Test plan
- [x] \`shared/tests/seed-tags-backfill.test.ts\` — 8 tests (100% têm axis_id/family/lineage/keywords válidos; ConceptLedgerWriter emite entry pra 100%; distribuição razoável ≥10% por família)
- [x] Build verde
- [x] Suite: shared 749 (+8) — zero regressão

## Próximo
Smoke STS deve mostrar \`multidim_bonus=+N (... dims: ...)\` nas reasons dos items selecionados — sinal de que o tutor está fazendo ponte tripla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)