### PR TITLE
[feat] Planejador hidrata Subject Knowledge (latent_needs + subject_proposed)

### DIFF
--- a/planejador/src/child-profile.ts
+++ b/planejador/src/child-profile.ts
@@ -50,6 +50,25 @@ export function personaToChildProfile(
         .map((s) => s.trim())
     : undefined;
 
+  // Subject Knowledge: hidrata latent_needs e subject_proposed do parental_profile.
+  // - latent_needs: lista livre do pai (não exige confirm do filho — dimensão
+  //   'need' do scorer multi-dim).
+  // - subject_proposed: derivado de aspirations.proposed_virtues quando presente
+  //   no fixture (em produção vem da subject_proposed table SQLite hidratada
+  //   pelo orchestrator).
+  const parentalProfile = profile["parental_profile"] as
+    | Record<string, unknown>
+    | undefined;
+
+  const rawLatentNeeds = parentalProfile?.["latent_needs"];
+  const latentNeeds = Array.isArray(rawLatentNeeds)
+    ? (rawLatentNeeds as unknown[])
+        .filter((x): x is string => typeof x === "string" && x.trim().length > 0)
+        .map((s) => s.trim())
+    : undefined;
+
+  const subjectProposed = extractSubjectProposed(parentalProfile);
+
   return {
     age: persona.age,
     domain_ranking: domainRanking,
@@ -57,7 +76,51 @@ export function personaToChildProfile(
     cycle_day: cycleDay,
     cycle_phase: cyclePhaseFor(cycleDay),
     interests,
+    ...(latentNeeds && latentNeeds.length > 0 ? { latent_needs: latentNeeds } : {}),
+    ...(subjectProposed ? { subject_proposed: subjectProposed } : {}),
   };
+}
+
+/**
+ * Deriva subject_proposed a partir do parental_profile.aspirations:
+ *   - axes_active: union de proposed_virtues[].axis (axis_id 1..12)
+ *   - complements_per_axis: vazio v1 (pai escolhe complementos no flow
+ *     de onboarding parental quando F6 Console UI entregar)
+ *
+ * v1: complement curation fica para PR futuro (catálogo lineage carrega
+ * default plural por axis; sem complement explícito, scorer ainda dispara
+ * lineage dim quando axis_active inclui o axis_id do item).
+ */
+function extractSubjectProposed(
+  parental: Record<string, unknown> | undefined,
+): ChildScoringProfile["subject_proposed"] | undefined {
+  if (!parental) return undefined;
+  const aspirations = parental["aspirations"] as
+    | Record<string, unknown>
+    | undefined;
+  if (!aspirations) return undefined;
+
+  const rawVirtues = aspirations["proposed_virtues"];
+  if (!Array.isArray(rawVirtues) || rawVirtues.length === 0) return undefined;
+
+  const axesActive: number[] = [];
+  for (const v of rawVirtues) {
+    if (v && typeof v === "object" && typeof (v as Record<string, unknown>)["axis"] === "number") {
+      const axisId = (v as Record<string, unknown>)["axis"] as number;
+      if (axisId >= 1 && axisId <= 12 && !axesActive.includes(axisId)) {
+        axesActive.push(axisId);
+      }
+    }
+  }
+  if (axesActive.length === 0) return undefined;
+
+  // complements_per_axis vazio v1 — fica pra onboarding parental compor.
+  const complementsPerAxis: Record<number, string[]> = {};
+  for (const a of axesActive) {
+    complementsPerAxis[a] = [];
+  }
+
+  return { axes_active: axesActive, complements_per_axis: complementsPerAxis };
 }
 
 /** Mapeia cycle_day → cycle_phase conforme BRIDGING_PLAYBOOK linhas 2700-2715. */

--- a/planejador/tests/child-profile.test.ts
+++ b/planejador/tests/child-profile.test.ts
@@ -75,3 +75,136 @@ describe("cyclePhaseFor", () => {
     expect(cyclePhaseFor(19)).toBeUndefined();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────
+// Subject Knowledge hidratação (latent_needs + subject_proposed)
+// ─────────────────────────────────────────────────────────────────
+
+describe("personaToChildProfile — Subject Knowledge fields", () => {
+  it("extrai latent_needs de parental_profile.latent_needs", () => {
+    const persona = makePersona({
+      profile: {
+        parental_profile: {
+          latent_needs: ["autocontrole", "abertura emocional", " perda do tio Kenji "],
+        },
+      },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.latent_needs).toEqual([
+      "autocontrole",
+      "abertura emocional",
+      "perda do tio Kenji",
+    ]);
+  });
+
+  it("omite latent_needs quando array vazio", () => {
+    const persona = makePersona({
+      profile: { parental_profile: { latent_needs: [] } },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.latent_needs).toBeUndefined();
+  });
+
+  it("omite latent_needs quando parental_profile ausente", () => {
+    const persona = makePersona({ profile: {} });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.latent_needs).toBeUndefined();
+  });
+
+  it("filtra strings vazias e tipos inválidos em latent_needs", () => {
+    const persona = makePersona({
+      profile: {
+        parental_profile: {
+          latent_needs: ["autocontrole", "", 42, null, "  ", "abertura"],
+        },
+      },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.latent_needs).toEqual(["autocontrole", "abertura"]);
+  });
+
+  it("extrai subject_proposed.axes_active de aspirations.proposed_virtues", () => {
+    const persona = makePersona({
+      profile: {
+        parental_profile: {
+          aspirations: {
+            proposed_virtues: [
+              { axis: 3, note: "coragem civil" },
+              { axis: 7 },
+              { axis: 12 },
+            ],
+          },
+        },
+      },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.subject_proposed?.axes_active).toEqual([3, 7, 12]);
+  });
+
+  it("dedup axes_active mesmo com virtudes repetidas", () => {
+    const persona = makePersona({
+      profile: {
+        parental_profile: {
+          aspirations: {
+            proposed_virtues: [{ axis: 3 }, { axis: 3 }, { axis: 7 }],
+          },
+        },
+      },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.subject_proposed?.axes_active).toEqual([3, 7]);
+  });
+
+  it("complements_per_axis vazio pra cada axis (v1)", () => {
+    const persona = makePersona({
+      profile: {
+        parental_profile: {
+          aspirations: { proposed_virtues: [{ axis: 4 }, { axis: 11 }] },
+        },
+      },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.subject_proposed?.complements_per_axis).toEqual({ 4: [], 11: [] });
+  });
+
+  it("ignora axes fora de 1..12", () => {
+    const persona = makePersona({
+      profile: {
+        parental_profile: {
+          aspirations: {
+            proposed_virtues: [{ axis: 0 }, { axis: 13 }, { axis: 5 }],
+          },
+        },
+      },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.subject_proposed?.axes_active).toEqual([5]);
+  });
+
+  it("omite subject_proposed quando aspirations ausente", () => {
+    const persona = makePersona({
+      profile: { parental_profile: { latent_needs: ["x"] } },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.subject_proposed).toBeUndefined();
+    expect(p.latent_needs).toEqual(["x"]);
+  });
+
+  it("omite subject_proposed quando proposed_virtues vazio", () => {
+    const persona = makePersona({
+      profile: {
+        parental_profile: { aspirations: { proposed_virtues: [] } },
+      },
+    });
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.subject_proposed).toBeUndefined();
+  });
+
+  it("preserva backcompat — persona sem subject knowledge fields funciona", () => {
+    const persona = makePersona({});
+    const p = personaToChildProfile(persona, emptyState);
+    expect(p.age).toBe(13);
+    expect(p.subject_proposed).toBeUndefined();
+    expect(p.latent_needs).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Sem este PR, scorer multi-dim recebe 3 dimensões zeradas (\`need\`, \`lineage\`, \`moves_toward_proposed\`) — bonus combinatorial só dispara via \`interest\` isolado, perdendo a maior parte do ganho da Fase 5.

### Mudanças
\`personaToChildProfile\` lê \`persona.profile.parental_profile\`:
- **\`latent_needs\`**: string list (filtra vazios/non-string; omite se vazio)
- **\`subject_proposed\`** derivado de \`aspirations.proposed_virtues\`:
  - \`axes_active\` = union \`{axis: N}\` (dedup, 1..12 filter)
  - \`complements_per_axis\` = \`{}\` por axis (vazio v1; curadoria fica pra onboarding parental quando F6 entregar)

## Test plan
- [x] \`planejador/tests/child-profile.test.ts\` — 10 tests novos cobrindo extração, dedup, omissões, edge cases, backcompat (22/22 total)
- [x] Suite: planejador 332 (+10), shared 749, motor 329 — zero regressão

## Próximos passos
- Backfill fixtures Ryo/Kei com \`latent_needs\` + \`aspirations\` populados (PR separado curto)
- Smoke pós-merge: verificar \`multidim_bonus\` aparece nas reasons

🤖 Generated with [Claude Code](https://claude.com/claude-code)