### PR TITLE
[feat] PR 1 tracer — JourneyStage + SessionPhase + journey_state foundation

### DIFF
--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -132,6 +132,23 @@ CREATE INDEX IF NOT EXISTS idx_vas_subject
   ON vertical_affinity_signals(subject_id);
 CREATE INDEX IF NOT EXISTS idx_vas_score
   ON vertical_affinity_signals(score_affinity);
+
+-- Journey State — Fase 8 PR 1 (spec 2026-05-25 §3 + §10.1).
+-- Estado da jornada cross-session por sujeito (stage atual, discoveries
+-- contadas pro threshold, override parental). Atualizado lazy na leitura
+-- a partir de subject_knowledge.
+CREATE TABLE IF NOT EXISTS journey_state (
+  subject_id            TEXT PRIMARY KEY,
+  stage                 TEXT NOT NULL DEFAULT 'discovery_only' CHECK(stage IN (
+    'discovery_only', 'mapping_ready', 'applied_double_helix'
+  )),
+  stage_entered_at      TEXT NOT NULL,
+  discoveries_count     INTEGER NOT NULL DEFAULT 0,
+  families_covered      TEXT NOT NULL DEFAULT '[]',
+  override_by_parent    TEXT,
+  last_updated_at       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_journey_stage ON journey_state(stage);
 `;
 
 export interface InitDbOptions {

--- a/packages/ebrota-console-bff/src/journey-state-repo.ts
+++ b/packages/ebrota-console-bff/src/journey-state-repo.ts
@@ -1,0 +1,203 @@
+/**
+ * Journey State Repository — leitura + upsert do estado de jornada do sujeito.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md §3
+ *
+ * Estratégia v1: lazy compute. Quando alguém pede journey_state e a tabela
+ * não tem entry (ou está stale), recomputa a partir de subject_knowledge
+ * (discoveries_count + families_covered) e upserta.
+ *
+ * Auto-transição: se entries do ledger satisfazem readyForMapping E o
+ * stage atual é discovery_only sem override parental → upgrade pra
+ * mapping_ready. O `applied_double_helix` exige ratificação explícita do
+ * pai (não auto-transição).
+ */
+
+import type { Database as DatabaseType } from "better-sqlite3";
+import {
+  initialJourneyState,
+  readyForMapping,
+  computeDiscoveryMaturity,
+  type JourneyState,
+  type JourneyStage,
+  type SubjectKnowledgeEntry,
+} from "@ascendimacy/shared";
+
+interface JourneyStateRow {
+  subject_id: string;
+  stage: JourneyStage;
+  stage_entered_at: string;
+  discoveries_count: number;
+  families_covered: string;
+  override_by_parent: string | null;
+  last_updated_at: string;
+}
+
+function rowToState(row: JourneyStateRow): JourneyState {
+  return {
+    subject_id: row.subject_id,
+    stage: row.stage,
+    stage_entered_at: row.stage_entered_at,
+    discoveries_count: row.discoveries_count,
+    families_covered: JSON.parse(row.families_covered),
+    override_by_parent: row.override_by_parent
+      ? JSON.parse(row.override_by_parent)
+      : undefined,
+    last_updated_at: row.last_updated_at,
+  };
+}
+
+interface SkRow {
+  id: string;
+  subject_id: string;
+  type: string;
+  source: string;
+  confidence: number;
+  confirmed_at: string | null;
+  alignment: string;
+  payload_json: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+}
+
+function loadDiscoveryEntries(
+  db: DatabaseType,
+  subjectId: string,
+): SubjectKnowledgeEntry[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM subject_knowledge
+       WHERE subject_id = ? AND type IN ('interest','value','need','discovery')
+       ORDER BY created_at ASC`,
+    )
+    .all(subjectId) as SkRow[];
+  return rows.map((r) => ({
+    id: r.id,
+    subject_id: r.subject_id,
+    type: r.type as SubjectKnowledgeEntry["type"],
+    source: r.source as SubjectKnowledgeEntry["source"],
+    confidence: r.confidence,
+    confirmed_at: r.confirmed_at,
+    alignment: r.alignment as SubjectKnowledgeEntry["alignment"],
+    payload: JSON.parse(r.payload_json),
+    turn_ref: r.turn_ref,
+    session_id: r.session_id,
+    created_at: r.created_at,
+  }));
+}
+
+const UPSERT_SQL = `
+  INSERT INTO journey_state (
+    subject_id, stage, stage_entered_at, discoveries_count,
+    families_covered, override_by_parent, last_updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(subject_id) DO UPDATE SET
+    stage = excluded.stage,
+    stage_entered_at = excluded.stage_entered_at,
+    discoveries_count = excluded.discoveries_count,
+    families_covered = excluded.families_covered,
+    override_by_parent = excluded.override_by_parent,
+    last_updated_at = excluded.last_updated_at
+`;
+
+function persist(db: DatabaseType, state: JourneyState): void {
+  db.prepare(UPSERT_SQL).run(
+    state.subject_id,
+    state.stage,
+    state.stage_entered_at,
+    state.discoveries_count,
+    JSON.stringify(state.families_covered),
+    state.override_by_parent ? JSON.stringify(state.override_by_parent) : null,
+    state.last_updated_at,
+  );
+}
+
+/**
+ * Lê (ou inicializa+computa) o journey_state do sujeito.
+ *
+ * Sempre recomputa discoveries_count + families_covered do ledger atual,
+ * e avalia auto-transição discovery_only → mapping_ready. Persiste resultado.
+ */
+export function readOrComputeJourneyState(
+  db: DatabaseType,
+  subjectId: string,
+): JourneyState {
+  const row = db
+    .prepare("SELECT * FROM journey_state WHERE subject_id = ?")
+    .get(subjectId) as JourneyStateRow | undefined;
+
+  let state = row
+    ? rowToState(row)
+    : initialJourneyState(subjectId);
+
+  // Recompute discoveries do ledger (sempre fresh).
+  const entries = loadDiscoveryEntries(db, subjectId);
+  const { discoveries_count, families_covered } = computeDiscoveryMaturity(entries);
+  state = {
+    ...state,
+    discoveries_count,
+    families_covered,
+    last_updated_at: new Date().toISOString(),
+  };
+
+  // Auto-transição discovery_only → mapping_ready quando threshold bate
+  // E não há override parental forçando ficar.
+  if (
+    state.stage === "discovery_only" &&
+    state.override_by_parent?.forced_stage !== "discovery_only" &&
+    readyForMapping({ state })
+  ) {
+    state = {
+      ...state,
+      stage: "mapping_ready",
+      stage_entered_at: state.last_updated_at,
+    };
+  }
+
+  persist(db, state);
+  return state;
+}
+
+/**
+ * Aplica override parental. Forçar applied_double_helix manualmente é
+ * suportado mas raro (típicamente o stage corre auto após ratificação
+ * em mapping_ready).
+ */
+export function setParentalOverride(
+  db: DatabaseType,
+  subjectId: string,
+  forcedStage: JourneyStage,
+  reason: string,
+): JourneyState {
+  const current = readOrComputeJourneyState(db, subjectId);
+  const now = new Date().toISOString();
+  const next: JourneyState = {
+    ...current,
+    stage: forcedStage,
+    stage_entered_at:
+      current.stage === forcedStage ? current.stage_entered_at : now,
+    override_by_parent: { forced_stage: forcedStage, reason, timestamp: now },
+    last_updated_at: now,
+  };
+  persist(db, next);
+  return next;
+}
+
+/**
+ * Limpa override parental (sujeito volta a fluir pelo critério automático).
+ */
+export function clearParentalOverride(
+  db: DatabaseType,
+  subjectId: string,
+): JourneyState {
+  const current = readOrComputeJourneyState(db, subjectId);
+  const next: JourneyState = {
+    ...current,
+    override_by_parent: undefined,
+    last_updated_at: new Date().toISOString(),
+  };
+  persist(db, next);
+  // Re-avalia sem override pra ver se threshold bate agora
+  return readOrComputeJourneyState(db, subjectId);
+}

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -60,7 +60,13 @@ import {
   computeMapPositions,
   listFrameworks,
   type SubjectKnowledgeEntry,
+  type JourneyStage,
 } from "@ascendimacy/shared";
+import {
+  readOrComputeJourneyState,
+  setParentalOverride,
+  clearParentalOverride,
+} from "./journey-state-repo.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -553,7 +559,6 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       ? req.query.framework.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
       : undefined;
 
-    // Carrega entries do ledger pra projeção (todas as types relevantes).
     const entries = opts.db
       .prepare(
         `SELECT id, subject_id, type, source, confidence, confirmed_at,
@@ -597,6 +602,42 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       }),
     };
   });
+
+  // ── Journey State endpoints (Fase 8 PR 1) ────────────────────────
+  // GET /subjects/:id/journey-state — recomputa e retorna estado atual
+  fastify.get<{ Params: { id: string } }>(
+    "/subjects/:id/journey-state",
+    async (req) => ({
+      state: readOrComputeJourneyState(opts.db, req.params.id),
+    }),
+  );
+
+  // POST /subjects/:id/journey-state/override — pai força stage específico
+  fastify.post<{
+    Params: { id: string };
+    Body: { stage: JourneyStage; reason: string };
+  }>("/subjects/:id/journey-state/override", async (req, reply) => {
+    const { stage, reason } = req.body ?? ({} as { stage?: JourneyStage; reason?: string });
+    if (
+      stage !== "discovery_only" &&
+      stage !== "mapping_ready" &&
+      stage !== "applied_double_helix"
+    ) {
+      return reply.code(400).send({ error: "stage inválido" });
+    }
+    if (typeof reason !== "string" || reason.trim().length === 0) {
+      return reply.code(400).send({ error: "reason obrigatório" });
+    }
+    return { state: setParentalOverride(opts.db, req.params.id, stage, reason) };
+  });
+
+  // DELETE /subjects/:id/journey-state/override — remove override
+  fastify.delete<{ Params: { id: string } }>(
+    "/subjects/:id/journey-state/override",
+    async (req) => ({
+      state: clearParentalOverride(opts.db, req.params.id),
+    }),
+  );
 
   // POST /rescan — re-indexa o tracesDir (manual trigger).
   // Útil quando STS roda em outro processo e deposita novos traces;

--- a/packages/ebrota-console-bff/tests/journey-state.test.ts
+++ b/packages/ebrota-console-bff/tests/journey-state.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests journey_state pipeline: ledger entries → readOrComputeJourneyState
+ * → endpoints REST + override parental.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import {
+  readOrComputeJourneyState,
+  setParentalOverride,
+  clearParentalOverride,
+} from "../src/journey-state-repo.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient, type MockDaemonClient } from "../src/daemon-client.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+let db: DatabaseType;
+let daemon: MockDaemonClient;
+let server: BffServer;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+function seedDiscovery(
+  subjectId: string,
+  type: "interest" | "value" | "need" | "discovery",
+  family: string | null,
+  i: number,
+): void {
+  const payload: Record<string, unknown> = { kind: type, label: `entry-${i}` };
+  if (family) payload["family"] = family;
+  db.prepare(
+    `INSERT INTO subject_knowledge (
+      id, subject_id, type, source, confidence, confirmed_at,
+      alignment, payload_json, turn_ref, session_id, created_at
+    ) VALUES (?, ?, ?, 'self_declared', 0.8, ?, 'unknown', ?, ?, ?, ?)`,
+  ).run(
+    `sk-${i}`,
+    subjectId,
+    type,
+    `s1__t${i}`,
+    JSON.stringify(payload),
+    `s1__t${i}`,
+    "s1",
+    new Date(2026, 4, 25, 10, i).toISOString(),
+  );
+}
+
+describe("readOrComputeJourneyState — auto-init", () => {
+  it("sujeito novo retorna discovery_only com counts zerados", () => {
+    const s = readOrComputeJourneyState(db, "kei");
+    expect(s.stage).toBe("discovery_only");
+    expect(s.discoveries_count).toBe(0);
+    expect(s.families_covered).toEqual([]);
+  });
+
+  it("conta discoveries do ledger", () => {
+    for (let i = 0; i < 5; i++) seedDiscovery("ryo", "interest", "carater", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.discoveries_count).toBe(5);
+    expect(s.families_covered).toEqual(["carater"]);
+  });
+});
+
+describe("auto-transição discovery_only → mapping_ready", () => {
+  it("não transiciona com 5 discoveries em 1 família", () => {
+    for (let i = 0; i < 5; i++) seedDiscovery("ryo", "interest", "carater", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("discovery_only");
+  });
+
+  it("não transiciona com 10 discoveries mas 2 famílias", () => {
+    for (let i = 0; i < 5; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 5; i < 10; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("discovery_only");
+  });
+
+  it("transiciona com 10 discoveries em 3 famílias", () => {
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 7; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 7; i < 10; i++) seedDiscovery("ryo", "discovery", "cognicao_si", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("mapping_ready");
+    expect(s.discoveries_count).toBe(10);
+    expect(s.families_covered).toEqual(["carater", "cognicao_si", "disposicao"]);
+  });
+
+  it("aplica imediatamente: chamada idempotente, fica em mapping_ready", () => {
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 8; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 8; i < 12; i++) seedDiscovery("ryo", "need", "cognicao_si", i);
+    const s1 = readOrComputeJourneyState(db, "ryo");
+    expect(s1.stage).toBe("mapping_ready");
+    // 2ª chamada não regride
+    const s2 = readOrComputeJourneyState(db, "ryo");
+    expect(s2.stage).toBe("mapping_ready");
+    expect(s2.discoveries_count).toBe(12);
+  });
+});
+
+describe("override parental", () => {
+  it("setParentalOverride força stage", () => {
+    const s = setParentalOverride(db, "ryo", "applied_double_helix", "pais ratificaram");
+    expect(s.stage).toBe("applied_double_helix");
+    expect(s.override_by_parent?.forced_stage).toBe("applied_double_helix");
+    expect(s.override_by_parent?.reason).toBe("pais ratificaram");
+  });
+
+  it("override 'discovery_only' impede auto-transição mesmo com threshold OK", () => {
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 8; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 8; i < 12; i++) seedDiscovery("ryo", "need", "cognicao_si", i);
+    setParentalOverride(db, "ryo", "discovery_only", "filho pediu mais descoberta");
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("discovery_only");
+  });
+
+  it("clearParentalOverride restaura auto-flow", () => {
+    setParentalOverride(db, "ryo", "discovery_only", "test");
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 8; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 8; i < 12; i++) seedDiscovery("ryo", "need", "cognicao_si", i);
+
+    const beforeClear = readOrComputeJourneyState(db, "ryo");
+    expect(beforeClear.stage).toBe("discovery_only");
+
+    const afterClear = clearParentalOverride(db, "ryo");
+    expect(afterClear.stage).toBe("mapping_ready");
+    expect(afterClear.override_by_parent).toBeUndefined();
+  });
+});
+
+describe("endpoints REST /subjects/:id/journey-state", () => {
+  const inject = async (method: "GET" | "POST" | "DELETE", url: string, body?: unknown) => {
+    const res = await server.fastify.inject({
+      method,
+      url,
+      ...(body !== undefined ? { payload: body } : {}),
+    });
+    return {
+      status: res.statusCode,
+      body: res.body ? JSON.parse(res.body) : null,
+    };
+  };
+
+  it("GET retorna state inicial pra sujeito novo", async () => {
+    const r = await inject("GET", "/subjects/ryo/journey-state");
+    expect(r.status).toBe(200);
+    expect(r.body.state.stage).toBe("discovery_only");
+  });
+
+  it("POST override aplica e retorna novo state", async () => {
+    const r = await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "applied_double_helix",
+      reason: "ratificado",
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.state.stage).toBe("applied_double_helix");
+    expect(r.body.state.override_by_parent.reason).toBe("ratificado");
+  });
+
+  it("POST override rejeita stage inválido", async () => {
+    const r = await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "garbage",
+      reason: "x",
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("POST override rejeita reason vazio", async () => {
+    const r = await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "mapping_ready",
+      reason: "",
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("DELETE override remove e re-avalia", async () => {
+    await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "discovery_only",
+      reason: "hold",
+    });
+    const after = await inject("DELETE", "/subjects/ryo/journey-state/override");
+    expect(after.status).toBe(200);
+    expect(after.body.state.override_by_parent).toBeUndefined();
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -27,6 +27,7 @@ export * from "./subject-knowledge-writers.js";
 export * from "./concept-ledger-writer.js";
 export * from "./recall-check-evaluator.js";
 export * from "./map-framework.js";
+export * from "./session-phases.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/session-phases.ts
+++ b/shared/src/session-phases.ts
@@ -1,0 +1,226 @@
+/**
+ * SessionPhase + JourneyStage — Fase 8 (Session Phases + Strategist).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md
+ *
+ * Foundation types do tracer bullet. Comportamento phase-aware vem em PR
+ * seguinte (PR 2 motor). Strategist em PR 3.
+ *
+ * Princípio: sessão tem 3 níveis temporais — JOURNEY (cross-session,
+ * meses) > STAGE (1-N sessões) > SESSION (15+30+5 min) > PHASE (sub-bloco).
+ */
+
+import type { SubjectKnowledgeEntry } from "./subject-knowledge.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// SessionPhase — 4 fases intra-sessão (spec §2)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type SessionPhase =
+  | "ice_breaker"        // 15 min — abrir + descobrir + tom seguro
+  | "challenge_explain"  // ~5 min — apresentar desafio
+  | "challenge_execute"  // 30 min — ação efetiva (StrategyPlan em execução)
+  | "follow_up";         // 5 min — consolidar, comparar plano vs demonstração
+
+export const SESSION_PHASES: readonly SessionPhase[] = [
+  "ice_breaker",
+  "challenge_explain",
+  "challenge_execute",
+  "follow_up",
+] as const;
+
+export interface SessionTiming {
+  total_minutes: number;
+  ice_breaker_minutes: number;
+  challenge_explain_minutes: number;
+  challenge_execute_minutes: number;
+  follow_up_minutes: number;
+}
+
+/** Configuração default da sessão eBrota — 15+30+5 = 50min total (spec SP-01). */
+export const DEFAULT_SESSION_TIMING: SessionTiming = {
+  total_minutes: 50,
+  ice_breaker_minutes: 15,
+  challenge_explain_minutes: 0, // embutido nos últimos 5min do ice_breaker
+  challenge_execute_minutes: 30,
+  follow_up_minutes: 5,
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// JourneyStage — 3 stages cross-session (spec §3)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type JourneyStage =
+  | "discovery_only"          // primeiras sessões: SÓ mapear
+  | "mapping_ready"            // transição: motor propõe mapa, pai ratifica
+  | "applied_double_helix";    // sessões correntes: Strategist + ponte tripla
+
+export const JOURNEY_STAGES: readonly JourneyStage[] = [
+  "discovery_only",
+  "mapping_ready",
+  "applied_double_helix",
+] as const;
+
+export interface JourneyState {
+  subject_id: string;
+  stage: JourneyStage;
+  stage_entered_at: string;
+  discoveries_count: number;
+  /** Famílias do catálogo Subject Knowledge já cobertas por discoveries. */
+  families_covered: string[];
+  override_by_parent?: {
+    forced_stage: JourneyStage;
+    reason: string;
+    timestamp: string;
+  };
+  last_updated_at: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// SessionStateResolver — decide fase atual heuristicamente (spec §7.1)
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface SessionStateInput {
+  /** Número do turn atual na sessão (1-indexed). */
+  turn: number;
+  /** Minutos médios por turn (default 4 — observado em smokes reais). */
+  avgMinutesPerTurn?: number;
+  /** Override explícito de minutos elapsed (para integrações futuras com tempo real). */
+  elapsedMinutesOverride?: number;
+  /** Stage atual da jornada do sujeito. */
+  journeyStage: JourneyStage;
+  /** Configuração temporal da sessão. */
+  timing?: SessionTiming;
+}
+
+export interface SessionStateOutput {
+  phase: SessionPhase;
+  journey_stage: JourneyStage;
+  elapsed_minutes_estimate: number;
+  /** Quantos minutos restam na fase atual antes da transição automática. */
+  minutes_until_next_phase: number;
+}
+
+const DEFAULT_AVG_MIN_PER_TURN = 4;
+
+/**
+ * Resolve fase + stage. Heurística v1: phase = f(elapsed_minutes).
+ * Override por elapsedMinutesOverride quando tempo real é conhecido.
+ */
+export function resolveSessionState(input: SessionStateInput): SessionStateOutput {
+  const timing = input.timing ?? DEFAULT_SESSION_TIMING;
+  const elapsed =
+    input.elapsedMinutesOverride !== undefined
+      ? input.elapsedMinutesOverride
+      : input.turn * (input.avgMinutesPerTurn ?? DEFAULT_AVG_MIN_PER_TURN);
+
+  const iceEnd = timing.ice_breaker_minutes;
+  const explainEnd = iceEnd + timing.challenge_explain_minutes;
+  const executeEnd = explainEnd + timing.challenge_execute_minutes;
+
+  let phase: SessionPhase;
+  let nextBoundary: number;
+  if (elapsed < iceEnd) {
+    phase = "ice_breaker";
+    nextBoundary = iceEnd;
+  } else if (elapsed < explainEnd) {
+    phase = "challenge_explain";
+    nextBoundary = explainEnd;
+  } else if (elapsed < executeEnd) {
+    phase = "challenge_execute";
+    nextBoundary = executeEnd;
+  } else {
+    phase = "follow_up";
+    nextBoundary = timing.total_minutes;
+  }
+
+  return {
+    phase,
+    journey_stage: input.journeyStage,
+    elapsed_minutes_estimate: elapsed,
+    minutes_until_next_phase: Math.max(0, nextBoundary - elapsed),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Threshold de maturidade — saída de discovery_only (spec §3.2, SP-04)
+// ─────────────────────────────────────────────────────────────────────────
+
+export const READY_FOR_MAPPING_MIN_DISCOVERIES = 10;
+export const READY_FOR_MAPPING_MIN_FAMILIES = 3;
+
+export interface ReadyForMappingInput {
+  state: JourneyState;
+  /** Override explícito dos pais ("force mapping_ready" / "stay in discovery"). */
+  parentOverride?: JourneyStage;
+}
+
+/**
+ * Avalia se o sujeito está pronto pra avançar de discovery_only para
+ * mapping_ready. Critério (ratificado 2026-05-25):
+ *   - ≥10 descobertas distribuídas em ≥3 famílias (saturação)
+ *   - OU override parental explícito
+ */
+export function readyForMapping(input: ReadyForMappingInput): boolean {
+  if (input.parentOverride === "mapping_ready" || input.parentOverride === "applied_double_helix") {
+    return true;
+  }
+  if (input.parentOverride === "discovery_only") {
+    return false; // pai forçou ficar em descoberta
+  }
+  return (
+    input.state.discoveries_count >= READY_FOR_MAPPING_MIN_DISCOVERIES &&
+    input.state.families_covered.length >= READY_FOR_MAPPING_MIN_FAMILIES
+  );
+}
+
+/**
+ * Helper: deriva families_covered + discoveries_count de uma lista de
+ * SubjectKnowledgeEntry. Usado pelo BFF pra computar estado a partir
+ * do ledger. Conta tipos discovery-like (interest/value/need/discovery).
+ */
+export function computeDiscoveryMaturity(
+  entries: SubjectKnowledgeEntry[],
+  axisToFamilyFn?: (axisId: number) => string | undefined,
+): { discoveries_count: number; families_covered: string[] } {
+  const discoveryTypes: ReadonlySet<string> = new Set([
+    "interest",
+    "value",
+    "need",
+    "discovery",
+  ]);
+  const families = new Set<string>();
+  let count = 0;
+  for (const e of entries) {
+    if (!discoveryTypes.has(e.type)) continue;
+    count += 1;
+    // Tenta extrair família via lineage_anchor do payload se houver,
+    // senão via axis_id quando presente, senão via heurística parcial.
+    const payload = e.payload as Record<string, unknown>;
+    if (typeof payload["family"] === "string") {
+      families.add(payload["family"] as string);
+    } else if (typeof payload["axis_id"] === "number" && axisToFamilyFn) {
+      const fam = axisToFamilyFn(payload["axis_id"] as number);
+      if (fam) families.add(fam);
+    }
+    // Discoveries sem axis_id/family não contam pro multi-família mas
+    // contam pro count total — caller decide se é OK na thresh.
+  }
+  return {
+    discoveries_count: count,
+    families_covered: Array.from(families).sort(),
+  };
+}
+
+/** Inicializa journey_state pra sujeito novo. */
+export function initialJourneyState(subjectId: string): JourneyState {
+  const now = new Date().toISOString();
+  return {
+    subject_id: subjectId,
+    stage: "discovery_only",
+    stage_entered_at: now,
+    discoveries_count: 0,
+    families_covered: [],
+    last_updated_at: now,
+  };
+}

--- a/shared/tests/session-phases.test.ts
+++ b/shared/tests/session-phases.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests SessionPhase + JourneyStage + SessionStateResolver + threshold.
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md
+ */
+import { describe, it, expect } from "vitest";
+import {
+  resolveSessionState,
+  readyForMapping,
+  computeDiscoveryMaturity,
+  initialJourneyState,
+  DEFAULT_SESSION_TIMING,
+  READY_FOR_MAPPING_MIN_DISCOVERIES,
+  READY_FOR_MAPPING_MIN_FAMILIES,
+  type SubjectKnowledgeEntry,
+  type JourneyState,
+} from "../src/index.js";
+
+const NOW = "2026-05-25T18:00:00.000Z";
+
+describe("resolveSessionState — heurística temporal", () => {
+  it("turn 1 (4min) → ice_breaker", () => {
+    const r = resolveSessionState({ turn: 1, journeyStage: "discovery_only" });
+    expect(r.phase).toBe("ice_breaker");
+    expect(r.elapsed_minutes_estimate).toBe(4);
+    expect(r.minutes_until_next_phase).toBe(11);
+  });
+
+  it("turn 4 (16min) → challenge_execute (sem challenge_explain explícito)", () => {
+    const r = resolveSessionState({ turn: 4, journeyStage: "discovery_only" });
+    // 16min > ice_end(15) + explain(0) = 15. Entra em execute.
+    expect(r.phase).toBe("challenge_execute");
+  });
+
+  it("turn 11 (44min) → challenge_execute (limite)", () => {
+    const r = resolveSessionState({ turn: 11, journeyStage: "applied_double_helix" });
+    expect(r.phase).toBe("challenge_execute");
+  });
+
+  it("turn 12 (48min) → follow_up", () => {
+    const r = resolveSessionState({ turn: 12, journeyStage: "applied_double_helix" });
+    expect(r.phase).toBe("follow_up");
+    expect(r.elapsed_minutes_estimate).toBe(48);
+  });
+
+  it("avgMinutesPerTurn override altera elapsed", () => {
+    const r = resolveSessionState({
+      turn: 3,
+      avgMinutesPerTurn: 2,
+      journeyStage: "discovery_only",
+    });
+    expect(r.elapsed_minutes_estimate).toBe(6);
+    expect(r.phase).toBe("ice_breaker");
+  });
+
+  it("elapsedMinutesOverride vence heurística por turn", () => {
+    const r = resolveSessionState({
+      turn: 1,
+      elapsedMinutesOverride: 47,
+      journeyStage: "applied_double_helix",
+    });
+    expect(r.elapsed_minutes_estimate).toBe(47);
+    expect(r.phase).toBe("follow_up"); // 47 > 45 = ice+execute
+  });
+
+  it("preserva journey_stage no output", () => {
+    const r = resolveSessionState({ turn: 1, journeyStage: "applied_double_helix" });
+    expect(r.journey_stage).toBe("applied_double_helix");
+  });
+});
+
+describe("readyForMapping — threshold", () => {
+  const baseState: JourneyState = {
+    subject_id: "ryo",
+    stage: "discovery_only",
+    stage_entered_at: NOW,
+    discoveries_count: 0,
+    families_covered: [],
+    last_updated_at: NOW,
+  };
+
+  it("false quando count < threshold", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: READY_FOR_MAPPING_MIN_DISCOVERIES - 1,
+          families_covered: ["carater", "disposicao", "cognicao_si"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("false quando famílias < threshold", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: 20,
+          families_covered: ["carater", "disposicao"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("true quando ambos critérios batem", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: READY_FOR_MAPPING_MIN_DISCOVERIES,
+          families_covered: ["carater", "disposicao", "cognicao_si"],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("override parental 'mapping_ready' força true", () => {
+    expect(
+      readyForMapping({
+        state: baseState,
+        parentOverride: "mapping_ready",
+      }),
+    ).toBe(true);
+  });
+
+  it("override parental 'applied_double_helix' também força true", () => {
+    expect(
+      readyForMapping({
+        state: baseState,
+        parentOverride: "applied_double_helix",
+      }),
+    ).toBe(true);
+  });
+
+  it("override parental 'discovery_only' força false mesmo com threshold OK", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: 100,
+          families_covered: ["carater", "disposicao", "cognicao_si"],
+        },
+        parentOverride: "discovery_only",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("computeDiscoveryMaturity", () => {
+  const makeEntry = (
+    type: SubjectKnowledgeEntry["type"],
+    payload: Record<string, unknown>,
+  ): SubjectKnowledgeEntry => ({
+    id: `id-${Math.random()}`,
+    subject_id: "ryo",
+    type,
+    source: "self_declared",
+    confidence: 0.8,
+    confirmed_at: NOW,
+    alignment: "unknown",
+    payload: { kind: type, ...payload } as SubjectKnowledgeEntry["payload"],
+    turn_ref: "s1__t1",
+    session_id: "s1",
+    created_at: NOW,
+  });
+
+  it("count = só interest/value/need/discovery; boundary_event não conta", () => {
+    const entries = [
+      makeEntry("interest", { label: "tênis" }),
+      makeEntry("value", { label: "esforço" }),
+      makeEntry("boundary_event", { topic_category: "x", signal_type: "deflection_thematic", intensity: "mid", motor_response: "muda_tema", severity_band: "routine" }),
+    ];
+    const r = computeDiscoveryMaturity(entries);
+    expect(r.discoveries_count).toBe(2);
+  });
+
+  it("families_covered dedup + sorted", () => {
+    const entries = [
+      makeEntry("interest", { label: "x", family: "carater" }),
+      makeEntry("interest", { label: "y", family: "disposicao" }),
+      makeEntry("value", { label: "z", family: "carater" }), // dup
+    ];
+    const r = computeDiscoveryMaturity(entries);
+    expect(r.families_covered).toEqual(["carater", "disposicao"]);
+  });
+
+  it("entries sem family/axis_id não contribuem pra families", () => {
+    const entries = [
+      makeEntry("interest", { label: "x" }), // sem family
+      makeEntry("value", { label: "y" }),
+    ];
+    const r = computeDiscoveryMaturity(entries);
+    expect(r.discoveries_count).toBe(2);
+    expect(r.families_covered).toEqual([]);
+  });
+
+  it("usa axisToFamilyFn quando payload tem axis_id mas não family", () => {
+    const entries = [
+      makeEntry("interest", { label: "x", axis_id: 3 }),
+    ];
+    const r = computeDiscoveryMaturity(entries, (axisId) =>
+      axisId >= 1 && axisId <= 4 ? "carater" : "outra",
+    );
+    expect(r.families_covered).toEqual(["carater"]);
+  });
+});
+
+describe("initialJourneyState", () => {
+  it("começa em discovery_only", () => {
+    const s = initialJourneyState("ryo");
+    expect(s.subject_id).toBe("ryo");
+    expect(s.stage).toBe("discovery_only");
+    expect(s.discoveries_count).toBe(0);
+    expect(s.families_covered).toEqual([]);
+    expect(s.override_by_parent).toBeUndefined();
+  });
+});
+
+describe("DEFAULT_SESSION_TIMING", () => {
+  it("totaliza 50 min", () => {
+    const t = DEFAULT_SESSION_TIMING;
+    expect(t.ice_breaker_minutes + t.challenge_explain_minutes + t.challenge_execute_minutes + t.follow_up_minutes).toBe(t.total_minutes);
+    expect(t.total_minutes).toBe(50);
+  });
+});
+
+describe("constants integridade", () => {
+  it("threshold valores ratificados (10 / 3)", () => {
+    expect(READY_FOR_MAPPING_MIN_DISCOVERIES).toBe(10);
+    expect(READY_FOR_MAPPING_MIN_FAMILIES).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
**PR 1 do tracer bullet** ([spec 2026-05-25](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md) §2 §3 §10). Foundation: tipos + tabela + resolver + endpoints. **Comportamento phase-aware** vem em PR 2.

### Tipos (shared/src/session-phases.ts)
- \`SessionPhase\`: ice_breaker · challenge_explain · challenge_execute · follow_up
- \`JourneyStage\`: discovery_only · mapping_ready · applied_double_helix
- \`DEFAULT_SESSION_TIMING\`: 15+30+5 = 50 min
- \`resolveSessionState\` — heurística temporal (avg 4min/turn; override real-time)
- \`readyForMapping\` — threshold ≥10 discoveries em ≥3 famílias + override parental
- \`computeDiscoveryMaturity\` — deriva count + families do ledger

### Schema (BFF SQLite)
Nova tabela \`journey_state\` com CHECK em stage + index. Lazy compute: \`readOrComputeJourneyState\` recomputa do ledger e auto-transiciona discovery_only → mapping_ready quando threshold bate.

### Endpoints REST novos
- \`GET /subjects/:id/journey-state\`
- \`POST /subjects/:id/journey-state/override { stage, reason }\`
- \`DELETE /subjects/:id/journey-state/override\`

## Test plan
- [x] \`shared/tests/session-phases.test.ts\` — 20 tests (resolver heurística, threshold, override parental, computeDiscoveryMaturity)
- [x] \`packages/ebrota-console-bff/tests/journey-state.test.ts\` — 14 tests (lazy recompute, auto-transição, override semântica, endpoints REST)
- [x] Suite: shared 769 (+20) · bff 135 (+18) · motor 329 · planejador 332 — zero regressão

## Próximo
PR 2 motor — phase-aware behavior (materializer ice_breaker tom + DiscoveryWriter agressivo + ledger gating por fase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)