### PR TITLE
[feat] Planejador hidrata Strategist context (latent_needs + subject_proposed)

### DIFF
--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -801,6 +801,18 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
       ? evaluateAllTransitions(profileId, recentSignals, turnsSinceLastTransition)
       : [];
 
+  // Fase 8 PR — Strategist context (sub-PR pós tracer bullet):
+  // Propaga subject_proposed + latent_needs do ChildScoringProfile pro
+  // contextHints, pra motor-drota's composeStrategyPlan consumir quando
+  // journey_stage = applied_double_helix. Sem isso, Strategist v1 retorna
+  // null e ponte tripla não tem norte.
+  if (child.subject_proposed) {
+    contextHints["subject_proposed"] = child.subject_proposed;
+  }
+  if (child.latent_needs && child.latent_needs.length > 0) {
+    contextHints["latent_needs"] = child.latent_needs;
+  }
+
   // motor#25 (handoff #25 B5): Shannon entropy do candidate set antes de retornar.
   const candidateSetEntropy = shannonEntropy(slimPool.map((s) => s.item.id));
 

--- a/planejador/tests/plan-strategist-context.test.ts
+++ b/planejador/tests/plan-strategist-context.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests sub-PR Strategist context — planejador hidrata contextHints
+ * com subject_proposed + latent_needs do parental_profile.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { planTurn } from "../src/plan.js";
+
+process.env["USE_MOCK_LLM"] = "true";
+
+const mockState = {
+  sessionId: "s-strategist-ctx",
+  trustLevel: 0.3,
+  budgetRemaining: 100,
+  turn: 0,
+  eventLog: [],
+};
+
+const mockAdquirente = {
+  id: "jun",
+  name: "Jun Ochiai",
+  defaults: { style: "direto", language: "pt-br" },
+};
+
+const mockInventory = [
+  {
+    id: "kids.helix.session",
+    title: "Helix",
+    category: "kids",
+    estimatedSacrifice: 1,
+    estimatedConfidenceGain: 4,
+  },
+];
+
+beforeAll(() => {});
+
+describe("planTurn — Strategist context propagation", () => {
+  it("injeta subject_proposed em contextHints quando parental_profile.aspirations existe", async () => {
+    const persona = {
+      id: "ryo",
+      name: "Ryo",
+      age: 13,
+      profile: {
+        parental_profile: {
+          aspirations: {
+            proposed_virtues: [
+              { axis: 3 },
+              { axis: 7 },
+              { axis: 11 },
+            ],
+          },
+        },
+      },
+    };
+    const output = await planTurn({
+      sessionId: mockState.sessionId,
+      persona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    const subjectProposed = output.contextHints["subject_proposed"] as
+      | { axes_active: number[] }
+      | undefined;
+    expect(subjectProposed).toBeDefined();
+    expect(subjectProposed?.axes_active).toEqual([3, 7, 11]);
+  });
+
+  it("injeta latent_needs em contextHints quando parental_profile.latent_needs existe", async () => {
+    const persona = {
+      id: "ryo",
+      name: "Ryo",
+      age: 13,
+      profile: {
+        parental_profile: {
+          latent_needs: ["autocontrole", "abertura emocional"],
+        },
+      },
+    };
+    const output = await planTurn({
+      sessionId: mockState.sessionId,
+      persona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["latent_needs"]).toEqual([
+      "autocontrole",
+      "abertura emocional",
+    ]);
+  });
+
+  it("ambos juntos quando parental_profile completo", async () => {
+    const persona = {
+      id: "ryo",
+      name: "Ryo",
+      age: 13,
+      profile: {
+        parental_profile: {
+          aspirations: {
+            proposed_virtues: [{ axis: 4 }],
+          },
+          latent_needs: ["x"],
+        },
+      },
+    };
+    const output = await planTurn({
+      sessionId: mockState.sessionId,
+      persona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["subject_proposed"]).toBeDefined();
+    expect(output.contextHints["latent_needs"]).toEqual(["x"]);
+  });
+
+  it("omite ambos quando parental_profile não tem aspirations nem latent_needs", async () => {
+    const persona = {
+      id: "ryo",
+      name: "Ryo",
+      age: 13,
+      profile: {
+        parental_profile: {
+          // só campos do core sem Subject Knowledge fields
+          family_values: { principles: ["x"] },
+        },
+      },
+    };
+    const output = await planTurn({
+      sessionId: mockState.sessionId,
+      persona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["subject_proposed"]).toBeUndefined();
+    expect(output.contextHints["latent_needs"]).toBeUndefined();
+  });
+
+  it("backcompat — persona sem parental_profile inteiro", async () => {
+    const persona = {
+      id: "ryo",
+      name: "Ryo",
+      age: 13,
+      profile: { interests: ["x"] },
+    };
+    const output = await planTurn({
+      sessionId: mockState.sessionId,
+      persona,
+      adquirente: mockAdquirente,
+      inventory: mockInventory,
+      state: mockState,
+      incomingMessage: "oi",
+    });
+    expect(output.contextHints["subject_proposed"]).toBeUndefined();
+    expect(output.contextHints["latent_needs"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Sub-PR pós tracer bullet. Conecta a ponte que faltava: planejador propaga \`subject_proposed\` + \`latent_needs\` do ChildScoringProfile pro \`contextHints\`. Motor (PR 3) já lê desses campos no \`composeStrategyPlan\`.

**Sem este PR**, Strategist sempre retorna null em \`applied_double_helix\` porque \`subjectProposed\` chega undefined.

### Mudança em plan.ts
Após \`sacrifice_breakdown\` e antes de Shannon entropy:
\`\`\`ts
if (child.subject_proposed) {
  contextHints["subject_proposed"] = child.subject_proposed;
}
if (child.latent_needs && child.latent_needs.length > 0) {
  contextHints["latent_needs"] = child.latent_needs;
}
\`\`\`

Fonte: \`personaToChildProfile\` (PR #211) já extrai de \`parental_profile.aspirations.proposed_virtues\` + \`.latent_needs\`.

## Test plan
- [x] \`plan-strategist-context.test.ts\` — 5 tests (injeção subject_proposed, latent_needs, ambos juntos, omissão quando ausente, backcompat persona sem parental_profile)
- [x] Suite: planejador 337 (+5) — zero regressão

## Próximo
Smoke real \`tracer-helix-3sessions-ryo\` validador end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)