### PR TITLE
[feat] scorer multidim — tokenize latent_needs + interest fallback

### DIFF
--- a/shared/src/scorer.ts
+++ b/shared/src/scorer.ts
@@ -371,6 +371,46 @@ export interface MultiDimMatches {
   internalization_history: boolean;
 }
 
+/**
+ * Stopwords PT-BR pequenas — filtradas ao tokenizar latent_needs/interests
+ * pra evitar match espúrio em palavras irrelevantes.
+ */
+const TOKENIZE_STOPWORDS: ReadonlySet<string> = new Set([
+  "de", "da", "do", "das", "dos", "em", "para", "com", "sem", "por",
+  "a", "o", "as", "os", "um", "uma", "uns", "umas", "no", "na", "nos", "nas",
+  "que", "se", "e", "ou", "mas",
+]);
+
+/**
+ * Tokenize string longa em palavras significativas (>3 chars, sem stopwords).
+ * Usado pra match de latent_needs ("expressão emocional" → ["expressão","emocional"])
+ * contra haystack curto (keywords/domain).
+ */
+function tokenizeForMatch(s: string): string[] {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 3 && !TOKENIZE_STOPWORDS.has(t));
+}
+
+/**
+ * Match via tokens (sempre): needle longa quebrada em tokens >3 chars
+ * (sem stopwords) que vão match individualmente contra haystack.
+ *
+ * Evita que stopword na needle (ex: "coisa importante de verdade")
+ * matche trivialmente via substring.
+ */
+function fuzzyMatch(needle: string, haystack: string[]): boolean {
+  const tokens = tokenizeForMatch(needle);
+  if (tokens.length === 0) return false;
+  // Match bidirecional só quando ambos lados têm length >3 — evita
+  // "de" (haystack curto) matchear como substring de "verdade" (tok longo).
+  return tokens.some((tok) =>
+    haystack.some((h) => h.length > 3 && (h.includes(tok) || tok.includes(h))),
+  );
+}
+
 export function evaluateMultiDimMatches(
   item: ContentItem,
   child: ChildScoringProfile,
@@ -385,17 +425,15 @@ export function evaluateMultiDimMatches(
     .filter(Boolean)
     .map((s) => String(s).toLowerCase());
 
-  const interest =
-    (child.interests ?? []).some((i) => {
-      const needle = i.toLowerCase().trim();
-      return needle.length > 0 && haystack.some((h) => h.includes(needle) || needle.includes(h));
-    });
+  // interest: persona.interests OU fallback pra domain_ranking quando vazio
+  const interestSource =
+    child.interests && child.interests.length > 0
+      ? child.interests
+      : Object.keys(child.domain_ranking ?? {});
+  const interest = interestSource.some((i) => fuzzyMatch(i, haystack));
 
-  const need =
-    (child.latent_needs ?? []).some((n) => {
-      const needle = n.toLowerCase().trim();
-      return needle.length > 0 && haystack.some((h) => h.includes(needle) || needle.includes(h));
-    });
+  // need: tokenize latent_needs longos (ex: "expressão emocional")
+  const need = (child.latent_needs ?? []).some((n) => fuzzyMatch(n, haystack));
 
   let lineage = false;
   let movesTowardProposed = false;

--- a/shared/tests/scorer-heuristic-refinement.test.ts
+++ b/shared/tests/scorer-heuristic-refinement.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests refinements de heurística no scorer multi-dim:
+ * - latent_needs longos são tokenizados (match palavra a palavra)
+ * - interest fallback pra domain_ranking quando interests vazio
+ */
+import { describe, it, expect } from "vitest";
+import { evaluateMultiDimMatches } from "../src/scorer.js";
+import type { CuriosityHookItem } from "../src/content-item.js";
+
+const baseItem = (overrides: Partial<CuriosityHookItem>): CuriosityHookItem => ({
+  id: "test-item",
+  type: "curiosity_hook",
+  domain: "biologia",
+  casel_target: ["SA"],
+  age_range: [10, 15],
+  surprise: 7,
+  verified: true,
+  base_score: 5,
+  fact: "x",
+  bridge: "y",
+  quest: "z",
+  sacrifice_type: "reflect",
+  axis_id: 11,
+  family: "cognicao_si",
+  lineage_anchor: "paideia/gnothi_seauton",
+  extracted_keywords: ["expressao", "emocional", "sentimentos"],
+  ...overrides,
+});
+
+describe("scorer heuristic refinement — latent_needs tokenization", () => {
+  it("match exato palavra única funciona (caso simples)", () => {
+    const item = baseItem({});
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      latent_needs: ["emocional"],
+    });
+    expect(m.need).toBe(true);
+  });
+
+  it("string longa 'expressão emocional' agora matcha keyword 'emocional'", () => {
+    const item = baseItem({});
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      latent_needs: ["expressão emocional"], // antes nunca matchava (string longa)
+    });
+    expect(m.need).toBe(true);
+  });
+
+  it("frase muito longa parece estranha mas extrai tokens >3 chars", () => {
+    const item = baseItem({ extracted_keywords: ["acadêmico"] });
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      latent_needs: ["equilíbrio acadêmico sem pressão"],
+    });
+    expect(m.need).toBe(true);
+  });
+
+  it("stopwords PT-BR não disparam falso match", () => {
+    const item = baseItem({ extracted_keywords: ["de", "com", "para"] });
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      latent_needs: ["coisa importante de verdade"],
+    });
+    expect(m.need).toBe(false); // só "de" matcharia, mas é stopword
+  });
+
+  it("retorna false quando nenhum token bate", () => {
+    const item = baseItem({ extracted_keywords: ["zen", "shoshin"] });
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      latent_needs: ["coisas totalmente diferentes do conteúdo"],
+    });
+    expect(m.need).toBe(false);
+  });
+});
+
+describe("scorer heuristic refinement — interest fallback domain_ranking", () => {
+  it("usa interests quando presente (caso normal)", () => {
+    const item = baseItem({ domain: "biologia" });
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      interests: ["biologia"],
+    });
+    expect(m.interest).toBe(true);
+  });
+
+  it("fallback pra domain_ranking keys quando interests vazio/ausente", () => {
+    const item = baseItem({ domain: "biologia" });
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      domain_ranking: { biologia: { score: 0.8 }, social: { score: 0.5 } },
+    });
+    expect(m.interest).toBe(true); // veio do domain_ranking, não interests
+  });
+
+  it("fallback considera só nomes dos domínios (keys), não scores", () => {
+    const item = baseItem({ domain: "matematica" });
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      domain_ranking: { matematica: { score: 0.5 } },
+    });
+    expect(m.interest).toBe(true);
+  });
+
+  it("interests explícitos VENCEM domain_ranking quando ambos presentes", () => {
+    const item = baseItem({ domain: "fisica" });
+    const m = evaluateMultiDimMatches(item, {
+      age: 12,
+      interests: ["fisica"], // matcha
+      domain_ranking: { biologia: { score: 0.9 } }, // ignorado
+    });
+    expect(m.interest).toBe(true);
+  });
+
+  it("retorna false sem interests e sem domain_ranking", () => {
+    const item = baseItem({});
+    const m = evaluateMultiDimMatches(item, { age: 12 });
+    expect(m.interest).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Refinamento da heurística do scorer multi-dim baseado em achados da smoke pós F1-F5:
- \`latent_needs\` longos ("expressão emocional") nunca matchavam contra \`extracted_keywords\` curtas
- \`interest\` exigia \`interests:[]\` no profile; fixtures legadas têm só \`domain_ranking\` → dim sempre false

### Mudanças
- \`tokenizeForMatch\`: split + filter stopwords PT-BR + length>3
- \`fuzzyMatch\`: match bidirecional só quando ambos lados tem length>3 (evita "de" matchear "verdade")
- \`interest\` fallback: \`keys(domain_ranking)\` quando \`interests\` vazio/ausente
- \`latent_needs\`: tokeniza string longa, match algum token vs haystack

## Test plan
- [x] 10 tests novos cobrindo tokenization + stopwords + interest fallback + ambos juntos
- [x] Suite shared 759 (+10) — zero regressão

## Próximo
Próxima smoke (pós-tracer-bullet) deve mostrar \`multidim_bonus\` disparando dim \`interest\` E \`need\` (antes só lineage+moves_toward_proposed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)