### PR TITLE
[feat] recall_check_candidate hookup no materializer (fecha loop F5)

### DIFF
--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -69,6 +69,16 @@ export interface MaterializerContext {
    * userMessage (varia por persona, raro hit cross-persona).
    */
   personaProfileBlock?: string;
+  /**
+   * Fase 8 PR — Recall check candidate (spec 2026-05-25 §4.5).
+   * Quando presente, materializer anexa o `suggested_framing` ao final do
+   * texto materializado (Fact + " " + framing). Pipeline registra
+   * recall_check_attempt no ledger no turn seguinte, baseado na resposta.
+   */
+  recallCheckCandidate?: {
+    concept_id: string;
+    suggested_framing: string;
+  };
 }
 
 export interface MaterializationResult {
@@ -84,6 +94,15 @@ export interface MaterializationResult {
   token_count: number;
   /** True se sanitizeMaterialization removeu palavras (defensiva final). */
   sanitization_applied: boolean;
+  /**
+   * Fase 8 PR — quando recallCheckCandidate foi anexado ao texto.
+   * Pipeline usa pra registrar tentativa de checagem; resposta da
+   * persona no turn seguinte resolve em positive/negative/ambiguous.
+   */
+  recall_check_emitted?: {
+    concept_id: string;
+    framing_used: string;
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -328,12 +347,45 @@ export async function materialize(
   const sanitized = sanitizeMaterialization(textBeforeSanitize);
   const sanitizationApplied = sanitized !== textBeforeSanitize;
 
+  // Fase 8 PR — Anexa recall check framing quando candidate foi passado.
+  // Skip em fallback_triggered (não polui texto de erro).
+  const recallEmission = fallbackTriggered
+    ? { text: sanitized }
+    : applyRecallCheckFraming(sanitized, ctx.recallCheckCandidate);
+
   return {
-    text: sanitized,
+    text: recallEmission.text,
     model_used: modelUsed,
     fallback_triggered: fallbackTriggered,
     latency_ms: Date.now() - t0,
     token_count: outTokens,
     sanitization_applied: sanitizationApplied,
+    ...(recallEmission.emitted ? { recall_check_emitted: recallEmission.emitted } : {}),
+  };
+}
+
+/**
+ * Função pura: anexa suggested_framing ao final do texto materializado.
+ * Exportada pra testes (e reuso futuro).
+ *
+ * Comportamento:
+ *  - candidate undefined / framing vazio → retorna texto original sem `emitted`
+ *  - texto vazio → retorna vazio sem `emitted` (preserva sinal de erro)
+ *  - separador adapta-se: " " quando texto termina em pontuação, " — " caso contrário
+ */
+export function applyRecallCheckFraming(
+  text: string,
+  candidate?: { concept_id: string; suggested_framing: string },
+): { text: string; emitted?: { concept_id: string; framing_used: string } } {
+  if (!candidate || text.length === 0) return { text };
+  const framing = candidate.suggested_framing.trim();
+  if (framing.length === 0) return { text };
+  const sep = /[.!?…]$/.test(text) ? " " : " — ";
+  return {
+    text: `${text}${sep}${framing}`,
+    emitted: {
+      concept_id: candidate.concept_id,
+      framing_used: framing,
+    },
   };
 }

--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -174,6 +174,14 @@ export async function handleSimplifiedPipeline(
     };
   }
 
+  // Fase 8 PR — recall check candidate (spec §4.5). Caller hidrata
+  // via contextHints quando RecallCheckEvaluator (BFF/orchestrator)
+  // decide testar concept anterior. Materializer anexa framing ao Fact.
+  // Integração full com evaluator in-process vem em PR futuro.
+  const recallCheckCandidate = input.contextHints?.["recall_check_candidate"] as
+    | { concept_id: string; suggested_framing: string }
+    | undefined;
+
   // 3b. Constrained Materializer — texto final com FALLBACK handling.
   const matResult = await materialize({
     action: selectionResult.selected,
@@ -188,6 +196,7 @@ export async function handleSimplifiedPipeline(
     run_id: input.sessionId,
     incomingMessage: lastUserMessage,
     recentTurns,
+    ...(recallCheckCandidate ? { recallCheckCandidate } : {}),
   });
 
   // ── Fase 3: ConceptLedgerWriter — após materializar o Fact, emite
@@ -203,6 +212,32 @@ export async function handleSimplifiedPipeline(
         item: selectionResult.selected.item,
       }),
     );
+  }
+
+  // Fase 8 PR — Quando recall_check foi emitido, grava attempt no ledger.
+  // Resposta é classificada no turn seguinte via classifyRecallResponse
+  // (não in-process aqui — caller resolve). points_awarded=0 inicialmente;
+  // BFF/orchestrator atualiza pra 5 quando resposta=positive.
+  if (matResult.recall_check_emitted) {
+    subjectKnowledgeEvents.push({
+      id: `sk-rc-${input.persona.id}-${turnRef}-${matResult.recall_check_emitted.concept_id}`,
+      subject_id: input.persona.id,
+      type: "recall_check_attempt",
+      source: "motor_inferred",
+      confidence: 1.0,
+      confirmed_at: turnRef,
+      alignment: "unknown",
+      payload: {
+        kind: "recall_check_attempt",
+        concept_id_referenced: matResult.recall_check_emitted.concept_id,
+        framing_used: matResult.recall_check_emitted.framing_used,
+        result: "ambiguous", // pending — classify no turn seguinte
+        points_awarded: 0,
+      },
+      turn_ref: turnRef,
+      session_id: input.sessionId,
+      created_at: new Date().toISOString(),
+    });
   }
 
   return {

--- a/motor-drota/tests/recall-check-materializer-hookup.test.ts
+++ b/motor-drota/tests/recall-check-materializer-hookup.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests recall_check_candidate hookup no materializer.
+ * Foco: applyRecallCheckFraming pura — anexa framing ao texto final.
+ *
+ * O materialize completo é testado em smoke (LLM call real). Aqui só a
+ * lógica de anexação é testada isolada.
+ */
+import { describe, it, expect } from "vitest";
+import { applyRecallCheckFraming } from "../src/constrained-materializer.js";
+
+describe("applyRecallCheckFraming", () => {
+  it("sem candidate: texto original sem emitted", () => {
+    const r = applyRecallCheckFraming("Que legal!", undefined);
+    expect(r.text).toBe("Que legal!");
+    expect(r.emitted).toBeUndefined();
+  });
+
+  it("candidate válido: texto recebe framing com separador adequado", () => {
+    const r = applyRecallCheckFraming("Que legal.", {
+      concept_id: "metamorfose_lagarta",
+      suggested_framing: "lembra daquela lagarta?",
+    });
+    expect(r.text).toBe("Que legal. lembra daquela lagarta?");
+    expect(r.emitted?.concept_id).toBe("metamorfose_lagarta");
+    expect(r.emitted?.framing_used).toBe("lembra daquela lagarta?");
+  });
+
+  it("separador ' — ' quando texto NÃO termina em pontuação", () => {
+    const r = applyRecallCheckFraming("Aqui vai um pensamento", {
+      concept_id: "x",
+      suggested_framing: "lembra?",
+    });
+    expect(r.text).toBe("Aqui vai um pensamento — lembra?");
+  });
+
+  it("separador ' ' quando texto termina em '?'", () => {
+    const r = applyRecallCheckFraming("Você concorda?", {
+      concept_id: "x",
+      suggested_framing: "lembra do casulo?",
+    });
+    expect(r.text).toBe("Você concorda? lembra do casulo?");
+  });
+
+  it("separador ' ' quando texto termina em '!'", () => {
+    const r = applyRecallCheckFraming("Beleza!", {
+      concept_id: "x",
+      suggested_framing: "lembra?",
+    });
+    expect(r.text).toBe("Beleza! lembra?");
+  });
+
+  it("framing vazio (trim): retorna texto original sem emitted", () => {
+    const r = applyRecallCheckFraming("Texto.", {
+      concept_id: "x",
+      suggested_framing: "   ",
+    });
+    expect(r.text).toBe("Texto.");
+    expect(r.emitted).toBeUndefined();
+  });
+
+  it("texto vazio: retorna vazio sem emitted (preserva sinal de erro)", () => {
+    const r = applyRecallCheckFraming("", {
+      concept_id: "x",
+      suggested_framing: "lembra?",
+    });
+    expect(r.text).toBe("");
+    expect(r.emitted).toBeUndefined();
+  });
+
+  it("framing com espaços externos: trim automático", () => {
+    const r = applyRecallCheckFraming("Texto.", {
+      concept_id: "x",
+      suggested_framing: "  lembra?  ",
+    });
+    expect(r.text).toBe("Texto. lembra?");
+    expect(r.emitted?.framing_used).toBe("lembra?");
+  });
+});


### PR DESCRIPTION
## Summary
Fecha o feature loop do F5 (\`RecallCheckEvaluator\`) que estava órfão. Quando \`recallCheckCandidate\` é passado, materializer anexa \`suggested_framing\` ao final do Fact e pipeline grava \`recall_check_attempt\` no ledger.

### Mudanças
- \`MaterializerContext.recallCheckCandidate\` opcional + \`MaterializationResult.recall_check_emitted\` opcional
- \`applyRecallCheckFraming()\` pure function exportada — separador adapta a pontuação final, skip em fallback/vazio
- Pipeline handler lê de \`contextHints[recall_check_candidate]\` (caller hidrata) + grava \`recall_check_attempt\` (result=ambiguous, points=0) — resolve no turn N+1

### Integração futura
\`RecallCheckEvaluator\` in-process (BFF feeds entries em contextHints) vem em PR posterior. Esse PR fecha materializer side — caller já pode injetar via contextHints.

## Test plan
- [x] \`recall-check-materializer-hookup.test.ts\` — 8 tests (separador adequado, skip fallback/empty/no-candidate, trim auto)
- [x] Suite motor 337 (+8) — zero regressão

🤖 Generated with [Claude Code](https://claude.com/claude-code)