### PR TITLE
[feat] MapFramework registry + 4 frameworks v1 (sub-fase 8.3)

### DIFF
--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -56,6 +56,11 @@ import {
   listBoundaryEvents,
   summarizeBoundariesByCategory,
 } from "./subject-knowledge-repo.js";
+import {
+  computeMapPositions,
+  listFrameworks,
+  type SubjectKnowledgeEntry,
+} from "@ascendimacy/shared";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -527,6 +532,71 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       summary: summarizeBoundariesByCategory(opts.db, req.params.id),
     }),
   );
+
+  // ── MapFramework endpoints (Fase 8 sub-fase 8.3) ──────────────────
+  // GET /frameworks — lista frameworks registrados (display_name + dims)
+  fastify.get("/frameworks", async () => ({
+    frameworks: listFrameworks().map((fw) => ({
+      id: fw.id,
+      display_name: fw.display_name,
+      dimensions: fw.dimensions,
+      render_hint: fw.render_hint,
+    })),
+  }));
+
+  // GET /subjects/:id/maps[?framework=X,Y] — projeções multi-framework
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { framework?: string };
+  }>("/subjects/:id/maps", async (req) => {
+    const frameworkIds = req.query.framework
+      ? req.query.framework.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
+      : undefined;
+
+    // Carrega entries do ledger pra projeção (todas as types relevantes).
+    const entries = opts.db
+      .prepare(
+        `SELECT id, subject_id, type, source, confidence, confirmed_at,
+                alignment, payload_json, turn_ref, session_id, created_at
+         FROM subject_knowledge
+         WHERE subject_id = ?`,
+      )
+      .all(req.params.id) as Array<{
+        id: string;
+        subject_id: string;
+        type: string;
+        source: string;
+        confidence: number;
+        confirmed_at: string | null;
+        alignment: string;
+        payload_json: string;
+        turn_ref: string;
+        session_id: string;
+        created_at: string;
+      }>;
+
+    const skEntries: SubjectKnowledgeEntry[] = entries.map((row) => ({
+      id: row.id,
+      subject_id: row.subject_id,
+      type: row.type as SubjectKnowledgeEntry["type"],
+      source: row.source as SubjectKnowledgeEntry["source"],
+      confidence: row.confidence,
+      confirmed_at: row.confirmed_at,
+      alignment: row.alignment as SubjectKnowledgeEntry["alignment"],
+      payload: JSON.parse(row.payload_json),
+      turn_ref: row.turn_ref,
+      session_id: row.session_id,
+      created_at: row.created_at,
+    }));
+
+    return {
+      maps: computeMapPositions({
+        subjectId: req.params.id,
+        entries: skEntries,
+        ...(frameworkIds ? { frameworkIds } : {}),
+      }),
+    };
+  });
 
   // POST /rescan — re-indexa o tracesDir (manual trigger).
   // Útil quando STS roda em outro processo e deposita novos traces;

--- a/packages/ebrota-console-bff/tests/map-framework-endpoints.test.ts
+++ b/packages/ebrota-console-bff/tests/map-framework-endpoints.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import {
+  createMockDaemonClient,
+  type MockDaemonClient,
+} from "../src/daemon-client.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+let db: DatabaseType;
+let daemon: MockDaemonClient;
+let server: BffServer;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+});
+afterEach(async () => {
+  await server.close();
+});
+
+function seedPresentedConcept(subjectId: string, axis: number, i: number) {
+  db.prepare(
+    `INSERT INTO subject_knowledge (
+      id, subject_id, type, source, confidence, confirmed_at,
+      alignment, payload_json, turn_ref, session_id, created_at
+    ) VALUES (?, ?, 'presented_concept', 'motor_inferred', 1.0, ?, 'unknown', ?, ?, ?, ?)`,
+  ).run(
+    `pc-${i}`,
+    subjectId,
+    `s1__t${i}`,
+    JSON.stringify({
+      kind: "presented_concept",
+      concept_id: `c-${i}`,
+      keywords: ["x"],
+      lineage_anchor: "estoica/x",
+      axis_id: axis,
+      family: axis <= 4 ? "carater" : axis <= 8 ? "disposicao" : "cognicao_si",
+      points: 1,
+    }),
+    `s1__t${i}`,
+    "s1",
+    new Date(2026, 4, 25, 10, i).toISOString(),
+  );
+}
+
+const inject = async (url: string) => {
+  const res = await server.fastify.inject({ method: "GET", url });
+  return { status: res.statusCode, body: JSON.parse(res.body) };
+};
+
+describe("GET /frameworks", () => {
+  it("retorna lista dos 4 frameworks v1", async () => {
+    const r = await inject("/frameworks");
+    expect(r.status).toBe(200);
+    const ids = r.body.frameworks.map((fw: { id: string }) => fw.id);
+    expect(ids).toContain("valores_classicos");
+    expect(ids).toContain("gardner");
+    expect(ids).toContain("casel");
+    expect(ids).toContain("dreyfus_by_domain");
+  });
+
+  it("cada framework tem display_name + dimensions + render_hint", async () => {
+    const r = await inject("/frameworks");
+    for (const fw of r.body.frameworks) {
+      expect(typeof fw.display_name).toBe("string");
+      expect(Array.isArray(fw.dimensions)).toBe(true);
+      expect(["radar", "bar", "tree", "list"]).toContain(fw.render_hint);
+    }
+  });
+});
+
+describe("GET /subjects/:id/maps", () => {
+  it("retorna projeções em todos os frameworks por default", async () => {
+    seedPresentedConcept("ryo", 3, 1);
+    seedPresentedConcept("ryo", 3, 2);
+    seedPresentedConcept("ryo", 11, 3);
+    const r = await inject("/subjects/ryo/maps");
+    expect(r.status).toBe(200);
+    const positions = r.body.maps.positions;
+    expect(Object.keys(positions).sort()).toEqual([
+      "casel",
+      "dreyfus_by_domain",
+      "gardner",
+      "valores_classicos",
+    ]);
+    expect(positions.valores_classicos.axis_3).toBe(2);
+    expect(positions.valores_classicos.axis_11).toBe(1);
+  });
+
+  it("filter ?framework=X retorna só esse framework", async () => {
+    seedPresentedConcept("ryo", 3, 1);
+    const r = await inject("/subjects/ryo/maps?framework=valores_classicos");
+    expect(Object.keys(r.body.maps.positions)).toEqual(["valores_classicos"]);
+  });
+
+  it("filter ?framework=X,Y retorna só esses", async () => {
+    const r = await inject("/subjects/ryo/maps?framework=casel,gardner");
+    const keys = Object.keys(r.body.maps.positions).sort();
+    expect(keys).toEqual(["casel", "gardner"]);
+  });
+
+  it("sujeito sem entries retorna positions zeradas", async () => {
+    const r = await inject("/subjects/none/maps?framework=valores_classicos");
+    expect(r.status).toBe(200);
+    for (let i = 1; i <= 12; i++) {
+      expect(r.body.maps.positions.valores_classicos[`axis_${i}`]).toBe(0);
+    }
+  });
+
+  it("casel projection usa axis→casel mapping", async () => {
+    seedPresentedConcept("ryo", 1, 1); // axis 1 → DM
+    seedPresentedConcept("ryo", 7, 2); // axis 7 → REL
+    const r = await inject("/subjects/ryo/maps?framework=casel");
+    expect(r.body.maps.positions.casel.DM).toBe(1);
+    expect(r.body.maps.positions.casel.REL).toBe(1);
+    expect(r.body.maps.positions.casel.SA).toBe(0);
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -26,6 +26,7 @@ export * from "./subject-knowledge.js";
 export * from "./subject-knowledge-writers.js";
 export * from "./concept-ledger-writer.js";
 export * from "./recall-check-evaluator.js";
+export * from "./map-framework.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/map-framework.ts
+++ b/shared/src/map-framework.ts
@@ -1,0 +1,256 @@
+/**
+ * MapFramework registry — Fase 8 sub-fase 8.3 (spec §4).
+ *
+ * Cada framework pedagógico é uma LENTE projetável sobre o subject_knowledge
+ * ledger. O sujeito-real é um ponto multi-dim projetado em cada lente
+ * independentemente. Adicionar nova lente = registrar projeção, sem migration.
+ *
+ * Frameworks v1 (release inicial):
+ *   - valores_classicos  — catálogo lineage F4 (12 eixos × 9 tradições)
+ *   - gardner            — 9 inteligências múltiplas
+ *   - casel              — SA/SM/SOC/REL/DM
+ *   - dreyfus_by_domain  — Dreyfus level por domínio
+ *
+ * Registry é singleton lazy — registerFramework antes do primeiro getCatalog.
+ */
+
+import type { SubjectKnowledgeEntry } from "./subject-knowledge.js";
+
+export interface MapFramework {
+  /** ID único — usado nas tabelas/UI/endpoints. */
+  id: string;
+  /** Nome humano-legível. */
+  display_name: string;
+  /** Dimensões da lente (axis IDs, channels, etc — depende do framework). */
+  dimensions: readonly string[];
+  /** Renderização sugerida pra Console UI. */
+  render_hint: "radar" | "bar" | "tree" | "list";
+  /**
+   * Função de projeção pura: lê entries do ledger e devolve posicionamento
+   * do sujeito naquela lente. Map<dimensionId, valor>. O shape do valor é
+   * decidido pelo framework (number/object/etc).
+   */
+  project: (entries: SubjectKnowledgeEntry[]) => Map<string, unknown>;
+}
+
+/** Estado projetado por sujeito em todos os frameworks registrados. */
+export interface SubjectMapPosition {
+  subject_id: string;
+  computed_at: string;
+  /** frameworkId → (dimensionId → valor). */
+  positions: Record<string, Record<string, unknown>>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Registry — singleton lazy
+// ─────────────────────────────────────────────────────────────────────────
+
+const FRAMEWORK_REGISTRY: Map<string, MapFramework> = new Map();
+
+export function registerFramework(fw: MapFramework): void {
+  FRAMEWORK_REGISTRY.set(fw.id, fw);
+}
+
+export function getFramework(id: string): MapFramework | undefined {
+  return FRAMEWORK_REGISTRY.get(id);
+}
+
+export function listFrameworks(): MapFramework[] {
+  return Array.from(FRAMEWORK_REGISTRY.values());
+}
+
+/** Reset — só pra tests. */
+export function resetFrameworkRegistry(): void {
+  FRAMEWORK_REGISTRY.clear();
+  registerDefaultFrameworks();
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Framework: valores_classicos (12 eixos, paideia/aristotélica/etc)
+// ─────────────────────────────────────────────────────────────────────────
+
+const VALORES_AXES = Array.from({ length: 12 }, (_, i) => `axis_${i + 1}`);
+
+const valoresClassicos: MapFramework = {
+  id: "valores_classicos",
+  display_name: "Valores Clássicos (12 eixos)",
+  dimensions: VALORES_AXES,
+  render_hint: "radar",
+  project(entries) {
+    const points = new Map<string, number>();
+    for (const ax of VALORES_AXES) points.set(ax, 0);
+    for (const e of entries) {
+      if (e.type === "presented_concept" && e.payload.kind === "presented_concept") {
+        const key = `axis_${e.payload.axis_id}`;
+        points.set(key, (points.get(key) ?? 0) + e.payload.points);
+      } else if (e.type === "recall_check_attempt" && e.payload.kind === "recall_check_attempt") {
+        // recall_check positivo soma points_awarded ao axis do concept original
+        // — em v1, sem cross-lookup (precisaríamos correlacionar pelo concept_id).
+        // Por hora, se points_awarded > 0, atribuímos ao axis 0 marker — caller
+        // pode pós-processar com lookup completo.
+        if (e.payload.points_awarded > 0) {
+          points.set("axis_unknown", (points.get("axis_unknown") ?? 0) + e.payload.points_awarded);
+        }
+      }
+    }
+    return new Map(points);
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Framework: gardner (9 inteligências)
+// ─────────────────────────────────────────────────────────────────────────
+
+const GARDNER_CHANNELS = [
+  "linguistic",
+  "logical_mathematical",
+  "spatial",
+  "musical",
+  "bodily_kinesthetic",
+  "interpersonal",
+  "intrapersonal",
+  "naturalist",
+  "existential",
+] as const;
+
+const gardner: MapFramework = {
+  id: "gardner",
+  display_name: "Inteligências de Gardner",
+  dimensions: GARDNER_CHANNELS,
+  render_hint: "bar",
+  project(entries) {
+    // v1: score por channel = soma de "discovery interest"
+    // cujos extracted_keywords (do concept apresentado) batem com channel-name
+    // Heurística simples — projeção mais sofisticada em fase futura.
+    const scores = new Map<string, number>();
+    for (const ch of GARDNER_CHANNELS) scores.set(ch, 0);
+    for (const e of entries) {
+      if (e.type !== "interest") continue;
+      if (e.payload.kind !== "interest") continue;
+      const label = (e.payload.label ?? "").toLowerCase();
+      for (const ch of GARDNER_CHANNELS) {
+        if (label.includes(ch.replace("_", " ")) || label.includes(ch.split("_")[0])) {
+          scores.set(ch, (scores.get(ch) ?? 0) + 1);
+        }
+      }
+    }
+    return new Map(scores);
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Framework: casel (5 dimensões SEL)
+// ─────────────────────────────────────────────────────────────────────────
+
+const CASEL_DIMS = ["SA", "SM", "SOC", "REL", "DM"] as const;
+
+const casel: MapFramework = {
+  id: "casel",
+  display_name: "CASEL (Aprendizado Socioemocional)",
+  dimensions: CASEL_DIMS,
+  render_hint: "radar",
+  project(entries) {
+    // v1: count de presented_concept agrupado por inferência axis→casel
+    // Mapeamento aproximado:
+    //   axis 1 (Prudência) → DM
+    //   axis 2 (Justiça) → SOC
+    //   axis 3 (Fortaleza) → SM
+    //   axis 4 (Temperança) → SM
+    //   axis 5-8 (Disposição) → REL/SOC
+    //   axis 9-12 (Cognição-de-si) → SA
+    const counts = new Map<string, number>();
+    for (const dim of CASEL_DIMS) counts.set(dim, 0);
+    for (const e of entries) {
+      if (e.type !== "presented_concept" || e.payload.kind !== "presented_concept") continue;
+      const dim = axisToCasel(e.payload.axis_id);
+      if (dim) counts.set(dim, (counts.get(dim) ?? 0) + 1);
+    }
+    return new Map(counts);
+  },
+};
+
+function axisToCasel(axisId: number): string | null {
+  if (axisId === 1) return "DM";
+  if (axisId === 2) return "SOC";
+  if (axisId === 3 || axisId === 4) return "SM";
+  if (axisId >= 5 && axisId <= 8) return "REL";
+  if (axisId >= 9 && axisId <= 12) return "SA";
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Framework: dreyfus_by_domain (level por domínio)
+// ─────────────────────────────────────────────────────────────────────────
+
+const dreyfusByDomain: MapFramework = {
+  id: "dreyfus_by_domain",
+  display_name: "Dreyfus por Domínio",
+  dimensions: [], // dinâmico — depende dos domínios observados
+  render_hint: "tree",
+  project(entries) {
+    // v1: agrega menções por domínio (palavra-chave) + heurística simples
+    // de level. Refino em fase futura.
+    // shape do valor: { mentions: N, level: "novice|apprentice|practitioner|proficient|expert" }
+    const byDomain = new Map<string, { mentions: number; level: string }>();
+    for (const e of entries) {
+      if (e.type !== "interest" && e.type !== "value" && e.type !== "discovery") continue;
+      const payload = e.payload as { label?: string };
+      const label = (payload.label ?? "").toLowerCase().trim();
+      if (label.length === 0) continue;
+      // v1: domain = label inteira (não normalizado); refinar com extraction
+      const prev = byDomain.get(label) ?? { mentions: 0, level: "novice" };
+      const mentions = prev.mentions + 1;
+      const level =
+        mentions >= 8 ? "proficient" :
+        mentions >= 4 ? "practitioner" :
+        mentions >= 2 ? "apprentice" : "novice";
+      byDomain.set(label, { mentions, level });
+    }
+    return new Map(byDomain);
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Bootstrap — registra defaults
+// ─────────────────────────────────────────────────────────────────────────
+
+function registerDefaultFrameworks(): void {
+  registerFramework(valoresClassicos);
+  registerFramework(gardner);
+  registerFramework(casel);
+  registerFramework(dreyfusByDomain);
+}
+
+// Auto-register on module load
+registerDefaultFrameworks();
+
+// ─────────────────────────────────────────────────────────────────────────
+// API pública: computa posição completa do sujeito em todos os frameworks
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface ComputeMapPositionsInput {
+  subjectId: string;
+  entries: SubjectKnowledgeEntry[];
+  /** Filtra a lista — undefined = todos os frameworks registrados. */
+  frameworkIds?: string[];
+}
+
+export function computeMapPositions(
+  input: ComputeMapPositionsInput,
+): SubjectMapPosition {
+  const positions: Record<string, Record<string, unknown>> = {};
+  const fws = input.frameworkIds
+    ? input.frameworkIds
+        .map((id) => FRAMEWORK_REGISTRY.get(id))
+        .filter((fw): fw is MapFramework => fw !== undefined)
+    : Array.from(FRAMEWORK_REGISTRY.values());
+  for (const fw of fws) {
+    const map = fw.project(input.entries);
+    positions[fw.id] = Object.fromEntries(map.entries());
+  }
+  return {
+    subject_id: input.subjectId,
+    computed_at: new Date().toISOString(),
+    positions,
+  };
+}

--- a/shared/tests/map-framework.test.ts
+++ b/shared/tests/map-framework.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests MapFramework registry — projeções multi-framework (sub-fase 8.3).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeMapPositions,
+  listFrameworks,
+  getFramework,
+  registerFramework,
+  resetFrameworkRegistry,
+  type SubjectKnowledgeEntry,
+  type MapFramework,
+} from "../src/index.js";
+
+const NOW = "2026-05-25T18:00:00.000Z";
+
+const makeEntry = (
+  type: SubjectKnowledgeEntry["type"],
+  payload: Record<string, unknown>,
+): SubjectKnowledgeEntry => ({
+  id: `id-${Math.random()}`,
+  subject_id: "ryo",
+  type,
+  source: "self_declared",
+  confidence: 0.9,
+  confirmed_at: NOW,
+  alignment: "unknown",
+  payload: { kind: type, ...payload } as SubjectKnowledgeEntry["payload"],
+  turn_ref: "s1__t1",
+  session_id: "s1",
+  created_at: NOW,
+});
+
+describe("MapFramework registry — default frameworks", () => {
+  it("registra os 4 frameworks v1 por default", () => {
+    const fws = listFrameworks();
+    const ids = fws.map((fw) => fw.id);
+    expect(ids).toContain("valores_classicos");
+    expect(ids).toContain("gardner");
+    expect(ids).toContain("casel");
+    expect(ids).toContain("dreyfus_by_domain");
+  });
+
+  it("getFramework retorna instância por ID", () => {
+    const fw = getFramework("valores_classicos");
+    expect(fw?.display_name).toContain("Valores Clássicos");
+    expect(fw?.dimensions.length).toBe(12);
+  });
+
+  it("getFramework retorna undefined pra ID inexistente", () => {
+    expect(getFramework("inexistente")).toBeUndefined();
+  });
+
+  it("render_hint definido em todos defaults", () => {
+    for (const fw of listFrameworks()) {
+      expect(["radar", "bar", "tree", "list"]).toContain(fw.render_hint);
+    }
+  });
+});
+
+describe("valores_classicos — projeção", () => {
+  it("soma pontos de presented_concept por axis_id", () => {
+    const entries = [
+      makeEntry("presented_concept", {
+        concept_id: "x",
+        keywords: ["x"],
+        lineage_anchor: "estoica/x",
+        axis_id: 3,
+        family: "carater",
+        points: 1,
+      }),
+      makeEntry("presented_concept", {
+        concept_id: "y",
+        keywords: ["y"],
+        lineage_anchor: "zen/y",
+        axis_id: 3,
+        family: "carater",
+        points: 1,
+      }),
+      makeEntry("presented_concept", {
+        concept_id: "z",
+        keywords: ["z"],
+        lineage_anchor: "paideia/z",
+        axis_id: 11,
+        family: "cognicao_si",
+        points: 1,
+      }),
+    ];
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["valores_classicos"],
+    });
+    const valores = pos.positions["valores_classicos"];
+    expect(valores["axis_3"]).toBe(2);
+    expect(valores["axis_11"]).toBe(1);
+    expect(valores["axis_1"]).toBe(0); // sem entries
+  });
+
+  it("não conta entries de outros types (interest, boundary)", () => {
+    const entries = [
+      makeEntry("interest", { label: "tênis" }),
+      makeEntry("boundary_event", {
+        signal_type: "deflection_thematic",
+        topic_category: "x",
+        intensity: "low",
+        motor_response: "muda_tema",
+        severity_band: "routine",
+      }),
+    ];
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["valores_classicos"],
+    });
+    // Todos axes ficam zero
+    for (let i = 1; i <= 12; i++) {
+      expect(pos.positions["valores_classicos"][`axis_${i}`]).toBe(0);
+    }
+  });
+});
+
+describe("casel — projeção via axis→casel mapping", () => {
+  it("axis 1 (Prudência) → DM", () => {
+    const entries = [
+      makeEntry("presented_concept", {
+        concept_id: "x",
+        keywords: ["x"],
+        lineage_anchor: "estoica/x",
+        axis_id: 1,
+        family: "carater",
+        points: 1,
+      }),
+    ];
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["casel"],
+    });
+    expect(pos.positions["casel"]["DM"]).toBe(1);
+    expect(pos.positions["casel"]["SA"]).toBe(0);
+  });
+
+  it("axis 11 (Autoconhecimento) → SA", () => {
+    const entries = [
+      makeEntry("presented_concept", {
+        concept_id: "x",
+        keywords: ["x"],
+        lineage_anchor: "paideia/gnothi_seauton",
+        axis_id: 11,
+        family: "cognicao_si",
+        points: 1,
+      }),
+    ];
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["casel"],
+    });
+    expect(pos.positions["casel"]["SA"]).toBe(1);
+  });
+
+  it("axis 7 (Compaixão) → REL", () => {
+    const entries = [
+      makeEntry("presented_concept", {
+        concept_id: "x",
+        keywords: ["x"],
+        lineage_anchor: "hebraica/hesed",
+        axis_id: 7,
+        family: "disposicao",
+        points: 1,
+      }),
+    ];
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["casel"],
+    });
+    expect(pos.positions["casel"]["REL"]).toBe(1);
+  });
+});
+
+describe("gardner — projeção via interest matching", () => {
+  it("interest com label 'linguistic' incrementa channel", () => {
+    const entries = [
+      makeEntry("interest", { label: "linguistic" }),
+    ];
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["gardner"],
+    });
+    expect(pos.positions["gardner"]["linguistic"]).toBe(1);
+  });
+
+  it("não conta interest sem match a channel", () => {
+    const entries = [makeEntry("interest", { label: "futebol" })];
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["gardner"],
+    });
+    const gardner = pos.positions["gardner"];
+    for (const channelKey of Object.keys(gardner)) {
+      expect(gardner[channelKey]).toBe(0);
+    }
+  });
+});
+
+describe("dreyfus_by_domain — projeção heurística", () => {
+  it("mais menções → level upgrade", () => {
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      makeEntry("interest", { label: "matematica" }),
+    );
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries,
+      frameworkIds: ["dreyfus_by_domain"],
+    });
+    const mat = pos.positions["dreyfus_by_domain"]["matematica"] as
+      | { mentions: number; level: string }
+      | undefined;
+    expect(mat?.mentions).toBe(5);
+    expect(mat?.level).toBe("practitioner"); // >=4
+  });
+});
+
+describe("computeMapPositions — filtros e composição", () => {
+  it("sem frameworkIds: roda todos os registrados", () => {
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries: [],
+    });
+    expect(Object.keys(pos.positions).sort()).toEqual([
+      "casel",
+      "dreyfus_by_domain",
+      "gardner",
+      "valores_classicos",
+    ]);
+  });
+
+  it("frameworkIds filtra subset", () => {
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries: [],
+      frameworkIds: ["gardner"],
+    });
+    expect(Object.keys(pos.positions)).toEqual(["gardner"]);
+  });
+
+  it("framework inexistente é ignorado silenciosamente", () => {
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries: [],
+      frameworkIds: ["inexistente", "casel"],
+    });
+    expect(Object.keys(pos.positions)).toEqual(["casel"]);
+  });
+
+  it("subject_id + computed_at preservados", () => {
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries: [],
+    });
+    expect(pos.subject_id).toBe("ryo");
+    expect(typeof pos.computed_at).toBe("string");
+  });
+});
+
+describe("registerFramework — custom framework", () => {
+  it("registra novo framework e retorna em listFrameworks", () => {
+    const custom: MapFramework = {
+      id: "test_custom",
+      display_name: "Teste Custom",
+      dimensions: ["d1", "d2"],
+      render_hint: "list",
+      project: () => new Map([["d1", 42]]),
+    };
+    registerFramework(custom);
+    expect(getFramework("test_custom")).toBeDefined();
+    resetFrameworkRegistry();
+    expect(getFramework("test_custom")).toBeUndefined();
+  });
+
+  it("projeção custom é usada em computeMapPositions", () => {
+    const custom: MapFramework = {
+      id: "always_42",
+      display_name: "Always 42",
+      dimensions: ["x"],
+      render_hint: "list",
+      project: () => new Map([["x", 42]]),
+    };
+    registerFramework(custom);
+    const pos = computeMapPositions({
+      subjectId: "ryo",
+      entries: [],
+      frameworkIds: ["always_42"],
+    });
+    expect(pos.positions["always_42"]["x"]).toBe(42);
+    resetFrameworkRegistry();
+  });
+});


### PR DESCRIPTION
## Summary
Sub-fase 8.3 da [spec Session Phases](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md) §4. Mapas pedagógicos como **lentes projetáveis** sobre o \`subject_knowledge\` ledger.

### Princípio
- Cada framework é **view derivada** — sujeito-real é ponto multi-dim posicionado em cada lente independentemente
- Adicionar nova lente = registrar projeção, **sem migration de DB**

### Frameworks v1 registrados (auto na importação)
| ID | Dims | Render | Projeção |
|---|---|---|---|
| \`valores_classicos\` | 12 axes | radar | soma \`presented_concept.points\` por axis |
| \`gardner\` | 9 channels | bar | keyword match em interest labels |
| \`casel\` | SA/SM/SOC/REL/DM | radar | axis→casel mapping |
| \`dreyfus_by_domain\` | dinâmico | tree | mentions count + level heurístico |

### Endpoints REST novos
- \`GET /frameworks\` — lista metadados (display_name + dimensions + render_hint)
- \`GET /subjects/:id/maps[?framework=X,Y]\` — projeções filtradas

### Como adicionar novo framework
\`\`\`ts
import { registerFramework } from "@ascendimacy/shared";

registerFramework({
  id: "bushido_classical",
  display_name: "Bushido — 7 Virtudes",
  dimensions: ["yuki", "gi", "jin", "rei", "makoto", "meiyo", "chugi"],
  render_hint: "radar",
  project: (entries) => /* projeção própria */,
});
\`\`\`
Sem migration. Console UI lê do registry e renderiza.

## Test plan
- [x] \`shared/tests/map-framework.test.ts\` — 18 tests (defaults + projeções específicas + filtros + custom registration)
- [x] \`packages/ebrota-console-bff/tests/map-framework-endpoints.test.ts\` — 7 tests (endpoints + filtros + data real)
- [x] Suite: shared 777 (+18) · bff 128 (+7) — zero regressão

## Próximo
Console UI Mapa de Jornada (F6) consome esses endpoints com view toggle por framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)