### PR TITLE
[feat] Catálogo playbook-moves.yaml v1 + loader (13 moves substantivos)

### DIFF
--- a/motor-drota/data/playbook-moves.yaml
+++ b/motor-drota/data/playbook-moves.yaml
@@ -1,0 +1,175 @@
+# Playbook Moves Catalog v1 — vocabulário pedagógico do Strategist.
+#
+# Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md §5
+#
+# Cada move é um verbo pedagógico componível. Strategist compõe sessões
+# selecionando 1-3 moves do catálogo combinados criativamente, ancorados
+# em targets nos mapas multi-framework.
+#
+# v1: 13 moves substantivos cobrindo as 4 SessionPhases.
+# Spec separada (sub-spec): 2026-05-25-playbook-moves-catalog-v1.md (futuro)
+
+version: 1
+
+moves:
+  # ─── ICE_BREAKER (15 min — abrir + descobrir) ──────────────────────
+
+  - id: open_with_interest_probe
+    phase: ice_breaker
+    estimated_minutes: 5
+    framing_template: >-
+      "Tem alguma coisa que tá te interessando agora? Pode ser
+      qualquer coisa — algo que você faz, que aprende, ou que fica
+      na sua cabeça mesmo sem querer."
+    success_signal: sujeito_declarou_interesse_concreto
+    targets:
+      - framework: gardner
+        goal: probe_channel_preference
+    notes: >-
+      Move inaugural por excelência. Discovery agressiva — keyword
+      matching + framework projection sobre a resposta.
+
+  - id: reflect_back
+    phase: ice_breaker
+    estimated_minutes: 2
+    framing_template: '"Deixa eu ver se entendi: {summary}. É isso?"'
+    success_signal: sujeito_confirmou_ou_corrigiu
+    notes: >-
+      Espelha o que sujeito disse pra confirmar entendimento. Útil
+      quando sinal ambíguo ou múltiplas interpretações.
+
+  - id: ask_open_about_routine
+    phase: ice_breaker
+    estimated_minutes: 4
+    framing_template: >-
+      "Como tá sua rotina agora? Tem algo nela que te energiza,
+      e algo que te drena?"
+    success_signal: sujeito_descreveu_aspectos_rotina
+    targets:
+      - framework: casel
+        goal: probe_SA
+    notes: >-
+      Descobre context + sinal de SA/SM via auto-relato.
+
+  - id: validate_emotion_present
+    phase: ice_breaker
+    estimated_minutes: 2
+    framing_template: >-
+      "{emotion_observed} faz sentido nessa situação. Não precisa
+      consertar agora — só registrar."
+    success_signal: sujeito_relaxou_postura_defensiva
+    notes: >-
+      Quando assessor detecta mood baixo / sinal de distress.
+      Sem ação, só reconhecimento. Constrói trust pra futuras fases.
+
+  # ─── CHALLENGE_EXPLAIN (transição — 3-5 min) ────────────────────────
+
+  - id: offer_choice
+    phase: challenge_explain
+    estimated_minutes: 3
+    framing_template: >-
+      "Tenho 2 caminhos pra próxima parte: (a) {choice_a} ou
+      (b) {choice_b}. Qual te interessa mais?"
+    success_signal: sujeito_escolheu_caminho
+    notes: >-
+      Dar agência logo no início da execução. Tradeoffs visíveis
+      = sujeito sente que pilota.
+
+  - id: propose_challenge_anchor
+    phase: challenge_explain
+    estimated_minutes: 4
+    framing_template: >-
+      "Vou propor uma coisa pra fazer: {challenge_description}.
+      Isso conecta com {anchor_to_interest}. Quer experimentar?"
+    success_signal: sujeito_aceitou_ou_negociou
+    notes: >-
+      Apresenta o desafio do bloco execute, ancorado em interesse
+      previamente descoberto. Opt-out explícito.
+
+  # ─── CHALLENGE_EXECUTE (30 min — ação efetiva) ──────────────────────
+
+  - id: propose_dilemma
+    phase: challenge_execute
+    estimated_minutes: 10
+    framing_template: >-
+      "Imagina: {dilemma}. Você escolheria {option_a} ou
+      {option_b}? Por quê?"
+    success_signal: sujeito_escolheu_E_justificou
+    targets:
+      - framework: valores_classicos
+        goal: expose_axis
+    notes: >-
+      Move clássico de demonstração de phronesis / responsabilidade.
+      Justificativa é o sinal de internalização — não a escolha em si.
+
+  - id: request_demonstration_multimodal
+    phase: challenge_execute
+    estimated_minutes: 15
+    framing_template: >-
+      "Me mostra como você faria {action}. Pode ser por foto,
+      áudio, ou descrever em texto — o que for melhor."
+    success_signal: sujeito_demonstrou_action_em_modalidade
+    notes: >-
+      Demonstração multi-modal explícita (texto/imagem/som). Usar
+      quando target é Gardner não-linguistic (bodily, spatial, musical).
+
+  - id: bridge_to_lineage
+    phase: challenge_execute
+    estimated_minutes: 5
+    framing_template: >-
+      "O que você acabou de fazer me lembra de {lineage_name}:
+      {lineage_short_def}. Faz sentido pra você no que falou?"
+    success_signal: sujeito_ressoou_com_lineage
+    targets:
+      - framework: valores_classicos
+        goal: bridge_to_axis
+    notes: >-
+      Ponte tripla — conecta ação do sujeito com complemento clássico
+      do subject_proposed. Strategist puxa lineage do catálogo F4.
+
+  - id: ask_recall
+    phase: challenge_execute
+    estimated_minutes: 2
+    framing_template: '"Lembra daquela ideia de {concept}? O que ficou disso pra você?"'
+    success_signal: sujeito_demonstrou_recall_positivo
+    notes: >-
+      Checagem ativa de internalização (+5pt se positive). Spec §4.5.
+      Usar 1× por sessão em applied_double_helix.
+
+  - id: surface_contradiction
+    phase: challenge_execute
+    estimated_minutes: 6
+    framing_template: >-
+      "Você disse {statement_a}, mas também {statement_b}.
+      Como esses dois ficam juntos pra você?"
+    success_signal: sujeito_articulou_resolução_ou_aceitou_tensão
+    notes: >-
+      Move avançado — exige rapport alto + applied stage. Expõe
+      contradição sem julgamento; sujeito decide se concilia ou
+      reconhece a tensão.
+
+  # ─── FOLLOW_UP (5 min — consolidar) ─────────────────────────────────
+
+  - id: name_what_was_demonstrated
+    phase: follow_up
+    estimated_minutes: 3
+    framing_template: >-
+      "Hoje você {demonstration_observed}. Isso é {label_pedagogico}
+      — não como rótulo, mas como nome do que você tava fazendo."
+    success_signal: sujeito_reconheceu_ou_renomeou
+    notes: >-
+      Nomear a capacidade demonstrada com vocabulário clássico.
+      Permite re-rotulagem pelo sujeito ("eu chamaria de X") —
+      adoção do conceito vira sinal.
+
+  - id: hook_next_session
+    phase: follow_up
+    estimated_minutes: 2
+    framing_template: >-
+      "Na próxima vez, talvez a gente {next_idea}. Topa pensar
+      sobre {open_question} até lá?"
+    success_signal: sujeito_aceitou_gancho_ou_propôs_alternativa
+    notes: >-
+      Fecha com continuidade explícita. Pergunta aberta pendente é
+      gatilho pro motor lembrar na próxima sessão (via cross-session
+      memory do persona-simulator + journey_state).

--- a/motor-drota/src/playbook-moves-loader.ts
+++ b/motor-drota/src/playbook-moves-loader.ts
@@ -1,0 +1,208 @@
+/**
+ * Loader do catálogo Playbook Moves YAML.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md §5
+ *
+ * Carrega motor-drota/data/playbook-moves.yaml, valida estrutura, oferece
+ * consulta filtrada por phase / target framework. Strategist consome.
+ *
+ * Independente do strategy-plan.ts (que define StrategyPlan + composeStrategyPlan).
+ * Quando ambos forem usados juntos, motor importa daqui.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const DEFAULT_PLAYBOOK_PATH = join(
+  __dirname,
+  "..",
+  "data",
+  "playbook-moves.yaml",
+);
+
+export type PlaybookPhase =
+  | "ice_breaker"
+  | "challenge_explain"
+  | "challenge_execute"
+  | "follow_up";
+
+export interface PlaybookTarget {
+  framework: string;
+  goal: string;
+}
+
+export interface PlaybookMoveSpec {
+  id: string;
+  phase: PlaybookPhase;
+  estimated_minutes: number;
+  framing_template: string;
+  success_signal: string;
+  targets?: PlaybookTarget[];
+  notes?: string;
+}
+
+export interface PlaybookCatalog {
+  version: number;
+  moves: PlaybookMoveSpec[];
+}
+
+export interface LoadOptions {
+  path?: string;
+  strict?: boolean;
+}
+
+export interface ValidationIssue {
+  level: "error" | "warning";
+  code: string;
+  message: string;
+  move_id?: string;
+}
+
+const PHASES: ReadonlySet<PlaybookPhase> = new Set<PlaybookPhase>([
+  "ice_breaker",
+  "challenge_explain",
+  "challenge_execute",
+  "follow_up",
+]);
+
+export function validatePlaybookCatalog(
+  cat: PlaybookCatalog,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const seenIds = new Set<string>();
+  if (!Array.isArray(cat.moves) || cat.moves.length === 0) {
+    issues.push({
+      level: "error",
+      code: "moves_empty",
+      message: "catálogo precisa de ao menos 1 move",
+    });
+    return issues;
+  }
+  for (const move of cat.moves) {
+    if (typeof move.id !== "string" || move.id.length === 0) {
+      issues.push({
+        level: "error",
+        code: "move_id_invalid",
+        message: "move sem id válido",
+      });
+      continue;
+    }
+    if (seenIds.has(move.id)) {
+      issues.push({
+        level: "error",
+        code: "move_id_duplicate",
+        message: `move id '${move.id}' duplicado`,
+        move_id: move.id,
+      });
+    }
+    seenIds.add(move.id);
+    if (!PHASES.has(move.phase)) {
+      issues.push({
+        level: "error",
+        code: "move_phase_invalid",
+        message: `move '${move.id}' phase '${move.phase}' inválida`,
+        move_id: move.id,
+      });
+    }
+    if (typeof move.estimated_minutes !== "number" || move.estimated_minutes <= 0) {
+      issues.push({
+        level: "error",
+        code: "move_estimated_minutes_invalid",
+        message: `move '${move.id}' estimated_minutes deve ser >0`,
+        move_id: move.id,
+      });
+    }
+    if (typeof move.framing_template !== "string" || move.framing_template.length === 0) {
+      issues.push({
+        level: "error",
+        code: "move_framing_template_empty",
+        message: `move '${move.id}' framing_template vazio`,
+        move_id: move.id,
+      });
+    }
+    if (typeof move.success_signal !== "string" || move.success_signal.length === 0) {
+      issues.push({
+        level: "error",
+        code: "move_success_signal_empty",
+        message: `move '${move.id}' success_signal vazio`,
+        move_id: move.id,
+      });
+    }
+  }
+  // Cobertura: ≥1 move por phase
+  const phasesCovered = new Set(cat.moves.map((m) => m.phase));
+  for (const ph of PHASES) {
+    if (!phasesCovered.has(ph)) {
+      issues.push({
+        level: "warning",
+        code: "phase_uncovered",
+        message: `phase '${ph}' sem nenhum move — Strategist pode não ter opção`,
+      });
+    }
+  }
+  return issues;
+}
+
+export interface LoadPlaybookResult {
+  catalog: PlaybookCatalog;
+  issues: ValidationIssue[];
+}
+
+export function loadPlaybookMoves(opts: LoadOptions = {}): LoadPlaybookResult {
+  const path = opts.path ?? DEFAULT_PLAYBOOK_PATH;
+  const strict = opts.strict ?? true;
+  const raw = readFileSync(path, "utf-8");
+  const parsed = yaml.load(raw);
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`playbook-moves: YAML root inválido em ${path}`);
+  }
+  const catalog = parsed as PlaybookCatalog;
+  if (!Array.isArray(catalog.moves)) {
+    throw new Error(`playbook-moves: campo 'moves' obrigatório (array) em ${path}`);
+  }
+  const issues = validatePlaybookCatalog(catalog);
+  if (strict) {
+    const errors = issues.filter((i) => i.level === "error");
+    if (errors.length > 0) {
+      const summary = errors.map((i) => `  [${i.code}] ${i.message}`).join("\n");
+      throw new Error(`playbook-moves: ${errors.length} erro(s):\n${summary}`);
+    }
+  }
+  return { catalog, issues };
+}
+
+let cachedCatalog: PlaybookCatalog | undefined;
+
+export function getPlaybookCatalog(): PlaybookCatalog {
+  if (cachedCatalog === undefined) {
+    cachedCatalog = loadPlaybookMoves().catalog;
+  }
+  return cachedCatalog;
+}
+
+export function resetPlaybookCache(): void {
+  cachedCatalog = undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// API de consulta
+// ─────────────────────────────────────────────────────────────────────────
+
+export function getMoveById(id: string): PlaybookMoveSpec | undefined {
+  return getPlaybookCatalog().moves.find((m) => m.id === id);
+}
+
+export function getMovesByPhase(phase: PlaybookPhase): PlaybookMoveSpec[] {
+  return getPlaybookCatalog().moves.filter((m) => m.phase === phase);
+}
+
+export function getMovesByTargetFramework(framework: string): PlaybookMoveSpec[] {
+  return getPlaybookCatalog().moves.filter((m) =>
+    (m.targets ?? []).some((t) => t.framework === framework),
+  );
+}

--- a/motor-drota/tests/playbook-moves-loader.test.ts
+++ b/motor-drota/tests/playbook-moves-loader.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { dump as yamlDump } from "js-yaml";
+import {
+  loadPlaybookMoves,
+  getPlaybookCatalog,
+  resetPlaybookCache,
+  getMoveById,
+  getMovesByPhase,
+  getMovesByTargetFramework,
+  validatePlaybookCatalog,
+  type PlaybookCatalog,
+} from "../src/playbook-moves-loader.js";
+
+beforeEach(() => {
+  resetPlaybookCache();
+});
+
+describe("loadPlaybookMoves — catálogo default", () => {
+  it("carrega motor-drota/data/playbook-moves.yaml sem erros", () => {
+    const result = loadPlaybookMoves();
+    expect(result.issues.filter((i) => i.level === "error")).toEqual([]);
+  });
+
+  it("contém ≥10 moves (v1 deve ser substancial)", () => {
+    const { catalog } = loadPlaybookMoves();
+    expect(catalog.moves.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("todos os IDs únicos", () => {
+    const { catalog } = loadPlaybookMoves();
+    const ids = catalog.moves.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("todas as 4 phases têm pelo menos 1 move (cobertura)", () => {
+    const { catalog } = loadPlaybookMoves();
+    const phasesCovered = new Set(catalog.moves.map((m) => m.phase));
+    expect(phasesCovered.has("ice_breaker")).toBe(true);
+    expect(phasesCovered.has("challenge_explain")).toBe(true);
+    expect(phasesCovered.has("challenge_execute")).toBe(true);
+    expect(phasesCovered.has("follow_up")).toBe(true);
+  });
+
+  it("todos os moves têm framing_template + success_signal não-vazio", () => {
+    const { catalog } = loadPlaybookMoves();
+    for (const m of catalog.moves) {
+      expect(m.framing_template.length).toBeGreaterThan(0);
+      expect(m.success_signal.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("estimated_minutes coerente (>0 e <30 por move)", () => {
+    const { catalog } = loadPlaybookMoves();
+    for (const m of catalog.moves) {
+      expect(m.estimated_minutes).toBeGreaterThan(0);
+      expect(m.estimated_minutes).toBeLessThanOrEqual(30);
+    }
+  });
+});
+
+describe("getPlaybookCatalog — singleton cache", () => {
+  it("retorna mesma instância em chamadas subsequentes", () => {
+    const c1 = getPlaybookCatalog();
+    const c2 = getPlaybookCatalog();
+    expect(c1).toBe(c2);
+  });
+
+  it("resetPlaybookCache força recarga", () => {
+    const c1 = getPlaybookCatalog();
+    resetPlaybookCache();
+    const c2 = getPlaybookCatalog();
+    expect(c1).not.toBe(c2);
+    expect(c1.moves.length).toBe(c2.moves.length);
+  });
+});
+
+describe("query helpers", () => {
+  it("getMoveById encontra move existente", () => {
+    const m = getMoveById("propose_dilemma");
+    expect(m?.phase).toBe("challenge_execute");
+  });
+
+  it("getMoveById retorna undefined pra ID inexistente", () => {
+    expect(getMoveById("inexistente")).toBeUndefined();
+  });
+
+  it("getMovesByPhase('ice_breaker') retorna só moves dessa fase", () => {
+    const moves = getMovesByPhase("ice_breaker");
+    expect(moves.length).toBeGreaterThan(0);
+    expect(moves.every((m) => m.phase === "ice_breaker")).toBe(true);
+  });
+
+  it("getMovesByPhase('follow_up') tem ≥1 move", () => {
+    expect(getMovesByPhase("follow_up").length).toBeGreaterThan(0);
+  });
+
+  it("getMovesByTargetFramework('valores_classicos') retorna moves anchored", () => {
+    const moves = getMovesByTargetFramework("valores_classicos");
+    expect(moves.length).toBeGreaterThan(0);
+    for (const m of moves) {
+      expect(
+        (m.targets ?? []).some((t) => t.framework === "valores_classicos"),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("validatePlaybookCatalog — detecção de issues", () => {
+  it("detecta IDs duplicados", () => {
+    const bad: PlaybookCatalog = {
+      version: 1,
+      moves: [
+        {
+          id: "dup",
+          phase: "ice_breaker",
+          estimated_minutes: 5,
+          framing_template: "x",
+          success_signal: "y",
+        },
+        {
+          id: "dup",
+          phase: "follow_up",
+          estimated_minutes: 3,
+          framing_template: "a",
+          success_signal: "b",
+        },
+      ],
+    };
+    const issues = validatePlaybookCatalog(bad);
+    expect(issues.some((i) => i.code === "move_id_duplicate")).toBe(true);
+  });
+
+  it("detecta phase inválida", () => {
+    const bad: PlaybookCatalog = {
+      version: 1,
+      moves: [
+        {
+          id: "x",
+          // @ts-expect-error testing invalid phase
+          phase: "nonsense",
+          estimated_minutes: 5,
+          framing_template: "x",
+          success_signal: "y",
+        },
+      ],
+    };
+    const issues = validatePlaybookCatalog(bad);
+    expect(issues.some((i) => i.code === "move_phase_invalid")).toBe(true);
+  });
+
+  it("warning quando phase sem moves (uncovered)", () => {
+    const bad: PlaybookCatalog = {
+      version: 1,
+      moves: [
+        {
+          id: "only_ice",
+          phase: "ice_breaker",
+          estimated_minutes: 5,
+          framing_template: "x",
+          success_signal: "y",
+        },
+      ],
+    };
+    const issues = validatePlaybookCatalog(bad);
+    const warnings = issues.filter((i) => i.code === "phase_uncovered");
+    expect(warnings.length).toBe(3); // missing 3 phases
+  });
+});
+
+describe("loadPlaybookMoves — strict mode + erros", () => {
+  it("strict lança erro quando catálogo inválido", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "playbook-bad-"));
+    const path = join(tmp, "bad.yaml");
+    writeFileSync(
+      path,
+      yamlDump({
+        version: 1,
+        moves: [
+          {
+            id: "dup",
+            phase: "ice_breaker",
+            estimated_minutes: 5,
+            framing_template: "x",
+            success_signal: "y",
+          },
+          {
+            id: "dup",
+            phase: "follow_up",
+            estimated_minutes: 3,
+            framing_template: "a",
+            success_signal: "b",
+          },
+        ],
+      }),
+    );
+    expect(() => loadPlaybookMoves({ path })).toThrow(/erro\(s\)/);
+  });
+
+  it("strict=false retorna catálogo + issues mesmo com erros", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "playbook-bad-"));
+    const path = join(tmp, "bad.yaml");
+    writeFileSync(
+      path,
+      yamlDump({
+        version: 1,
+        moves: [
+          {
+            id: "dup",
+            phase: "ice_breaker",
+            estimated_minutes: 5,
+            framing_template: "x",
+            success_signal: "y",
+          },
+          {
+            id: "dup",
+            phase: "follow_up",
+            estimated_minutes: 3,
+            framing_template: "a",
+            success_signal: "b",
+          },
+        ],
+      }),
+    );
+    const r = loadPlaybookMoves({ path, strict: false });
+    expect(r.catalog.moves.length).toBe(2);
+    expect(r.issues.some((i) => i.level === "error")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Sub-spec do [Session Phases + Strategist](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md) §5. Materializa o vocabulário pedagógico do Strategist como dados YAML em vez dos stubs hardcoded.

### Catálogo v1 — 13 moves substantivos
| Phase | Moves |
|---|---|
| **ice_breaker** (4) | open_with_interest_probe · reflect_back · ask_open_about_routine · validate_emotion_present |
| **challenge_explain** (2) | offer_choice · propose_challenge_anchor |
| **challenge_execute** (5) | propose_dilemma · request_demonstration_multimodal · bridge_to_lineage · ask_recall · surface_contradiction |
| **follow_up** (2) | name_what_was_demonstrated · hook_next_session |

Cada move: \`id\`, \`phase\`, \`estimated_minutes\`, \`framing_template\`, \`success_signal\`, \`targets\` (multi-framework), \`notes\`

### Loader + Validator
- \`loadPlaybookMoves\` strict default — falha hard em catálogo inválido
- 8 códigos de issue (id duplicate, phase invalid, etc) + warning phase_uncovered
- Helpers: \`getMoveById\`, \`getMovesByPhase\`, \`getMovesByTargetFramework\`

## Test plan
- [x] \`playbook-moves-loader.test.ts\` — 18 tests (defaults + cobertura + queries + validation + strict)
- [x] Build verde
- [x] Suite motor +18 — zero regressão

## Próximo
Quando PR 3 (#215) mergear em main, abro PR de unificação que faz Strategist consumir do catálogo YAML em vez de \`PLAYBOOK_MOVES\` const.

🤖 Generated with [Claude Code](https://claude.com/claude-code)