### PR TITLE
[feat] Tracer Bullet consolidated — Foundation + Phase-aware + Strategist (substitui #213/#214/#215)

### DIFF
--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -26,7 +26,18 @@ import {
   extractDiscoveries,
   extractBoundaryEvents,
   extractPresentedConcepts,
+  resolveSessionState,
+  type JourneyStage,
+  type SessionPhase,
 } from "@ascendimacy/shared";
+
+/** PR 2 tracer — confidence threshold por fase pro DiscoveryWriter. */
+const DISCOVERY_MIN_CONFIDENCE_BY_PHASE: Record<SessionPhase, number> = {
+  ice_breaker: 0.4,        // agressivo — captura sinais frágeis
+  challenge_explain: 0.5,
+  challenge_execute: 0.6,  // normal
+  follow_up: 0.7,          // conservador — só sinais fortes
+};
 
 import { assess } from "./unified-assessor.js";
 import { selectAction } from "./pragmatic-selector.js";
@@ -68,10 +79,24 @@ export async function handleSimplifiedPipeline(
     engagement: assessment.engagement,
   };
 
+  // ── PR 2 tracer: resolveSessionState pra phase-aware behavior ──
+  // Journey stage vem por contextHints (planejador hidrata via BFF).
+  // Default discovery_only quando ausente (backcompat — primeiras sessões
+  // sem fase aplicada).
+  const journeyStage =
+    (input.contextHints?.["journey_stage"] as JourneyStage | undefined) ??
+    "discovery_only";
+  const sessionState = resolveSessionState({
+    turn: input.state.turn,
+    journeyStage,
+  });
+
   // ── Subject Knowledge Fase 2: writers extraem eventos do turn ──
   const turnRef = `${input.sessionId}__turn_${input.state.turn}`;
   const subjectKnowledgeEvents: SubjectKnowledgeEntry[] = [];
   // 1. Descobertas (interest/value/need) — só da fala do sujeito.
+  //    PR 2: threshold de confidence ajustado por fase
+  //    (ice_breaker agressivo, follow_up conservador).
   subjectKnowledgeEvents.push(
     ...extractDiscoveries({
       subjectId: input.persona.id,
@@ -80,6 +105,7 @@ export async function handleSimplifiedPipeline(
       lastUserMessage,
       signals: assessment.signals,
       mood: assessment.mood,
+      minConfidence: DISCOVERY_MIN_CONFIDENCE_BY_PHASE[sessionState.phase],
     }),
   );
   // 2. Boundary events — registra recuo quando signals indicam.
@@ -135,6 +161,7 @@ export async function handleSimplifiedPipeline(
       linguisticMaterialization: "Me conta o que está passando na sua cabeça.",
       assessment: assessmentForOutput,
       subjectKnowledgeEvents,
+      sessionState,
       ...(selectionResult.escalate_reason
         ? { skipReason: selectionResult.escalate_reason }
         : {}),
@@ -171,6 +198,7 @@ export async function handleSimplifiedPipeline(
       linguisticMaterialization: inauguralResult.text,
       assessment: assessmentForOutput,
       subjectKnowledgeEvents,
+      sessionState,
     };
   }
 
@@ -203,6 +231,7 @@ export async function handleSimplifiedPipeline(
   // presented_concept (+1pt) se item está taggeado com axis_id/family/
   // lineage_anchor/extracted_keywords. Items legados sem tags simplesmente
   // não geram entry. Fallback (rawText vazio) também não conta.
+  // PR 2: sessionPhase gate — ice_breaker NÃO acumula ledger.
   if (!matResult.fallback_triggered) {
     subjectKnowledgeEvents.push(
       ...extractPresentedConcepts({
@@ -210,6 +239,7 @@ export async function handleSimplifiedPipeline(
         sessionId: input.sessionId,
         turnRef,
         item: selectionResult.selected.item,
+        sessionPhase: sessionState.phase,
       }),
     );
   }
@@ -246,6 +276,7 @@ export async function handleSimplifiedPipeline(
     linguisticMaterialization: matResult.text,
     assessment: assessmentForOutput,
     subjectKnowledgeEvents,
+    sessionState,
     ...(matResult.fallback_triggered
       ? { skipReason: "materializer_fallback" }
       : {}),

--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -27,8 +27,11 @@ import {
   extractBoundaryEvents,
   extractPresentedConcepts,
   resolveSessionState,
+  composeStrategyPlan,
   type JourneyStage,
   type SessionPhase,
+  type StrategyPlan,
+  type SubjectKnowledgeEntry as SkEntry,
 } from "@ascendimacy/shared";
 
 /** PR 2 tracer — confidence threshold por fase pro DiscoveryWriter. */
@@ -90,6 +93,34 @@ export async function handleSimplifiedPipeline(
     turn: input.state.turn,
     journeyStage,
   });
+
+  // ── PR 3 tracer: Strategist.compose no início (turn 1) ──
+  // Só ativo em applied_double_helix; outras stages = null.
+  // v1: heurística template-based (sem LLM call).
+  let strategyPlan: StrategyPlan | undefined;
+  if (
+    journeyStage === "applied_double_helix" &&
+    input.state.turn <= 1
+  ) {
+    const prior = (input.contextHints?.["subject_knowledge_entries"] as
+      | SkEntry[]
+      | undefined) ?? [];
+    const latentNeeds = input.contextHints?.["latent_needs"] as
+      | string[]
+      | undefined;
+    const subjectProposed = input.contextHints?.["subject_proposed"] as
+      | { axes_active: number[]; complements_per_axis: Record<number, string[]> }
+      | undefined;
+    const composed = composeStrategyPlan({
+      sessionId: input.sessionId,
+      subjectId: input.persona.id,
+      journeyStage,
+      knowledgeEntries: prior,
+      latentNeeds,
+      subjectProposed,
+    });
+    if (composed) strategyPlan = composed;
+  }
 
   // ── Subject Knowledge Fase 2: writers extraem eventos do turn ──
   const turnRef = `${input.sessionId}__turn_${input.state.turn}`;
@@ -162,6 +193,7 @@ export async function handleSimplifiedPipeline(
       assessment: assessmentForOutput,
       subjectKnowledgeEvents,
       sessionState,
+      ...(strategyPlan ? { strategyPlan } : {}),
       ...(selectionResult.escalate_reason
         ? { skipReason: selectionResult.escalate_reason }
         : {}),
@@ -199,6 +231,7 @@ export async function handleSimplifiedPipeline(
       assessment: assessmentForOutput,
       subjectKnowledgeEvents,
       sessionState,
+      ...(strategyPlan ? { strategyPlan } : {}),
     };
   }
 
@@ -277,6 +310,7 @@ export async function handleSimplifiedPipeline(
     assessment: assessmentForOutput,
     subjectKnowledgeEvents,
     sessionState,
+    ...(strategyPlan ? { strategyPlan } : {}),
     ...(matResult.fallback_triggered
       ? { skipReason: "materializer_fallback" }
       : {}),

--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -132,6 +132,23 @@ CREATE INDEX IF NOT EXISTS idx_vas_subject
   ON vertical_affinity_signals(subject_id);
 CREATE INDEX IF NOT EXISTS idx_vas_score
   ON vertical_affinity_signals(score_affinity);
+
+-- Journey State — Fase 8 PR 1 (spec 2026-05-25 §3 + §10.1).
+-- Estado da jornada cross-session por sujeito (stage atual, discoveries
+-- contadas pro threshold, override parental). Atualizado lazy na leitura
+-- a partir de subject_knowledge.
+CREATE TABLE IF NOT EXISTS journey_state (
+  subject_id            TEXT PRIMARY KEY,
+  stage                 TEXT NOT NULL DEFAULT 'discovery_only' CHECK(stage IN (
+    'discovery_only', 'mapping_ready', 'applied_double_helix'
+  )),
+  stage_entered_at      TEXT NOT NULL,
+  discoveries_count     INTEGER NOT NULL DEFAULT 0,
+  families_covered      TEXT NOT NULL DEFAULT '[]',
+  override_by_parent    TEXT,
+  last_updated_at       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_journey_stage ON journey_state(stage);
 `;
 
 export interface InitDbOptions {

--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -149,6 +149,24 @@ CREATE TABLE IF NOT EXISTS journey_state (
   last_updated_at       TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_journey_stage ON journey_state(stage);
+
+-- StrategyPlan — Fase 8 PR 3 (spec 2026-05-25 §5 + §10.2).
+-- 1 plan por sessão em journey_stage=applied_double_helix. Composto pelo
+-- Strategist no início (challenge_explain) e referenciado durante execute.
+-- demonstrations_observed atualizado no follow_up.
+CREATE TABLE IF NOT EXISTS strategy_plans (
+  session_id                    TEXT PRIMARY KEY,
+  subject_id                    TEXT NOT NULL,
+  composed_at                   TEXT NOT NULL,
+  target_demonstrations_json    TEXT NOT NULL,
+  playbook_composition_json     TEXT NOT NULL,
+  overall_success_criteria      TEXT,
+  fallback_strategy             TEXT,
+  subject_map_snapshot_json     TEXT,
+  demonstrations_observed_json  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_strategy_plans_subject
+  ON strategy_plans(subject_id);
 `;
 
 export interface InitDbOptions {

--- a/packages/ebrota-console-bff/src/journey-state-repo.ts
+++ b/packages/ebrota-console-bff/src/journey-state-repo.ts
@@ -1,0 +1,203 @@
+/**
+ * Journey State Repository — leitura + upsert do estado de jornada do sujeito.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md §3
+ *
+ * Estratégia v1: lazy compute. Quando alguém pede journey_state e a tabela
+ * não tem entry (ou está stale), recomputa a partir de subject_knowledge
+ * (discoveries_count + families_covered) e upserta.
+ *
+ * Auto-transição: se entries do ledger satisfazem readyForMapping E o
+ * stage atual é discovery_only sem override parental → upgrade pra
+ * mapping_ready. O `applied_double_helix` exige ratificação explícita do
+ * pai (não auto-transição).
+ */
+
+import type { Database as DatabaseType } from "better-sqlite3";
+import {
+  initialJourneyState,
+  readyForMapping,
+  computeDiscoveryMaturity,
+  type JourneyState,
+  type JourneyStage,
+  type SubjectKnowledgeEntry,
+} from "@ascendimacy/shared";
+
+interface JourneyStateRow {
+  subject_id: string;
+  stage: JourneyStage;
+  stage_entered_at: string;
+  discoveries_count: number;
+  families_covered: string;
+  override_by_parent: string | null;
+  last_updated_at: string;
+}
+
+function rowToState(row: JourneyStateRow): JourneyState {
+  return {
+    subject_id: row.subject_id,
+    stage: row.stage,
+    stage_entered_at: row.stage_entered_at,
+    discoveries_count: row.discoveries_count,
+    families_covered: JSON.parse(row.families_covered),
+    override_by_parent: row.override_by_parent
+      ? JSON.parse(row.override_by_parent)
+      : undefined,
+    last_updated_at: row.last_updated_at,
+  };
+}
+
+interface SkRow {
+  id: string;
+  subject_id: string;
+  type: string;
+  source: string;
+  confidence: number;
+  confirmed_at: string | null;
+  alignment: string;
+  payload_json: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+}
+
+function loadDiscoveryEntries(
+  db: DatabaseType,
+  subjectId: string,
+): SubjectKnowledgeEntry[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM subject_knowledge
+       WHERE subject_id = ? AND type IN ('interest','value','need','discovery')
+       ORDER BY created_at ASC`,
+    )
+    .all(subjectId) as SkRow[];
+  return rows.map((r) => ({
+    id: r.id,
+    subject_id: r.subject_id,
+    type: r.type as SubjectKnowledgeEntry["type"],
+    source: r.source as SubjectKnowledgeEntry["source"],
+    confidence: r.confidence,
+    confirmed_at: r.confirmed_at,
+    alignment: r.alignment as SubjectKnowledgeEntry["alignment"],
+    payload: JSON.parse(r.payload_json),
+    turn_ref: r.turn_ref,
+    session_id: r.session_id,
+    created_at: r.created_at,
+  }));
+}
+
+const UPSERT_SQL = `
+  INSERT INTO journey_state (
+    subject_id, stage, stage_entered_at, discoveries_count,
+    families_covered, override_by_parent, last_updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(subject_id) DO UPDATE SET
+    stage = excluded.stage,
+    stage_entered_at = excluded.stage_entered_at,
+    discoveries_count = excluded.discoveries_count,
+    families_covered = excluded.families_covered,
+    override_by_parent = excluded.override_by_parent,
+    last_updated_at = excluded.last_updated_at
+`;
+
+function persist(db: DatabaseType, state: JourneyState): void {
+  db.prepare(UPSERT_SQL).run(
+    state.subject_id,
+    state.stage,
+    state.stage_entered_at,
+    state.discoveries_count,
+    JSON.stringify(state.families_covered),
+    state.override_by_parent ? JSON.stringify(state.override_by_parent) : null,
+    state.last_updated_at,
+  );
+}
+
+/**
+ * Lê (ou inicializa+computa) o journey_state do sujeito.
+ *
+ * Sempre recomputa discoveries_count + families_covered do ledger atual,
+ * e avalia auto-transição discovery_only → mapping_ready. Persiste resultado.
+ */
+export function readOrComputeJourneyState(
+  db: DatabaseType,
+  subjectId: string,
+): JourneyState {
+  const row = db
+    .prepare("SELECT * FROM journey_state WHERE subject_id = ?")
+    .get(subjectId) as JourneyStateRow | undefined;
+
+  let state = row
+    ? rowToState(row)
+    : initialJourneyState(subjectId);
+
+  // Recompute discoveries do ledger (sempre fresh).
+  const entries = loadDiscoveryEntries(db, subjectId);
+  const { discoveries_count, families_covered } = computeDiscoveryMaturity(entries);
+  state = {
+    ...state,
+    discoveries_count,
+    families_covered,
+    last_updated_at: new Date().toISOString(),
+  };
+
+  // Auto-transição discovery_only → mapping_ready quando threshold bate
+  // E não há override parental forçando ficar.
+  if (
+    state.stage === "discovery_only" &&
+    state.override_by_parent?.forced_stage !== "discovery_only" &&
+    readyForMapping({ state })
+  ) {
+    state = {
+      ...state,
+      stage: "mapping_ready",
+      stage_entered_at: state.last_updated_at,
+    };
+  }
+
+  persist(db, state);
+  return state;
+}
+
+/**
+ * Aplica override parental. Forçar applied_double_helix manualmente é
+ * suportado mas raro (típicamente o stage corre auto após ratificação
+ * em mapping_ready).
+ */
+export function setParentalOverride(
+  db: DatabaseType,
+  subjectId: string,
+  forcedStage: JourneyStage,
+  reason: string,
+): JourneyState {
+  const current = readOrComputeJourneyState(db, subjectId);
+  const now = new Date().toISOString();
+  const next: JourneyState = {
+    ...current,
+    stage: forcedStage,
+    stage_entered_at:
+      current.stage === forcedStage ? current.stage_entered_at : now,
+    override_by_parent: { forced_stage: forcedStage, reason, timestamp: now },
+    last_updated_at: now,
+  };
+  persist(db, next);
+  return next;
+}
+
+/**
+ * Limpa override parental (sujeito volta a fluir pelo critério automático).
+ */
+export function clearParentalOverride(
+  db: DatabaseType,
+  subjectId: string,
+): JourneyState {
+  const current = readOrComputeJourneyState(db, subjectId);
+  const next: JourneyState = {
+    ...current,
+    override_by_parent: undefined,
+    last_updated_at: new Date().toISOString(),
+  };
+  persist(db, next);
+  // Re-avalia sem override pra ver se threshold bate agora
+  return readOrComputeJourneyState(db, subjectId);
+}

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -60,7 +60,13 @@ import {
   computeMapPositions,
   listFrameworks,
   type SubjectKnowledgeEntry,
+  type JourneyStage,
 } from "@ascendimacy/shared";
+import {
+  readOrComputeJourneyState,
+  setParentalOverride,
+  clearParentalOverride,
+} from "./journey-state-repo.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -597,6 +603,42 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       }),
     };
   });
+
+  // ── Journey State endpoints (Fase 8 PR 1) ────────────────────────
+  // GET /subjects/:id/journey-state — recomputa e retorna estado atual
+  fastify.get<{ Params: { id: string } }>(
+    "/subjects/:id/journey-state",
+    async (req) => ({
+      state: readOrComputeJourneyState(opts.db, req.params.id),
+    }),
+  );
+
+  // POST /subjects/:id/journey-state/override — pai força stage específico
+  fastify.post<{
+    Params: { id: string };
+    Body: { stage: JourneyStage; reason: string };
+  }>("/subjects/:id/journey-state/override", async (req, reply) => {
+    const { stage, reason } = req.body ?? ({} as { stage?: JourneyStage; reason?: string });
+    if (
+      stage !== "discovery_only" &&
+      stage !== "mapping_ready" &&
+      stage !== "applied_double_helix"
+    ) {
+      return reply.code(400).send({ error: "stage inválido" });
+    }
+    if (typeof reason !== "string" || reason.trim().length === 0) {
+      return reply.code(400).send({ error: "reason obrigatório" });
+    }
+    return { state: setParentalOverride(opts.db, req.params.id, stage, reason) };
+  });
+
+  // DELETE /subjects/:id/journey-state/override — remove override
+  fastify.delete<{ Params: { id: string } }>(
+    "/subjects/:id/journey-state/override",
+    async (req) => ({
+      state: clearParentalOverride(opts.db, req.params.id),
+    }),
+  );
 
   // POST /rescan — re-indexa o tracesDir (manual trigger).
   // Útil quando STS roda em outro processo e deposita novos traces;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -67,6 +67,10 @@ import {
   setParentalOverride,
   clearParentalOverride,
 } from "./journey-state-repo.js";
+import {
+  getStrategyPlan,
+  listStrategyPlansBySubject,
+} from "./strategy-plan-repo.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -639,6 +643,30 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       state: clearParentalOverride(opts.db, req.params.id),
     }),
   );
+
+  // ── StrategyPlan endpoints (Fase 8 PR 3) ─────────────────────────
+  // GET /sessions/:id/strategy-plan — plan composto pra esta sessão
+  fastify.get<{ Params: { id: string } }>(
+    "/sessions/:id/strategy-plan",
+    async (req, reply) => {
+      const plan = getStrategyPlan(opts.db, req.params.id);
+      if (!plan) {
+        return reply.code(404).send({ error: "strategy_plan não encontrado" });
+      }
+      return { plan };
+    },
+  );
+
+  // GET /subjects/:id/strategy-plans — histórico recente
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>("/subjects/:id/strategy-plans", async (req) => {
+    const limit = req.query.limit ? parseInt(req.query.limit, 10) : undefined;
+    return {
+      plans: listStrategyPlansBySubject(opts.db, req.params.id, limit ?? 20),
+    };
+  });
 
   // POST /rescan — re-indexa o tracesDir (manual trigger).
   // Útil quando STS roda em outro processo e deposita novos traces;

--- a/packages/ebrota-console-bff/src/strategy-plan-repo.ts
+++ b/packages/ebrota-console-bff/src/strategy-plan-repo.ts
@@ -1,0 +1,101 @@
+/**
+ * Strategy Plan Repository — persistência + queries do StrategyPlan.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md §5 §10.2
+ */
+
+import type { Database as DatabaseType } from "better-sqlite3";
+import type {
+  StrategyPlan,
+  TargetDemonstration,
+  PlaybookCompositionStep,
+} from "@ascendimacy/shared";
+
+interface StrategyPlanRow {
+  session_id: string;
+  subject_id: string;
+  composed_at: string;
+  target_demonstrations_json: string;
+  playbook_composition_json: string;
+  overall_success_criteria: string | null;
+  fallback_strategy: string | null;
+  subject_map_snapshot_json: string | null;
+  demonstrations_observed_json: string | null;
+}
+
+function rowToPlan(row: StrategyPlanRow): StrategyPlan {
+  return {
+    session_id: row.session_id,
+    subject_id: row.subject_id,
+    composed_at: row.composed_at,
+    target_demonstrations: JSON.parse(row.target_demonstrations_json) as TargetDemonstration[],
+    playbook_composition: JSON.parse(row.playbook_composition_json) as PlaybookCompositionStep[],
+    overall_success_criteria: row.overall_success_criteria ?? "",
+    fallback_strategy: row.fallback_strategy ?? undefined,
+    subject_map_snapshot: row.subject_map_snapshot_json
+      ? JSON.parse(row.subject_map_snapshot_json)
+      : undefined,
+    demonstrations_observed: row.demonstrations_observed_json
+      ? (JSON.parse(row.demonstrations_observed_json) as TargetDemonstration[])
+      : undefined,
+  };
+}
+
+const UPSERT_SQL = `
+  INSERT INTO strategy_plans (
+    session_id, subject_id, composed_at,
+    target_demonstrations_json, playbook_composition_json,
+    overall_success_criteria, fallback_strategy,
+    subject_map_snapshot_json, demonstrations_observed_json
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(session_id) DO UPDATE SET
+    target_demonstrations_json = excluded.target_demonstrations_json,
+    playbook_composition_json = excluded.playbook_composition_json,
+    overall_success_criteria = excluded.overall_success_criteria,
+    fallback_strategy = excluded.fallback_strategy,
+    subject_map_snapshot_json = excluded.subject_map_snapshot_json,
+    demonstrations_observed_json = excluded.demonstrations_observed_json
+`;
+
+export function upsertStrategyPlan(
+  db: DatabaseType,
+  plan: StrategyPlan,
+): void {
+  db.prepare(UPSERT_SQL).run(
+    plan.session_id,
+    plan.subject_id,
+    plan.composed_at,
+    JSON.stringify(plan.target_demonstrations),
+    JSON.stringify(plan.playbook_composition),
+    plan.overall_success_criteria ?? null,
+    plan.fallback_strategy ?? null,
+    plan.subject_map_snapshot ? JSON.stringify(plan.subject_map_snapshot) : null,
+    plan.demonstrations_observed
+      ? JSON.stringify(plan.demonstrations_observed)
+      : null,
+  );
+}
+
+export function getStrategyPlan(
+  db: DatabaseType,
+  sessionId: string,
+): StrategyPlan | null {
+  const row = db
+    .prepare("SELECT * FROM strategy_plans WHERE session_id = ?")
+    .get(sessionId) as StrategyPlanRow | undefined;
+  return row ? rowToPlan(row) : null;
+}
+
+export function listStrategyPlansBySubject(
+  db: DatabaseType,
+  subjectId: string,
+  limit = 20,
+): StrategyPlan[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM strategy_plans WHERE subject_id = ?
+       ORDER BY composed_at DESC LIMIT ?`,
+    )
+    .all(subjectId, limit) as StrategyPlanRow[];
+  return rows.map(rowToPlan);
+}

--- a/packages/ebrota-console-bff/tests/journey-state.test.ts
+++ b/packages/ebrota-console-bff/tests/journey-state.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests journey_state pipeline: ledger entries → readOrComputeJourneyState
+ * → endpoints REST + override parental.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import {
+  readOrComputeJourneyState,
+  setParentalOverride,
+  clearParentalOverride,
+} from "../src/journey-state-repo.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient, type MockDaemonClient } from "../src/daemon-client.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+let db: DatabaseType;
+let daemon: MockDaemonClient;
+let server: BffServer;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+function seedDiscovery(
+  subjectId: string,
+  type: "interest" | "value" | "need" | "discovery",
+  family: string | null,
+  i: number,
+): void {
+  const payload: Record<string, unknown> = { kind: type, label: `entry-${i}` };
+  if (family) payload["family"] = family;
+  db.prepare(
+    `INSERT INTO subject_knowledge (
+      id, subject_id, type, source, confidence, confirmed_at,
+      alignment, payload_json, turn_ref, session_id, created_at
+    ) VALUES (?, ?, ?, 'self_declared', 0.8, ?, 'unknown', ?, ?, ?, ?)`,
+  ).run(
+    `sk-${i}`,
+    subjectId,
+    type,
+    `s1__t${i}`,
+    JSON.stringify(payload),
+    `s1__t${i}`,
+    "s1",
+    new Date(2026, 4, 25, 10, i).toISOString(),
+  );
+}
+
+describe("readOrComputeJourneyState — auto-init", () => {
+  it("sujeito novo retorna discovery_only com counts zerados", () => {
+    const s = readOrComputeJourneyState(db, "kei");
+    expect(s.stage).toBe("discovery_only");
+    expect(s.discoveries_count).toBe(0);
+    expect(s.families_covered).toEqual([]);
+  });
+
+  it("conta discoveries do ledger", () => {
+    for (let i = 0; i < 5; i++) seedDiscovery("ryo", "interest", "carater", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.discoveries_count).toBe(5);
+    expect(s.families_covered).toEqual(["carater"]);
+  });
+});
+
+describe("auto-transição discovery_only → mapping_ready", () => {
+  it("não transiciona com 5 discoveries em 1 família", () => {
+    for (let i = 0; i < 5; i++) seedDiscovery("ryo", "interest", "carater", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("discovery_only");
+  });
+
+  it("não transiciona com 10 discoveries mas 2 famílias", () => {
+    for (let i = 0; i < 5; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 5; i < 10; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("discovery_only");
+  });
+
+  it("transiciona com 10 discoveries em 3 famílias", () => {
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 7; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 7; i < 10; i++) seedDiscovery("ryo", "discovery", "cognicao_si", i);
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("mapping_ready");
+    expect(s.discoveries_count).toBe(10);
+    expect(s.families_covered).toEqual(["carater", "cognicao_si", "disposicao"]);
+  });
+
+  it("aplica imediatamente: chamada idempotente, fica em mapping_ready", () => {
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 8; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 8; i < 12; i++) seedDiscovery("ryo", "need", "cognicao_si", i);
+    const s1 = readOrComputeJourneyState(db, "ryo");
+    expect(s1.stage).toBe("mapping_ready");
+    // 2ª chamada não regride
+    const s2 = readOrComputeJourneyState(db, "ryo");
+    expect(s2.stage).toBe("mapping_ready");
+    expect(s2.discoveries_count).toBe(12);
+  });
+});
+
+describe("override parental", () => {
+  it("setParentalOverride força stage", () => {
+    const s = setParentalOverride(db, "ryo", "applied_double_helix", "pais ratificaram");
+    expect(s.stage).toBe("applied_double_helix");
+    expect(s.override_by_parent?.forced_stage).toBe("applied_double_helix");
+    expect(s.override_by_parent?.reason).toBe("pais ratificaram");
+  });
+
+  it("override 'discovery_only' impede auto-transição mesmo com threshold OK", () => {
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 8; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 8; i < 12; i++) seedDiscovery("ryo", "need", "cognicao_si", i);
+    setParentalOverride(db, "ryo", "discovery_only", "filho pediu mais descoberta");
+    const s = readOrComputeJourneyState(db, "ryo");
+    expect(s.stage).toBe("discovery_only");
+  });
+
+  it("clearParentalOverride restaura auto-flow", () => {
+    setParentalOverride(db, "ryo", "discovery_only", "test");
+    for (let i = 0; i < 4; i++) seedDiscovery("ryo", "interest", "carater", i);
+    for (let i = 4; i < 8; i++) seedDiscovery("ryo", "value", "disposicao", i);
+    for (let i = 8; i < 12; i++) seedDiscovery("ryo", "need", "cognicao_si", i);
+
+    const beforeClear = readOrComputeJourneyState(db, "ryo");
+    expect(beforeClear.stage).toBe("discovery_only");
+
+    const afterClear = clearParentalOverride(db, "ryo");
+    expect(afterClear.stage).toBe("mapping_ready");
+    expect(afterClear.override_by_parent).toBeUndefined();
+  });
+});
+
+describe("endpoints REST /subjects/:id/journey-state", () => {
+  const inject = async (method: "GET" | "POST" | "DELETE", url: string, body?: unknown) => {
+    const res = await server.fastify.inject({
+      method,
+      url,
+      ...(body !== undefined ? { payload: body } : {}),
+    });
+    return {
+      status: res.statusCode,
+      body: res.body ? JSON.parse(res.body) : null,
+    };
+  };
+
+  it("GET retorna state inicial pra sujeito novo", async () => {
+    const r = await inject("GET", "/subjects/ryo/journey-state");
+    expect(r.status).toBe(200);
+    expect(r.body.state.stage).toBe("discovery_only");
+  });
+
+  it("POST override aplica e retorna novo state", async () => {
+    const r = await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "applied_double_helix",
+      reason: "ratificado",
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.state.stage).toBe("applied_double_helix");
+    expect(r.body.state.override_by_parent.reason).toBe("ratificado");
+  });
+
+  it("POST override rejeita stage inválido", async () => {
+    const r = await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "garbage",
+      reason: "x",
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("POST override rejeita reason vazio", async () => {
+    const r = await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "mapping_ready",
+      reason: "",
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("DELETE override remove e re-avalia", async () => {
+    await inject("POST", "/subjects/ryo/journey-state/override", {
+      stage: "discovery_only",
+      reason: "hold",
+    });
+    const after = await inject("DELETE", "/subjects/ryo/journey-state/override");
+    expect(after.status).toBe(200);
+    expect(after.body.state.override_by_parent).toBeUndefined();
+  });
+});

--- a/packages/ebrota-console-bff/tests/strategy-plan-repo.test.ts
+++ b/packages/ebrota-console-bff/tests/strategy-plan-repo.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import {
+  upsertStrategyPlan,
+  getStrategyPlan,
+  listStrategyPlansBySubject,
+} from "../src/strategy-plan-repo.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient, type MockDaemonClient } from "../src/daemon-client.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+import type { StrategyPlan } from "@ascendimacy/shared";
+
+let db: DatabaseType;
+let server: BffServer;
+let daemon: MockDaemonClient;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+});
+afterEach(async () => {
+  await server.close();
+});
+
+const makePlan = (sessionId: string, subjectId = "ryo"): StrategyPlan => ({
+  session_id: sessionId,
+  subject_id: subjectId,
+  composed_at: new Date().toISOString(),
+  target_demonstrations: [
+    {
+      framework: "valores_classicos",
+      dimension: "axis_3",
+      goal: "expose",
+      rationale: "test",
+    },
+  ],
+  playbook_composition: [
+    {
+      move_id: "propose_dilemma",
+      phase: "challenge_execute",
+      estimated_minutes: 10,
+      success_signal: "x",
+    },
+  ],
+  overall_success_criteria: "y",
+  fallback_strategy: "z",
+});
+
+describe("strategy-plan-repo", () => {
+  it("upsert + get retorna mesmo plan", () => {
+    const plan = makePlan("sess-1");
+    upsertStrategyPlan(db, plan);
+    const got = getStrategyPlan(db, "sess-1");
+    expect(got?.session_id).toBe("sess-1");
+    expect(got?.target_demonstrations[0].dimension).toBe("axis_3");
+    expect(got?.playbook_composition[0].move_id).toBe("propose_dilemma");
+  });
+
+  it("get retorna null se sessão não existe", () => {
+    expect(getStrategyPlan(db, "missing")).toBeNull();
+  });
+
+  it("upsert atualiza plan existente (idempotente)", () => {
+    upsertStrategyPlan(db, makePlan("sess-1"));
+    const updated = {
+      ...makePlan("sess-1"),
+      overall_success_criteria: "atualizado",
+    };
+    upsertStrategyPlan(db, updated);
+    const got = getStrategyPlan(db, "sess-1");
+    expect(got?.overall_success_criteria).toBe("atualizado");
+  });
+
+  it("list ordena por composed_at desc", () => {
+    const p1: StrategyPlan = { ...makePlan("s-1"), composed_at: "2026-05-20T00:00:00Z" };
+    const p2: StrategyPlan = { ...makePlan("s-2"), composed_at: "2026-05-25T00:00:00Z" };
+    upsertStrategyPlan(db, p1);
+    upsertStrategyPlan(db, p2);
+    const list = listStrategyPlansBySubject(db, "ryo");
+    expect(list.map((p) => p.session_id)).toEqual(["s-2", "s-1"]);
+  });
+});
+
+describe("endpoints REST", () => {
+  const inject = async (url: string) => {
+    const res = await server.fastify.inject({ method: "GET", url });
+    return { status: res.statusCode, body: res.body ? JSON.parse(res.body) : null };
+  };
+
+  it("GET /sessions/:id/strategy-plan 404 quando não existe", async () => {
+    const r = await inject("/sessions/missing/strategy-plan");
+    expect(r.status).toBe(404);
+  });
+
+  it("GET /sessions/:id/strategy-plan retorna plan persistido", async () => {
+    upsertStrategyPlan(db, makePlan("sess-x"));
+    const r = await inject("/sessions/sess-x/strategy-plan");
+    expect(r.status).toBe(200);
+    expect(r.body.plan.session_id).toBe("sess-x");
+  });
+
+  it("GET /subjects/:id/strategy-plans lista vazia retorna []", async () => {
+    const r = await inject("/subjects/none/strategy-plans");
+    expect(r.status).toBe(200);
+    expect(r.body.plans).toEqual([]);
+  });
+
+  it("GET /subjects/:id/strategy-plans lista plans do sujeito", async () => {
+    upsertStrategyPlan(db, makePlan("a"));
+    upsertStrategyPlan(db, makePlan("b"));
+    upsertStrategyPlan(db, makePlan("c", "kei"));
+    const r = await inject("/subjects/ryo/strategy-plans");
+    expect(r.body.plans).toHaveLength(2);
+    expect(r.body.plans.every((p: StrategyPlan) => p.subject_id === "ryo")).toBe(true);
+  });
+});

--- a/shared/src/concept-ledger-writer.ts
+++ b/shared/src/concept-ledger-writer.ts
@@ -18,6 +18,16 @@ export interface ConceptLedgerWriterInput {
   sessionId: string;
   turnRef: string;
   item: ContentItem;
+  /**
+   * PR 2 tracer — fase atual da sessão. Quando = "ice_breaker",
+   * writer retorna null automaticamente (ledger NÃO acumula durante
+   * quebra-gelo; presented_concept é instrumento de internalization
+   * pedagógica, não de descoberta).
+   *
+   * Outras fases não bloqueiam. Default (undefined): comportamento
+   * backcompat — emite sempre que item está taggeado.
+   */
+  sessionPhase?: "ice_breaker" | "challenge_explain" | "challenge_execute" | "follow_up";
 }
 
 /**
@@ -36,6 +46,9 @@ export interface ConceptLedgerWriterInput {
 export function extractPresentedConcept(
   input: ConceptLedgerWriterInput,
 ): SubjectKnowledgeEntry | null {
+  // PR 2: gate por fase — ice_breaker NÃO acumula ledger
+  if (input.sessionPhase === "ice_breaker") return null;
+
   const { item } = input;
   if (
     typeof item.axis_id !== "number" ||

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -115,6 +115,13 @@ export interface EvaluateAndSelectOutput {
     elapsed_minutes_estimate: number;
     minutes_until_next_phase: number;
   };
+  /**
+   * Fase 8 PR 3: StrategyPlan composto pelo Strategist quando
+   * journey_stage = applied_double_helix. Apenas no início da sessão
+   * (turn baixo / challenge_explain); turns subsequentes referenciam o
+   * mesmo plan via session_id.
+   */
+  strategyPlan?: import("./strategy-plan.js").StrategyPlan;
 }
 
 export interface ExecutePlaybookInput {

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -105,6 +105,16 @@ export interface EvaluateAndSelectOutput {
    * Undefined no fluxo antigo (backward compat).
    */
   subjectKnowledgeEvents?: import("./subject-knowledge.js").SubjectKnowledgeEntry[];
+  /**
+   * Fase 8 PR 2: resolved session state (phase + journey_stage + elapsed).
+   * Propagado pro trace pra Console UI Mapa de Jornada (F6) consumir.
+   */
+  sessionState?: {
+    phase: import("./session-phases.js").SessionPhase;
+    journey_stage: import("./session-phases.js").JourneyStage;
+    elapsed_minutes_estimate: number;
+    minutes_until_next_phase: number;
+  };
 }
 
 export interface ExecutePlaybookInput {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -28,6 +28,7 @@ export * from "./concept-ledger-writer.js";
 export * from "./recall-check-evaluator.js";
 export * from "./map-framework.js";
 export * from "./session-phases.js";
+export * from "./strategy-plan.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -27,6 +27,7 @@ export * from "./subject-knowledge-writers.js";
 export * from "./concept-ledger-writer.js";
 export * from "./recall-check-evaluator.js";
 export * from "./map-framework.js";
+export * from "./session-phases.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/session-phases.ts
+++ b/shared/src/session-phases.ts
@@ -196,7 +196,8 @@ export function computeDiscoveryMaturity(
     count += 1;
     // Tenta extrair família via lineage_anchor do payload se houver,
     // senão via axis_id quando presente, senão via heurística parcial.
-    const payload = e.payload as Record<string, unknown>;
+    // Double cast unknown → Record evita TS2352 com union discriminada.
+    const payload = e.payload as unknown as Record<string, unknown>;
     if (typeof payload["family"] === "string") {
       families.add(payload["family"] as string);
     } else if (typeof payload["axis_id"] === "number" && axisToFamilyFn) {

--- a/shared/src/session-phases.ts
+++ b/shared/src/session-phases.ts
@@ -1,0 +1,226 @@
+/**
+ * SessionPhase + JourneyStage — Fase 8 (Session Phases + Strategist).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md
+ *
+ * Foundation types do tracer bullet. Comportamento phase-aware vem em PR
+ * seguinte (PR 2 motor). Strategist em PR 3.
+ *
+ * Princípio: sessão tem 3 níveis temporais — JOURNEY (cross-session,
+ * meses) > STAGE (1-N sessões) > SESSION (15+30+5 min) > PHASE (sub-bloco).
+ */
+
+import type { SubjectKnowledgeEntry } from "./subject-knowledge.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// SessionPhase — 4 fases intra-sessão (spec §2)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type SessionPhase =
+  | "ice_breaker"        // 15 min — abrir + descobrir + tom seguro
+  | "challenge_explain"  // ~5 min — apresentar desafio
+  | "challenge_execute"  // 30 min — ação efetiva (StrategyPlan em execução)
+  | "follow_up";         // 5 min — consolidar, comparar plano vs demonstração
+
+export const SESSION_PHASES: readonly SessionPhase[] = [
+  "ice_breaker",
+  "challenge_explain",
+  "challenge_execute",
+  "follow_up",
+] as const;
+
+export interface SessionTiming {
+  total_minutes: number;
+  ice_breaker_minutes: number;
+  challenge_explain_minutes: number;
+  challenge_execute_minutes: number;
+  follow_up_minutes: number;
+}
+
+/** Configuração default da sessão eBrota — 15+30+5 = 50min total (spec SP-01). */
+export const DEFAULT_SESSION_TIMING: SessionTiming = {
+  total_minutes: 50,
+  ice_breaker_minutes: 15,
+  challenge_explain_minutes: 0, // embutido nos últimos 5min do ice_breaker
+  challenge_execute_minutes: 30,
+  follow_up_minutes: 5,
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// JourneyStage — 3 stages cross-session (spec §3)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type JourneyStage =
+  | "discovery_only"          // primeiras sessões: SÓ mapear
+  | "mapping_ready"            // transição: motor propõe mapa, pai ratifica
+  | "applied_double_helix";    // sessões correntes: Strategist + ponte tripla
+
+export const JOURNEY_STAGES: readonly JourneyStage[] = [
+  "discovery_only",
+  "mapping_ready",
+  "applied_double_helix",
+] as const;
+
+export interface JourneyState {
+  subject_id: string;
+  stage: JourneyStage;
+  stage_entered_at: string;
+  discoveries_count: number;
+  /** Famílias do catálogo Subject Knowledge já cobertas por discoveries. */
+  families_covered: string[];
+  override_by_parent?: {
+    forced_stage: JourneyStage;
+    reason: string;
+    timestamp: string;
+  };
+  last_updated_at: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// SessionStateResolver — decide fase atual heuristicamente (spec §7.1)
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface SessionStateInput {
+  /** Número do turn atual na sessão (1-indexed). */
+  turn: number;
+  /** Minutos médios por turn (default 4 — observado em smokes reais). */
+  avgMinutesPerTurn?: number;
+  /** Override explícito de minutos elapsed (para integrações futuras com tempo real). */
+  elapsedMinutesOverride?: number;
+  /** Stage atual da jornada do sujeito. */
+  journeyStage: JourneyStage;
+  /** Configuração temporal da sessão. */
+  timing?: SessionTiming;
+}
+
+export interface SessionStateOutput {
+  phase: SessionPhase;
+  journey_stage: JourneyStage;
+  elapsed_minutes_estimate: number;
+  /** Quantos minutos restam na fase atual antes da transição automática. */
+  minutes_until_next_phase: number;
+}
+
+const DEFAULT_AVG_MIN_PER_TURN = 4;
+
+/**
+ * Resolve fase + stage. Heurística v1: phase = f(elapsed_minutes).
+ * Override por elapsedMinutesOverride quando tempo real é conhecido.
+ */
+export function resolveSessionState(input: SessionStateInput): SessionStateOutput {
+  const timing = input.timing ?? DEFAULT_SESSION_TIMING;
+  const elapsed =
+    input.elapsedMinutesOverride !== undefined
+      ? input.elapsedMinutesOverride
+      : input.turn * (input.avgMinutesPerTurn ?? DEFAULT_AVG_MIN_PER_TURN);
+
+  const iceEnd = timing.ice_breaker_minutes;
+  const explainEnd = iceEnd + timing.challenge_explain_minutes;
+  const executeEnd = explainEnd + timing.challenge_execute_minutes;
+
+  let phase: SessionPhase;
+  let nextBoundary: number;
+  if (elapsed < iceEnd) {
+    phase = "ice_breaker";
+    nextBoundary = iceEnd;
+  } else if (elapsed < explainEnd) {
+    phase = "challenge_explain";
+    nextBoundary = explainEnd;
+  } else if (elapsed < executeEnd) {
+    phase = "challenge_execute";
+    nextBoundary = executeEnd;
+  } else {
+    phase = "follow_up";
+    nextBoundary = timing.total_minutes;
+  }
+
+  return {
+    phase,
+    journey_stage: input.journeyStage,
+    elapsed_minutes_estimate: elapsed,
+    minutes_until_next_phase: Math.max(0, nextBoundary - elapsed),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Threshold de maturidade — saída de discovery_only (spec §3.2, SP-04)
+// ─────────────────────────────────────────────────────────────────────────
+
+export const READY_FOR_MAPPING_MIN_DISCOVERIES = 10;
+export const READY_FOR_MAPPING_MIN_FAMILIES = 3;
+
+export interface ReadyForMappingInput {
+  state: JourneyState;
+  /** Override explícito dos pais ("force mapping_ready" / "stay in discovery"). */
+  parentOverride?: JourneyStage;
+}
+
+/**
+ * Avalia se o sujeito está pronto pra avançar de discovery_only para
+ * mapping_ready. Critério (ratificado 2026-05-25):
+ *   - ≥10 descobertas distribuídas em ≥3 famílias (saturação)
+ *   - OU override parental explícito
+ */
+export function readyForMapping(input: ReadyForMappingInput): boolean {
+  if (input.parentOverride === "mapping_ready" || input.parentOverride === "applied_double_helix") {
+    return true;
+  }
+  if (input.parentOverride === "discovery_only") {
+    return false; // pai forçou ficar em descoberta
+  }
+  return (
+    input.state.discoveries_count >= READY_FOR_MAPPING_MIN_DISCOVERIES &&
+    input.state.families_covered.length >= READY_FOR_MAPPING_MIN_FAMILIES
+  );
+}
+
+/**
+ * Helper: deriva families_covered + discoveries_count de uma lista de
+ * SubjectKnowledgeEntry. Usado pelo BFF pra computar estado a partir
+ * do ledger. Conta tipos discovery-like (interest/value/need/discovery).
+ */
+export function computeDiscoveryMaturity(
+  entries: SubjectKnowledgeEntry[],
+  axisToFamilyFn?: (axisId: number) => string | undefined,
+): { discoveries_count: number; families_covered: string[] } {
+  const discoveryTypes: ReadonlySet<string> = new Set([
+    "interest",
+    "value",
+    "need",
+    "discovery",
+  ]);
+  const families = new Set<string>();
+  let count = 0;
+  for (const e of entries) {
+    if (!discoveryTypes.has(e.type)) continue;
+    count += 1;
+    // Tenta extrair família via lineage_anchor do payload se houver,
+    // senão via axis_id quando presente, senão via heurística parcial.
+    const payload = e.payload as Record<string, unknown>;
+    if (typeof payload["family"] === "string") {
+      families.add(payload["family"] as string);
+    } else if (typeof payload["axis_id"] === "number" && axisToFamilyFn) {
+      const fam = axisToFamilyFn(payload["axis_id"] as number);
+      if (fam) families.add(fam);
+    }
+    // Discoveries sem axis_id/family não contam pro multi-família mas
+    // contam pro count total — caller decide se é OK na thresh.
+  }
+  return {
+    discoveries_count: count,
+    families_covered: Array.from(families).sort(),
+  };
+}
+
+/** Inicializa journey_state pra sujeito novo. */
+export function initialJourneyState(subjectId: string): JourneyState {
+  const now = new Date().toISOString();
+  return {
+    subject_id: subjectId,
+    stage: "discovery_only",
+    stage_entered_at: now,
+    discoveries_count: 0,
+    families_covered: [],
+    last_updated_at: now,
+  };
+}

--- a/shared/src/strategy-plan.ts
+++ b/shared/src/strategy-plan.ts
@@ -1,0 +1,233 @@
+/**
+ * StrategyPlan + Strategist — Fase 8 PR 3 (tracer bullet).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md §5
+ *
+ * Strategist compõe plano de sessão em journey_stage=applied_double_helix.
+ * NÃO é selecionador de content_item — é compositor criativo de playbook
+ * moves pra levar o sujeito a demonstrar capacidades nos mapas.
+ *
+ * v1 tracer: heurística pura template-based (sem LLM call).
+ * Cruzamento opinião×portfólio via LLM entra em fase posterior.
+ */
+
+import type { JourneyStage, SessionPhase } from "./session-phases.js";
+import type { SubjectKnowledgeEntry } from "./subject-knowledge.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// PlaybookMove — verbos pedagógicos componíveis (catálogo)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type PlaybookMoveId =
+  | "propose_dilemma"          // apresenta dilema realista, pede decisão
+  | "request_demonstration"     // pede pra mostrar algo concreto
+  | "offer_choice"              // dá 2-3 opções com tradeoffs
+  | "reflect_back"              // espelha o que sujeito disse
+  | "bridge_to_lineage"         // conecta com complemento clássico
+  | "ask_recall";               // checa internalização anterior
+
+export interface PlaybookMove {
+  id: PlaybookMoveId;
+  phase: SessionPhase;
+  /** Tempo estimado em minutos. */
+  estimated_minutes: number;
+  /** Framing genérico — Materializer customiza com contexto. */
+  framing_template: string;
+  /** Success signal observável pra Trigger Evaluator detectar. */
+  success_signal: string;
+}
+
+/**
+ * Catálogo v1 — apenas `propose_dilemma` real; outros são stubs futuros.
+ * Quando catálogo crescer, vira YAML separado (sub-spec).
+ */
+export const PLAYBOOK_MOVES: Record<PlaybookMoveId, PlaybookMove> = {
+  propose_dilemma: {
+    id: "propose_dilemma",
+    phase: "challenge_execute",
+    estimated_minutes: 10,
+    framing_template:
+      "Vou te propor uma situação. Imagina: {dilemma}. Você escolheria {option_a} ou {option_b}? Por quê?",
+    success_signal: "sujeito_escolheu_E_justificou",
+  },
+  request_demonstration: {
+    id: "request_demonstration",
+    phase: "challenge_execute",
+    estimated_minutes: 15,
+    framing_template: "Me mostra como você faria {action}. Pode ser por foto, áudio ou descrição.",
+    success_signal: "sujeito_demonstrou_action",
+  },
+  offer_choice: {
+    id: "offer_choice",
+    phase: "challenge_explain",
+    estimated_minutes: 3,
+    framing_template: "Tenho 2 caminhos: (a) {choice_a} ou (b) {choice_b}. Qual te interessa mais?",
+    success_signal: "sujeito_escolheu_caminho",
+  },
+  reflect_back: {
+    id: "reflect_back",
+    phase: "ice_breaker",
+    estimated_minutes: 2,
+    framing_template: "Deixa eu ver se entendi: {summary}. É isso?",
+    success_signal: "sujeito_confirmou_ou_corrigiu",
+  },
+  bridge_to_lineage: {
+    id: "bridge_to_lineage",
+    phase: "challenge_execute",
+    estimated_minutes: 5,
+    framing_template:
+      "Isso me lembra uma ideia antiga — {lineage_name}: {lineage_short}. Faz sentido pra você no que falamos?",
+    success_signal: "sujeito_ressoou_com_lineage",
+  },
+  ask_recall: {
+    id: "ask_recall",
+    phase: "challenge_execute",
+    estimated_minutes: 2,
+    framing_template: "Lembra daquela ideia de {concept}? O que ficou disso pra você?",
+    success_signal: "sujeito_demonstrou_recall_positivo",
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// StrategyPlan — plano por sessão (spec §5.2)
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface TargetDemonstration {
+  framework: string;             // ex: "valores_classicos"
+  dimension: string;             // ex: "axis_1"
+  goal: "expose" | "explore" | "challenge" | "consolidate";
+  rationale: string;
+}
+
+export interface PlaybookCompositionStep {
+  move_id: PlaybookMoveId;
+  phase: SessionPhase;
+  estimated_minutes: number;
+  content_inputs?: string[];     // IDs opcionais de content_seeds
+  success_signal: string;
+}
+
+export interface StrategyPlan {
+  session_id: string;
+  subject_id: string;
+  composed_at: string;
+  target_demonstrations: TargetDemonstration[];
+  playbook_composition: PlaybookCompositionStep[];
+  overall_success_criteria: string;
+  fallback_strategy?: string;
+  /** Snapshot do mapa pro audit log. */
+  subject_map_snapshot?: Record<string, unknown>;
+  /** Outcome — atualizado no follow_up. */
+  demonstrations_observed?: TargetDemonstration[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Strategist.compose — v1 template-based (sem LLM)
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface StrategistInput {
+  sessionId: string;
+  subjectId: string;
+  journeyStage: JourneyStage;
+  /** Entries do ledger usadas pra inferir interesses + necessidades. */
+  knowledgeEntries: SubjectKnowledgeEntry[];
+  /** Latent needs do parental_profile (passado pelo planejador). */
+  latentNeeds?: string[];
+  /** Subject proposed do parental_profile. */
+  subjectProposed?: {
+    axes_active: number[];
+    complements_per_axis: Record<number, string[]>;
+  };
+}
+
+const FAMILY_PRIORITY: Array<"carater" | "disposicao" | "cognicao_si"> = [
+  "carater",
+  "disposicao",
+  "cognicao_si",
+];
+
+/**
+ * v1 template-based: identifica 1 target_demonstration baseado em
+ * eixo do subject_proposed com menor evidência no ledger; compõe 1
+ * playbook move `propose_dilemma` no `challenge_execute`.
+ *
+ * Retorna null quando stage não é applied_double_helix — outros stages
+ * não usam Strategist (ice_breaker / mapping_ready têm pipeline próprio).
+ *
+ * LLM call entra em fase posterior (cruzamento opinião×portfólio).
+ */
+export function composeStrategyPlan(input: StrategistInput): StrategyPlan | null {
+  if (input.journeyStage !== "applied_double_helix") {
+    return null;
+  }
+
+  // Identifica eixos ativos no proposto; default lista vazia
+  const axesActive = input.subjectProposed?.axes_active ?? [];
+  if (axesActive.length === 0) {
+    // Sem subject_proposed populado, plan vazio — caller decide o que fazer
+    return null;
+  }
+
+  // Heurística: escolhe primeiro eixo proposto que NÃO tem presented_concept
+  // recente (= dimensão menos exposta). Fallback: primeiro eixo da lista.
+  const presentedAxes = new Set<number>();
+  for (const e of input.knowledgeEntries) {
+    if (e.type === "presented_concept" && e.payload.kind === "presented_concept") {
+      presentedAxes.add(e.payload.axis_id);
+    }
+  }
+  const targetAxis = axesActive.find((ax) => !presentedAxes.has(ax)) ?? axesActive[0];
+  const targetFamily = familyForAxis(targetAxis);
+
+  const targetDemonstration: TargetDemonstration = {
+    framework: "valores_classicos",
+    dimension: `axis_${targetAxis}`,
+    goal: presentedAxes.has(targetAxis) ? "consolidate" : "expose",
+    rationale: presentedAxes.has(targetAxis)
+      ? `Eixo ${targetAxis} já tem apresentação anterior; consolidar via dilema.`
+      : `Eixo ${targetAxis} ainda sem presented_concept; expor via dilema concreto.`,
+  };
+
+  // Composição v1: 1 playbook move (propose_dilemma)
+  const dilemmaMove: PlaybookCompositionStep = {
+    move_id: "propose_dilemma",
+    phase: "challenge_execute",
+    estimated_minutes: PLAYBOOK_MOVES.propose_dilemma.estimated_minutes,
+    success_signal: PLAYBOOK_MOVES.propose_dilemma.success_signal,
+  };
+
+  return {
+    session_id: input.sessionId,
+    subject_id: input.subjectId,
+    composed_at: new Date().toISOString(),
+    target_demonstrations: [targetDemonstration],
+    playbook_composition: [dilemmaMove],
+    overall_success_criteria: `Sujeito escolheu E justificou no dilema sobre ${targetFamily}.`,
+    fallback_strategy: "Se sujeito deflectir o dilema, retornar a reflect_back e re-propor adaptado.",
+  };
+}
+
+function familyForAxis(axis: number): string {
+  if (axis >= 1 && axis <= 4) return FAMILY_PRIORITY[0];
+  if (axis >= 5 && axis <= 8) return FAMILY_PRIORITY[1];
+  if (axis >= 9 && axis <= 12) return FAMILY_PRIORITY[2];
+  return "desconhecida";
+}
+
+/**
+ * Helper: dado um StrategyPlan + estado atual da sessão, retorna o
+ * próximo playbook move a executar (ou null se plano esgotado).
+ *
+ * v1: ordem linear; quando execute terminar (esgotou moves), null.
+ */
+export function nextPlaybookMove(
+  plan: StrategyPlan,
+  currentPhase: SessionPhase,
+  movesExecutedInSession: number,
+): PlaybookCompositionStep | null {
+  const remaining = plan.playbook_composition.filter(
+    (m) => m.phase === currentPhase,
+  );
+  if (movesExecutedInSession >= remaining.length) return null;
+  return remaining[movesExecutedInSession];
+}

--- a/shared/src/subject-knowledge-writers.ts
+++ b/shared/src/subject-knowledge-writers.ts
@@ -33,6 +33,17 @@ export interface DiscoveryWriterInput {
   signals?: string[];
   /** Mood opcional pra calibrar confidence. */
   mood?: number;
+  /**
+   * PR 2 tracer — threshold de confidence ajustável por fase.
+   * Entries com confidence < minConfidence são suprimidas.
+   * Default: 0 (sem filtro — preserva comportamento atual).
+   *
+   * Uso típico:
+   *  - ice_breaker → 0.4 (agressivo, captura sinais frágeis)
+   *  - challenge_execute → 0.6 (normal)
+   *  - follow_up → 0.7 (conservador, só sinais fortes)
+   */
+  minConfidence?: number;
 }
 
 const INTEREST_PATTERNS: Array<{ re: RegExp; intensity: "low" | "mid" | "high" }> = [
@@ -141,6 +152,10 @@ export function extractDiscoveries(
     }
   }
 
+  // PR 2 tracer — filtra por threshold de confidence quando aplicado.
+  if (input.minConfidence !== undefined && input.minConfidence > 0) {
+    return out.filter((e) => e.confidence >= input.minConfidence!);
+  }
   return out;
 }
 

--- a/shared/tests/session-phases.test.ts
+++ b/shared/tests/session-phases.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests SessionPhase + JourneyStage + SessionStateResolver + threshold.
+ * Spec: ascendimacy-ops/docs/specs/2026-05-25-session-phases-journey-stages-strategist.md
+ */
+import { describe, it, expect } from "vitest";
+import {
+  resolveSessionState,
+  readyForMapping,
+  computeDiscoveryMaturity,
+  initialJourneyState,
+  DEFAULT_SESSION_TIMING,
+  READY_FOR_MAPPING_MIN_DISCOVERIES,
+  READY_FOR_MAPPING_MIN_FAMILIES,
+  type SubjectKnowledgeEntry,
+  type JourneyState,
+} from "../src/index.js";
+
+const NOW = "2026-05-25T18:00:00.000Z";
+
+describe("resolveSessionState — heurística temporal", () => {
+  it("turn 1 (4min) → ice_breaker", () => {
+    const r = resolveSessionState({ turn: 1, journeyStage: "discovery_only" });
+    expect(r.phase).toBe("ice_breaker");
+    expect(r.elapsed_minutes_estimate).toBe(4);
+    expect(r.minutes_until_next_phase).toBe(11);
+  });
+
+  it("turn 4 (16min) → challenge_execute (sem challenge_explain explícito)", () => {
+    const r = resolveSessionState({ turn: 4, journeyStage: "discovery_only" });
+    // 16min > ice_end(15) + explain(0) = 15. Entra em execute.
+    expect(r.phase).toBe("challenge_execute");
+  });
+
+  it("turn 11 (44min) → challenge_execute (limite)", () => {
+    const r = resolveSessionState({ turn: 11, journeyStage: "applied_double_helix" });
+    expect(r.phase).toBe("challenge_execute");
+  });
+
+  it("turn 12 (48min) → follow_up", () => {
+    const r = resolveSessionState({ turn: 12, journeyStage: "applied_double_helix" });
+    expect(r.phase).toBe("follow_up");
+    expect(r.elapsed_minutes_estimate).toBe(48);
+  });
+
+  it("avgMinutesPerTurn override altera elapsed", () => {
+    const r = resolveSessionState({
+      turn: 3,
+      avgMinutesPerTurn: 2,
+      journeyStage: "discovery_only",
+    });
+    expect(r.elapsed_minutes_estimate).toBe(6);
+    expect(r.phase).toBe("ice_breaker");
+  });
+
+  it("elapsedMinutesOverride vence heurística por turn", () => {
+    const r = resolveSessionState({
+      turn: 1,
+      elapsedMinutesOverride: 47,
+      journeyStage: "applied_double_helix",
+    });
+    expect(r.elapsed_minutes_estimate).toBe(47);
+    expect(r.phase).toBe("follow_up"); // 47 > 45 = ice+execute
+  });
+
+  it("preserva journey_stage no output", () => {
+    const r = resolveSessionState({ turn: 1, journeyStage: "applied_double_helix" });
+    expect(r.journey_stage).toBe("applied_double_helix");
+  });
+});
+
+describe("readyForMapping — threshold", () => {
+  const baseState: JourneyState = {
+    subject_id: "ryo",
+    stage: "discovery_only",
+    stage_entered_at: NOW,
+    discoveries_count: 0,
+    families_covered: [],
+    last_updated_at: NOW,
+  };
+
+  it("false quando count < threshold", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: READY_FOR_MAPPING_MIN_DISCOVERIES - 1,
+          families_covered: ["carater", "disposicao", "cognicao_si"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("false quando famílias < threshold", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: 20,
+          families_covered: ["carater", "disposicao"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("true quando ambos critérios batem", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: READY_FOR_MAPPING_MIN_DISCOVERIES,
+          families_covered: ["carater", "disposicao", "cognicao_si"],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("override parental 'mapping_ready' força true", () => {
+    expect(
+      readyForMapping({
+        state: baseState,
+        parentOverride: "mapping_ready",
+      }),
+    ).toBe(true);
+  });
+
+  it("override parental 'applied_double_helix' também força true", () => {
+    expect(
+      readyForMapping({
+        state: baseState,
+        parentOverride: "applied_double_helix",
+      }),
+    ).toBe(true);
+  });
+
+  it("override parental 'discovery_only' força false mesmo com threshold OK", () => {
+    expect(
+      readyForMapping({
+        state: {
+          ...baseState,
+          discoveries_count: 100,
+          families_covered: ["carater", "disposicao", "cognicao_si"],
+        },
+        parentOverride: "discovery_only",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("computeDiscoveryMaturity", () => {
+  const makeEntry = (
+    type: SubjectKnowledgeEntry["type"],
+    payload: Record<string, unknown>,
+  ): SubjectKnowledgeEntry => ({
+    id: `id-${Math.random()}`,
+    subject_id: "ryo",
+    type,
+    source: "self_declared",
+    confidence: 0.8,
+    confirmed_at: NOW,
+    alignment: "unknown",
+    payload: { kind: type, ...payload } as SubjectKnowledgeEntry["payload"],
+    turn_ref: "s1__t1",
+    session_id: "s1",
+    created_at: NOW,
+  });
+
+  it("count = só interest/value/need/discovery; boundary_event não conta", () => {
+    const entries = [
+      makeEntry("interest", { label: "tênis" }),
+      makeEntry("value", { label: "esforço" }),
+      makeEntry("boundary_event", { topic_category: "x", signal_type: "deflection_thematic", intensity: "mid", motor_response: "muda_tema", severity_band: "routine" }),
+    ];
+    const r = computeDiscoveryMaturity(entries);
+    expect(r.discoveries_count).toBe(2);
+  });
+
+  it("families_covered dedup + sorted", () => {
+    const entries = [
+      makeEntry("interest", { label: "x", family: "carater" }),
+      makeEntry("interest", { label: "y", family: "disposicao" }),
+      makeEntry("value", { label: "z", family: "carater" }), // dup
+    ];
+    const r = computeDiscoveryMaturity(entries);
+    expect(r.families_covered).toEqual(["carater", "disposicao"]);
+  });
+
+  it("entries sem family/axis_id não contribuem pra families", () => {
+    const entries = [
+      makeEntry("interest", { label: "x" }), // sem family
+      makeEntry("value", { label: "y" }),
+    ];
+    const r = computeDiscoveryMaturity(entries);
+    expect(r.discoveries_count).toBe(2);
+    expect(r.families_covered).toEqual([]);
+  });
+
+  it("usa axisToFamilyFn quando payload tem axis_id mas não family", () => {
+    const entries = [
+      makeEntry("interest", { label: "x", axis_id: 3 }),
+    ];
+    const r = computeDiscoveryMaturity(entries, (axisId) =>
+      axisId >= 1 && axisId <= 4 ? "carater" : "outra",
+    );
+    expect(r.families_covered).toEqual(["carater"]);
+  });
+});
+
+describe("initialJourneyState", () => {
+  it("começa em discovery_only", () => {
+    const s = initialJourneyState("ryo");
+    expect(s.subject_id).toBe("ryo");
+    expect(s.stage).toBe("discovery_only");
+    expect(s.discoveries_count).toBe(0);
+    expect(s.families_covered).toEqual([]);
+    expect(s.override_by_parent).toBeUndefined();
+  });
+});
+
+describe("DEFAULT_SESSION_TIMING", () => {
+  it("totaliza 50 min", () => {
+    const t = DEFAULT_SESSION_TIMING;
+    expect(t.ice_breaker_minutes + t.challenge_explain_minutes + t.challenge_execute_minutes + t.follow_up_minutes).toBe(t.total_minutes);
+    expect(t.total_minutes).toBe(50);
+  });
+});
+
+describe("constants integridade", () => {
+  it("threshold valores ratificados (10 / 3)", () => {
+    expect(READY_FOR_MAPPING_MIN_DISCOVERIES).toBe(10);
+    expect(READY_FOR_MAPPING_MIN_FAMILIES).toBe(3);
+  });
+});

--- a/shared/tests/strategy-plan.test.ts
+++ b/shared/tests/strategy-plan.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests Strategist + StrategyPlan (PR 3 tracer).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  composeStrategyPlan,
+  nextPlaybookMove,
+  PLAYBOOK_MOVES,
+  type StrategyPlan,
+  type SubjectKnowledgeEntry,
+} from "../src/index.js";
+
+const baseInput = {
+  sessionId: "s1",
+  subjectId: "ryo",
+};
+
+describe("composeStrategyPlan — gating por journey_stage", () => {
+  it("retorna null em discovery_only", () => {
+    const plan = composeStrategyPlan({
+      ...baseInput,
+      journeyStage: "discovery_only",
+      knowledgeEntries: [],
+      subjectProposed: { axes_active: [3], complements_per_axis: { 3: [] } },
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("retorna null em mapping_ready", () => {
+    const plan = composeStrategyPlan({
+      ...baseInput,
+      journeyStage: "mapping_ready",
+      knowledgeEntries: [],
+      subjectProposed: { axes_active: [3], complements_per_axis: {} },
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("retorna null em applied_double_helix sem subject_proposed", () => {
+    const plan = composeStrategyPlan({
+      ...baseInput,
+      journeyStage: "applied_double_helix",
+      knowledgeEntries: [],
+    });
+    expect(plan).toBeNull();
+  });
+});
+
+describe("composeStrategyPlan — composição v1", () => {
+  it("compõe plan com 1 target_demonstration + 1 playbook move", () => {
+    const plan = composeStrategyPlan({
+      ...baseInput,
+      journeyStage: "applied_double_helix",
+      knowledgeEntries: [],
+      subjectProposed: {
+        axes_active: [3, 7, 11],
+        complements_per_axis: { 3: ["andreia"], 7: ["hesed"], 11: ["gnothi_seauton"] },
+      },
+    });
+    expect(plan).not.toBeNull();
+    expect(plan!.target_demonstrations).toHaveLength(1);
+    expect(plan!.playbook_composition).toHaveLength(1);
+    expect(plan!.playbook_composition[0].move_id).toBe("propose_dilemma");
+    expect(plan!.playbook_composition[0].phase).toBe("challenge_execute");
+  });
+
+  it("target prioriza eixo sem presented_concept anterior (goal=expose)", () => {
+    const presented: SubjectKnowledgeEntry = {
+      id: "pc-1",
+      subject_id: "ryo",
+      type: "presented_concept",
+      source: "motor_inferred",
+      confidence: 1.0,
+      confirmed_at: "s0__t2",
+      alignment: "unknown",
+      payload: {
+        kind: "presented_concept",
+        concept_id: "old",
+        keywords: ["x"],
+        lineage_anchor: "estoica/x",
+        axis_id: 3,
+        family: "carater",
+        points: 1,
+      },
+      turn_ref: "s0__t2",
+      session_id: "s0",
+      created_at: "2026-05-25",
+    };
+    const plan = composeStrategyPlan({
+      ...baseInput,
+      journeyStage: "applied_double_helix",
+      knowledgeEntries: [presented],
+      subjectProposed: {
+        axes_active: [3, 7],
+        complements_per_axis: { 3: [], 7: [] },
+      },
+    });
+    expect(plan!.target_demonstrations[0].dimension).toBe("axis_7");
+    expect(plan!.target_demonstrations[0].goal).toBe("expose");
+  });
+
+  it("fallback consolidate quando todos os eixos já têm presented_concept", () => {
+    const presented = (axisId: number, i: number): SubjectKnowledgeEntry => ({
+      id: `pc-${i}`,
+      subject_id: "ryo",
+      type: "presented_concept",
+      source: "motor_inferred",
+      confidence: 1.0,
+      confirmed_at: "s0__t",
+      alignment: "unknown",
+      payload: {
+        kind: "presented_concept",
+        concept_id: `x-${i}`,
+        keywords: ["x"],
+        lineage_anchor: "estoica/x",
+        axis_id: axisId,
+        family: axisId <= 4 ? "carater" : axisId <= 8 ? "disposicao" : "cognicao_si",
+        points: 1,
+      },
+      turn_ref: "s0__t",
+      session_id: "s0",
+      created_at: "2026-05-25",
+    });
+    const plan = composeStrategyPlan({
+      ...baseInput,
+      journeyStage: "applied_double_helix",
+      knowledgeEntries: [presented(3, 1), presented(7, 2)],
+      subjectProposed: {
+        axes_active: [3, 7],
+        complements_per_axis: { 3: [], 7: [] },
+      },
+    });
+    expect(plan!.target_demonstrations[0].goal).toBe("consolidate");
+  });
+
+  it("plan inclui fallback_strategy + overall_success_criteria", () => {
+    const plan = composeStrategyPlan({
+      ...baseInput,
+      journeyStage: "applied_double_helix",
+      knowledgeEntries: [],
+      subjectProposed: { axes_active: [3], complements_per_axis: {} },
+    });
+    expect(plan!.fallback_strategy).toBeDefined();
+    expect(plan!.overall_success_criteria.length).toBeGreaterThan(0);
+  });
+});
+
+describe("nextPlaybookMove", () => {
+  const plan: StrategyPlan = {
+    session_id: "s1",
+    subject_id: "ryo",
+    composed_at: "2026-05-25",
+    target_demonstrations: [],
+    playbook_composition: [
+      {
+        move_id: "propose_dilemma",
+        phase: "challenge_execute",
+        estimated_minutes: 10,
+        success_signal: "x",
+      },
+    ],
+    overall_success_criteria: "y",
+  };
+
+  it("retorna 1º move quando phase bate e nenhum executado", () => {
+    const move = nextPlaybookMove(plan, "challenge_execute", 0);
+    expect(move?.move_id).toBe("propose_dilemma");
+  });
+
+  it("retorna null quando phase não bate", () => {
+    const move = nextPlaybookMove(plan, "ice_breaker", 0);
+    expect(move).toBeNull();
+  });
+
+  it("retorna null quando moves esgotados", () => {
+    const move = nextPlaybookMove(plan, "challenge_execute", 1);
+    expect(move).toBeNull();
+  });
+});
+
+describe("PLAYBOOK_MOVES catálogo v1", () => {
+  it("tem 6 moves stub", () => {
+    expect(Object.keys(PLAYBOOK_MOVES).length).toBe(6);
+  });
+
+  it("propose_dilemma está em challenge_execute", () => {
+    expect(PLAYBOOK_MOVES.propose_dilemma.phase).toBe("challenge_execute");
+  });
+
+  it("todos os moves têm framing_template + success_signal", () => {
+    for (const m of Object.values(PLAYBOOK_MOVES)) {
+      expect(m.framing_template.length).toBeGreaterThan(0);
+      expect(m.success_signal.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/shared/tests/writers-phase-aware.test.ts
+++ b/shared/tests/writers-phase-aware.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests PR 2 tracer — phase-aware behavior em writers.
+ * - DiscoveryWriter: threshold minConfidence filtra entries
+ * - ConceptLedgerWriter: ice_breaker gate suprime presented_concept
+ */
+import { describe, it, expect } from "vitest";
+import { extractDiscoveries } from "../src/subject-knowledge-writers.js";
+import { extractPresentedConcept } from "../src/concept-ledger-writer.js";
+import type { CuriosityHookItem } from "../src/content-item.js";
+
+const baseInput = {
+  subjectId: "ryo",
+  sessionId: "s1",
+  turnRef: "s1__t1",
+};
+
+describe("extractDiscoveries — minConfidence threshold", () => {
+  it("sem threshold, retorna todas as entries detectadas", () => {
+    const out = extractDiscoveries({
+      ...baseInput,
+      lastUserMessage: "eu gosto de tênis e queria muito poder dormir mais",
+    });
+    expect(out.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("threshold 0.4 (ice_breaker) preserva quase tudo", () => {
+    const out = extractDiscoveries({
+      ...baseInput,
+      lastUserMessage: "eu gosto de tênis",
+      minConfidence: 0.4,
+    });
+    // 'gosto de' = interest mid (0.7), passa 0.4
+    expect(out.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("threshold 0.6 (challenge_execute) filtra value/need (≤0.55)", () => {
+    const out = extractDiscoveries({
+      ...baseInput,
+      lastUserMessage: "pra mim importa amizade e queria muito poder dormir",
+      minConfidence: 0.6,
+    });
+    // value (0.55) e need (0.5) ficam abaixo de 0.6
+    expect(out.filter((e) => e.type === "value")).toHaveLength(0);
+    expect(out.filter((e) => e.type === "need")).toHaveLength(0);
+  });
+
+  it("threshold 0.7 (follow_up) filtra também interest mid", () => {
+    const out = extractDiscoveries({
+      ...baseInput,
+      lastUserMessage: "eu gosto de tênis",
+      minConfidence: 0.71,
+    });
+    // interest mid é 0.7, abaixo de 0.71 → filtra
+    expect(out).toHaveLength(0);
+  });
+
+  it("threshold 0.7 preserva interest high (0.9)", () => {
+    const out = extractDiscoveries({
+      ...baseInput,
+      lastUserMessage: "adoro skate, é meu favorito",
+      minConfidence: 0.7,
+    });
+    expect(out.length).toBeGreaterThan(0);
+    expect(out[0].confidence).toBeGreaterThanOrEqual(0.7);
+  });
+});
+
+const taggedItem: CuriosityHookItem = {
+  id: "metamorfose_lagarta",
+  type: "curiosity_hook",
+  domain: "biologia",
+  casel_target: ["SA"],
+  age_range: [10, 15],
+  surprise: 8,
+  verified: true,
+  base_score: 7,
+  fact: "x",
+  bridge: "y",
+  quest: "z",
+  sacrifice_type: "reflect",
+  axis_id: 4,
+  family: "carater",
+  lineage_anchor: "zen/shoshin",
+  extracted_keywords: ["lagarta", "casulo"],
+};
+
+describe("extractPresentedConcept — phase gate", () => {
+  it("ice_breaker suprime entry mesmo com item tagged", () => {
+    const entry = extractPresentedConcept({
+      ...baseInput,
+      item: taggedItem,
+      sessionPhase: "ice_breaker",
+    });
+    expect(entry).toBeNull();
+  });
+
+  it("challenge_explain permite emissão", () => {
+    const entry = extractPresentedConcept({
+      ...baseInput,
+      item: taggedItem,
+      sessionPhase: "challenge_explain",
+    });
+    expect(entry).not.toBeNull();
+  });
+
+  it("challenge_execute permite emissão (caso principal)", () => {
+    const entry = extractPresentedConcept({
+      ...baseInput,
+      item: taggedItem,
+      sessionPhase: "challenge_execute",
+    });
+    expect(entry).not.toBeNull();
+  });
+
+  it("follow_up permite emissão", () => {
+    const entry = extractPresentedConcept({
+      ...baseInput,
+      item: taggedItem,
+      sessionPhase: "follow_up",
+    });
+    expect(entry).not.toBeNull();
+  });
+
+  it("backcompat: sem sessionPhase emite (preserva comportamento PR 3)", () => {
+    const entry = extractPresentedConcept({
+      ...baseInput,
+      item: taggedItem,
+    });
+    expect(entry).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
**Consolidação dos 3 PRs do tracer bullet** (PR 1 + PR 2 + PR 3) num único, após conflitos irreconciliáveis com os PRs subsequentes mergeados primeiro (#216-#220).

Conteúdo idêntico ao planejado — mesmo cherry-picks de:
- \`e506d73\` PR 1 → JourneyStage + SessionPhase + journey_state foundation
- \`25ce308\` PR 2 → phase-aware writers + sessionState propagation
- \`54eb934\` PR 3 → Strategist minimal + StrategyPlan schema

### Entregas
- **shared/src/session-phases.ts** — types + resolveSessionState + readyForMapping + computeDiscoveryMaturity
- **shared/src/strategy-plan.ts** — PlaybookMove + StrategyPlan + composeStrategyPlan + nextPlaybookMove
- **BFF SQLite** — tabelas \`journey_state\` + \`strategy_plans\`
- **BFF endpoints REST** — GET/POST/DELETE \`/subjects/:id/journey-state\` + \`/sessions/:id/strategy-plan\` + \`/subjects/:id/strategy-plans\`
- **Materializer phase-aware** — DiscoveryWriter threshold por fase, ConceptLedger ice_breaker gate
- **Pipeline integration** — resolveSessionState + Strategist hook em journey_stage=applied_double_helix
- **sessionState + strategyPlan** propagados no \`EvaluateAndSelectOutput\`

### Suíte
- shared **820** (+51 vs main pre-tracer) — sessions-phases 20 + strategy-plan 13 + multidim 12 + recall 17 etc
- motor **355** (+26 vs pre-tracer) — phase-aware writers 10 + playbook moves 18 + recall hookup
- bff **150** (+15) — journey-state 14 + strategy-plan 8 + map-framework 7 etc
- planejador **337** — preservado

### Substitui PRs antigos
Vou fechar #213, #214, #215 com referência a este PR (não dá pra rebasear devido conflitos múltiplos).

## Test plan
- [x] Cherry-pick limpo dos 3 commits originais (conteúdo idêntico)
- [x] Build verde em 4 workspaces
- [x] Suite consolidada · zero regressão
- [x] Conflitos resolvidos: shared/src/index.ts (imports), bff/src/server.ts (imports + endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)