### PR TITLE
[feat] Mini-UI Console: painéis Jornada/Mapas/Descobertas

### DIFF
--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -9,6 +9,9 @@
   import Replay from "./components/Replay.svelte";
   import DebugPanel from "./components/DebugPanel.svelte";
   import Analytics from "./components/Analytics.svelte";
+  import JourneyPanel from "./components/JourneyPanel.svelte";
+  import MapsPanel from "./components/MapsPanel.svelte";
+  import DiscoveriesPanel from "./components/DiscoveriesPanel.svelte";
   import { createApiClient } from "./lib/api.js";
   import {
     bffStatus,
@@ -98,6 +101,9 @@
   <Replay {api} />
   <DebugPanel {api} />
   <Analytics {api} />
+  <JourneyPanel {api} />
+  <MapsPanel {api} />
+  <DiscoveriesPanel {api} />
 
   <footer>
     <p class="muted">

--- a/packages/ebrota-console-ui/src/components/DiscoveriesPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/DiscoveriesPanel.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import type {
+    ApiClient,
+    SubjectKnowledgeEntryLike,
+    BoundarySummary,
+  } from "../lib/api.js";
+  import { discoveriesPanelOpen, tracerSubjectId } from "../lib/stores.js";
+
+  export let api: ApiClient;
+
+  let discoveries: SubjectKnowledgeEntryLike[] = [];
+  let boundariesSummary: BoundarySummary[] = [];
+  let typeFilter = "";
+  let loading = false;
+  let err: string | null = null;
+
+  async function load(): Promise<void> {
+    loading = true;
+    err = null;
+    try {
+      const [d, s] = await Promise.all([
+        api.listSubjectDiscoveries($tracerSubjectId, {
+          ...(typeFilter ? { type: typeFilter } : {}),
+          limit: 100,
+        }),
+        api.getBoundariesSummary($tracerSubjectId),
+      ]);
+      discoveries = d.discoveries;
+      boundariesSummary = s.summary;
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    }
+    loading = false;
+  }
+
+  $: if ($discoveriesPanelOpen) void load();
+  $: typeFilter, $discoveriesPanelOpen && void load();
+
+  function shortLabel(e: SubjectKnowledgeEntryLike): string {
+    const p = e.payload;
+    if (typeof p["label"] === "string") return p["label"];
+    if (typeof p["concept_id"] === "string") return p["concept_id"];
+    if (typeof p["signal_type"] === "string") return p["signal_type"];
+    return e.type;
+  }
+
+  function badgeColor(type: string): string {
+    if (type === "interest") return "#1976d2";
+    if (type === "value") return "#388e3c";
+    if (type === "need") return "#f57c00";
+    if (type === "discovery") return "#7b1fa2";
+    if (type === "boundary_event") return "#b00020";
+    if (type === "presented_concept") return "#00897b";
+    if (type === "recall_check_attempt") return "#ef6c00";
+    return "#666";
+  }
+</script>
+
+{#if $discoveriesPanelOpen}
+  <div class="modal-backdrop" on:click={() => discoveriesPanelOpen.set(false)} on:keydown={(e) => e.key === "Escape" && discoveriesPanelOpen.set(false)} role="presentation">
+    <div class="modal" on:click|stopPropagation role="dialog" aria-label="Descobertas">
+      <header>
+        <h2>🔍 Descobertas — {$tracerSubjectId}</h2>
+        <button on:click={() => discoveriesPanelOpen.set(false)} aria-label="Fechar">×</button>
+      </header>
+
+      <div class="filters">
+        <label for="disc-subject">subject_id:</label>
+        <input id="disc-subject" type="text" bind:value={$tracerSubjectId} on:blur={load} />
+        <label for="disc-type">type:</label>
+        <select id="disc-type" bind:value={typeFilter}>
+          <option value="">(todos)</option>
+          <option value="interest">interest</option>
+          <option value="value">value</option>
+          <option value="need">need</option>
+          <option value="discovery">discovery</option>
+        </select>
+        <button on:click={load} disabled={loading}>{loading ? "..." : "Reload"}</button>
+      </div>
+
+      {#if err}<p class="err">{err}</p>{/if}
+
+      {#if boundariesSummary.length > 0}
+        <section class="boundaries">
+          <h3>⚠️ Boundaries (agregados por topic_category)</h3>
+          <ul>
+            {#each boundariesSummary as b}
+              <li>
+                <span class="topic">{b.topic_category}</span>
+                <span class="counts">
+                  {b.count}× <span class:high={b.high_intensity_count > 0}>(high {b.high_intensity_count})</span>
+                </span>
+                <span class="when">last: {new Date(b.last_seen_at).toLocaleString()}</span>
+              </li>
+            {/each}
+          </ul>
+        </section>
+      {/if}
+
+      <section class="timeline">
+        <h3>Descobertas timeline ({discoveries.length})</h3>
+        {#if discoveries.length === 0}
+          <p class="empty">Nenhuma descoberta pra este sujeito ainda.</p>
+        {:else}
+          <ul>
+            {#each discoveries as d}
+              <li>
+                <span class="badge" style="background: {badgeColor(d.type)}">{d.type}</span>
+                <span class="label">{shortLabel(d)}</span>
+                <span class="conf">conf={d.confidence.toFixed(2)}</span>
+                <span class="when">{new Date(d.created_at).toLocaleString()}</span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100; display: flex; align-items: center; justify-content: center; }
+  .modal { background: #fff; padding: 1.5rem; border-radius: 8px; width: min(800px, 90vw); max-height: 90vh; overflow-y: auto; }
+  header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+  header h2 { margin: 0; font-size: 1.1rem; }
+  header button { background: transparent; border: none; font-size: 1.5rem; cursor: pointer; }
+  .filters { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
+  .filters input, .filters select { padding: 0.3rem; }
+  .err { color: #b00020; }
+  .boundaries { background: #fff3e0; padding: 0.75rem; border-radius: 4px; border-left: 3px solid #f57c00; margin-bottom: 1rem; }
+  .boundaries h3 { margin: 0 0 0.5rem 0; font-size: 0.95rem; }
+  .boundaries ul { list-style: none; padding: 0; }
+  .boundaries li { display: grid; grid-template-columns: 1fr auto auto; gap: 0.5rem; padding: 0.3rem 0; align-items: center; }
+  .topic { font-weight: 600; }
+  .counts .high { color: #b00020; font-weight: 600; }
+  .when { color: #999; font-size: 0.8rem; }
+  .timeline h3 { font-size: 0.95rem; margin-bottom: 0.5rem; }
+  .timeline ul { list-style: none; padding: 0; }
+  .timeline li { display: grid; grid-template-columns: auto 1fr auto auto; gap: 0.5rem; padding: 0.4rem; border-bottom: 1px solid #f0f0f0; align-items: center; }
+  .badge { color: white; padding: 0.15rem 0.5rem; border-radius: 3px; font-size: 0.75rem; font-weight: 600; }
+  .label { font-family: monospace; color: #333; word-break: break-word; }
+  .conf { color: #888; font-size: 0.8rem; }
+  .empty { color: #999; font-style: italic; padding: 1rem; background: #f7f7f7; border-radius: 4px; }
+</style>

--- a/packages/ebrota-console-ui/src/components/JourneyPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/JourneyPanel.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { ApiClient, JourneyStateLike } from "../lib/api.js";
+  import {
+    journeyPanelOpen,
+    tracerSubjectId,
+  } from "../lib/stores.js";
+
+  export let api: ApiClient;
+
+  let state: JourneyStateLike | null = null;
+  let loading = false;
+  let err: string | null = null;
+  let overrideStage: "discovery_only" | "mapping_ready" | "applied_double_helix" = "mapping_ready";
+  let overrideReason = "";
+
+  async function load(): Promise<void> {
+    loading = true;
+    err = null;
+    try {
+      const r = await api.getJourneyState($tracerSubjectId);
+      state = r.state;
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+      state = null;
+    }
+    loading = false;
+  }
+
+  async function applyOverride(): Promise<void> {
+    if (overrideReason.trim().length === 0) {
+      err = "Reason obrigatório";
+      return;
+    }
+    try {
+      const r = await api.setJourneyOverride($tracerSubjectId, overrideStage, overrideReason);
+      state = r.state;
+      overrideReason = "";
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function clearOverride(): Promise<void> {
+    try {
+      const r = await api.clearJourneyOverride($tracerSubjectId);
+      state = r.state;
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  $: if ($journeyPanelOpen) void load();
+</script>
+
+{#if $journeyPanelOpen}
+  <div class="modal-backdrop" on:click={() => journeyPanelOpen.set(false)} on:keydown={(e) => e.key === "Escape" && journeyPanelOpen.set(false)} role="presentation">
+    <div class="modal" on:click|stopPropagation role="dialog" aria-label="Journey State">
+      <header>
+        <h2>🧭 Journey State — {$tracerSubjectId}</h2>
+        <button on:click={() => journeyPanelOpen.set(false)} aria-label="Fechar">×</button>
+      </header>
+
+      <div class="subject-picker">
+        <label for="journey-subject">subject_id:</label>
+        <input id="journey-subject" type="text" bind:value={$tracerSubjectId} on:blur={load} />
+        <button on:click={load} disabled={loading}>{loading ? "..." : "Reload"}</button>
+      </div>
+
+      {#if err}
+        <p class="err">{err}</p>
+      {/if}
+
+      {#if state}
+        <div class="state-card">
+          <div class="row">
+            <span class="lbl">Stage:</span>
+            <span class="val stage-{state.stage}">{state.stage}</span>
+          </div>
+          <div class="row">
+            <span class="lbl">Discoveries:</span>
+            <span class="val">{state.discoveries_count} / 10 (threshold)</span>
+          </div>
+          <div class="bar">
+            <div class="bar-fill" style="width: {Math.min(100, state.discoveries_count * 10)}%"></div>
+          </div>
+          <div class="row">
+            <span class="lbl">Famílias cobertas:</span>
+            <span class="val">{state.families_covered.length} / 3 — {state.families_covered.join(", ") || "(nenhuma)"}</span>
+          </div>
+          <div class="row">
+            <span class="lbl">Stage entered:</span>
+            <span class="val muted">{new Date(state.stage_entered_at).toLocaleString()}</span>
+          </div>
+          {#if state.override_by_parent}
+            <div class="override">
+              <strong>⚠️ Override parental ativo:</strong>
+              <p>Forçado pra <code>{state.override_by_parent.forced_stage}</code></p>
+              <p class="reason">"{state.override_by_parent.reason}"</p>
+              <button on:click={clearOverride}>Limpar override</button>
+            </div>
+          {/if}
+        </div>
+
+        <details class="override-form">
+          <summary>Aplicar override parental</summary>
+          <div class="form">
+            <label for="override-stage">Forçar stage:</label>
+            <select id="override-stage" bind:value={overrideStage}>
+              <option value="discovery_only">discovery_only</option>
+              <option value="mapping_ready">mapping_ready</option>
+              <option value="applied_double_helix">applied_double_helix</option>
+            </select>
+            <label for="override-reason">Reason:</label>
+            <input id="override-reason" type="text" bind:value={overrideReason} placeholder="ratificado pelo pai..." />
+            <button on:click={applyOverride}>Aplicar</button>
+          </div>
+        </details>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .modal {
+    background: #fff; padding: 1.5rem; border-radius: 8px;
+    width: min(640px, 90vw); max-height: 90vh; overflow-y: auto;
+  }
+  header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+  header h2 { margin: 0; font-size: 1.1rem; }
+  header button { background: transparent; border: none; font-size: 1.5rem; cursor: pointer; }
+  .subject-picker { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
+  .subject-picker input { flex: 1; padding: 0.3rem; }
+  .err { color: #b00020; font-size: 0.9rem; }
+  .state-card { background: #f7f7f7; padding: 1rem; border-radius: 4px; }
+  .row { display: flex; justify-content: space-between; padding: 0.3rem 0; }
+  .lbl { font-weight: 600; color: #555; }
+  .val { color: #222; }
+  .muted { color: #999; font-size: 0.85rem; }
+  .stage-discovery_only { color: #1976d2; }
+  .stage-mapping_ready { color: #f57c00; }
+  .stage-applied_double_helix { color: #388e3c; }
+  .bar { background: #ddd; height: 8px; border-radius: 4px; margin: 0.5rem 0; overflow: hidden; }
+  .bar-fill { background: #1976d2; height: 100%; transition: width 0.3s; }
+  .override { background: #fff3e0; padding: 0.75rem; border-radius: 4px; margin-top: 1rem; border-left: 3px solid #f57c00; }
+  .override .reason { font-style: italic; color: #555; margin: 0.3rem 0; }
+  .override-form { margin-top: 1rem; }
+  .override-form summary { cursor: pointer; padding: 0.5rem; background: #eee; border-radius: 4px; }
+  .form { display: grid; grid-template-columns: auto 1fr; gap: 0.5rem; align-items: center; margin-top: 0.5rem; }
+  .form button { grid-column: 1 / span 2; padding: 0.4rem; }
+</style>

--- a/packages/ebrota-console-ui/src/components/MapsPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/MapsPanel.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import type { ApiClient, FrameworkMeta, SubjectMapLike } from "../lib/api.js";
+  import { mapsPanelOpen, tracerSubjectId } from "../lib/stores.js";
+
+  export let api: ApiClient;
+
+  let frameworks: FrameworkMeta[] = [];
+  let activeFramework = "valores_classicos";
+  let maps: SubjectMapLike | null = null;
+  let loading = false;
+  let err: string | null = null;
+
+  async function loadFrameworks(): Promise<void> {
+    try {
+      const r = await api.listFrameworks();
+      frameworks = r.frameworks;
+      if (frameworks.length > 0 && !frameworks.find((f) => f.id === activeFramework)) {
+        activeFramework = frameworks[0].id;
+      }
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function loadMaps(): Promise<void> {
+    loading = true;
+    err = null;
+    try {
+      const r = await api.getSubjectMaps($tracerSubjectId);
+      maps = r.maps;
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+      maps = null;
+    }
+    loading = false;
+  }
+
+  $: if ($mapsPanelOpen) {
+    void loadFrameworks();
+    void loadMaps();
+  }
+
+  function fmtVal(v: unknown): string {
+    if (typeof v === "number") return v.toFixed(0);
+    if (typeof v === "object" && v !== null) return JSON.stringify(v);
+    return String(v);
+  }
+
+  function nonZeroEntries(positions: Record<string, unknown> | undefined): Array<[string, unknown]> {
+    if (!positions) return [];
+    return Object.entries(positions).filter(([, v]) => {
+      if (typeof v === "number") return v > 0;
+      if (typeof v === "object" && v !== null) return true;
+      return Boolean(v);
+    });
+  }
+</script>
+
+{#if $mapsPanelOpen}
+  <div class="modal-backdrop" on:click={() => mapsPanelOpen.set(false)} on:keydown={(e) => e.key === "Escape" && mapsPanelOpen.set(false)} role="presentation">
+    <div class="modal" on:click|stopPropagation role="dialog" aria-label="Mapas multi-framework">
+      <header>
+        <h2>🗺️ Mapas — {$tracerSubjectId}</h2>
+        <button on:click={() => mapsPanelOpen.set(false)} aria-label="Fechar">×</button>
+      </header>
+
+      <div class="subject-picker">
+        <label for="maps-subject">subject_id:</label>
+        <input id="maps-subject" type="text" bind:value={$tracerSubjectId} on:blur={loadMaps} />
+        <button on:click={loadMaps} disabled={loading}>{loading ? "..." : "Reload"}</button>
+      </div>
+
+      {#if err}<p class="err">{err}</p>{/if}
+
+      <div class="tabs">
+        {#each frameworks as fw}
+          <button
+            class="tab"
+            class:active={activeFramework === fw.id}
+            on:click={() => (activeFramework = fw.id)}
+          >
+            {fw.display_name}
+          </button>
+        {/each}
+      </div>
+
+      {#if maps && frameworks.find((f) => f.id === activeFramework)}
+        {@const fw = frameworks.find((f) => f.id === activeFramework)}
+        <div class="framework-view">
+          <p class="meta">render hint: <code>{fw?.render_hint}</code> · {fw?.dimensions.length} dimensões</p>
+          {#if nonZeroEntries(maps.positions[activeFramework]).length === 0}
+            <p class="empty">Nenhuma posição com valor > 0 nesta lente. Sujeito ainda sem entries suficientes.</p>
+          {:else}
+            <ul class="dims">
+              {#each nonZeroEntries(maps.positions[activeFramework]) as [dim, val]}
+                <li>
+                  <span class="dim-name">{dim}</span>
+                  <span class="dim-val">{fmtVal(val)}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+          <details class="raw">
+            <summary>JSON cru</summary>
+            <pre>{JSON.stringify(maps.positions[activeFramework], null, 2)}</pre>
+          </details>
+        </div>
+      {/if}
+
+      <p class="muted">computed_at: {maps?.computed_at ? new Date(maps.computed_at).toLocaleString() : "—"}</p>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100; display: flex; align-items: center; justify-content: center; }
+  .modal { background: #fff; padding: 1.5rem; border-radius: 8px; width: min(720px, 90vw); max-height: 90vh; overflow-y: auto; }
+  header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+  header h2 { margin: 0; font-size: 1.1rem; }
+  header button { background: transparent; border: none; font-size: 1.5rem; cursor: pointer; }
+  .subject-picker { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
+  .subject-picker input { flex: 1; padding: 0.3rem; }
+  .err { color: #b00020; }
+  .tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid #ddd; margin-bottom: 1rem; flex-wrap: wrap; }
+  .tab { padding: 0.5rem 1rem; background: transparent; border: none; cursor: pointer; border-bottom: 2px solid transparent; font-size: 0.9rem; }
+  .tab.active { border-bottom-color: #1976d2; font-weight: 600; }
+  .framework-view .meta { color: #888; font-size: 0.85rem; }
+  .empty { color: #999; font-style: italic; padding: 1rem; background: #f7f7f7; border-radius: 4px; }
+  .dims { list-style: none; padding: 0; }
+  .dims li { display: flex; justify-content: space-between; padding: 0.4rem 0.6rem; border-bottom: 1px solid #f0f0f0; }
+  .dim-name { font-family: monospace; color: #333; }
+  .dim-val { font-weight: 600; color: #1976d2; }
+  .raw { margin-top: 1rem; }
+  .raw summary { cursor: pointer; }
+  .raw pre { background: #f7f7f7; padding: 0.5rem; border-radius: 4px; font-size: 0.8rem; overflow-x: auto; }
+  .muted { color: #999; font-size: 0.8rem; margin-top: 1rem; }
+</style>

--- a/packages/ebrota-console-ui/src/components/Status.svelte
+++ b/packages/ebrota-console-ui/src/components/Status.svelte
@@ -4,7 +4,10 @@
     bffStatus,
     consoleMode,
     debugPanelOpen,
+    discoveriesPanelOpen,
+    journeyPanelOpen,
     libraryOpen,
+    mapsPanelOpen,
   } from "../lib/stores.js";
   import type { ApiClient } from "../lib/api.js";
   import type { ConsoleMode } from "../lib/types.js";
@@ -89,6 +92,39 @@
     title="Debug LLM (raio-X tail)"
   >
     🔬 Debug
+  </button>
+
+  <button
+    type="button"
+    class="tracer-toggle"
+    class:active={$journeyPanelOpen}
+    on:click={() => journeyPanelOpen.update((o) => !o)}
+    data-testid="journey-toggle"
+    title="Journey State — stage da jornada do sujeito"
+  >
+    🧭 Jornada
+  </button>
+
+  <button
+    type="button"
+    class="tracer-toggle"
+    class:active={$mapsPanelOpen}
+    on:click={() => mapsPanelOpen.update((o) => !o)}
+    data-testid="maps-toggle"
+    title="Mapas multi-framework"
+  >
+    🗺️ Mapas
+  </button>
+
+  <button
+    type="button"
+    class="tracer-toggle"
+    class:active={$discoveriesPanelOpen}
+    on:click={() => discoveriesPanelOpen.update((o) => !o)}
+    data-testid="discoveries-toggle"
+    title="Descobertas + boundaries"
+  >
+    🔍 Descobertas
   </button>
 
   <button

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -206,6 +206,72 @@ export interface ApiClient {
   getPersonaEvolution(personaId: string): Promise<PersonaEvolution>;
   /** Resolve URL completa pro EventSource consumir SSE. */
   turnStateSseUrl(sessionId: string): string;
+
+  // ─── Subject Knowledge + Journey + Maps (Mini-UI tracer views) ─────
+  listSubjectDiscoveries(
+    subjectId: string,
+    opts?: { type?: string; limit?: number },
+  ): Promise<{ discoveries: SubjectKnowledgeEntryLike[] }>;
+  listSubjectBoundaries(
+    subjectId: string,
+    opts?: { limit?: number },
+  ): Promise<{ boundaries: SubjectKnowledgeEntryLike[] }>;
+  getBoundariesSummary(
+    subjectId: string,
+  ): Promise<{ summary: BoundarySummary[] }>;
+  getJourneyState(subjectId: string): Promise<{ state: JourneyStateLike }>;
+  setJourneyOverride(
+    subjectId: string,
+    stage: string,
+    reason: string,
+  ): Promise<{ state: JourneyStateLike }>;
+  clearJourneyOverride(subjectId: string): Promise<{ state: JourneyStateLike }>;
+  listFrameworks(): Promise<{ frameworks: FrameworkMeta[] }>;
+  getSubjectMaps(
+    subjectId: string,
+    frameworkIds?: string[],
+  ): Promise<{ maps: SubjectMapLike }>;
+}
+
+export interface SubjectKnowledgeEntryLike {
+  id: string;
+  type: string;
+  source: string;
+  confidence: number;
+  payload: Record<string, unknown>;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+}
+
+export interface BoundarySummary {
+  topic_category: string;
+  count: number;
+  high_intensity_count: number;
+  last_seen_at: string;
+}
+
+export interface JourneyStateLike {
+  subject_id: string;
+  stage: "discovery_only" | "mapping_ready" | "applied_double_helix";
+  stage_entered_at: string;
+  discoveries_count: number;
+  families_covered: string[];
+  override_by_parent?: { forced_stage: string; reason: string; timestamp: string };
+  last_updated_at: string;
+}
+
+export interface FrameworkMeta {
+  id: string;
+  display_name: string;
+  dimensions: readonly string[];
+  render_hint: "radar" | "bar" | "tree" | "list";
+}
+
+export interface SubjectMapLike {
+  subject_id: string;
+  computed_at: string;
+  positions: Record<string, Record<string, unknown>>;
 }
 
 export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
@@ -316,6 +382,62 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
       ),
     turnStateSseUrl: (sessionId) =>
       `${baseUrl}/sessions/${encodeURIComponent(sessionId)}/turn-state`,
+
+    // ── Mini-UI tracer views ─────────────────────────────────────
+    listSubjectDiscoveries: (subjectId, opts) => {
+      const params = new URLSearchParams();
+      if (opts?.type !== undefined) params.set("type", opts.type);
+      if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+      const q = params.toString();
+      return get<{ discoveries: SubjectKnowledgeEntryLike[] }>(
+        `/subjects/${encodeURIComponent(subjectId)}/discoveries${q ? `?${q}` : ""}`,
+      );
+    },
+    listSubjectBoundaries: (subjectId, opts) => {
+      const params = new URLSearchParams();
+      if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+      const q = params.toString();
+      return get<{ boundaries: SubjectKnowledgeEntryLike[] }>(
+        `/subjects/${encodeURIComponent(subjectId)}/boundaries${q ? `?${q}` : ""}`,
+      );
+    },
+    getBoundariesSummary: (subjectId) =>
+      get<{ summary: BoundarySummary[] }>(
+        `/subjects/${encodeURIComponent(subjectId)}/boundaries/summary`,
+      ),
+    getJourneyState: (subjectId) =>
+      get<{ state: JourneyStateLike }>(
+        `/subjects/${encodeURIComponent(subjectId)}/journey-state`,
+      ),
+    setJourneyOverride: (subjectId, stage, reason) =>
+      post<{ state: JourneyStateLike }>(
+        `/subjects/${encodeURIComponent(subjectId)}/journey-state/override`,
+        { stage, reason },
+      ),
+    clearJourneyOverride: async (subjectId) => {
+      const res = await f(
+        `${baseUrl}/subjects/${encodeURIComponent(subjectId)}/journey-state/override`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        throw new Error(
+          `BFF DELETE journey-state/override failed: ${res.status}`,
+        );
+      }
+      return (await res.json()) as { state: JourneyStateLike };
+    },
+    listFrameworks: () =>
+      get<{ frameworks: FrameworkMeta[] }>("/frameworks"),
+    getSubjectMaps: (subjectId, frameworkIds) => {
+      const params = new URLSearchParams();
+      if (frameworkIds && frameworkIds.length > 0) {
+        params.set("framework", frameworkIds.join(","));
+      }
+      const q = params.toString();
+      return get<{ maps: SubjectMapLike }>(
+        `/subjects/${encodeURIComponent(subjectId)}/maps${q ? `?${q}` : ""}`,
+      );
+    },
   };
 }
 

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -64,3 +64,11 @@ export const analyticsOpen = writable<boolean>(false);
  *  via API + store reset. */
 import type { DebugLlmCallEvent } from "./api.js";
 export const debugLlmEvents = writable<DebugLlmCallEvent[]>([]);
+
+/** Mini-UI tracer views (Fase 8): toggles abrem/fecham painéis. */
+export const journeyPanelOpen = writable<boolean>(false);
+export const mapsPanelOpen = writable<boolean>(false);
+export const discoveriesPanelOpen = writable<boolean>(false);
+
+/** Subject ID corrente nos painéis tracer. Default ryo-ochiai. */
+export const tracerSubjectId = writable<string>("ryo-ochiai");


### PR DESCRIPTION
## Summary
Resolve gap visual descoberto durante smoke tracer: backend tinha journey_state + maps multi-framework + discoveries indexados, mas UI atual (C-MX-08) só consumia Session Library/Replay/Analytics. Operador não conseguia ver nada do que F1-F7 entregou.

Mini-UI sem polish — **destrava visualização hoje**. F6 polido (radar charts + drill-down completo) vem depois.

### 3 painéis novos (modais)
- **🧭 Jornada** — stage atual + progress bar (X/10 discoveries · Y/3 famílias) + override parental
- **🗺️ Mapas** — tabs por framework (valores_classicos · gardner · casel · dreyfus_by_domain) + dimensões com valores
- **🔍 Descobertas** — boundaries summary agregado + timeline de discoveries com badges coloridos

### Lib extensions
ApiClient ganhou 8 métodos consumindo endpoints já existentes no BFF (Fase 8). Types novos: \`SubjectKnowledgeEntryLike\`, \`BoundarySummary\`, \`JourneyStateLike\`, \`FrameworkMeta\`, \`SubjectMapLike\`.

## Test plan
- [x] Build UI verde (62 modules, 101KB bundle)
- [x] Vite HMR aplica automático em dev
- [ ] Manual: abrir http://localhost:5173 → clicar nos 3 botões novos → verificar dados de \`ryo-ochiai\` aparecem (1 interest, journey stage discovery_only, axis_11 = 3pts em valores_classicos, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)