### PR TITLE
[fix ops#1126] Scorer expose gate + surprise downgrade (monoculture fix)

### DIFF
--- a/content/hooks/seed.json
+++ b/content/hooks/seed.json
@@ -351,7 +351,7 @@
       7,
       14
     ],
-    "surprise": 10,
+    "surprise": 7,
     "verified": true,
     "base_score": 7,
     "fact": "Golfinhos têm NOME. Cada golfinho cria um assovio único que é SÓ dele. Os outros chamam pelo assovio. Se o golfinho morre, os amigos repetem o assovio dele por dias.",
@@ -467,7 +467,7 @@
       7,
       14
     ],
-    "surprise": 10,
+    "surprise": 7,
     "verified": true,
     "base_score": 7,
     "fact": "Dentro do casulo, a lagarta se dissolve COMPLETAMENTE em sopa. Vira líquido. Não \"cresce asas\" — se destrói e reconstrói do zero como borboleta.",
@@ -1692,7 +1692,7 @@
       7,
       14
     ],
-    "surprise": 10,
+    "surprise": 7,
     "verified": true,
     "base_score": 7,
     "fact": "No Japão, quando uma tigela quebra, reparam com OURO. Não escondem a rachadura — celebram. O objeto quebrado vale MAIS que o inteiro. Chama 金継ぎ kintsugi.",

--- a/shared/src/scorer.ts
+++ b/shared/src/scorer.ts
@@ -93,6 +93,28 @@ export const INTERNALIZATION_HISTORY_THRESHOLD = 3;
  */
 export const USED_IN_SESSION_PENALTY = 100;
 
+/**
+ * Expose gate — items com sacrifice_type=expose pedem ao sujeito que mostre
+ * vulnerabilidade ("você já se sentiu assim?"). Disparam mal quando ele
+ * está fechado: trust baixa, mood ruim, ou sinais explícitos de recusa
+ * (frame_rejection, deflection_thematic).
+ *
+ * Observado no smoke tracer-helix-3sessions-ryo: bio_caterpillar_dissolve
+ * dominou 3 sessões consecutivas; Ryo disse "por que você quer tanto ficar
+ * falando de lágrima? é estranho" na S3T4. Penalty -8 derruba expose pra
+ * baixo dos hooks neutros (base_score~5-10) sem excluí-los completamente.
+ */
+export const EXPOSE_GATE_PENALTY = 8;
+/** Threshold de trust abaixo do qual expose dispara penalty. */
+export const EXPOSE_GATE_TRUST_THRESHOLD = 0.5;
+/** Threshold de mood abaixo do qual expose dispara penalty. */
+export const EXPOSE_GATE_MOOD_THRESHOLD = 6;
+/** Sinais que indicam recusa de frame — expose vira inapropriado. */
+export const EXPOSE_GATE_BLOCKING_SIGNALS: readonly string[] = [
+  "frame_rejection",
+  "deflection_thematic",
+];
+
 export interface DomainRankEntry {
   score: number;
 }
@@ -150,6 +172,14 @@ export interface ChildScoringProfile {
    * Map axis_id → pontos totais.
    */
   internalization_axis_points?: Record<number, number>;
+
+  /**
+   * Confiança acumulada [0..1]. Cross-session, vinda do subject_knowledge
+   * ledger ou heurística do BFF. Usado pelo expose gate: items vulneráveis
+   * desabilitados quando trust < EXPOSE_GATE_TRUST_THRESHOLD.
+   * Ausente → tratado como 1.0 (sem gate).
+   */
+  trust?: number;
 }
 
 export interface ScoringContext {
@@ -177,6 +207,20 @@ export interface ScoringContext {
    * usam fallback `SACRIFICE_BASE_EFFORT_DEFAULT (8)` → 0 adjustment.
    */
   sacrifice_cost_by_id?: Record<string, number>;
+
+  /**
+   * Mood corrente do sujeito [0..10] vindo do unified-assessor. Usado pelo
+   * expose gate: items vulneráveis desabilitados quando mood < threshold.
+   * Ausente → mood neutro (sem gate).
+   */
+  current_mood?: number;
+
+  /**
+   * Signals extraídos do turn corrente OU dos N turns recentes (caller decide).
+   * Expose gate dispara penalty quando contém `frame_rejection` ou
+   * `deflection_thematic` — sujeito recusou frame, vulnerabilidade não cabe.
+   */
+  recent_signals?: string[];
 }
 
 function daysBetween(laterIso: string, earlierIso: string): number {
@@ -344,6 +388,37 @@ export function scoreItem(
       .map(([k]) => k)
       .join(",");
     reasons.push(`multidim_bonus=+${multiBonus} (${matchedCount} dims: ${dimList})`);
+  }
+
+  // Expose gate: items que pedem vulnerabilidade sofrem penalty quando o
+  // sujeito está fechado. Aplicado APÓS multi-dim (não bloqueia, só baixa
+  // ranking) e ANTES de used_in_session (este último vence sempre).
+  // `sacrifice_type` só existe em curiosity_hook + cultural_diamond.
+  if ("sacrifice_type" in item && item.sacrifice_type === "expose") {
+    const trustLow =
+      typeof child.trust === "number" && child.trust < EXPOSE_GATE_TRUST_THRESHOLD;
+    const moodLow =
+      typeof context.current_mood === "number" &&
+      context.current_mood < EXPOSE_GATE_MOOD_THRESHOLD;
+    const signalBlock =
+      context.recent_signals?.some((s) =>
+        EXPOSE_GATE_BLOCKING_SIGNALS.includes(s),
+      ) ?? false;
+    if (trustLow || moodLow || signalBlock) {
+      score -= EXPOSE_GATE_PENALTY;
+      const triggers: string[] = [];
+      if (trustLow) triggers.push(`trust=${child.trust?.toFixed(2)}`);
+      if (moodLow) triggers.push(`mood=${context.current_mood}`);
+      if (signalBlock) {
+        const blocked = context.recent_signals?.filter((s) =>
+          EXPOSE_GATE_BLOCKING_SIGNALS.includes(s),
+        );
+        triggers.push(`signals=[${blocked?.join(",")}]`);
+      }
+      reasons.push(
+        `expose_gate_penalty=-${EXPOSE_GATE_PENALTY} (${triggers.join(", ")})`,
+      );
+    }
   }
 
   // motor#23: penalidade forte para items já usados nesta sessão.

--- a/shared/tests/scorer-expose-gate.test.ts
+++ b/shared/tests/scorer-expose-gate.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests do expose gate (motor fix tático monoculture).
+ *
+ * Contexto: smoke tracer-helix-3sessions-ryo mostrou bio_caterpillar_dissolve
+ * dominando 3 sessões consecutivas porque surprise=10 + sacrifice_type=expose
+ * batia em qualquer ranking, mesmo quando Ryo recusava o frame. Spec capturada
+ * em ops#1133 §3.6 (gate por contexto receptivo).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  scoreItem,
+  EXPOSE_GATE_PENALTY,
+  EXPOSE_GATE_TRUST_THRESHOLD,
+  EXPOSE_GATE_MOOD_THRESHOLD,
+  type ChildScoringProfile,
+  type ScoringContext,
+} from "../src/scorer.js";
+import type { CuriosityHookItem } from "../src/content-item.js";
+
+const NOW = "2026-05-26T12:00:00.000Z";
+
+const exposeItem = (id: string): CuriosityHookItem => ({
+  id,
+  type: "curiosity_hook",
+  domain: "biologia",
+  casel_target: ["SA"],
+  age_range: [10, 15],
+  surprise: 7,
+  verified: true,
+  base_score: 10,
+  fact: "x",
+  bridge: "y",
+  quest: "z",
+  sacrifice_type: "expose",
+});
+
+const reflectItem = (id: string): CuriosityHookItem => ({
+  ...exposeItem(id),
+  sacrifice_type: "reflect",
+});
+
+const child: ChildScoringProfile = { age: 12 };
+
+describe("expose gate", () => {
+  it("não penaliza expose quando contexto neutro (sem trust/mood/signals)", () => {
+    const item = exposeItem("test_expose");
+    const ctx: ScoringContext = { now: NOW };
+    const r = scoreItem(item, child, ctx);
+    expect(r.reasons.some((s) => s.startsWith("expose_gate_penalty"))).toBe(false);
+  });
+
+  it("penaliza expose quando trust < threshold", () => {
+    const item = exposeItem("test_expose");
+    const ctx: ScoringContext = { now: NOW };
+    const profileLow: ChildScoringProfile = {
+      ...child,
+      trust: EXPOSE_GATE_TRUST_THRESHOLD - 0.1,
+    };
+    const r = scoreItem(item, profileLow, ctx);
+    const reason = r.reasons.find((s) => s.startsWith("expose_gate_penalty"));
+    expect(reason).toBeDefined();
+    expect(reason).toContain("trust=");
+  });
+
+  it("NÃO penaliza expose quando trust >= threshold", () => {
+    const item = exposeItem("test_expose");
+    const ctx: ScoringContext = { now: NOW };
+    const profileOk: ChildScoringProfile = { ...child, trust: 0.8 };
+    const r = scoreItem(item, profileOk, ctx);
+    expect(r.reasons.some((s) => s.startsWith("expose_gate_penalty"))).toBe(false);
+  });
+
+  it("penaliza expose quando mood < threshold", () => {
+    const item = exposeItem("test_expose");
+    const ctx: ScoringContext = {
+      now: NOW,
+      current_mood: EXPOSE_GATE_MOOD_THRESHOLD - 1,
+    };
+    const r = scoreItem(item, child, ctx);
+    const reason = r.reasons.find((s) => s.startsWith("expose_gate_penalty"));
+    expect(reason).toBeDefined();
+    expect(reason).toContain("mood=");
+  });
+
+  it("penaliza expose quando recent_signals contém frame_rejection", () => {
+    const item = exposeItem("test_expose");
+    const ctx: ScoringContext = {
+      now: NOW,
+      recent_signals: ["frame_rejection"],
+    };
+    const r = scoreItem(item, child, ctx);
+    const reason = r.reasons.find((s) => s.startsWith("expose_gate_penalty"));
+    expect(reason).toBeDefined();
+    expect(reason).toContain("signals=[frame_rejection]");
+  });
+
+  it("penaliza expose quando recent_signals contém deflection_thematic", () => {
+    const item = exposeItem("test_expose");
+    const ctx: ScoringContext = {
+      now: NOW,
+      recent_signals: ["deflection_thematic"],
+    };
+    const r = scoreItem(item, child, ctx);
+    expect(r.reasons.some((s) => s.startsWith("expose_gate_penalty"))).toBe(true);
+  });
+
+  it("NÃO penaliza items com sacrifice_type !== 'expose'", () => {
+    const item = reflectItem("test_reflect");
+    const ctx: ScoringContext = {
+      now: NOW,
+      current_mood: 0,
+      recent_signals: ["frame_rejection"],
+    };
+    const profileLow: ChildScoringProfile = { ...child, trust: 0 };
+    const r = scoreItem(item, profileLow, ctx);
+    expect(r.reasons.some((s) => s.startsWith("expose_gate_penalty"))).toBe(false);
+  });
+
+  it("derruba expose abaixo de reflect quando todos triggers ativos", () => {
+    const ctx: ScoringContext = {
+      now: NOW,
+      current_mood: 4,
+      recent_signals: ["frame_rejection"],
+    };
+    const profileLow: ChildScoringProfile = { ...child, trust: 0.3 };
+    const exposeScored = scoreItem(exposeItem("a"), profileLow, ctx);
+    const reflectScored = scoreItem(reflectItem("b"), profileLow, ctx);
+    expect(exposeScored.score).toBeLessThan(reflectScored.score);
+    expect(reflectScored.score - exposeScored.score).toBeGreaterThanOrEqual(
+      EXPOSE_GATE_PENALTY,
+    );
+  });
+
+  it("penalty é aplicado uma vez mesmo com múltiplos triggers", () => {
+    const item = exposeItem("test_expose");
+    const ctx: ScoringContext = {
+      now: NOW,
+      current_mood: 2,
+      recent_signals: ["frame_rejection", "deflection_thematic"],
+    };
+    const profileLow: ChildScoringProfile = { ...child, trust: 0.1 };
+    const r = scoreItem(item, profileLow, ctx);
+    const penaltyReasons = r.reasons.filter((s) =>
+      s.startsWith("expose_gate_penalty"),
+    );
+    expect(penaltyReasons).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Sintoma

Smoke `tracer-helix-3sessions-ryo` (3 sessões Ryo, cross-session) mostrou `bio_caterpillar_dissolve` dominando turn após turn. Ryo recusou explicitamente na **S3T4**:

> "por que você quer tanto ficar falando de lágrima? é estranho"

**Causa raiz:** `surprise=10` + `sacrifice_type=expose` batia ranking em qualquer contexto, mesmo quando trust baixa / signals de recusa.

## Fix tático (sem schema change, backward 100%)

### 1. Surprise downgrade 10→7 nos 3 items expose+surprise=10

- `bio_caterpillar_dissolve`
- `bio_dolphin_names`
- `myth_kintsugi_philosophy`

Surprise=10 estava roubando +6 boost sobre items neutros — incompatível com a relação per-tripla (item × sujeito × contexto) que a spec ops#1133 propõe.

### 2. Expose gate no scorer

Items `sacrifice_type=expose` levam `-8` penalty quando contexto não-receptivo:

- `child.trust < 0.5` (acumulada cross-session)
- `context.current_mood < 6`
- `context.recent_signals` contém `frame_rejection` ou `deflection_thematic`

**Tipos opcionais novos** (ausentes → gate inativo, backward compat):
- `ChildScoringProfile.trust?: number`
- `ScoringContext.current_mood?: number`
- `ScoringContext.recent_signals?: string[]`

Constantes exportadas pra audit/tunning: `EXPOSE_GATE_PENALTY`, `EXPOSE_GATE_TRUST_THRESHOLD`, `EXPOSE_GATE_MOOD_THRESHOLD`, `EXPOSE_GATE_BLOCKING_SIGNALS`.

## Por que tático?

Estrutura completa (multi-dim por objetivo, per-tripla scoring, depth resources, polaridade tríplice estática/relativa) está em **spec ops#1133** (aguarda ratificação). Este é o quick win do sintoma observado, sem esperar refactor maior.

## Test plan

- [x] 9 novos casos em `scorer-expose-gate.test.ts`
  - cada trigger isolado (trust / mood / signals)
  - sacrifice_type≠expose imune
  - expose perde ranking pra reflect quando todos triggers ativos
  - penalty aplicado uma vez mesmo com múltiplos triggers
- [x] 829 + 9 = 838 testes shared verdes
- [x] motor-drota + planejador builds verdes, 337 tests verdes (sem regressão)
- [ ] Re-rodar smoke `tracer-helix-3sessions-ryo` pós-merge — esperado: lagarta NÃO domina mais 3 sessões consecutivas

🤖 Generated with [Claude Code](https://claude.com/claude-code)