### PR TITLE
[feat ops#1133] Sub-fase 5.1 — taught_axes + axis_attempt_outcome (schemas)

### DIFF
--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -82,7 +82,8 @@ CREATE TABLE IF NOT EXISTS subject_knowledge (
   type          TEXT NOT NULL CHECK(type IN (
     'interest', 'value', 'need', 'discovery',
     'boundary_event', 'presented_concept',
-    'recall_check_attempt', 'vertical_affinity_signal'
+    'recall_check_attempt', 'vertical_affinity_signal',
+    'axis_attempt_outcome'
   )),
   source        TEXT NOT NULL CHECK(source IN (
     'self_declared', 'parent_claimed', 'motor_inferred'

--- a/shared/src/content-item.ts
+++ b/shared/src/content-item.ts
@@ -167,6 +167,33 @@ export interface ContentItemBase {
   lineage_anchor?: string;
   /** Palavras-chave do conceito pra futura detecção de recall. */
   extracted_keywords?: string[];
+
+  /**
+   * Scorer Objective-Driven sub-fase 5.1 — polaridade pedagógica tríplice.
+   * Spec: 2026-05-26-scorer-objective-driven.md §3.1.
+   *
+   * Item pode ser exemplo POSITIVO de uma virtude (lagarta = +autoconhecimento)
+   * E anti-exemplo de outra (dilema "quem pisou no outro" = -justiça). Anti-
+   * exemplos são pedagogicamente valiosos — discernir o errado treina julgamento
+   * (estoico `praemeditatio malorum`; tragédia aristotélica).
+   *
+   * Campos OPCIONAIS — items legados sem tags funcionam via fallback
+   * `taught_axes ?? [axis_id]`. Sub-fase 5.7 (curadoria) backfilla 30-40 items
+   * principais com tags revisadas manualmente.
+   *
+   * `taught_axes` (sem sufixo) é union helper — quando ausente, consumers
+   * devem computar via `computeTaughtAxes(item)`.
+   */
+  taught_axes_positive?: number[];
+  taught_axes_negative?: number[];
+  taught_axes?: number[];
+
+  /**
+   * Lineage anchors plausíveis — múltiplos quando item ressoa em várias
+   * tradições. Strategist usa pra match com `currentObjectives.lineages`.
+   * Backward compat: se ausente, fallback `[lineage_anchor]` (sub-fase 5.2).
+   */
+  taught_lineages?: string[];
 }
 
 export interface CuriosityHookItem extends ContentItemBase {
@@ -302,4 +329,45 @@ export function isContentItem(value: unknown): value is ContentItem {
     if (!SACRIFICE_TYPES.includes(v.sacrifice_type as SacrificeType)) return false;
   }
   return true;
+}
+
+/**
+ * Scorer Objective-Driven sub-fase 5.1 — union de eixos ensinados.
+ *
+ * Resolução por precedência:
+ *   1. `taught_axes` explícito (curado manualmente) — usa direto
+ *   2. union de `taught_axes_positive ∪ taught_axes_negative`
+ *   3. fallback `[axis_id]` (backward compat com schema pré-sub-fase-5.1)
+ *   4. `[]` quando nenhum dos campos populado
+ *
+ * Garante invariante usado por `coberturaObjetivos` (sub-fase 5.3):
+ *   "todo item tem zero ou mais eixos ensinados; vazio = inelegível pra match".
+ */
+export function computeTaughtAxes(item: ContentItemBase): number[] {
+  if (item.taught_axes && item.taught_axes.length > 0) {
+    return item.taught_axes;
+  }
+  const positive = item.taught_axes_positive ?? [];
+  const negative = item.taught_axes_negative ?? [];
+  if (positive.length > 0 || negative.length > 0) {
+    return Array.from(new Set([...positive, ...negative]));
+  }
+  if (typeof item.axis_id === "number") {
+    return [item.axis_id];
+  }
+  return [];
+}
+
+/**
+ * Mesma resolução pra lineages — `taught_lineages` explícito ou
+ * fallback `[lineage_anchor]`. Vazio quando nenhum.
+ */
+export function computeTaughtLineages(item: ContentItemBase): string[] {
+  if (item.taught_lineages && item.taught_lineages.length > 0) {
+    return item.taught_lineages;
+  }
+  if (item.lineage_anchor) {
+    return [item.lineage_anchor];
+  }
+  return [];
 }

--- a/shared/src/subject-knowledge.ts
+++ b/shared/src/subject-knowledge.ts
@@ -27,7 +27,8 @@ export type SubjectKnowledgeType =
   | "boundary_event"
   | "presented_concept"
   | "recall_check_attempt"
-  | "vertical_affinity_signal";
+  | "vertical_affinity_signal"
+  | "axis_attempt_outcome";
 
 export type SubjectKnowledgeSource =
   | "self_declared"
@@ -64,7 +65,8 @@ export type SubjectKnowledgePayload =
   | BoundaryEventPayload
   | PresentedConceptPayload
   | RecallCheckAttemptPayload
-  | VerticalAffinitySignalPayload;
+  | VerticalAffinitySignalPayload
+  | AxisAttemptOutcomePayload;
 
 export interface InterestPayload {
   kind: "interest";
@@ -134,6 +136,28 @@ export interface VerticalAffinitySignalPayload {
   vertical_kind: "axis" | "lineage";
   vertical_id: string;
   score_affinity: number;
+}
+
+/**
+ * Scorer Objective-Driven sub-fase 5.1 — outcome de tentativa por (item, axis).
+ *
+ * Spec ops#1133 §3.2. DiscoveryWriter (sub-fase 5.5) detecta engagement do
+ * turn N+1 sobre item apresentado no turn N e grava este payload. Scorer
+ * (sub-fase 5.6) consulta histórico pra computar `surpriseEfetivo` — surprise
+ * estática decresce por (item, sujeito) quando engagement falhou.
+ *
+ * `signal_basis`: lista signals que levaram à classificação (e.g.,
+ * `["frame_rejection","mood_drift_down"]` → deflected; `["positive_mood"]` →
+ * engaged). `penalty_applied`: pontos a descontar do surprise quando o item
+ * voltar a ser scored (cumulativo cross-session).
+ */
+export interface AxisAttemptOutcomePayload {
+  kind: "axis_attempt_outcome";
+  item_id: string;
+  axis_id: number;
+  outcome: "engaged" | "deflected" | "neutral";
+  signal_basis: string[];
+  penalty_applied: number;
 }
 
 /**

--- a/shared/tests/taught-axes.test.ts
+++ b/shared/tests/taught-axes.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests sub-fase 5.1 Scorer Objective-Driven — schema additions.
+ *
+ * Spec ops#1133 §3.1 (polaridade tríplice) + §3.2 (axis_attempt_outcome).
+ * Foundation only — sem mudança de comportamento. Valida precedência de
+ * resolução de `computeTaughtAxes` + tipos do enum + payload AxisAttemptOutcome.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeTaughtAxes,
+  computeTaughtLineages,
+  type ContentItemBase,
+} from "../src/content-item.js";
+import type {
+  AxisAttemptOutcomePayload,
+  SubjectKnowledgeEntry,
+} from "../src/subject-knowledge.js";
+
+const baseItem: ContentItemBase = {
+  id: "test_item",
+  domain: "biologia",
+  casel_target: ["SA"],
+  age_range: [10, 15],
+  surprise: 7,
+  verified: true,
+  base_score: 5,
+};
+
+describe("computeTaughtAxes — sub-fase 5.1 precedência", () => {
+  it("usa taught_axes explícito quando presente", () => {
+    const item: ContentItemBase = {
+      ...baseItem,
+      taught_axes: [4, 11, 12],
+      taught_axes_positive: [4],
+      axis_id: 99,
+    };
+    expect(computeTaughtAxes(item)).toEqual([4, 11, 12]);
+  });
+
+  it("computa union de positive + negative quando taught_axes ausente", () => {
+    const item: ContentItemBase = {
+      ...baseItem,
+      taught_axes_positive: [4, 11],
+      taught_axes_negative: [11, 12],
+      axis_id: 99,
+    };
+    const result = computeTaughtAxes(item);
+    expect(result.slice().sort((a, b) => a - b)).toEqual([4, 11, 12]);
+  });
+
+  it("fallback pra [axis_id] quando nenhum taught_* populado", () => {
+    const item: ContentItemBase = { ...baseItem, axis_id: 7 };
+    expect(computeTaughtAxes(item)).toEqual([7]);
+  });
+
+  it("retorna [] quando nada populado (item legado sem axis_id)", () => {
+    const item: ContentItemBase = { ...baseItem };
+    expect(computeTaughtAxes(item)).toEqual([]);
+  });
+
+  it("dedup quando taught_axes_positive e negative têm overlap", () => {
+    const item: ContentItemBase = {
+      ...baseItem,
+      taught_axes_positive: [4, 4, 11],
+      taught_axes_negative: [11, 12, 12],
+    };
+    const result = computeTaughtAxes(item);
+    expect(result.slice().sort((a, b) => a - b)).toEqual([4, 11, 12]);
+  });
+
+  it("array vazio de taught_axes não bloqueia fallback", () => {
+    const item: ContentItemBase = {
+      ...baseItem,
+      taught_axes: [],
+      taught_axes_positive: [5],
+    };
+    expect(computeTaughtAxes(item)).toEqual([5]);
+  });
+});
+
+describe("computeTaughtLineages — sub-fase 5.1", () => {
+  it("usa taught_lineages explícito", () => {
+    const item: ContentItemBase = {
+      ...baseItem,
+      taught_lineages: ["estoica/dicotomia", "zen/shoshin"],
+      lineage_anchor: "outra/legacy",
+    };
+    expect(computeTaughtLineages(item)).toEqual([
+      "estoica/dicotomia",
+      "zen/shoshin",
+    ]);
+  });
+
+  it("fallback pra [lineage_anchor]", () => {
+    const item: ContentItemBase = {
+      ...baseItem,
+      lineage_anchor: "estoica/dicotomia_controle",
+    };
+    expect(computeTaughtLineages(item)).toEqual(["estoica/dicotomia_controle"]);
+  });
+
+  it("vazio quando nada", () => {
+    const item: ContentItemBase = { ...baseItem };
+    expect(computeTaughtLineages(item)).toEqual([]);
+  });
+});
+
+describe("AxisAttemptOutcomePayload — sub-fase 5.1 schema", () => {
+  it("aceita outcome engaged/deflected/neutral", () => {
+    const engaged: AxisAttemptOutcomePayload = {
+      kind: "axis_attempt_outcome",
+      item_id: "bio_caterpillar_dissolve",
+      axis_id: 11,
+      outcome: "engaged",
+      signal_basis: ["positive_engagement"],
+      penalty_applied: 0,
+    };
+    const deflected: AxisAttemptOutcomePayload = {
+      kind: "axis_attempt_outcome",
+      item_id: "bio_caterpillar_dissolve",
+      axis_id: 11,
+      outcome: "deflected",
+      signal_basis: ["frame_rejection", "deflection_thematic"],
+      penalty_applied: 3,
+    };
+    const neutral: AxisAttemptOutcomePayload = {
+      kind: "axis_attempt_outcome",
+      item_id: "bio_dolphin_names",
+      axis_id: 11,
+      outcome: "neutral",
+      signal_basis: [],
+      penalty_applied: 1,
+    };
+    expect(engaged.outcome).toBe("engaged");
+    expect(deflected.outcome).toBe("deflected");
+    expect(neutral.outcome).toBe("neutral");
+  });
+
+  it("aceita type=axis_attempt_outcome no SubjectKnowledgeEntry", () => {
+    const entry: SubjectKnowledgeEntry = {
+      id: "skn-1",
+      subject_id: "ryo-ochiai",
+      type: "axis_attempt_outcome",
+      source: "motor_inferred",
+      confidence: 0.9,
+      confirmed_at: null,
+      alignment: "unknown",
+      payload: {
+        kind: "axis_attempt_outcome",
+        item_id: "bio_caterpillar_dissolve",
+        axis_id: 11,
+        outcome: "deflected",
+        signal_basis: ["frame_rejection"],
+        penalty_applied: 3,
+      },
+      turn_ref: "S1-T4",
+      session_id: "session-1",
+      created_at: "2026-05-26T08:00:00Z",
+    };
+    expect(entry.type).toBe("axis_attempt_outcome");
+    expect((entry.payload as AxisAttemptOutcomePayload).outcome).toBe(
+      "deflected",
+    );
+  });
+});


### PR DESCRIPTION
Foundation pra **Scorer Objective-Driven** (spec [ops#1133](https://github.com/ascendimacy/ascendimacy-ops/pull/1133) §3.1 + §3.2). Schemas + helpers + tests apenas — SEM mudança de comportamento. Backward 100%.

## Spec §3.1 — Polaridade pedagógica tríplice (ContentItemBase)

4 campos OPCIONAIS novos:
- \`taught_axes_positive?: number[]\` — axes onde item é exemplo POSITIVO
- \`taught_axes_negative?: number[]\` — axes onde item é ANTI-EXEMPLO  
- \`taught_axes?: number[]\` — union helper
- \`taught_lineages?: string[]\` — multi-lineage anchors

Princípio user 2026-05-26: item pode ser positivo de uma virtude E negativo de outra. Anti-exemplos são pedagogicamente valiosos (estoico *praemeditatio malorum*; tragédia aristotélica).

Helpers \`computeTaughtAxes(item)\` + \`computeTaughtLineages(item)\` com precedência: explícito → union positive+negative → fallback \`[axis_id]\` → \`[]\`. Garante invariante usado por \`coberturaObjetivos\` (sub-fase 5.3).

## Spec §3.2 — SubjectKnowledgeType: axis_attempt_outcome

Novo enum + \`AxisAttemptOutcomePayload\`:
- \`item_id\`, \`axis_id\`, \`outcome\` (engaged|deflected|neutral)
- \`signal_basis[]\` — quais signals levaram à classificação
- \`penalty_applied\` — pontos a descontar do surprise efetivo

CHECK constraint do \`subject_knowledge.type\` ampliado.

## Migration estratégia

SQLite \`CREATE TABLE IF NOT EXISTS\` não recria CHECK em DBs existentes. Como nenhum writer ainda emite \`axis_attempt_outcome\` (sub-fase 5.5 não landou), DBs antigos seguem funcionando. Migration formal entra como pre-step do PR 5.5 (rebuild via sqlite_master idiom).

## Test plan

- [x] 11 novos casos em \`taught-axes.test.ts\` — precedência dos 4 níveis, dedup, payload variants
- [x] 839 shared + 150 BFF + 337 motor/planejador tests verdes
- [x] Build shared + BFF limpos

## Próximas sub-fases (não nesta PR)

- **5.2**: \`evaluateMultiDimMatches\` usa \`computeTaughtAxes\` (cobertura múltipla)
- **5.3**: \`coberturaObjetivos\` + \`riquezaPedagogica\` + currentObjectives
- **5.4**: Planejador hidrata currentObjectives via Strategist
- **5.5+5.6**: Writer + scorer consomem \`axis_attempt_outcome\` (feedback loop)
- **5.7**: Backfill 30-40 items com taught_axes revisados (curadoria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)