### PR TITLE
[feat ops#1126] Replay engine x-ray + smoke tests Mini-UI panels

### DIFF
--- a/packages/ebrota-console-ui/src/components/Replay.svelte
+++ b/packages/ebrota-console-ui/src/components/Replay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { replaySessionId, globalError } from "../lib/stores.js";
   import type { ApiClient, ReplayTrace } from "../lib/api.js";
+  import ReplayTurnDetail from "./ReplayTurnDetail.svelte";
 
   export let api: ApiClient;
 
@@ -113,6 +114,7 @@
                     <p>{turn.finalResponse}</p>
                   </div>
                 {/if}
+                <ReplayTurnDetail {turn} />
               </li>
             {/each}
           </ol>

--- a/packages/ebrota-console-ui/src/components/ReplayTurnDetail.svelte
+++ b/packages/ebrota-console-ui/src/components/ReplayTurnDetail.svelte
@@ -1,0 +1,372 @@
+<script lang="ts">
+  /**
+   * ReplayTurnDetail — engine x-ray expansível por turn no Replay.
+   *
+   * Surfaces o que já existe em trace.json (motorTrace.{plan, drota, exec}
+   * + subjectKnowledgeEvents + flags do turn). Não busca dados extras do
+   * BFF — render puro do trace.
+   *
+   * Out of scope (v1): LLM calls raw (entries vazias nos STS traces), Journey
+   * snapshots por turn (não capturados — necessitaria estender writers).
+   */
+  import type { ReplayTraceTurn, ReplayScoredItemLike } from "../lib/api.js";
+
+  export let turn: ReplayTraceTurn;
+
+  let expanded = false;
+
+  $: motor = turn.motorTrace ?? {};
+  $: plan = motor.plan ?? {};
+  $: drota = motor.drota ?? {};
+  $: exec = motor.exec ?? {};
+  $: pool = (plan.contentPool ?? []) as ReplayScoredItemLike[];
+  $: selected = drota.selectedContent ?? null;
+  $: selectedId =
+    selected?.item && typeof selected.item.id === "string"
+      ? selected.item.id
+      : null;
+  // Subject Knowledge events: turn-level OR drota nested (legacy)
+  $: skEvents = (turn.subjectKnowledgeEvents ??
+    drota.subjectKnowledgeEvents ??
+    []) as Array<Record<string, unknown>>;
+  $: hasEngineData =
+    pool.length > 0 ||
+    selected !== null ||
+    skEvents.length > 0 ||
+    plan.strategicRationale !== undefined ||
+    plan.instruction_addition !== undefined ||
+    exec.eventLogged !== undefined;
+
+  function fmtScore(s: number | undefined): string {
+    if (typeof s !== "number") return "?";
+    return s.toFixed(2);
+  }
+
+  function fmtMs(ms: number | undefined): string {
+    if (typeof ms !== "number") return "?";
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+
+  function eventBadge(type: string): string {
+    if (type === "interest") return "#1976d2";
+    if (type === "value") return "#388e3c";
+    if (type === "need") return "#f57c00";
+    if (type === "discovery") return "#7b1fa2";
+    if (type === "boundary_event") return "#b00020";
+    if (type === "presented_concept") return "#00897b";
+    if (type === "recall_check_attempt") return "#ef6c00";
+    if (type === "axis_attempt_outcome") return "#5d4037";
+    return "#666";
+  }
+
+  function eventLabel(e: Record<string, unknown>): string {
+    const payload = (e["payload"] ?? {}) as Record<string, unknown>;
+    if (typeof payload["label"] === "string") return payload["label"];
+    if (typeof payload["concept_id"] === "string") return payload["concept_id"];
+    if (typeof payload["item_id"] === "string") return String(payload["item_id"]);
+    if (typeof payload["topic_category"] === "string")
+      return `topic=${payload["topic_category"]}`;
+    return JSON.stringify(payload).slice(0, 80);
+  }
+</script>
+
+{#if hasEngineData || turn.trustLevel !== undefined}
+  <div class="engine-detail" data-testid="engine-detail">
+    <button
+      type="button"
+      class="toggle"
+      on:click={() => (expanded = !expanded)}
+      aria-expanded={expanded}
+      data-testid="engine-toggle"
+    >
+      <span class="caret">{expanded ? "▼" : "▶"}</span>
+      Engine x-ray
+      <span class="badges">
+        {#if turn.trustLevel !== undefined}
+          <span class="badge">trust={turn.trustLevel.toFixed(2)}</span>
+        {/if}
+        {#if turn.budgetRemaining !== undefined}
+          <span class="badge">budget={turn.budgetRemaining}</span>
+        {/if}
+        {#if turn.playbookId}
+          <span class="badge mono">{turn.playbookId}</span>
+        {/if}
+        {#if turn.durationMs !== undefined}
+          <span class="badge">{fmtMs(turn.durationMs)}</span>
+        {/if}
+        {#if skEvents.length > 0}
+          <span class="badge sk">{skEvents.length} sk</span>
+        {/if}
+        {#if pool.length > 0}
+          <span class="badge pool">{pool.length} pool</span>
+        {/if}
+      </span>
+    </button>
+
+    {#if expanded}
+      <div class="sections">
+        {#if plan.strategicRationale || plan.instruction_addition || plan.candidateSetEntropy !== undefined}
+          <section class="plan">
+            <h4>🧠 Plan</h4>
+            {#if plan.strategicRationale}
+              <p><strong>rationale:</strong> {plan.strategicRationale}</p>
+            {/if}
+            {#if plan.instruction_addition}
+              <p><strong>instruction:</strong> {plan.instruction_addition}</p>
+            {/if}
+            {#if plan.candidateSetEntropy !== undefined}
+              <p>
+                <strong>entropy:</strong>
+                <code>{plan.candidateSetEntropy.toFixed(3)}</code>
+              </p>
+            {/if}
+            {#if plan.contextHints}
+              <details class="raw">
+                <summary>contextHints (JSON)</summary>
+                <pre>{JSON.stringify(plan.contextHints, null, 2)}</pre>
+              </details>
+            {/if}
+          </section>
+        {/if}
+
+        {#if pool.length > 0}
+          <section class="pool" data-testid="pool-section">
+            <h4>🎯 Pool top-{Math.min(pool.length, 5)} (selected ↗)</h4>
+            <ol>
+              {#each pool.slice(0, 5) as scored}
+                {@const id =
+                  typeof scored.item?.["id"] === "string"
+                    ? scored.item["id"]
+                    : "?"}
+                <li class:selected={id === selectedId}>
+                  <span class="iid">{id}</span>
+                  <span class="score">score={fmtScore(scored.score)}</span>
+                  {#if id === selectedId}<span class="picked">↗ SELECTED</span>{/if}
+                  {#if scored.reasons && scored.reasons.length > 0}
+                    <details class="reasons">
+                      <summary>reasons ({scored.reasons.length})</summary>
+                      <ul>
+                        {#each scored.reasons as r}
+                          <li><code>{r}</code></li>
+                        {/each}
+                      </ul>
+                    </details>
+                  {/if}
+                </li>
+              {/each}
+            </ol>
+            {#if drota.selectionRationale}
+              <p class="sel-rationale">
+                <strong>selectionRationale:</strong> {drota.selectionRationale}
+              </p>
+            {/if}
+          </section>
+        {/if}
+
+        {#if skEvents.length > 0}
+          <section class="sk" data-testid="sk-section">
+            <h4>🔍 Subject Knowledge writes ({skEvents.length})</h4>
+            <ul>
+              {#each skEvents as e}
+                {@const type =
+                  typeof e["type"] === "string" ? e["type"] : "unknown"}
+                <li>
+                  <span
+                    class="badge"
+                    style="background: {eventBadge(type)}; color: white">{type}</span
+                  >
+                  <span class="ev-label">{eventLabel(e)}</span>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/if}
+
+        {#if exec.eventLogged || exec.newState}
+          <section class="exec">
+            <h4>⚙️ Exec</h4>
+            {#if exec.eventLogged}
+              <details class="raw">
+                <summary>eventLogged</summary>
+                <pre>{JSON.stringify(exec.eventLogged, null, 2)}</pre>
+              </details>
+            {/if}
+            {#if exec.newState}
+              <details class="raw">
+                <summary>newState</summary>
+                <pre>{JSON.stringify(exec.newState, null, 2)}</pre>
+              </details>
+            {/if}
+          </section>
+        {/if}
+
+        {#if turn.cardEmissionSkipReason}
+          <p class="card-skip">
+            <strong>card emission skipped:</strong> {turn.cardEmissionSkipReason}
+          </p>
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .engine-detail {
+    margin-top: 0.4rem;
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-radius: 4px;
+    background: rgba(127, 127, 127, 0.04);
+    font-size: 0.8rem;
+  }
+  .toggle {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.4rem 0.6rem;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .toggle:hover {
+    background: rgba(127, 127, 127, 0.1);
+  }
+  .caret {
+    opacity: 0.6;
+    width: 0.8rem;
+  }
+  .badges {
+    display: inline-flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+    margin-left: auto;
+  }
+  .badge {
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    background: rgba(127, 127, 127, 0.15);
+    font-size: 0.7rem;
+  }
+  .badge.mono {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  }
+  .badge.sk { background: rgba(123, 31, 162, 0.2); }
+  .badge.pool { background: rgba(25, 118, 210, 0.2); }
+  .sections {
+    padding: 0.5rem 0.7rem;
+    border-top: 1px solid rgba(127, 127, 127, 0.2);
+  }
+  .sections section {
+    margin-bottom: 0.7rem;
+  }
+  .sections h4 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.8rem;
+  }
+  .sections p {
+    margin: 0.15rem 0;
+    line-height: 1.4;
+  }
+  .pool ol {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .pool li {
+    padding: 0.2rem 0;
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.4rem;
+    align-items: baseline;
+  }
+  .pool li.selected {
+    background: rgba(76, 175, 80, 0.12);
+    border-left: 2px solid #388e3c;
+    padding-left: 0.3rem;
+  }
+  .iid {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    word-break: break-all;
+  }
+  .score {
+    font-size: 0.75rem;
+    opacity: 0.75;
+  }
+  .picked {
+    color: #388e3c;
+    font-weight: 600;
+    font-size: 0.7rem;
+  }
+  .reasons {
+    grid-column: 1 / -1;
+    margin-left: 0.8rem;
+  }
+  .reasons summary {
+    cursor: pointer;
+    font-size: 0.7rem;
+    opacity: 0.7;
+  }
+  .reasons ul {
+    list-style: none;
+    padding: 0.2rem 0 0.2rem 1rem;
+    margin: 0;
+  }
+  .reasons code {
+    font-size: 0.7rem;
+  }
+  .sel-rationale {
+    margin-top: 0.4rem;
+    font-style: italic;
+    opacity: 0.85;
+  }
+  .sk ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .sk li {
+    padding: 0.15rem 0;
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+  }
+  .sk .badge {
+    padding: 0.05rem 0.4rem;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+  .ev-label {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    word-break: break-all;
+  }
+  .raw {
+    margin-top: 0.3rem;
+  }
+  .raw summary {
+    cursor: pointer;
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+  .raw pre {
+    background: rgba(127, 127, 127, 0.08);
+    padding: 0.4rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    overflow-x: auto;
+    margin: 0.2rem 0 0 0;
+    max-height: 200px;
+  }
+  .card-skip {
+    color: #b00020;
+    font-size: 0.75rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -106,6 +106,33 @@ export interface SessionLibraryEntry {
   tracePath: string | null;
 }
 
+export interface ReplayScoredItemLike {
+  item?: { id?: string; type?: string; domain?: string; axis_id?: number } & Record<string, unknown>;
+  score?: number;
+  reasons?: string[];
+}
+
+export interface ReplayMotorTraceLike {
+  plan?: {
+    contextHints?: unknown;
+    instruction_addition?: string;
+    strategicRationale?: string;
+    candidateSetEntropy?: number;
+    contentPool?: ReplayScoredItemLike[];
+  };
+  drota?: {
+    selectedContent?: ReplayScoredItemLike;
+    selectionRationale?: string;
+    linguisticMaterialization?: string;
+    subjectKnowledgeEvents?: unknown[];
+  };
+  exec?: {
+    eventLogged?: unknown;
+    newState?: unknown;
+    success?: boolean;
+  };
+}
+
 export interface ReplayTraceTurn {
   turnNumber?: number;
   sessionId?: string;
@@ -113,6 +140,26 @@ export interface ReplayTraceTurn {
   finalResponse?: string;
   timestamp?: string;
   entries?: Array<Record<string, unknown>>;
+
+  // ─── engine x-ray (S-OC-22 follow-up) — read straight from raw trace ────
+  /** Trust level pós-turn (0..1). */
+  trustLevel?: number;
+  /** Budget restante pra sessão (qualquer escala). */
+  budgetRemaining?: number;
+  playbookId?: string;
+  durationMs?: number;
+  /** Razão de skip de card emission, quando aplicável. */
+  cardEmissionSkipReason?: string;
+
+  /** Trace estruturado do motor pipeline (plan / drota / exec). */
+  motorTrace?: ReplayMotorTraceLike;
+
+  /**
+   * Subject Knowledge events emitidos por writers neste turn. Pode estar
+   * no nível do turn (preferido) OU em motorTrace.drota.subjectKnowledgeEvents
+   * (legacy STS schema).
+   */
+  subjectKnowledgeEvents?: unknown[];
 }
 
 export interface ReplayTrace {

--- a/packages/ebrota-console-ui/tests/components/DiscoveriesPanel.test.ts
+++ b/packages/ebrota-console-ui/tests/components/DiscoveriesPanel.test.ts
@@ -1,0 +1,116 @@
+/**
+ * DiscoveriesPanel smoke tests — verifica consumo de /subjects/:id/discoveries
+ * + /boundaries-summary.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import DiscoveriesPanel from "../../src/components/DiscoveriesPanel.svelte";
+import { discoveriesPanelOpen, tracerSubjectId } from "../../src/lib/stores.js";
+import type {
+  ApiClient,
+  SubjectKnowledgeEntryLike,
+  BoundarySummary,
+} from "../../src/lib/api.js";
+
+const buildApi = (
+  discoveries: SubjectKnowledgeEntryLike[] | Error,
+  summary: BoundarySummary[] = [],
+): ApiClient =>
+  ({
+    listSubjectDiscoveries: vi.fn(async () => {
+      if (discoveries instanceof Error) throw discoveries;
+      return { discoveries };
+    }),
+    getBoundariesSummary: vi.fn(async () => ({ summary })),
+  }) as never;
+
+beforeEach(() => {
+  discoveriesPanelOpen.set(false);
+  tracerSubjectId.set("test-subject");
+});
+
+const entry = (
+  type: string,
+  label: string,
+  confidence = 0.8,
+): SubjectKnowledgeEntryLike => ({
+  id: `${type}-${label}`,
+  type,
+  source: "motor_inferred",
+  confidence,
+  payload: { label },
+  turn_ref: "t1",
+  session_id: "s1",
+  created_at: "2026-05-26T10:00:00Z",
+});
+
+describe("DiscoveriesPanel", () => {
+  it("não renderiza quando fechado", () => {
+    render(DiscoveriesPanel, { api: buildApi([]) });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("mostra empty state quando 0 descobertas", async () => {
+    render(DiscoveriesPanel, { api: buildApi([]) });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Nenhuma descoberta pra este sujeito ainda/),
+      ).toBeDefined();
+    });
+  });
+
+  it("renderiza timeline de descobertas com badges por type", async () => {
+    render(DiscoveriesPanel, {
+      api: buildApi([
+        entry("interest", "tênis", 0.9),
+        entry("value", "persistência", 0.7),
+        entry("boundary_event", "corpo", 0.85),
+      ]),
+    });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText("tênis")).toBeDefined();
+    });
+    expect(screen.getByText("persistência")).toBeDefined();
+    // "interest"/"value" aparecem como option do select filter + badge na lista
+    expect(screen.getAllByText("interest").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("value").length).toBeGreaterThan(0);
+    expect(screen.getByText(/conf=0\.90/)).toBeDefined();
+  });
+
+  it("renderiza boundaries summary agregado", async () => {
+    render(DiscoveriesPanel, {
+      api: buildApi(
+        [entry("interest", "tênis")],
+        [
+          {
+            topic_category: "corpo",
+            count: 5,
+            high_intensity_count: 2,
+            last_seen_at: "2026-05-26T10:00:00Z",
+          },
+        ],
+      ),
+    });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/Boundaries/)).toBeDefined();
+    });
+    expect(screen.getByText("corpo")).toBeDefined();
+    expect(screen.getByText(/5×/)).toBeDefined();
+    expect(screen.getByText(/high 2/)).toBeDefined();
+  });
+
+  it("mostra erro quando API falha", async () => {
+    render(DiscoveriesPanel, {
+      api: buildApi(new Error("DB locked")),
+    });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/DB locked/)).toBeDefined();
+    });
+  });
+});

--- a/packages/ebrota-console-ui/tests/components/JourneyPanel.test.ts
+++ b/packages/ebrota-console-ui/tests/components/JourneyPanel.test.ts
@@ -1,0 +1,88 @@
+/**
+ * JourneyPanel smoke tests — verifica que UI consome /subjects/:id/journey-state
+ * corretamente em cenários vazio, populado e com override parental.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import JourneyPanel from "../../src/components/JourneyPanel.svelte";
+import { journeyPanelOpen, tracerSubjectId } from "../../src/lib/stores.js";
+import type { ApiClient, JourneyStateLike } from "../../src/lib/api.js";
+
+const buildApi = (state: JourneyStateLike | Error): ApiClient =>
+  ({
+    getJourneyState: vi.fn(async () => {
+      if (state instanceof Error) throw state;
+      return { state };
+    }),
+    setJourneyOverride: vi.fn(async (_id, stage, reason) => ({
+      state: {
+        ...(state as JourneyStateLike),
+        stage: stage as JourneyStateLike["stage"],
+        override_by_parent: { forced_stage: stage, reason, timestamp: "now" },
+      },
+    })),
+    clearJourneyOverride: vi.fn(async () => ({ state: state as JourneyStateLike })),
+  }) as never;
+
+beforeEach(() => {
+  journeyPanelOpen.set(false);
+  tracerSubjectId.set("test-subject");
+});
+
+describe("JourneyPanel", () => {
+  it("não renderiza modal quando fechado", () => {
+    render(JourneyPanel, { api: buildApi(makeState("discovery_only")) });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("mostra stage atual quando populado", async () => {
+    render(JourneyPanel, {
+      api: buildApi(makeState("applied_double_helix", 18, ["carater", "disposicao"])),
+    });
+    journeyPanelOpen.set(true);
+    await waitFor(() => {
+      // applied_double_helix aparece no select option + no badge → vários matches
+      expect(screen.getAllByText("applied_double_helix").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText(/18/)).toBeDefined();
+  });
+
+  it("mostra override parental quando presente", async () => {
+    const state = makeState("mapping_ready", 5, ["carater"]);
+    state.override_by_parent = {
+      forced_stage: "mapping_ready",
+      reason: "ainda sentindo cedo",
+      timestamp: "2026-05-26T10:00:00Z",
+    };
+    render(JourneyPanel, { api: buildApi(state) });
+    journeyPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/ainda sentindo cedo/)).toBeDefined();
+    });
+  });
+
+  it("mostra erro quando API falha", async () => {
+    render(JourneyPanel, { api: buildApi(new Error("BFF offline")) });
+    journeyPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/BFF offline/)).toBeDefined();
+    });
+  });
+});
+
+function makeState(
+  stage: JourneyStateLike["stage"],
+  discoveries = 0,
+  families: string[] = [],
+): JourneyStateLike {
+  return {
+    subject_id: "test-subject",
+    stage,
+    stage_entered_at: "2026-05-20T10:00:00Z",
+    discoveries_count: discoveries,
+    families_covered: families,
+    last_updated_at: "2026-05-26T10:00:00Z",
+  };
+}

--- a/packages/ebrota-console-ui/tests/components/MapsPanel.test.ts
+++ b/packages/ebrota-console-ui/tests/components/MapsPanel.test.ts
@@ -1,0 +1,110 @@
+/**
+ * MapsPanel smoke tests — verifica consumo de /frameworks + /subjects/:id/maps.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import MapsPanel from "../../src/components/MapsPanel.svelte";
+import { mapsPanelOpen, tracerSubjectId } from "../../src/lib/stores.js";
+import type {
+  ApiClient,
+  FrameworkMeta,
+  SubjectMapLike,
+} from "../../src/lib/api.js";
+
+const frameworks = (): FrameworkMeta[] => [
+  {
+    id: "valores_classicos",
+    display_name: "Valores clássicos",
+    dimensions: ["axis_1", "axis_2", "axis_11"],
+    render_hint: "radar",
+  },
+  {
+    id: "gardner",
+    display_name: "Gardner",
+    dimensions: ["intrapersonal", "interpersonal"],
+    render_hint: "bar",
+  },
+];
+
+const buildApi = (
+  fws: FrameworkMeta[] | Error,
+  maps: SubjectMapLike | Error,
+): ApiClient =>
+  ({
+    listFrameworks: vi.fn(async () => {
+      if (fws instanceof Error) throw fws;
+      return { frameworks: fws };
+    }),
+    getSubjectMaps: vi.fn(async () => {
+      if (maps instanceof Error) throw maps;
+      return { maps };
+    }),
+  }) as never;
+
+beforeEach(() => {
+  mapsPanelOpen.set(false);
+  tracerSubjectId.set("test-subject");
+});
+
+describe("MapsPanel", () => {
+  it("não renderiza modal quando fechado", () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), {
+        subject_id: "test-subject",
+        computed_at: "2026-05-26",
+        positions: {},
+      }),
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("mostra tabs de frameworks + dimensões com valor > 0", async () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), {
+        subject_id: "test-subject",
+        computed_at: "2026-05-26T10:00:00Z",
+        positions: {
+          valores_classicos: { axis_1: 3, axis_2: 0, axis_11: 5 },
+          gardner: { intrapersonal: 2, interpersonal: 0 },
+        },
+      }),
+    });
+    mapsPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText("Valores clássicos")).toBeDefined();
+    });
+    expect(screen.getByText("Gardner")).toBeDefined();
+    // Default tab = valores_classicos; axis_1 e axis_11 visíveis (axis_2 = 0)
+    expect(screen.getByText("axis_1")).toBeDefined();
+    expect(screen.getByText("axis_11")).toBeDefined();
+    expect(screen.queryByText("axis_2")).toBeNull();
+  });
+
+  it("mostra empty state quando nenhuma posição > 0", async () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), {
+        subject_id: "test-subject",
+        computed_at: "2026-05-26",
+        positions: { valores_classicos: { axis_1: 0, axis_2: 0 } },
+      }),
+    });
+    mapsPanelOpen.set(true);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Nenhuma posição com valor > 0/),
+      ).toBeDefined();
+    });
+  });
+
+  it("mostra erro quando getSubjectMaps falha", async () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), new Error("maps endpoint 500")),
+    });
+    mapsPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/maps endpoint 500/)).toBeDefined();
+    });
+  });
+});

--- a/packages/ebrota-console-ui/tests/components/ReplayTurnDetail.test.ts
+++ b/packages/ebrota-console-ui/tests/components/ReplayTurnDetail.test.ts
@@ -1,0 +1,165 @@
+/**
+ * ReplayTurnDetail smoke tests — engine x-ray per turn.
+ *
+ * Cobre cenários: motor data ausente (não renderiza nada),
+ * trace completo (pool + selected + SK events + plan).
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import ReplayTurnDetail from "../../src/components/ReplayTurnDetail.svelte";
+import type { ReplayTraceTurn } from "../../src/lib/api.js";
+
+const emptyTurn = (): ReplayTraceTurn => ({
+  turnNumber: 1,
+});
+
+const richTurn = (): ReplayTraceTurn => ({
+  turnNumber: 4,
+  trustLevel: 0.42,
+  budgetRemaining: 96,
+  playbookId: "helix-rapport-v1",
+  durationMs: 12345,
+  motorTrace: {
+    plan: {
+      strategicRationale: "explorar autoconhecimento via metáfora natural",
+      instruction_addition: "tom suave, evitar conceitos abstratos",
+      candidateSetEntropy: 2.41,
+      contextHints: { stage: "applied_double_helix" },
+      contentPool: [
+        {
+          item: { id: "bio_caterpillar_dissolve", axis_id: 11 },
+          score: 14.5,
+          reasons: ["base_score=10", "multidim_bonus=+6", "surprise_bonus=+3"],
+        },
+        {
+          item: { id: "bio_dolphin_names", axis_id: 11 },
+          score: 12.0,
+          reasons: ["base_score=10", "multidim_bonus=+4"],
+        },
+        {
+          item: { id: "myth_kintsugi_philosophy", axis_id: 3 },
+          score: 10.5,
+          reasons: ["base_score=10", "surprise_bonus=+1"],
+        },
+      ],
+    },
+    drota: {
+      selectedContent: {
+        item: { id: "bio_caterpillar_dissolve", axis_id: 11 },
+        score: 14.5,
+        reasons: ["base_score=10"],
+      },
+      selectionRationale: "highest score + matches casel_focus",
+      linguisticMaterialization: "Lagarta quando dissolve...",
+    },
+    exec: {
+      eventLogged: { kind: "presented_concept_logged" },
+      success: true,
+    },
+  },
+  subjectKnowledgeEvents: [
+    {
+      type: "presented_concept",
+      payload: { concept_id: "bio_caterpillar_dissolve", axis_id: 11 },
+    },
+    {
+      type: "boundary_event",
+      payload: { topic_category: "corpo" },
+    },
+  ],
+});
+
+describe("ReplayTurnDetail", () => {
+  it("não renderiza nada quando turn sem motor data", () => {
+    const { container } = render(ReplayTurnDetail, { turn: emptyTurn() });
+    expect(container.querySelector(".engine-detail")).toBeNull();
+  });
+
+  it("renderiza colapsado com badges quando trace tem motor data", () => {
+    render(ReplayTurnDetail, { turn: richTurn() });
+    expect(screen.getByText(/Engine x-ray/)).toBeDefined();
+    expect(screen.getByText(/trust=0\.42/)).toBeDefined();
+    expect(screen.getByText(/budget=96/)).toBeDefined();
+    expect(screen.getByText("helix-rapport-v1")).toBeDefined();
+    expect(screen.getByText(/2 sk/)).toBeDefined();
+    expect(screen.getByText(/3 pool/)).toBeDefined();
+  });
+
+  it("expande ao clicar e mostra todas as seções", async () => {
+    render(ReplayTurnDetail, { turn: richTurn() });
+    const toggle = screen.getByTestId("engine-toggle");
+    await fireEvent.click(toggle);
+
+    // Plan section
+    expect(
+      screen.getByText(/explorar autoconhecimento via metáfora natural/),
+    ).toBeDefined();
+    expect(screen.getByText(/tom suave/)).toBeDefined();
+    expect(screen.getByText("2.410")).toBeDefined(); // entropy
+
+    // Pool section
+    expect(screen.getByTestId("pool-section")).toBeDefined();
+    // bio_caterpillar_dissolve aparece no pool list — pode renderizar 1+ vezes
+    // dependendo do estado expand interno
+    expect(screen.getAllByText("bio_caterpillar_dissolve").length).toBeGreaterThan(0);
+    expect(screen.getByText("bio_dolphin_names")).toBeDefined();
+    expect(screen.getByText(/SELECTED/)).toBeDefined();
+    expect(screen.getByText(/highest score \+ matches casel_focus/)).toBeDefined();
+
+    // SK section
+    expect(screen.getByTestId("sk-section")).toBeDefined();
+    expect(screen.getByText("presented_concept")).toBeDefined();
+    expect(screen.getByText("boundary_event")).toBeDefined();
+  });
+
+  it("destaca o item selected dentro do pool", async () => {
+    const { container } = render(ReplayTurnDetail, { turn: richTurn() });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+    const selectedLi = container.querySelector("li.selected");
+    expect(selectedLi).not.toBeNull();
+    expect(selectedLi?.textContent).toContain("bio_caterpillar_dissolve");
+  });
+
+  it("renderiza só badges quando flags do turn presentes mas sem motorTrace", () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 1,
+      trustLevel: 0.55,
+      budgetRemaining: 80,
+      playbookId: "warmup",
+    };
+    render(ReplayTurnDetail, { turn });
+    expect(screen.getByText(/trust=0\.55/)).toBeDefined();
+    expect(screen.getByText("warmup")).toBeDefined();
+  });
+
+  it("fallback pra subjectKnowledgeEvents em motorTrace.drota (legacy STS)", async () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 2,
+      motorTrace: {
+        drota: {
+          subjectKnowledgeEvents: [
+            { type: "interest", payload: { label: "tênis" } },
+          ],
+        },
+      },
+    };
+    render(ReplayTurnDetail, { turn });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+    expect(screen.getByText("interest")).toBeDefined();
+    expect(screen.getByText("tênis")).toBeDefined();
+  });
+
+  it("mostra cardEmissionSkipReason quando presente", async () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 3,
+      trustLevel: 0.4,
+      cardEmissionSkipReason: "trust_below_threshold",
+      motorTrace: { plan: { strategicRationale: "x" } },
+    };
+    render(ReplayTurnDetail, { turn });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+    expect(screen.getByText(/trust_below_threshold/)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Replay engine x-ray

Novo sub-componente \`ReplayTurnDetail.svelte\` expansível dentro de cada turn do Replay. Surfaces o que **já existe** em trace.json — render-only, **sem mudança backend**.

Por turn:
- 🧠 **Plan**: strategicRationale, instruction_addition, candidateSetEntropy, contextHints (JSON expand)
- 🎯 **Pool top-5** + selected (highlight + ↗ SELECTED) + reasons[] per item + selectionRationale
- 🔍 **Subject Knowledge writes** do turn (badge colored por type) — turn.subjectKnowledgeEvents OR motorTrace.drota.subjectKnowledgeEvents (legacy STS)
- ⚙️ **Exec**: eventLogged, newState
- Badges colapsados: trust, budget, playbookId, durationMs, sk_count, pool_count
- cardEmissionSkipReason quando aplicável

**Out of scope v1** (entram em spec ops#TraceV2 a abrir):
- LLM calls raw (prompts/responses) — entries[] vazias nos STS traces
- Journey/Helix/Strategist snapshots por turn — não capturados pelos writers ainda

## Smoke tests Mini-UI (\"console alimentada corretamente\")

4 test files cobrindo painéis em main + ReplayTurnDetail. Pattern: api mockada com cenários **vazio + populado + erro** pra cada painel.

- \`ReplayTurnDetail.test.ts\` (7 testes)
- \`JourneyPanel.test.ts\` (4 testes)
- \`MapsPanel.test.ts\` (4 testes)
- \`DiscoveriesPanel.test.ts\` (5 testes)

Pega a regression \"nada no console\" observada antes do fix tracesDir.

## Test plan

- [x] **UI tests 118/118 verdes** (+20 vs main)
- [x] Build vite ✓
- [x] Smoke \`tracer-helix-3sessions-ryo\` PASS pós fix tático — 4 turns, 4 items distintos selected (lagarta apareceu 1×, não dominou)
- [ ] Strategist + Helix tests pendentes (dependem #224 mergear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)