### PR TITLE
[feat ops#1136] TV2-1: engine-trace-v2 types + Zod (foundation)

### DIFF
--- a/shared/src/engine-trace-v2.ts
+++ b/shared/src/engine-trace-v2.ts
@@ -1,0 +1,423 @@
+/**
+ * Engine Trace v2 — full engine telemetry per turn.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-trace-v2-full-engine-telemetry.md
+ *
+ * Convive AO LADO de `motorTrace` v1 (não substitui) — caller injeta
+ * `turn.engineTrace` no trace.json STS. Replay UI v2 consome v2 quando
+ * presente, com fallback graceful pra v1 quando ausente.
+ *
+ * Princípios:
+ *   1. Captura na fronteira do componente — cada writer/selector retorna sua seção
+ *   2. LLM calls catalogados num array flat (cross-component); seções por
+ *      componente referenciam via `llm_call_ref`
+ *   3. Backward 100% — todos os campos por turn opcionais; ausência ≠ erro
+ *   4. Privacy via env `MOTOR_TRACE_REDACT_PII` (default false em dev)
+ *
+ * Sub-fase TV2-1: tipos + Zod. Writers + UI consumer entram em TV2-2+.
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────
+// State snapshots — pre/post-turn read-only views dos repos do motor
+// ─────────────────────────────────────────────────────────────────────────
+
+export const JourneyStateSnapshotSchema = z.object({
+  stage: z.string(),
+  discoveries_count: z.number().int().nonnegative(),
+  families_covered: z.array(z.string()),
+});
+
+export const HelixStateSnapshotSchema = z.object({
+  activeDimension: z.string(),
+  activeLevel: z.number().int().nonnegative(),
+  cycleDay: z.number().int().nonnegative(),
+  progress: z.number().min(0).max(1),
+});
+
+export const SubjectProposedSnapshotSchema = z.object({
+  version: z.number().int().nonnegative(),
+  axes_active: z.array(z.number().int()),
+  ratified_at: z.string().nullable(),
+});
+
+export const ParentalProfileSnapshotSchema = z.object({
+  aspirations: z.array(z.string()).optional(),
+  latent_needs: z.array(z.string()).optional(),
+  complement_choices: z.record(z.string(), z.array(z.string())).optional(),
+});
+
+export const EngineStateSnapshotSchema = z.object({
+  journey_state: JourneyStateSnapshotSchema.optional(),
+  helix_state: HelixStateSnapshotSchema.optional(),
+  subject_proposed: SubjectProposedSnapshotSchema.optional(),
+  parental_profile: ParentalProfileSnapshotSchema.optional(),
+  trust_level: z.number().min(0).max(1),
+  budget_remaining: z.number(),
+  cycle_phase: z.string().optional(),
+  current_session_phase: z
+    .enum(["ice_breaker", "challenge_explain", "challenge_execute", "follow_up"])
+    .optional(),
+});
+
+export type JourneyStateSnapshot = z.infer<typeof JourneyStateSnapshotSchema>;
+export type HelixStateSnapshot = z.infer<typeof HelixStateSnapshotSchema>;
+export type SubjectProposedSnapshot = z.infer<typeof SubjectProposedSnapshotSchema>;
+export type ParentalProfileSnapshot = z.infer<typeof ParentalProfileSnapshotSchema>;
+export type EngineStateSnapshot = z.infer<typeof EngineStateSnapshotSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// State diff — explícito, computado por `computeStateDiff(pre, post)`
+// ─────────────────────────────────────────────────────────────────────────
+
+export const EngineStateDiffSchema = z.object({
+  journey_stage_transition: z
+    .object({
+      from: z.string(),
+      to: z.string(),
+      trigger: z.string(),
+    })
+    .optional(),
+  helix_advance: z
+    .object({
+      dimension_changed: z.boolean().optional(),
+      level_changed: z.boolean().optional(),
+      cycle_completed: z.boolean().optional(),
+    })
+    .optional(),
+  subject_knowledge_added_count: z.number().int().nonnegative(),
+  trust_delta: z.number(),
+  budget_delta: z.number(),
+  session_phase_transition: z
+    .object({ from: z.string(), to: z.string() })
+    .optional(),
+});
+
+export type EngineStateDiff = z.infer<typeof EngineStateDiffSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// LLM calls — catálogo flat cross-component
+// ─────────────────────────────────────────────────────────────────────────
+
+export const LlmCallRoleSchema = z.enum([
+  "assessor",
+  "materializer",
+  "planejador",
+  "parental_triage",
+  "strategist",
+  "other",
+]);
+export type LlmCallRole = z.infer<typeof LlmCallRoleSchema>;
+
+/**
+ * Providers observados pelo trace — superset do `LlmProvider` em
+ * llm-router.ts (que só cobre redes pagas). Trace precisa logar `local`
+ * (OVMS qwen) e `mock` (testes) também.
+ */
+export const TraceLlmProviderSchema = z.enum([
+  "anthropic",
+  "infomaniak",
+  "local",
+  "mock",
+]);
+export type TraceLlmProvider = z.infer<typeof TraceLlmProviderSchema>;
+
+export const LlmCallTraceSchema = z.object({
+  id: z.string(),
+  role: LlmCallRoleSchema,
+  provider: TraceLlmProviderSchema,
+  model: z.string(),
+  prompt: z.string(),
+  response: z.string(),
+  duration_ms: z.number().nonnegative(),
+  input_tokens: z.number().int().nonnegative().optional(),
+  output_tokens: z.number().int().nonnegative().optional(),
+  prompt_cache_hit: z.boolean().optional(),
+  redacted: z.boolean().optional(),
+  error: z.string().optional(),
+});
+
+export type LlmCallTrace = z.infer<typeof LlmCallTraceSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Subject Knowledge writes do turn (writer + trigger anotados)
+// ─────────────────────────────────────────────────────────────────────────
+
+export const SubjectKnowledgeWriterSchema = z.enum([
+  "discovery",
+  "boundary",
+  "concept_ledger",
+  "recall_check",
+  "axis_attempt_outcome",
+  "vertical_affinity",
+  "other",
+]);
+export type SubjectKnowledgeWriter = z.infer<typeof SubjectKnowledgeWriterSchema>;
+
+export const SubjectKnowledgeWriteTraceSchema = z.object({
+  type: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+  writer: SubjectKnowledgeWriterSchema,
+  triggered_by: z.string(),
+});
+
+export type SubjectKnowledgeWriteTrace = z.infer<
+  typeof SubjectKnowledgeWriteTraceSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Per-componente traces
+// ─────────────────────────────────────────────────────────────────────────
+
+export const AssessorTraceSchema = z.object({
+  inputs: z.object({
+    user_message: z.string(),
+    turn_history_window: z.number().int().nonnegative().optional(),
+  }),
+  outputs: z.object({
+    mood: z.number(),
+    signals: z.array(z.string()),
+    engagement: z.enum(["low", "mid", "high"]),
+  }),
+  mood_method: z.enum(["rule", "llm"]),
+  duration_ms: z.number().nonnegative(),
+  llm_call_ref: z.string().optional(),
+});
+
+const ScoredItemRefSchema = z.object({
+  item: z
+    .object({
+      id: z.string().optional(),
+      type: z.string().optional(),
+      domain: z.string().optional(),
+      axis_id: z.number().optional(),
+    })
+    .passthrough(),
+  score: z.number(),
+  reasons: z.array(z.string()).optional(),
+});
+
+export const PlanejadorTraceSchema = z.object({
+  inputs: z.object({
+    mood: z.number().optional(),
+    signals: z.array(z.string()).optional(),
+    recent_context: z.record(z.string(), z.unknown()).optional(),
+  }),
+  outputs: z.object({
+    contentPool: z.array(ScoredItemRefSchema),
+    contextHints: z.record(z.string(), z.unknown()).optional(),
+    instruction_addition: z.string().optional(),
+    strategicRationale: z.string().optional(),
+    candidateSetEntropy: z.number().optional(),
+  }),
+  triageDecision: z
+    .object({
+      route: z.enum(["parental", "drota"]),
+      reason: z.string(),
+    })
+    .optional(),
+  triggerEvaluation: z
+    .object({
+      transitions_checked: z.array(z.string()),
+      fired: z.string().optional(),
+    })
+    .optional(),
+  llm_call_ref: z.string().optional(),
+  duration_ms: z.number().nonnegative(),
+});
+
+export const StrategistTraceSchema = z.object({
+  inputs: z.object({
+    journey_stage: z.string(),
+    latent_needs: z.array(z.string()).optional(),
+    current_objectives: z.array(z.record(z.string(), z.unknown())).optional(),
+  }),
+  outputs: z.object({
+    plan_id: z.string().optional(),
+    target_demonstrations: z.array(z.record(z.string(), z.unknown())),
+    playbook_composition: z.array(z.record(z.string(), z.unknown())),
+  }),
+  composition_method: z.enum(["template_v1", "llm"]),
+  duration_ms: z.number().nonnegative(),
+});
+
+export const SelectorTraceSchema = z.object({
+  inputs: z.object({
+    pool_size: z.number().int().nonnegative(),
+    mood: z.number().optional(),
+    budget: z.number().optional(),
+  }),
+  filters_applied: z.array(
+    z.object({
+      name: z.string(),
+      items_removed: z.array(z.string()),
+      reason: z.string(),
+    }),
+  ),
+  outputs: z.object({
+    selected_id: z.string(),
+    pool_remaining: z.array(z.string()),
+  }),
+  duration_ms: z.number().nonnegative(),
+});
+
+export const MaterializerTraceSchema = z.object({
+  inputs: z.object({
+    selected_item_id: z.string(),
+    instruction_addition: z.string().optional(),
+    user_message: z.string(),
+  }),
+  stable_prefix_hash: z.string(),
+  user_message_constructed: z.string(),
+  outputs: z.object({
+    raw_response: z.string(),
+    final_text: z.string(),
+  }),
+  llm_call_ref: z.string(),
+  duration_ms: z.number().nonnegative(),
+});
+
+export type AssessorTrace = z.infer<typeof AssessorTraceSchema>;
+export type PlanejadorTrace = z.infer<typeof PlanejadorTraceSchema>;
+export type StrategistTrace = z.infer<typeof StrategistTraceSchema>;
+export type SelectorTrace = z.infer<typeof SelectorTraceSchema>;
+export type MaterializerTrace = z.infer<typeof MaterializerTraceSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// EngineTraceV2 — top-level aggregate per turn
+// ─────────────────────────────────────────────────────────────────────────
+
+export const ENGINE_TRACE_SCHEMA_VERSION = 2 as const;
+
+export const EngineTraceV2Schema = z.object({
+  schema_version: z.literal(2),
+  turn_started_at: z.string(),
+  turn_completed_at: z.string(),
+
+  pre_state: EngineStateSnapshotSchema,
+  post_state: EngineStateSnapshotSchema,
+  state_diff: EngineStateDiffSchema,
+
+  components: z.object({
+    unified_assessor: AssessorTraceSchema.optional(),
+    planejador: PlanejadorTraceSchema.optional(),
+    strategist: StrategistTraceSchema.optional(),
+    pragmatic_selector: SelectorTraceSchema.optional(),
+    constrained_materializer: MaterializerTraceSchema.optional(),
+  }),
+
+  llm_calls: z.array(LlmCallTraceSchema),
+
+  subject_knowledge_writes: z.array(SubjectKnowledgeWriteTraceSchema),
+
+  warnings: z.array(
+    z.object({
+      component: z.string(),
+      message: z.string(),
+      recoverable: z.literal(true),
+    }),
+  ),
+});
+
+export type EngineTraceV2 = z.infer<typeof EngineTraceV2Schema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Computa diff explícito entre dois snapshots — facilita render UI sem
+ * forçar consumer a derivar.
+ */
+export function computeStateDiff(
+  pre: EngineStateSnapshot,
+  post: EngineStateSnapshot,
+  subjectKnowledgeAddedCount: number,
+): EngineStateDiff {
+  const diff: EngineStateDiff = {
+    subject_knowledge_added_count: subjectKnowledgeAddedCount,
+    trust_delta: post.trust_level - pre.trust_level,
+    budget_delta: post.budget_remaining - pre.budget_remaining,
+  };
+
+  if (
+    pre.journey_state &&
+    post.journey_state &&
+    pre.journey_state.stage !== post.journey_state.stage
+  ) {
+    diff.journey_stage_transition = {
+      from: pre.journey_state.stage,
+      to: post.journey_state.stage,
+      trigger: "auto", // caller pode sobrescrever com razão específica
+    };
+  }
+
+  if (pre.helix_state && post.helix_state) {
+    const helix: NonNullable<EngineStateDiff["helix_advance"]> = {};
+    if (pre.helix_state.activeDimension !== post.helix_state.activeDimension) {
+      helix.dimension_changed = true;
+    }
+    if (pre.helix_state.activeLevel !== post.helix_state.activeLevel) {
+      helix.level_changed = true;
+    }
+    if (
+      pre.helix_state.progress >= 0 &&
+      post.helix_state.progress === 0 &&
+      pre.helix_state.cycleDay > post.helix_state.cycleDay
+    ) {
+      helix.cycle_completed = true;
+    }
+    if (Object.keys(helix).length > 0) {
+      diff.helix_advance = helix;
+    }
+  }
+
+  if (
+    pre.current_session_phase &&
+    post.current_session_phase &&
+    pre.current_session_phase !== post.current_session_phase
+  ) {
+    diff.session_phase_transition = {
+      from: pre.current_session_phase,
+      to: post.current_session_phase,
+    };
+  }
+
+  return diff;
+}
+
+/**
+ * Factory pra um EngineTraceV2 mínimo válido — usado por callers que
+ * querem começar a trace e depois preencher seções incrementalmente.
+ */
+export function createEmptyEngineTrace(opts: {
+  turn_started_at: string;
+  pre_state: EngineStateSnapshot;
+}): EngineTraceV2 {
+  return {
+    schema_version: ENGINE_TRACE_SCHEMA_VERSION,
+    turn_started_at: opts.turn_started_at,
+    turn_completed_at: opts.turn_started_at, // override on finalize
+    pre_state: opts.pre_state,
+    post_state: opts.pre_state, // override on finalize
+    state_diff: {
+      subject_knowledge_added_count: 0,
+      trust_delta: 0,
+      budget_delta: 0,
+    },
+    components: {},
+    llm_calls: [],
+    subject_knowledge_writes: [],
+    warnings: [],
+  };
+}
+
+/**
+ * Parse + valida JSON crua. Retorna `null` quando schema inválido —
+ * caller decide (UI: cai pra v1; STS scanner: warn + skip).
+ */
+export function parseEngineTraceV2(raw: unknown): EngineTraceV2 | null {
+  const result = EngineTraceV2Schema.safeParse(raw);
+  return result.success ? result.data : null;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -29,6 +29,7 @@ export * from "./recall-check-evaluator.js";
 export * from "./map-framework.js";
 export * from "./session-phases.js";
 export * from "./strategy-plan.js";
+export * from "./engine-trace-v2.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/tests/engine-trace-v2.test.ts
+++ b/shared/tests/engine-trace-v2.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests TV2-1 — engine-trace-v2 schema + helpers.
+ *
+ * Spec ops#1136 §2. Foundation only; sub-fase TV2-2+ usa esses tipos
+ * pra capturar telemetria real do motor.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  EngineTraceV2Schema,
+  ENGINE_TRACE_SCHEMA_VERSION,
+  createEmptyEngineTrace,
+  parseEngineTraceV2,
+  computeStateDiff,
+  type EngineStateSnapshot,
+  type EngineTraceV2,
+} from "../src/engine-trace-v2.js";
+
+const NOW = "2026-05-26T15:00:00Z";
+const LATER = "2026-05-26T15:00:30Z";
+
+const minimalSnapshot = (
+  overrides: Partial<EngineStateSnapshot> = {},
+): EngineStateSnapshot => ({
+  trust_level: 0.5,
+  budget_remaining: 100,
+  ...overrides,
+});
+
+describe("createEmptyEngineTrace", () => {
+  it("retorna estrutura válida segundo schema", () => {
+    const t = createEmptyEngineTrace({
+      turn_started_at: NOW,
+      pre_state: minimalSnapshot(),
+    });
+    const parsed = EngineTraceV2Schema.safeParse(t);
+    expect(parsed.success).toBe(true);
+    expect(t.schema_version).toBe(ENGINE_TRACE_SCHEMA_VERSION);
+    expect(t.llm_calls).toEqual([]);
+    expect(t.subject_knowledge_writes).toEqual([]);
+    expect(t.warnings).toEqual([]);
+    expect(t.components).toEqual({});
+  });
+
+  it("post_state inicializa = pre_state (sentinel pre-finalize)", () => {
+    const pre = minimalSnapshot({ trust_level: 0.42 });
+    const t = createEmptyEngineTrace({ turn_started_at: NOW, pre_state: pre });
+    expect(t.post_state).toEqual(pre);
+    expect(t.state_diff.trust_delta).toBe(0);
+  });
+});
+
+describe("EngineTraceV2Schema", () => {
+  it("aceita trace completo realista", () => {
+    const trace: EngineTraceV2 = {
+      schema_version: 2,
+      turn_started_at: NOW,
+      turn_completed_at: LATER,
+      pre_state: minimalSnapshot({
+        journey_state: {
+          stage: "discovery_only",
+          discoveries_count: 3,
+          families_covered: ["carater"],
+        },
+        trust_level: 0.4,
+      }),
+      post_state: minimalSnapshot({
+        journey_state: {
+          stage: "mapping_ready",
+          discoveries_count: 5,
+          families_covered: ["carater", "disposicao"],
+        },
+        trust_level: 0.45,
+        budget_remaining: 95,
+      }),
+      state_diff: {
+        subject_knowledge_added_count: 2,
+        trust_delta: 0.05,
+        budget_delta: -5,
+        journey_stage_transition: {
+          from: "discovery_only",
+          to: "mapping_ready",
+          trigger: "discoveries_threshold",
+        },
+      },
+      components: {
+        unified_assessor: {
+          inputs: { user_message: "tipo, jogando..." },
+          outputs: { mood: 7, signals: ["positive_engagement"], engagement: "mid" },
+          mood_method: "rule",
+          duration_ms: 12,
+        },
+        constrained_materializer: {
+          inputs: {
+            selected_item_id: "bio_caterpillar_dissolve",
+            instruction_addition: "tom suave",
+            user_message: "tipo, jogando...",
+          },
+          stable_prefix_hash: "sha256:abc",
+          user_message_constructed: "User: tipo, jogando...",
+          outputs: {
+            raw_response: "<frame>Lagarta...</frame>",
+            final_text: "Lagarta quando dissolve...",
+          },
+          llm_call_ref: "llm-2",
+          duration_ms: 2890,
+        },
+      },
+      llm_calls: [
+        {
+          id: "llm-1",
+          role: "assessor",
+          provider: "local",
+          model: "qwen14b",
+          prompt: "Classify mood + signals from: tipo, jogando...",
+          response: '{"mood":7,"signals":["positive_engagement"]}',
+          duration_ms: 1200,
+          input_tokens: 145,
+          output_tokens: 32,
+        },
+        {
+          id: "llm-2",
+          role: "materializer",
+          provider: "local",
+          model: "qwen14b",
+          prompt: "[stable prefix]\nUser: tipo, jogando...",
+          response: "<frame>Lagarta...</frame>",
+          duration_ms: 2890,
+          prompt_cache_hit: true,
+        },
+      ],
+      subject_knowledge_writes: [
+        {
+          type: "presented_concept",
+          payload: { concept_id: "bio_caterpillar_dissolve", axis_id: 11 },
+          writer: "concept_ledger",
+          triggered_by: "materializer_emit",
+        },
+      ],
+      warnings: [],
+    };
+    const r = EngineTraceV2Schema.safeParse(trace);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejeita schema_version diferente de 2", () => {
+    const t = createEmptyEngineTrace({
+      turn_started_at: NOW,
+      pre_state: minimalSnapshot(),
+    });
+    const bad = { ...t, schema_version: 1 } as unknown;
+    expect(EngineTraceV2Schema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejeita LLM call sem provider", () => {
+    const t = createEmptyEngineTrace({
+      turn_started_at: NOW,
+      pre_state: minimalSnapshot(),
+    });
+    t.llm_calls.push({
+      // @ts-expect-error — provider faltando intencional
+      id: "x",
+      role: "assessor",
+      model: "qwen14b",
+      prompt: "x",
+      response: "y",
+      duration_ms: 100,
+    });
+    expect(EngineTraceV2Schema.safeParse(t).success).toBe(false);
+  });
+
+  it("rejeita warning sem recoverable=true", () => {
+    const t = createEmptyEngineTrace({
+      turn_started_at: NOW,
+      pre_state: minimalSnapshot(),
+    });
+    // @ts-expect-error — recoverable false não permitido
+    t.warnings.push({ component: "x", message: "y", recoverable: false });
+    expect(EngineTraceV2Schema.safeParse(t).success).toBe(false);
+  });
+
+  it("aceita components todos ausentes (turn que não passou pipeline)", () => {
+    const t = createEmptyEngineTrace({
+      turn_started_at: NOW,
+      pre_state: minimalSnapshot(),
+    });
+    expect(EngineTraceV2Schema.safeParse(t).success).toBe(true);
+  });
+});
+
+describe("parseEngineTraceV2", () => {
+  it("retorna trace parseado em JSON válido", () => {
+    const t = createEmptyEngineTrace({
+      turn_started_at: NOW,
+      pre_state: minimalSnapshot(),
+    });
+    const json = JSON.parse(JSON.stringify(t));
+    const parsed = parseEngineTraceV2(json);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.schema_version).toBe(2);
+  });
+
+  it("retorna null em JSON inválido", () => {
+    expect(parseEngineTraceV2({ foo: "bar" })).toBeNull();
+    expect(parseEngineTraceV2(null)).toBeNull();
+    expect(parseEngineTraceV2("string")).toBeNull();
+  });
+});
+
+describe("computeStateDiff", () => {
+  it("captura trust + budget deltas", () => {
+    const pre = minimalSnapshot({ trust_level: 0.4, budget_remaining: 100 });
+    const post = minimalSnapshot({ trust_level: 0.5, budget_remaining: 92 });
+    const diff = computeStateDiff(pre, post, 0);
+    expect(diff.trust_delta).toBeCloseTo(0.1, 5);
+    expect(diff.budget_delta).toBe(-8);
+    expect(diff.subject_knowledge_added_count).toBe(0);
+  });
+
+  it("detecta journey_stage_transition", () => {
+    const pre = minimalSnapshot({
+      journey_state: {
+        stage: "discovery_only",
+        discoveries_count: 4,
+        families_covered: [],
+      },
+    });
+    const post = minimalSnapshot({
+      journey_state: {
+        stage: "mapping_ready",
+        discoveries_count: 5,
+        families_covered: ["carater"],
+      },
+    });
+    const diff = computeStateDiff(pre, post, 1);
+    expect(diff.journey_stage_transition).toEqual({
+      from: "discovery_only",
+      to: "mapping_ready",
+      trigger: "auto",
+    });
+  });
+
+  it("sem journey transition quando stage igual", () => {
+    const pre = minimalSnapshot({
+      journey_state: {
+        stage: "mapping_ready",
+        discoveries_count: 5,
+        families_covered: [],
+      },
+    });
+    const post = minimalSnapshot({
+      journey_state: {
+        stage: "mapping_ready",
+        discoveries_count: 6,
+        families_covered: [],
+      },
+    });
+    const diff = computeStateDiff(pre, post, 1);
+    expect(diff.journey_stage_transition).toBeUndefined();
+  });
+
+  it("detecta helix dimension change", () => {
+    const pre = minimalSnapshot({
+      helix_state: {
+        activeDimension: "SA",
+        activeLevel: 2,
+        cycleDay: 3,
+        progress: 0.4,
+      },
+    });
+    const post = minimalSnapshot({
+      helix_state: {
+        activeDimension: "SM",
+        activeLevel: 2,
+        cycleDay: 4,
+        progress: 0.5,
+      },
+    });
+    const diff = computeStateDiff(pre, post, 0);
+    expect(diff.helix_advance?.dimension_changed).toBe(true);
+    expect(diff.helix_advance?.level_changed).toBeUndefined();
+  });
+
+  it("detecta session_phase_transition", () => {
+    const pre = minimalSnapshot({ current_session_phase: "ice_breaker" });
+    const post = minimalSnapshot({ current_session_phase: "challenge_explain" });
+    const diff = computeStateDiff(pre, post, 0);
+    expect(diff.session_phase_transition).toEqual({
+      from: "ice_breaker",
+      to: "challenge_explain",
+    });
+  });
+});


### PR DESCRIPTION
Foundation pra **Trace v2** (spec ops#1136). Tipos TypeScript + Zod schemas + helpers; **SEM** nenhuma captura ainda — writers entram em TV2-2+. Backward 100%.

## Schema novo

`EngineTraceV2` top-level por turn (ao lado de motorTrace v1):
- schema_version: 2 (literal)
- pre_state + post_state + state_diff
- components: assessor/planejador/strategist/selector/materializer
- llm_calls[]: catálogo flat com prompt+response+ms+tokens+cache_hit
- subject_knowledge_writes[]: anotados com writer + triggered_by
- warnings[]: erros não-fatais

## Helpers

- `createEmptyEngineTrace({turn_started_at, pre_state})` — factory
- `computeStateDiff(pre, post, skCount)` — diff explícito (journey transition, helix advance, deltas)
- `parseEngineTraceV2(raw): T | null` — Zod safe parse

## Test plan

- [x] 14 testes novos em `engine-trace-v2.test.ts` — factory, schema completo, edge cases, computeStateDiff por dimensão
- [x] 842 shared tests verdes
- [x] Build shared limpo
- [x] `TraceLlmProvider` renomeado pra evitar conflict com `llm-router.LlmProvider` (superset: + local + mock)

## Próximas sub-fases (não nesta PR)

- **TV2-2**: gateway-client captura LlmCallTrace via wrapper
- **TV2-3**: 4 componentes (assessor/selector/materializer/planejador) retornam trace seções
- **TV2-4**: handleSimplifiedPipeline agrega + lê snapshots pre/post

🤖 Generated with [Claude Code](https://claude.com/claude-code)