### PR TITLE
[feat ops#1136] TV2-2: callGatewayWithTracing + LLM trace collector

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from "./map-framework.js";
 export * from "./session-phases.js";
 export * from "./strategy-plan.js";
 export * from "./engine-trace-v2.js";
+export * from "./llm-trace-collector.js";
 export * from "./parental-authorization.js";
 export * from "./gardner-onboarding.js";
 export * from "./card-catalog.js";

--- a/shared/src/llm-trace-collector.ts
+++ b/shared/src/llm-trace-collector.ts
@@ -1,0 +1,157 @@
+/**
+ * LLM trace collector — TV2-2 (spec ops#1136).
+ *
+ * Wrapper opcional sobre `callGateway` que captura `LlmCallTrace` por
+ * chamada. Preserva 100% a função original — callers que não passam
+ * collector seguem inalterados.
+ *
+ * Uso típico em handleSimplifiedPipeline (TV2-4):
+ *
+ *   const collector = createLlmTraceCollector();
+ *   await callGatewayWithTracing(req, "assessor", collector);
+ *   await callGatewayWithTracing(req, "materializer", collector);
+ *   engineTrace.llm_calls = collector.drain();
+ *
+ * Privacy: redação opt-in via env `MOTOR_TRACE_REDACT_PII=true` —
+ * substitui prompt + response por hashes (não literal). Default false
+ * em dev/CI (Karpathy P2 — simplicidade primeiro).
+ */
+
+import { randomBytes, createHash } from "node:crypto";
+import {
+  callGateway,
+  type GatewayChatCompletionInput,
+  type GatewayChatCompletionOutput,
+} from "./gateway-client.js";
+import type {
+  LlmCallTrace,
+  LlmCallRole,
+  TraceLlmProvider,
+} from "./engine-trace-v2.js";
+import type { LlmProvider } from "./llm-router.js";
+
+export interface LlmTraceCollector {
+  /** Anexa uma chamada. ID é gerado pelo wrapper se ausente. */
+  push(call: LlmCallTrace): void;
+  /** Retorna e limpa o buffer. */
+  drain(): LlmCallTrace[];
+  /** Peek sem consumir — pra inspect em tests. */
+  peek(): readonly LlmCallTrace[];
+  /** Quantos calls coletados. */
+  size(): number;
+}
+
+export function createLlmTraceCollector(): LlmTraceCollector {
+  const calls: LlmCallTrace[] = [];
+  return {
+    push: (call) => {
+      calls.push(call);
+    },
+    drain: () => calls.splice(0),
+    peek: () => calls,
+    size: () => calls.length,
+  };
+}
+
+/**
+ * Mapeia provider do gateway pra trace. `openai-compat` (OVMS local)
+ * vira `"local"`. Os 2 paid providers mantêm nome.
+ */
+export function mapGatewayProviderToTrace(p: LlmProvider): TraceLlmProvider {
+  if (p === "anthropic") return "anthropic";
+  if (p === "infomaniak") return "infomaniak";
+  return "local"; // openai-compat → local
+}
+
+/**
+ * Constrói representação textual do prompt enviado — concatena system +
+ * user. Não inclui assistant prefill (pouco usado, gateway-side). Útil
+ * pra debug em UI; provider real envia em formato message-array.
+ */
+export function buildPromptText(req: GatewayChatCompletionInput): string {
+  const parts: string[] = [];
+  if (req.cacheableSystemPrefix && req.cacheableSystemPrefix.length > 0) {
+    parts.push(`[CACHEABLE PREFIX]\n${req.cacheableSystemPrefix}`);
+  }
+  if (req.systemPrompt && req.systemPrompt.length > 0) {
+    parts.push(`[SYSTEM]\n${req.systemPrompt}`);
+  }
+  parts.push(`[USER]\n${req.userMessage}`);
+  return parts.join("\n\n");
+}
+
+/**
+ * Quando `MOTOR_TRACE_REDACT_PII=true`, substitui prompt/response por
+ * hashes deterministicos. Mantém shape do schema válido + permite
+ * comparar entre runs (mesmo hash = mesmo conteúdo).
+ */
+export function shouldRedactPii(): boolean {
+  return process.env["MOTOR_TRACE_REDACT_PII"] === "true";
+}
+
+function redactText(text: string): string {
+  const hash = createHash("sha256").update(text).digest("hex").slice(0, 16);
+  return `[REDACTED sha256:${hash} len=${text.length}]`;
+}
+
+function generateCallId(): string {
+  return `llm-${randomBytes(8).toString("hex")}`;
+}
+
+/**
+ * Wrapper sobre `callGateway` que coleta `LlmCallTrace`. Quando
+ * `collector` é undefined, comporta-se EXATAMENTE como `callGateway`.
+ *
+ * Em sucesso: push de LlmCallTrace com prompt/response/tokens/ms.
+ * Em erro: push de LlmCallTrace com `error` populado + re-throw.
+ */
+export async function callGatewayWithTracing(
+  req: GatewayChatCompletionInput,
+  role: LlmCallRole,
+  collector?: LlmTraceCollector,
+): Promise<GatewayChatCompletionOutput> {
+  if (collector === undefined) {
+    return callGateway(req);
+  }
+
+  const redact = shouldRedactPii();
+  const promptText = buildPromptText(req);
+  const startMs = Date.now();
+
+  try {
+    const result = await callGateway(req);
+    const tokensIn = result.tokens?.in;
+    const tokensOut = result.tokens?.out;
+    const cacheRead = result.tokens?.cacheRead;
+    collector.push({
+      id: generateCallId(),
+      role,
+      provider: mapGatewayProviderToTrace(result.provider),
+      model: result.model,
+      prompt: redact ? redactText(promptText) : promptText,
+      response: redact ? redactText(result.content) : result.content,
+      duration_ms: result.latency_ms ?? Date.now() - startMs,
+      ...(typeof tokensIn === "number" ? { input_tokens: tokensIn } : {}),
+      ...(typeof tokensOut === "number" ? { output_tokens: tokensOut } : {}),
+      ...(typeof cacheRead === "number" && cacheRead > 0
+        ? { prompt_cache_hit: true }
+        : {}),
+      ...(redact ? { redacted: true } : {}),
+    });
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    collector.push({
+      id: generateCallId(),
+      role,
+      provider: mapGatewayProviderToTrace(req.provider ?? "anthropic"),
+      model: req.model ?? "unknown",
+      prompt: redact ? redactText(promptText) : promptText,
+      response: "",
+      duration_ms: Date.now() - startMs,
+      error: message,
+      ...(redact ? { redacted: true } : {}),
+    });
+    throw err;
+  }
+}

--- a/shared/tests/llm-trace-collector.test.ts
+++ b/shared/tests/llm-trace-collector.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests TV2-2 — llm-trace-collector wrapper sobre callGateway.
+ *
+ * Mocka callGateway via vi.mock pra evitar I/O real. Cobre:
+ *   - collector undefined = transparent
+ *   - sucesso captura prompt/response/tokens/cache_hit
+ *   - erro captura err + re-throws
+ *   - redaction via env quando MOTOR_TRACE_REDACT_PII=true
+ *   - provider mapping (openai-compat → local)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createLlmTraceCollector,
+  callGatewayWithTracing,
+  mapGatewayProviderToTrace,
+  buildPromptText,
+  shouldRedactPii,
+} from "../src/llm-trace-collector.js";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+} from "../src/gateway-client.js";
+
+vi.mock("../src/gateway-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/gateway-client.js")>();
+  return {
+    ...actual,
+    callGateway: vi.fn(),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const gatewayMod = await import("../src/gateway-client.js");
+const mockedCallGateway = vi.mocked(gatewayMod.callGateway);
+
+const reqFixture = (): GatewayChatCompletionInput => ({
+  step: "assessor",
+  systemPrompt: "Be helpful.",
+  userMessage: "Como você se sente?",
+});
+
+const outputFixture = (
+  overrides: Partial<GatewayChatCompletionOutput> = {},
+): GatewayChatCompletionOutput => ({
+  content: "Me sinto bem.",
+  tokens: { in: 100, out: 20, reasoning: 0 },
+  provider: "anthropic",
+  model: "claude-opus-4-7",
+  latency_ms: 1234,
+  attempt_count: 1,
+  was_fallback: false,
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockedCallGateway.mockReset();
+  delete process.env["MOTOR_TRACE_REDACT_PII"];
+});
+
+afterEach(() => {
+  delete process.env["MOTOR_TRACE_REDACT_PII"];
+});
+
+describe("createLlmTraceCollector", () => {
+  it("começa vazio", () => {
+    const c = createLlmTraceCollector();
+    expect(c.size()).toBe(0);
+    expect(c.peek()).toEqual([]);
+  });
+
+  it("drain limpa e retorna calls", () => {
+    const c = createLlmTraceCollector();
+    c.push({
+      id: "x",
+      role: "assessor",
+      provider: "local",
+      model: "qwen14b",
+      prompt: "p",
+      response: "r",
+      duration_ms: 100,
+    });
+    expect(c.size()).toBe(1);
+    const drained = c.drain();
+    expect(drained).toHaveLength(1);
+    expect(c.size()).toBe(0);
+  });
+});
+
+describe("mapGatewayProviderToTrace", () => {
+  it("anthropic → anthropic", () => {
+    expect(mapGatewayProviderToTrace("anthropic")).toBe("anthropic");
+  });
+  it("infomaniak → infomaniak", () => {
+    expect(mapGatewayProviderToTrace("infomaniak")).toBe("infomaniak");
+  });
+  it("openai-compat → local", () => {
+    expect(mapGatewayProviderToTrace("openai-compat")).toBe("local");
+  });
+});
+
+describe("buildPromptText", () => {
+  it("concatena system + user", () => {
+    const text = buildPromptText({
+      step: "assessor",
+      systemPrompt: "Be kind.",
+      userMessage: "hi",
+    });
+    expect(text).toContain("[SYSTEM]\nBe kind.");
+    expect(text).toContain("[USER]\nhi");
+  });
+
+  it("inclui cacheableSystemPrefix quando presente", () => {
+    const text = buildPromptText({
+      step: "drota",
+      cacheableSystemPrefix: "STABLE_PREFIX",
+      systemPrompt: "extra",
+      userMessage: "u",
+    });
+    expect(text).toContain("[CACHEABLE PREFIX]\nSTABLE_PREFIX");
+    expect(text).toContain("[SYSTEM]\nextra");
+    expect(text).toContain("[USER]\nu");
+  });
+});
+
+describe("shouldRedactPii", () => {
+  it("false por default", () => {
+    expect(shouldRedactPii()).toBe(false);
+  });
+  it("true quando env=true", () => {
+    process.env["MOTOR_TRACE_REDACT_PII"] = "true";
+    expect(shouldRedactPii()).toBe(true);
+  });
+  it("false quando env=anything-else", () => {
+    process.env["MOTOR_TRACE_REDACT_PII"] = "yes";
+    expect(shouldRedactPii()).toBe(false);
+  });
+});
+
+describe("callGatewayWithTracing — transparent path", () => {
+  it("sem collector, comporta-se como callGateway (mesmo retorno)", async () => {
+    mockedCallGateway.mockResolvedValueOnce(outputFixture());
+    const result = await callGatewayWithTracing(reqFixture(), "assessor");
+    expect(result.content).toBe("Me sinto bem.");
+    expect(mockedCallGateway).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("callGatewayWithTracing — collector path", () => {
+  it("captura sucesso completo: prompt, response, tokens, ms, model", async () => {
+    mockedCallGateway.mockResolvedValueOnce(
+      outputFixture({
+        provider: "infomaniak",
+        model: "qwen3-coder",
+        latency_ms: 999,
+        tokens: { in: 50, out: 10, reasoning: 0 },
+      }),
+    );
+    const c = createLlmTraceCollector();
+    await callGatewayWithTracing(reqFixture(), "assessor", c);
+    const calls = c.drain();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      role: "assessor",
+      provider: "infomaniak",
+      model: "qwen3-coder",
+      duration_ms: 999,
+      input_tokens: 50,
+      output_tokens: 10,
+    });
+    expect(calls[0].prompt).toContain("Be helpful.");
+    expect(calls[0].prompt).toContain("Como você se sente?");
+    expect(calls[0].response).toBe("Me sinto bem.");
+    expect(calls[0].id).toMatch(/^llm-[a-f0-9]+$/);
+  });
+
+  it("captura prompt_cache_hit quando cacheRead > 0", async () => {
+    mockedCallGateway.mockResolvedValueOnce(
+      outputFixture({
+        tokens: { in: 100, out: 20, reasoning: 0, cacheRead: 80 },
+      }),
+    );
+    const c = createLlmTraceCollector();
+    await callGatewayWithTracing(reqFixture(), "materializer", c);
+    expect(c.peek()[0]?.prompt_cache_hit).toBe(true);
+  });
+
+  it("NÃO marca prompt_cache_hit quando cacheRead=0 ou ausente", async () => {
+    mockedCallGateway.mockResolvedValueOnce(outputFixture());
+    const c = createLlmTraceCollector();
+    await callGatewayWithTracing(reqFixture(), "materializer", c);
+    expect(c.peek()[0]?.prompt_cache_hit).toBeUndefined();
+  });
+
+  it("mapeia openai-compat → local", async () => {
+    mockedCallGateway.mockResolvedValueOnce(
+      outputFixture({ provider: "openai-compat", model: "qwen14b" }),
+    );
+    const c = createLlmTraceCollector();
+    await callGatewayWithTracing(reqFixture(), "assessor", c);
+    expect(c.peek()[0]?.provider).toBe("local");
+  });
+
+  it("erro: captura LlmCallTrace com error + re-throws", async () => {
+    mockedCallGateway.mockRejectedValueOnce(new Error("gateway timeout"));
+    const c = createLlmTraceCollector();
+    await expect(
+      callGatewayWithTracing(reqFixture(), "assessor", c),
+    ).rejects.toThrow("gateway timeout");
+    expect(c.size()).toBe(1);
+    expect(c.peek()[0]?.error).toBe("gateway timeout");
+    expect(c.peek()[0]?.response).toBe("");
+  });
+
+  it("acumula múltiplas chamadas em sequência", async () => {
+    mockedCallGateway
+      .mockResolvedValueOnce(outputFixture({ provider: "local", model: "qwen14b" }))
+      .mockResolvedValueOnce(outputFixture({ provider: "anthropic" }));
+    const c = createLlmTraceCollector();
+    await callGatewayWithTracing(reqFixture(), "assessor", c);
+    await callGatewayWithTracing(reqFixture(), "materializer", c);
+    expect(c.size()).toBe(2);
+    expect(c.peek()[0]?.role).toBe("assessor");
+    expect(c.peek()[1]?.role).toBe("materializer");
+  });
+});
+
+describe("callGatewayWithTracing — redaction", () => {
+  it("substitui prompt + response por hashes quando env=true", async () => {
+    process.env["MOTOR_TRACE_REDACT_PII"] = "true";
+    mockedCallGateway.mockResolvedValueOnce(outputFixture());
+    const c = createLlmTraceCollector();
+    await callGatewayWithTracing(reqFixture(), "assessor", c);
+    const call = c.peek()[0];
+    expect(call?.prompt).toMatch(/^\[REDACTED sha256:[a-f0-9]+ len=\d+\]$/);
+    expect(call?.response).toMatch(/^\[REDACTED sha256:[a-f0-9]+ len=\d+\]$/);
+    expect(call?.redacted).toBe(true);
+  });
+
+  it("preserva prompt literal quando env=false (default dev)", async () => {
+    mockedCallGateway.mockResolvedValueOnce(outputFixture());
+    const c = createLlmTraceCollector();
+    await callGatewayWithTracing(reqFixture(), "assessor", c);
+    const call = c.peek()[0];
+    expect(call?.prompt).toContain("Como você se sente?");
+    expect(call?.redacted).toBeUndefined();
+  });
+
+  it("redaction também no erro path", async () => {
+    process.env["MOTOR_TRACE_REDACT_PII"] = "true";
+    mockedCallGateway.mockRejectedValueOnce(new Error("boom"));
+    const c = createLlmTraceCollector();
+    await expect(
+      callGatewayWithTracing(reqFixture(), "assessor", c),
+    ).rejects.toThrow();
+    expect(c.peek()[0]?.prompt).toMatch(/^\[REDACTED/);
+    expect(c.peek()[0]?.redacted).toBe(true);
+  });
+});


### PR DESCRIPTION
Wrapper opcional sobre `callGateway` que captura `LlmCallTrace` por chamada. `callGateway()` original intocado — backward 100%.

## API nova

- `createLlmTraceCollector()` — push/drain/peek/size
- `callGatewayWithTracing(req, role, collector?)` — wrapper
- `buildPromptText(req)` — concatena cacheable prefix + system + user
- `mapGatewayProviderToTrace(p)` — openai-compat → local
- `shouldRedactPii()` — env `MOTOR_TRACE_REDACT_PII=true`

## Captura

| | Sucesso | Erro |
|---|---|---|
| prompt | full text (system+user) | full text |
| response | result.content | "" |
| duration_ms | result.latency_ms | now - start |
| input_tokens / output_tokens | result.tokens.in/out | omitted |
| prompt_cache_hit | true se cacheRead>0 | omitted |
| error | undefined | error.message |

Re-throws erro original — caller decide fallback.

## Privacy

`MOTOR_TRACE_REDACT_PII=true` substitui prompt + response por `[REDACTED sha256:abcd1234 len=N]`. Default false em dev/CI.

## Test plan

- [x] 20 casos novos cobrindo collector, mapping, prompt builder, transparent path, sucesso completo, cache_hit, erro+re-throw, sequência múltipla, redaction (success + error)
- [x] 862 shared + 337 motor/planejador verdes
- [x] Build shared limpo

## Próximas sub-fases

- **TV2-3**: 4 componentes (assessor/selector/materializer/planejador) retornam trace seções usando collector
- **TV2-4**: handleSimplifiedPipeline agrega tudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)