### PR TITLE
[feat ops#1136] TV2-3: 4 componentes retornam _trace seções

### DIFF
--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -18,8 +18,14 @@
  * model dali.
  */
 
-import { callGateway } from "@ascendimacy/shared";
-import type { ScoredContentItem, EngagementLevel } from "@ascendimacy/shared";
+import { callGateway, callGatewayWithTracing } from "@ascendimacy/shared";
+import type {
+  EngagementLevel,
+  LlmTraceCollector,
+  MaterializerTrace,
+  ScoredContentItem,
+} from "@ascendimacy/shared";
+import { createHash } from "node:crypto";
 import { sanitizeMaterialization } from "./select.js";
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -103,6 +109,16 @@ export interface MaterializationResult {
     concept_id: string;
     framing_used: string;
   };
+  /**
+   * TV2-3 (spec ops#1136): trace section opcional. Presente quando
+   * caller passou `opts.collector`. Inclui stable_prefix_hash, user
+   * message construído, raw response, final_text + llm_call_ref.
+   */
+  _trace?: MaterializerTrace;
+}
+
+export interface MaterializeOpts {
+  collector?: LlmTraceCollector;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -277,9 +293,11 @@ function adaptiveMaxTokens(
  */
 export async function materialize(
   ctx: MaterializerContext,
+  opts?: MaterializeOpts,
 ): Promise<MaterializationResult> {
   const t0 = Date.now();
   const userMessage = buildUserMessage(ctx);
+  const collector = opts?.collector;
   if (process.env["ASC_DEBUG_MATERIALIZER"] === "true") {
     // eslint-disable-next-line no-console
     console.error(
@@ -290,23 +308,25 @@ export async function materialize(
   let rawText: string;
   let modelUsed = "unknown";
   let outTokens = 0;
+  let llmCallId: string | undefined;
+  let cacheablePrefixUsed: string = STABLE_MATERIALIZER_PREFIX;
 
   try {
     // 2026-05-07 Nível A (#476 Phase 2): profile vai pro cacheableSystemPrefix
     // pra cache hit cross-turn dentro da sessão (profile constante por 6 turns
     // entre compressões). llama-server prefix caching pega automaticamente.
     const profileBlock = (ctx.personaProfileBlock ?? "").trim();
-    const cacheablePrefix =
+    cacheablePrefixUsed =
       profileBlock.length > 0
         ? `${STABLE_MATERIALIZER_PREFIX}\n\n${profileBlock}`
         : STABLE_MATERIALIZER_PREFIX;
 
-    const out = await callGateway({
+    const req = {
       step: ctx.llmStep ?? "drota",
       // systemPrompt vazio: tudo fixo está em cacheableSystemPrefix.
       // Preserva prefix caching no vLLM (Step 8 do handoff).
       systemPrompt: "",
-      cacheableSystemPrefix: cacheablePrefix,
+      cacheableSystemPrefix: cacheablePrefixUsed,
       userMessage,
       // 2026-05-05 (sts-realista): turn 1-3 mantém 300 (rapport curto).
       // turn 4+ permite 600 — abre espaço pra profundidade quando há contexto
@@ -317,19 +337,40 @@ export async function materialize(
       // Override explícito via ctx.maxTokens vence.
       maxTokens: ctx.maxTokens ?? adaptiveMaxTokens(ctx.turnCount, ctx.engagement, ctx.mood),
       run_id: ctx.run_id,
-    });
+    };
+    const beforeSize = collector?.size() ?? 0;
+    const out = collector
+      ? await callGatewayWithTracing(req, "materializer", collector)
+      : await callGateway(req);
     rawText = out.content;
     modelUsed = `${out.provider}:${out.model}`;
     outTokens = out.tokens.out;
+    llmCallId = collector?.peek()[beforeSize]?.id;
   } catch {
     // LLM error → texto neutro fallback hardcoded
+    const fallbackText = "Tô por aqui. Quando quiser me contar mais, conta.";
     return {
-      text: "Tô por aqui. Quando quiser me contar mais, conta.",
+      text: fallbackText,
       model_used: "fallback_hardcoded",
       fallback_triggered: true,
       latency_ms: Date.now() - t0,
       token_count: 0,
       sanitization_applied: false,
+      ...(collector
+        ? {
+            _trace: {
+              inputs: {
+                selected_item_id: ctx.action.item.id,
+                user_message: userMessage,
+              },
+              stable_prefix_hash: hashCacheablePrefix(cacheablePrefixUsed),
+              user_message_constructed: userMessage,
+              outputs: { raw_response: "", final_text: fallbackText },
+              llm_call_ref: collector.peek()[collector.size() - 1]?.id ?? "",
+              duration_ms: Date.now() - t0,
+            } satisfies MaterializerTrace,
+          }
+        : {}),
     };
   }
 
@@ -361,7 +402,33 @@ export async function materialize(
     token_count: outTokens,
     sanitization_applied: sanitizationApplied,
     ...(recallEmission.emitted ? { recall_check_emitted: recallEmission.emitted } : {}),
+    ...(collector
+      ? {
+          _trace: {
+            inputs: {
+              selected_item_id: ctx.action.item.id,
+              user_message: userMessage,
+            },
+            stable_prefix_hash: hashCacheablePrefix(cacheablePrefixUsed),
+            user_message_constructed: userMessage,
+            outputs: { raw_response: rawText, final_text: recallEmission.text },
+            llm_call_ref: llmCallId ?? "",
+            duration_ms: Date.now() - t0,
+          } satisfies MaterializerTrace,
+        }
+      : {}),
   };
+}
+
+/**
+ * Hash sha256 (first 16 chars) do cacheable prefix — pra debug do prefix
+ * caching cross-turn. Mesmo hash entre turns = cache hit no vLLM/llama-server.
+ */
+function hashCacheablePrefix(prefix: string): string {
+  return (
+    "sha256:" +
+    createHash("sha256").update(prefix).digest("hex").slice(0, 16)
+  );
 }
 
 /**

--- a/motor-drota/src/pragmatic-selector.ts
+++ b/motor-drota/src/pragmatic-selector.ts
@@ -19,6 +19,7 @@
 import { deductBudget } from "@ascendimacy/shared";
 import type {
   ScoredContentItem,
+  SelectorTrace,
   SessionState,
   EngagementLevel,
 } from "@ascendimacy/shared";
@@ -70,6 +71,19 @@ export interface SelectionResult {
   escalate_to: "bridge" | "planner" | null;
   /** Reason de escalação (se aplicável). */
   escalate_reason?: EscalationReason;
+
+  /**
+   * TV2-3 (spec ops#1136): trace section opcional. Presente quando
+   * caller passou `opts.captureTrace=true`. Estrutura: pool_size,
+   * mood, budget + filters_applied (criticality/budget/mood/engagement)
+   * com items_removed.
+   */
+  _trace?: SelectorTrace;
+}
+
+export interface SelectActionOpts {
+  /** Quando true, monta SelectorTrace em result._trace. */
+  captureTrace?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -157,9 +171,30 @@ function describeViabilityFilter(
  *
  * Sempre retorna SelectionResult válido, nunca lança.
  */
-export function selectAction(input: SelectorInput): SelectionResult {
+export function selectAction(
+  input: SelectorInput,
+  opts?: SelectActionOpts,
+): SelectionResult {
   const { candidates, assessment, state, criticalityByItemId } = input;
   const budgetBefore = state.budgetRemaining;
+  const t0 = Date.now();
+  const filtersApplied: SelectorTrace["filters_applied"] = [];
+  const buildTrace = opts?.captureTrace
+    ? (selectedId: string, poolRemaining: string[]): SelectorTrace => ({
+        inputs: {
+          pool_size: candidates.length,
+          mood: assessment.mood,
+          budget: budgetBefore,
+        },
+        filters_applied: filtersApplied,
+        outputs: { selected_id: selectedId, pool_remaining: poolRemaining },
+        duration_ms: Date.now() - t0,
+      })
+    : undefined;
+  const removedNotIn = (after: ScoredContentItem[]): string[] => {
+    const kept = new Set(after.map((c) => c.item.id));
+    return candidates.filter((c) => !kept.has(c.item.id)).map((c) => c.item.id);
+  };
 
   // Pool vazio → escala Planejador
   if (candidates.length === 0) {
@@ -175,6 +210,7 @@ export function selectAction(input: SelectorInput): SelectionResult {
       pulso_emitted: false,
       escalate_to: "planner",
       escalate_reason: "no_viable_action",
+      ...(buildTrace ? { _trace: buildTrace("", []) } : {}),
     };
   }
 
@@ -186,6 +222,13 @@ export function selectAction(input: SelectorInput): SelectionResult {
     const selected = securityActions[0]!;
     const cost = getCost(selected);
     const newState = deductBudget(state, cost);
+    if (buildTrace) {
+      filtersApplied.push({
+        name: "criticality_security_gate",
+        items_removed: removedNotIn(securityActions),
+        reason: "criticality=seguranca presente; outras filtradas",
+      });
+    }
     return {
       selected,
       newState,
@@ -198,12 +241,22 @@ export function selectAction(input: SelectorInput): SelectionResult {
       pulso_emitted: false,
       escalate_to: "bridge",
       escalate_reason: "criticality_seguranca",
+      ...(buildTrace
+        ? { _trace: buildTrace(selected.item.id, securityActions.map((c) => c.item.id)) }
+        : {}),
     };
   }
 
   // Step 4 (early) — Budget ≤ 0 → modo mínimo
   if (budgetBefore <= 0) {
     const minimal = applyCostCap(candidates, MINIMAL_COST_CAP);
+    if (buildTrace) {
+      filtersApplied.push({
+        name: "budget_exhausted_minimal_cap",
+        items_removed: removedNotIn(minimal),
+        reason: `budget=${budgetBefore} ≤ 0 → cost≤${MINIMAL_COST_CAP}`,
+      });
+    }
     if (minimal.length === 0) {
       return {
         selected: null,
@@ -217,6 +270,7 @@ export function selectAction(input: SelectorInput): SelectionResult {
         pulso_emitted: false,
         escalate_to: "planner",
         escalate_reason: "budget_exhausted",
+        ...(buildTrace ? { _trace: buildTrace("", []) } : {}),
       };
     }
     minimal.sort((a, b) => getCost(a) - getCost(b));
@@ -234,6 +288,9 @@ export function selectAction(input: SelectorInput): SelectionResult {
       budget_after: newState.budgetRemaining,
       pulso_emitted: false,
       escalate_to: null,
+      ...(buildTrace
+        ? { _trace: buildTrace(selected.item.id, minimal.map((c) => c.item.id)) }
+        : {}),
     };
   }
 
@@ -242,14 +299,29 @@ export function selectAction(input: SelectorInput): SelectionResult {
   const engagement = assessment.engagement;
 
   let viable: ScoredContentItem[];
+  let viabilityFilterName = "no_filter";
+  let viabilityFilterReason = "mood/budget ok";
   if (mood <= MOOD_LOW_THRESHOLD) {
     viable = applyCostCap(candidates, MOOD_LOW_COST_CAP);
+    viabilityFilterName = "mood_low_cap";
+    viabilityFilterReason = `mood=${mood} ≤ ${MOOD_LOW_THRESHOLD} → cost≤${MOOD_LOW_COST_CAP}`;
   } else if (engagement === "disengaging") {
     viable = applyCostCap(candidates, DISENGAGING_COST_CAP);
+    viabilityFilterName = "disengaging_cap";
+    viabilityFilterReason = `engagement=disengaging → cost≤${DISENGAGING_COST_CAP}`;
   } else if (budgetBefore < BUDGET_LOW_THRESHOLD) {
     viable = applyCostCap(candidates, BUDGET_LOW_COST_CAP);
+    viabilityFilterName = "budget_low_cap";
+    viabilityFilterReason = `budget=${budgetBefore} < ${BUDGET_LOW_THRESHOLD} → cost≤${BUDGET_LOW_COST_CAP}`;
   } else {
     viable = [...candidates];
+  }
+  if (buildTrace && viabilityFilterName !== "no_filter") {
+    filtersApplied.push({
+      name: viabilityFilterName,
+      items_removed: removedNotIn(viable),
+      reason: viabilityFilterReason,
+    });
   }
 
   // Step 3 — Sem viáveis → escala Planejador
@@ -266,6 +338,7 @@ export function selectAction(input: SelectorInput): SelectionResult {
       pulso_emitted: false,
       escalate_to: "planner",
       escalate_reason: "no_viable_action",
+      ...(buildTrace ? { _trace: buildTrace("", []) } : {}),
     };
   }
 
@@ -317,5 +390,8 @@ export function selectAction(input: SelectorInput): SelectionResult {
     budget_after: newState.budgetRemaining,
     pulso_emitted: false,
     escalate_to: null,
+    ...(buildTrace
+      ? { _trace: buildTrace(selected.item.id, viable.map((c) => c.item.id)) }
+      : {}),
   };
 }

--- a/motor-drota/src/unified-assessor.ts
+++ b/motor-drota/src/unified-assessor.ts
@@ -27,9 +27,15 @@
 
 import {
   callGateway,
+  callGatewayWithTracing,
   isSemanticSignal,
 } from "@ascendimacy/shared";
-import type { SemanticSignal, EngagementLevel } from "@ascendimacy/shared";
+import type {
+  AssessorTrace,
+  EngagementLevel,
+  LlmTraceCollector,
+  SemanticSignal,
+} from "@ascendimacy/shared";
 
 // ─────────────────────────────────────────────────────────────────────────
 // Tipos
@@ -81,6 +87,18 @@ export interface AssessmentResult {
 
   /** Latência da chamada LLM em ms (0 se rule-only). */
   latency_ms: number;
+
+  /**
+   * TV2-3 (spec ops#1136): trace section opcional. Presente quando
+   * caller passou `opts.collector`. Consumido pelo agregador
+   * EngineTraceV2.components.unified_assessor.
+   */
+  _trace?: AssessorTrace;
+}
+
+export interface AssessOpts {
+  /** Trace collector — quando presente, LLM call é coletada + _trace emitido. */
+  collector?: LlmTraceCollector;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -312,19 +330,26 @@ Responda em JSON.`;
 
 async function assessByLlm(
   input: AssessorInput,
-): Promise<{ result: LlmJsonOutput; latency_ms: number } | null> {
+  collector?: LlmTraceCollector,
+): Promise<{ result: LlmJsonOutput; latency_ms: number; llmCallId?: string } | null> {
   const t0 = Date.now();
   try {
-    const out = await callGateway({
+    const req = {
       step: "unified-assessor",
       systemPrompt: SYSTEM_PROMPT,
       userMessage: buildUserMessage(input),
       maxTokens: 256,
       run_id: input.run_id,
-    });
+    };
+    const beforeSize = collector?.size() ?? 0;
+    const out = collector
+      ? await callGatewayWithTracing(req, "assessor", collector)
+      : await callGateway(req);
     const parsed = parseJsonResponse(out.content);
     if (!parsed) return null;
-    return { result: parsed, latency_ms: Date.now() - t0 };
+    // Capture id do LLM call recém-adicionado (pra llm_call_ref no trace).
+    const llmCallId = collector?.peek()[beforeSize]?.id;
+    return { result: parsed, latency_ms: Date.now() - t0, llmCallId };
   } catch {
     return null;
   }
@@ -344,7 +369,28 @@ async function assessByLlm(
  */
 export async function assess(
   input: AssessorInput,
+  opts?: AssessOpts,
 ): Promise<AssessmentResult> {
+  const t0 = Date.now();
+  const buildTrace = opts?.collector
+    ? (
+        method: "rule" | "llm" | "fallback",
+        mood: number,
+        signals: SemanticSignal[],
+        engagement: EngagementLevel,
+        llmCallRef?: string,
+      ): AssessorTrace => ({
+        inputs: {
+          user_message: input.message,
+          turn_history_window: input.recentTurns.length,
+        },
+        outputs: { mood, signals, engagement },
+        mood_method: method,
+        duration_ms: Date.now() - t0,
+        ...(llmCallRef !== undefined ? { llm_call_ref: llmCallRef } : {}),
+      })
+    : undefined;
+
   // Step 1 — rule-based
   const rule = assessByRules(input);
   if (rule && rule.mood_confidence === "high") {
@@ -357,11 +403,14 @@ export async function assess(
       assessment_method: "rule_only",
       rationale: rule.rationale,
       latency_ms: 0,
+      ...(buildTrace
+        ? { _trace: buildTrace("rule", rule.mood, rule.signals, rule.engagement) }
+        : {}),
     };
   }
 
   // Step 2 — LLM (Haiku)
-  const llm = await assessByLlm(input);
+  const llm = await assessByLlm(input, opts?.collector);
   if (llm) {
     const validSignals = llm.result.signals.filter(isSemanticSignal);
     return {
@@ -373,6 +422,17 @@ export async function assess(
       assessment_method: "unified_haiku",
       rationale: llm.result.rationale,
       latency_ms: llm.latency_ms,
+      ...(buildTrace
+        ? {
+            _trace: buildTrace(
+              "llm",
+              llm.result.mood,
+              validSignals,
+              llm.result.engagement,
+              llm.llmCallId,
+            ),
+          }
+        : {}),
     };
   }
 
@@ -388,6 +448,9 @@ export async function assess(
       assessment_method: "rule_only",
       rationale: rule.rationale + " (LLM indisponível)",
       latency_ms: 0,
+      ...(buildTrace
+        ? { _trace: buildTrace("rule", rule.mood, rule.signals, rule.engagement) }
+        : {}),
     };
   }
 
@@ -400,5 +463,18 @@ export async function assess(
     assessment_method: "fallback",
     rationale: "fallback: rule-based ambíguo + LLM indisponível",
     latency_ms: 0,
+    ...(opts?.collector
+      ? {
+          _trace: {
+            inputs: {
+              user_message: input.message,
+              turn_history_window: input.recentTurns.length,
+            },
+            outputs: { mood: MOOD_FALLBACK, signals: [], engagement: "medium" },
+            mood_method: "fallback",
+            duration_ms: Date.now() - t0,
+          } satisfies AssessorTrace,
+        }
+      : {}),
   };
 }

--- a/motor-drota/tests/component-traces.test.ts
+++ b/motor-drota/tests/component-traces.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests TV2-3 — componentes retornam _trace quando collector passado.
+ *
+ * Cobre unified-assessor, pragmatic-selector, constrained-materializer.
+ * Planejador tem suite própria (testes em planejador/tests/).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { assess } from "../src/unified-assessor.js";
+import { selectAction } from "../src/pragmatic-selector.js";
+import { materialize } from "../src/constrained-materializer.js";
+import { createLlmTraceCollector } from "@ascendimacy/shared";
+import type {
+  ScoredContentItem,
+  SessionState,
+  ContentItem,
+} from "@ascendimacy/shared";
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: vi.fn(async () => ({
+      content: "mocked response",
+      tokens: { in: 50, out: 10, reasoning: 0 },
+      provider: "local" as const,
+      model: "qwen14b",
+      latency_ms: 500,
+      attempt_count: 1,
+      was_fallback: false,
+    })),
+    callGatewayWithTracing: vi.fn(async (_req, role, collector) => {
+      // Simula wrapper real — push trace + retorna resposta
+      const id = `llm-mock-${role}-${Date.now()}`;
+      collector?.push({
+        id,
+        role,
+        provider: "local",
+        model: "qwen14b",
+        prompt: "mock prompt",
+        response: "mocked response",
+        duration_ms: 500,
+      });
+      return {
+        content: "mocked response",
+        tokens: { in: 50, out: 10, reasoning: 0 },
+        provider: "local" as const,
+        model: "qwen14b",
+        latency_ms: 500,
+        attempt_count: 1,
+        was_fallback: false,
+      };
+    }),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("assess (unified-assessor) — TV2-3", () => {
+  it("sem collector, NÃO emite _trace (backward compat)", async () => {
+    const result = await assess({
+      message: "tô feliz pra caralho",
+      recentTurns: [],
+    });
+    expect(result._trace).toBeUndefined();
+  });
+
+  it("com collector, emite AssessorTrace (rule path)", async () => {
+    const collector = createLlmTraceCollector();
+    const result = await assess(
+      { message: "tô bem feliz!", recentTurns: [] },
+      { collector },
+    );
+    expect(result._trace).toBeDefined();
+    expect(result._trace?.outputs.mood).toBe(result.mood);
+    expect(result._trace?.outputs.signals).toEqual(result.signals);
+    expect(["rule", "llm", "fallback"]).toContain(result._trace?.mood_method);
+    expect(result._trace?.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("com collector, captura user_message + history_window", async () => {
+    const collector = createLlmTraceCollector();
+    const result = await assess(
+      {
+        message: "como vai?",
+        recentTurns: [
+          { role: "user", content: "oi" },
+          { role: "assistant", content: "olá" },
+        ],
+      },
+      { collector },
+    );
+    expect(result._trace?.inputs.user_message).toBe("como vai?");
+    expect(result._trace?.inputs.turn_history_window).toBe(2);
+  });
+});
+
+describe("selectAction (pragmatic-selector) — TV2-3", () => {
+  const makeItem = (
+    id: string,
+    sacrifice = 5,
+    score = 10,
+  ): ScoredContentItem => ({
+    item: {
+      id,
+      type: "curiosity_hook",
+      domain: "biologia",
+      casel_target: ["SA"],
+      age_range: [10, 15],
+      surprise: 7,
+      verified: true,
+      base_score: 5,
+      sacrifice_amount: sacrifice,
+      fact: "f",
+      bridge: "b",
+      quest: "q",
+      sacrifice_type: "reflect",
+    } as ContentItem,
+    score,
+    reasons: ["base_score=5"],
+  });
+
+  const state: SessionState = {
+    turn: 1,
+    sessionId: "s1",
+    userId: "u1",
+    budgetRemaining: 100,
+    statusMatrix: { honesty: [], integrity: [] },
+    eventLog: [],
+  } as never;
+
+  const assessment = {
+    mood: 7,
+    mood_confidence: "high" as const,
+    mood_method: "rule" as const,
+    signals: [],
+    engagement: "medium" as const,
+    assessment_method: "rule_only" as const,
+    rationale: "ok",
+    latency_ms: 0,
+  };
+
+  it("sem captureTrace, NÃO emite _trace", () => {
+    const result = selectAction({
+      candidates: [makeItem("a")],
+      assessment,
+      state,
+    });
+    expect(result._trace).toBeUndefined();
+  });
+
+  it("com captureTrace, emite SelectorTrace básico", () => {
+    const result = selectAction(
+      {
+        candidates: [makeItem("a"), makeItem("b", 8)],
+        assessment,
+        state,
+      },
+      { captureTrace: true },
+    );
+    expect(result._trace).toBeDefined();
+    expect(result._trace?.inputs.pool_size).toBe(2);
+    expect(result._trace?.inputs.mood).toBe(7);
+    expect(result._trace?.outputs.selected_id).toBe(result.selected?.item.id);
+    expect(result._trace?.outputs.pool_remaining).toContain("a");
+  });
+
+  it("mood baixo dispara mood_low_cap filter no trace", () => {
+    const result = selectAction(
+      {
+        candidates: [makeItem("expensive", 10), makeItem("cheap", 2)],
+        assessment: { ...assessment, mood: 2 },
+        state,
+      },
+      { captureTrace: true },
+    );
+    const filter = result._trace?.filters_applied.find(
+      (f) => f.name === "mood_low_cap",
+    );
+    expect(filter).toBeDefined();
+    expect(filter?.items_removed).toContain("expensive");
+    expect(filter?.items_removed).not.toContain("cheap");
+  });
+
+  it("pool vazio com trace ainda retorna estrutura válida", () => {
+    const result = selectAction(
+      { candidates: [], assessment, state },
+      { captureTrace: true },
+    );
+    expect(result._trace).toBeDefined();
+    expect(result._trace?.inputs.pool_size).toBe(0);
+    expect(result._trace?.outputs.selected_id).toBe("");
+  });
+});
+
+describe("materialize (constrained-materializer) — TV2-3", () => {
+  const ctx = {
+    action: {
+      item: {
+        id: "test_item",
+        type: "curiosity_hook" as const,
+        domain: "biologia",
+        casel_target: ["SA" as const],
+        age_range: [10, 15] as [number, number],
+        surprise: 7,
+        verified: true,
+        base_score: 5,
+        fact: "f",
+        bridge: "b",
+        quest: "q",
+        sacrifice_type: "reflect" as const,
+      },
+      score: 10,
+      reasons: [],
+    },
+    subjectNameForm: "Test",
+    mood: 7,
+    engagement: "medium" as const,
+    turnCount: 1,
+    budgetRemaining: 100,
+    jurisdictionActive: "br" as const,
+  };
+
+  it("sem collector, NÃO emite _trace", async () => {
+    const result = await materialize(ctx);
+    expect(result._trace).toBeUndefined();
+  });
+
+  it("com collector, emite MaterializerTrace com stable_prefix_hash + llm_call_ref", async () => {
+    const collector = createLlmTraceCollector();
+    const result = await materialize(ctx, { collector });
+    expect(result._trace).toBeDefined();
+    expect(result._trace?.inputs.selected_item_id).toBe("test_item");
+    expect(result._trace?.stable_prefix_hash).toMatch(/^sha256:[a-f0-9]{16}$/);
+    expect(result._trace?.outputs.raw_response).toBe("mocked response");
+    expect(result._trace?.outputs.final_text).toBeTruthy();
+    expect(result._trace?.llm_call_ref).toMatch(/^llm-mock-materializer/);
+  });
+
+  it("hash do prefix é determinístico cross-runs", async () => {
+    const collector1 = createLlmTraceCollector();
+    const collector2 = createLlmTraceCollector();
+    const r1 = await materialize(ctx, { collector: collector1 });
+    const r2 = await materialize(ctx, { collector: collector2 });
+    expect(r1._trace?.stable_prefix_hash).toBe(r2._trace?.stable_prefix_hash);
+  });
+});

--- a/planejador/src/llm-client.ts
+++ b/planejador/src/llm-client.ts
@@ -14,6 +14,7 @@
 
 import {
   callGateway,
+  callGatewayWithTracing,
   isDebugModeEnabled,
   getProviderForStep,
   getModelForStep,
@@ -21,6 +22,8 @@ import {
   shouldEnableThinking,
   getThinkingBudgetTokens,
   type LlmProvider,
+  type LlmCallRole,
+  type LlmTraceCollector,
 } from "@ascendimacy/shared";
 
 export interface LlmCallResult {
@@ -33,14 +36,29 @@ export interface LlmCallResult {
   model: string;
 }
 
-async function callViaGateway(step: string, systemPrompt: string, userMessage: string): Promise<LlmCallResult> {
+/**
+ * TV2-3 (spec ops#1136): opções opcionais pra coletar LlmCallTrace.
+ * Backward 100% — quando ausente, comporta-se como antes.
+ */
+export interface CallLlmOpts {
+  collector?: LlmTraceCollector;
+  /** Role pro trace catalog. Default "planejador". */
+  role?: LlmCallRole;
+}
+
+async function callViaGateway(
+  step: string,
+  systemPrompt: string,
+  userMessage: string,
+  opts?: CallLlmOpts,
+): Promise<LlmCallResult> {
   const provider = getProviderForStep(step);
   const model = getModelForStep(step, provider);
   const maxTokens = getMaxTokensForStep(step, model);
   const enableThinking = shouldEnableThinking(step, provider, isDebugModeEnabled());
   const thinkingBudgetTokens = enableThinking ? getThinkingBudgetTokens() : undefined;
 
-  const out = await callGateway({
+  const req = {
     step,
     provider,
     model,
@@ -50,7 +68,10 @@ async function callViaGateway(step: string, systemPrompt: string, userMessage: s
     enableThinking: enableThinking || undefined,
     thinkingBudgetTokens,
     run_id: process.env["ASC_DEBUG_RUN_ID"],
-  });
+  };
+  const out = opts?.collector
+    ? await callGatewayWithTracing(req, opts.role ?? "planejador", opts.collector)
+    : await callGateway(req);
 
   return {
     content: out.content,
@@ -64,8 +85,12 @@ async function callViaGateway(step: string, systemPrompt: string, userMessage: s
 /**
  * callLlm — motor#28c dispatcher via gateway pra step `planejador`.
  */
-export async function callLlm(systemPrompt: string, userMessage: string): Promise<LlmCallResult> {
-  return callViaGateway("planejador", systemPrompt, userMessage);
+export async function callLlm(
+  systemPrompt: string,
+  userMessage: string,
+  opts?: CallLlmOpts,
+): Promise<LlmCallResult> {
+  return callViaGateway("planejador", systemPrompt, userMessage, opts);
 }
 
 /**
@@ -74,8 +99,12 @@ export async function callLlm(systemPrompt: string, userMessage: string): Promis
  * Default agora é Infomaniak/mistral3 (small fast). Opt-in pra Anthropic Haiku
  * via HAIKU_TRIAGE_PROVIDER=anthropic.
  */
-export async function callHaiku(systemPrompt: string, userMessage: string): Promise<LlmCallResult> {
-  return callViaGateway("haiku-triage", systemPrompt, userMessage);
+export async function callHaiku(
+  systemPrompt: string,
+  userMessage: string,
+  opts?: CallLlmOpts,
+): Promise<LlmCallResult> {
+  return callViaGateway("haiku-triage", systemPrompt, userMessage, opts);
 }
 
 export async function callLlmMock(_systemPrompt: string, _userMessage: string): Promise<LlmCallResult> {

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -43,6 +43,12 @@ import {
   isExhausted,
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku, type LlmCallResult } from "./llm-client.js";
+import type { LlmTraceCollector, PlanejadorTrace } from "@ascendimacy/shared";
+
+export interface PlanTurnOpts {
+  /** TV2-3 (spec ops#1136): coletor pra LLM call + trace section. */
+  collector?: LlmTraceCollector;
+}
 import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
 import { evaluateAllTransitions, collectRecentSignals } from "./trigger-evaluator.js";
 import { personaToChildProfile } from "./child-profile.js";
@@ -274,7 +280,11 @@ function applyPinnedDecisions(pool: ContentItem[], persona: PlanTurnInput["perso
     });
 }
 
-export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
+export async function planTurn(
+  input: PlanTurnInput,
+  opts?: PlanTurnOpts,
+): Promise<PlanTurnOutput> {
+  const planT0 = Date.now();
   const sessionMode = input.state.sessionMode ?? "solo";
 
   // G-22 pool-builder integration (ops#1093) — hidratação de sacrifice context
@@ -432,6 +442,7 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   const t0 = Date.now();
   let llmResult: LlmCallResult | null = null;
   let llmLatency = 0;
+  let llmCallId: string | undefined;
   let rationale: { strategicRationale: string; contextHints: Record<string, unknown> };
   if (canSkipLlmRationale) {
     rationale = {
@@ -451,10 +462,15 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
       // Telemetry não bloqueia.
     }
   } else {
+    const beforeSize = opts?.collector?.size() ?? 0;
     llmResult = useMockLlm
       ? await callLlmMock(systemPrompt, userMessage)
-      : await callLlm(systemPrompt, userMessage);
+      : await callLlm(systemPrompt, userMessage, opts);
     llmLatency = Date.now() - t0;
+    // Captura llm_call_ref pro trace (se collector ativo + não-mock).
+    if (opts?.collector && !useMockLlm) {
+      llmCallId = opts.collector.peek()[beforeSize]?.id;
+    }
     rationale = parseRationale(llmResult.content);
     if (topK !== null && menuSource?.strategic_rationale == null) {
       // Menu hit mas rationale ausente → fallback to LLM. Log pra observability.
@@ -816,6 +832,25 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
   // motor#25 (handoff #25 B5): Shannon entropy do candidate set antes de retornar.
   const candidateSetEntropy = shannonEntropy(slimPool.map((s) => s.item.id));
 
+  const planTrace: PlanejadorTrace | undefined = opts?.collector
+    ? {
+        inputs: {},
+        outputs: {
+          contentPool: slimPool.map((s) => ({
+            item: { id: s.item.id, type: s.item.type, domain: s.item.domain },
+            score: s.score,
+            reasons: s.reasons,
+          })),
+          contextHints,
+          instruction_addition: gardnerInstruction.text,
+          strategicRationale: rationale.strategicRationale,
+          candidateSetEntropy,
+        },
+        ...(llmCallId !== undefined ? { llm_call_ref: llmCallId } : {}),
+        duration_ms: Date.now() - planT0,
+      }
+    : undefined;
+
   return {
     strategicRationale: rationale.strategicRationale,
     contentPool: slimPool,
@@ -823,6 +858,7 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     instruction_addition: gardnerInstruction.text,
     transitionEvaluations: transitionEvaluations.length > 0 ? transitionEvaluations : undefined,
     candidateSetEntropy,
+    ...(planTrace ? { _trace: planTrace } : {}),
   };
 }
 

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -38,6 +38,13 @@ export interface PlanTurnOutput {
   contentPool: ScoredContentItem[];
   contextHints: Record<string, unknown>;
   /**
+   * TV2-3 (spec ops#1136): trace section opcional. Presente quando
+   * caller passou `opts.collector` em planTurn. Inclui contentPool,
+   * contextHints, instruction_addition, strategicRationale, entropy +
+   * llm_call_ref + duration. Importado tardiamente pra evitar dep loop.
+   */
+  _trace?: import("./engine-trace-v2.js").PlanejadorTrace;
+  /**
    * Composed pelo planejador quando mixin ativo (ex: withGardnerProgram).
    * Repassado para `EvaluateAndSelectInput.instruction_addition` (Bloco 2b).
    */

--- a/shared/src/engine-trace-v2.ts
+++ b/shared/src/engine-trace-v2.ts
@@ -178,9 +178,11 @@ export const AssessorTraceSchema = z.object({
   outputs: z.object({
     mood: z.number(),
     signals: z.array(z.string()),
-    engagement: z.enum(["low", "mid", "high"]),
+    /** Alinhado com EngagementLevel em stable-state-cache.ts. */
+    engagement: z.enum(["high", "medium", "low", "disengaging"]),
   }),
-  mood_method: z.enum(["rule", "llm"]),
+  /** "fallback" cobre Step 3 do unified-assessor (rule ambíguo + LLM indisponível). */
+  mood_method: z.enum(["rule", "llm", "fallback"]),
   duration_ms: z.number().nonnegative(),
   llm_call_ref: z.string().optional(),
 });

--- a/shared/tests/engine-trace-v2.test.ts
+++ b/shared/tests/engine-trace-v2.test.ts
@@ -85,7 +85,7 @@ describe("EngineTraceV2Schema", () => {
       components: {
         unified_assessor: {
           inputs: { user_message: "tipo, jogando..." },
-          outputs: { mood: 7, signals: ["positive_engagement"], engagement: "mid" },
+          outputs: { mood: 7, signals: ["positive_engagement"], engagement: "medium" },
           mood_method: "rule",
           duration_ms: 12,
         },


### PR DESCRIPTION
Spec [ops#1136](https://github.com/ascendimacy/ascendimacy-ops/pull/1136) §3.1. Cada componente do pipeline ganha `opts` opcional pra emitir trace section. Backward 100%.

## Componentes estendidos

| Componente | Arg novo | Captura |
|---|---|---|
| **unified-assessor** `assess()` | `opts?: { collector }` | AssessorTrace: mood, signals, engagement, mood_method, llm_call_ref, duration |
| **pragmatic-selector** `selectAction()` | `opts?: { captureTrace }` | SelectorTrace: pool_size, filters_applied[] com items_removed + reason, selected_id |
| **constrained-materializer** `materialize()` | `opts?: { collector }` | MaterializerTrace: stable_prefix_hash (sha256), user_message, raw_response, final_text, llm_call_ref |
| **planejador** `planTurn()` | `opts?: { collector }` | PlanejadorTrace: contentPool, contextHints, instruction_addition, strategicRationale, entropy, llm_call_ref |

LLM components usam `callGatewayWithTracing` (TV2-2) automaticamente. Selector é puramente estrutural (zero LLM).

## Ajustes em TV2-1 (alinhamento domínio)

- `EngagementLevel`: `mid` → `medium`, + `disengaging` (alinha com `stable-state-cache.EngagementLevel`)
- `AssessorTrace.mood_method`: + `fallback` (Step 3 do assess)

## Test plan

- [x] 10 novos casos em `component-traces.test.ts`
  - assess: backward compat (sem collector) + emit _trace + captura history_window
  - selectAction: backward compat + filters_applied corretos (mood_low_cap) + empty pool
  - materialize: backward compat + stable_prefix_hash determinístico cross-runs
- [x] 862 shared + 337 motor/planejador tests verdes
- [x] Build limpo em todos os 3 workspaces

## Próximas sub-fases

- **TV2-4**: handleSimplifiedPipeline cria collector + agrega num EngineTraceV2 + lê snapshots pre/post
- **TV2-5**: STS trace-writer inclui `turn.engineTrace`
- **TV2-6+7**: UI Replay v2 consome (LLM x-ray panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)