### PR TITLE
fix(transitions): BUG-KT-01 — kids.transitions.yaml rubric lossy (ops#1141)

### DIFF
--- a/content/profiles/kids.transitions.yaml
+++ b/content/profiles/kids.transitions.yaml
@@ -28,8 +28,11 @@
 # explícitos vira tarefa F+1 se piloto mostrar precisão insuficiente.
 
 profile_id: kids
-schema_version: v0.2
-last_updated: "2026-04-28"
+schema_version: v0.3
+last_updated: "2026-05-26"
+# v0.3 — BUG-KT-01 (ops#1141) — schema extension:
+#   - confirmatory_min field (combina required + confirmatory; DT-A01-02 recuperado)
+#   - consecutive_turns field (regressões exigem persistência; DT-A01-03 recuperado)
 
 transitions:
 
@@ -54,11 +57,11 @@ transitions:
   # meta_cognitive_observation + voluntary_topic_deepening elevam confidence.
   # Janela: mínimo 5 turns em baia antes de virar pasto.
   #
-  # DT-A01-02: spec original pedia required_signals_all:[frame_synthesis] +
-  # required_signals_any:[meta_cog, voluntary_topic]. Schema atual não
-  # combina 2 grupos — frame_synthesis vira required (AND com 1 elemento),
-  # os outros 2 viram confirmatory (não bloqueiam, mas documentam).
-  # Semantic loss: signals "any" não são strictly required no v0.
+  # DT-A01-02 (recuperado em v0.3, BUG-KT-01 ops#1141):
+  # spec original pedia required_signals_all:[frame_synthesis] +
+  # required_signals_any:[meta_cog, voluntary_topic]. Schema v0.3 introduz
+  # confirmatory_min: combina grupos sem nested-schema —
+  # frame_synthesis MUST (required AND com 1 elemento) + 1 of confirmatory MUST.
   baia_to_pasto:
     required_signals:
       - frame_synthesis
@@ -67,6 +70,7 @@ transitions:
     confirmatory_signals:
       - meta_cognitive_observation
       - voluntary_topic_deepening
+    confirmatory_min: 1
     regression_to_baia_if:
       - distress_marker_high
       - gatekeeper_resistance
@@ -75,10 +79,10 @@ transitions:
   # Critério: distress alto OU 2 deflexões consecutivas.
   # Janela: 0 (regressão imediata, sem buffer).
   #
-  # DT-A01-03: spec pedia consecutive_turns_required: 2 — schema não
-  # suporta consecutive matching. v0 dispara em ocorrência única.
-  # Conservative: 1 distress_marker_high É suficiente; 1 deflection
-  # também (mais permissivo que spec). Refinar v1 se false positive alto.
+  # DT-A01-03 (recuperado em v0.3, BUG-KT-01 ops#1141): spec pedia
+  # consecutive_turns_required: 2 — schema v0.3 suporta. Regressão só dispara
+  # quando required signal aparece em 2 turnos consecutivos (evita false positive
+  # de pico isolado).
   regression_baia_to_brejo:
     required_signals:
       - distress_marker_high
@@ -87,10 +91,11 @@ transitions:
     match_mode: OR
     minimum_window_turns: 0
     confirmatory_signals: []
+    consecutive_turns: 2
 
   # ── Regressão pasto → baia (explícita) ────────────────────────────────
-  # Critério: distress alto OU resistência manifesta.
-  # Janela: 0 (regressão imediata).
+  # Critério: distress alto OU resistência manifesta em 2 turnos consecutivos.
+  # Janela: 0 (regressão imediata após confirmação).
   regression_pasto_to_baia:
     required_signals:
       - distress_marker_high
@@ -98,3 +103,4 @@ transitions:
     match_mode: OR
     minimum_window_turns: 0
     confirmatory_signals: []
+    consecutive_turns: 2

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -44,7 +44,11 @@ import {
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku, type LlmCallResult } from "./llm-client.js";
 import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
-import { evaluateAllTransitions, collectRecentSignals } from "./trigger-evaluator.js";
+import {
+  evaluateAllTransitions,
+  collectRecentSignals,
+  collectRecentSignalsPerTurn,
+} from "./trigger-evaluator.js";
 import { personaToChildProfile } from "./child-profile.js";
 import { lookupActionMenu } from "./strategist/menu-lookup.js";
 import {
@@ -795,10 +799,16 @@ export async function planTurn(input: PlanTurnInput): Promise<PlanTurnOutput> {
     data: Record<string, unknown>;
   }>;
   const recentSignals = collectRecentSignals(eventLog, 5);
+  const recentSignalsPerTurn = collectRecentSignalsPerTurn(eventLog, 5);
   const turnsSinceLastTransition = countTurnsSinceLastTransition(eventLog);
   const transitionEvaluations =
     recentSignals.length > 0
-      ? evaluateAllTransitions(profileId, recentSignals, turnsSinceLastTransition)
+      ? evaluateAllTransitions(
+          profileId,
+          recentSignals,
+          turnsSinceLastTransition,
+          recentSignalsPerTurn,
+        )
       : [];
 
   // Fase 8 PR — Strategist context (sub-PR pós tracer bullet):

--- a/planejador/src/trigger-evaluator.ts
+++ b/planejador/src/trigger-evaluator.ts
@@ -65,21 +65,34 @@ export function resetTransitionsConfigCache(): void {
  *
  * v0: caller emite events transition_evaluated mas NÃO move statusMatrix.
  *
+ * BUG-KT-01 (ops#1141): signalsPerTurn opcional — necessário pra transições
+ * com `consecutive_turns` definido. Quando ausente, transições que exigem
+ * consecutive_turns retornam fired=false. Para suportar regressões com persistência,
+ * caller deve usar `collectRecentSignalsPerTurn` em vez de `collectRecentSignals`.
+ *
  * @param profileId perfil (kids, eprumo, drota-corp, ...)
  * @param signalsObserved signals únicos das últimas N turns (já deduped)
  * @param turnsSinceLastTransition mínima janela em turns no estado atual
+ * @param signalsPerTurn (opcional) signals por turno em ordem cronológica
  */
 export function evaluateAllTransitions(
   profileId: string,
   signalsObserved: string[],
   turnsSinceLastTransition: number,
+  signalsPerTurn?: string[][],
 ): TransitionEvaluationResult[] {
   const config = loadTransitionsConfig(profileId);
   if (!config) return [];
   const results: TransitionEvaluationResult[] = [];
   for (const [name, rule] of Object.entries(config.transitions)) {
     results.push(
-      evaluateTransition(name, rule, signalsObserved, turnsSinceLastTransition),
+      evaluateTransition(
+        name,
+        rule,
+        signalsObserved,
+        turnsSinceLastTransition,
+        signalsPerTurn,
+      ),
     );
   }
   return results;
@@ -108,4 +121,26 @@ export function collectRecentSignals(
     }
   }
   return Array.from(new Set(all));
+}
+
+/**
+ * BUG-KT-01 (ops#1141): variante per-turn de collectRecentSignals.
+ *
+ * Retorna lista de listas — uma por turno — preservando estrutura cronológica.
+ * Necessária pra transições com `consecutive_turns` (regressões com persistência).
+ *
+ * @returns string[][] em ordem cronológica (último = turno mais recente)
+ */
+export function collectRecentSignalsPerTurn(
+  eventLog: Array<{ type: string; data: Record<string, unknown> }>,
+  lookbackTurns: number = 5,
+): string[][] {
+  const signalEvents = eventLog
+    .filter((e) => e.type === "signals_extracted")
+    .slice(-lookbackTurns);
+  return signalEvents.map((ev) => {
+    const data = ev.data as { signals?: unknown };
+    if (!Array.isArray(data.signals)) return [];
+    return data.signals.filter((s): s is string => typeof s === "string");
+  });
 }

--- a/planejador/tests/trigger-evaluator.test.ts
+++ b/planejador/tests/trigger-evaluator.test.ts
@@ -257,11 +257,30 @@ describe("kids.transitions.yaml — A-01 acceptance criteria", () => {
     expect(baiaToPasto?.fired).toBe(false);
   });
 
-  it("regression_baia_to_brejo dispara com distress_marker_high (window=0)", () => {
+  // BUG-KT-01 (ops#1141): regressões agora exigem consecutive_turns: 2.
+  // Signal isolado num turn não basta; precisa de signalsPerTurn com signal
+  // em 2 turnos consecutivos (recupera DT-A01-03 da spec original).
+
+  it("regression_baia_to_brejo NÃO dispara com 1 turno de distress (consecutive_turns: 2)", () => {
     const results = evaluateAllTransitions(
       "kids",
       ["distress_marker_high"],
       0,
+      [["distress_marker_high"]],
+    );
+    const regr = results.find(
+      (r) => r.transition_name === "regression_baia_to_brejo",
+    );
+    expect(regr?.fired).toBe(false);
+    expect(regr?.reason).toContain("consecutive");
+  });
+
+  it("regression_baia_to_brejo dispara com distress em 2 turnos consecutivos", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["distress_marker_high"],
+      0,
+      [["distress_marker_high"], ["distress_marker_high"]],
     );
     const regr = results.find(
       (r) => r.transition_name === "regression_baia_to_brejo",
@@ -269,11 +288,12 @@ describe("kids.transitions.yaml — A-01 acceptance criteria", () => {
     expect(regr?.fired).toBe(true);
   });
 
-  it("regression_baia_to_brejo dispara com deflection_silence", () => {
+  it("regression_baia_to_brejo dispara com deflection_silence em 2 turnos", () => {
     const results = evaluateAllTransitions(
       "kids",
       ["deflection_silence"],
       0,
+      [["deflection_silence"], ["deflection_silence"]],
     );
     const regr = results.find(
       (r) => r.transition_name === "regression_baia_to_brejo",
@@ -281,16 +301,43 @@ describe("kids.transitions.yaml — A-01 acceptance criteria", () => {
     expect(regr?.fired).toBe(true);
   });
 
-  it("regression_pasto_to_baia dispara com gatekeeper_resistance (window=0)", () => {
+  it("regression_baia_to_brejo NÃO dispara com signal apenas no penúltimo turn", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["deflection_silence"],
+      0,
+      [["deflection_silence"], ["mood_drift_up"]],
+    );
+    const regr = results.find(
+      (r) => r.transition_name === "regression_baia_to_brejo",
+    );
+    expect(regr?.fired).toBe(false);
+  });
+
+  it("regression_pasto_to_baia dispara com gatekeeper_resistance em 2 turnos", () => {
     const results = evaluateAllTransitions(
       "kids",
       ["gatekeeper_resistance"],
       0,
+      [["gatekeeper_resistance"], ["gatekeeper_resistance"]],
     );
     const regr = results.find(
       (r) => r.transition_name === "regression_pasto_to_baia",
     );
     expect(regr?.fired).toBe(true);
+  });
+
+  it("baia_to_pasto exige confirmatory_min: 1 — só frame_synthesis NÃO basta", () => {
+    const results = evaluateAllTransitions(
+      "kids",
+      ["frame_synthesis"],
+      6,
+    );
+    const baiaToPasto = results.find(
+      (r) => r.transition_name === "baia_to_pasto",
+    );
+    expect(baiaToPasto?.fired).toBe(false);
+    expect(baiaToPasto?.reason).toContain("confirmatory_min");
   });
 
   it("texto neutro (signals vazios) → nenhuma transição dispara", () => {

--- a/shared/src/transitions-schema.ts
+++ b/shared/src/transitions-schema.ts
@@ -20,13 +20,26 @@ export const TransitionRuleSchema = z.object({
   required_signals: z.array(z.string()).min(1),
   /** Janela mínima de turns desde último estado anterior. */
   minimum_window_turns: z.number().int().nonnegative().default(0),
-  /** Signals confirmatórios — não bloqueiam, mas elevam confidence. */
+  /** Signals confirmatórios — não bloqueiam por default. Se confirmatory_min > 0, exige N matches. */
   confirmatory_signals: z.array(z.string()).default([]),
+  /**
+   * BUG-KT-01 (ops#1141): mínimo de confirmatory_signals que devem matchar
+   * pra transição firar. Default 0 = backward compat (confirmatory não bloqueia).
+   * Quando >0, recupera semântica do DT-A01-02 (combinar required_all + required_any).
+   */
+  confirmatory_min: z.number().int().nonnegative().default(0),
   /** Signals que regridem o estado (se aparecem, transição não acontece + estado pode voltar). */
   regression_to_brejo_if: z.array(z.string()).optional(),
   regression_to_baia_if: z.array(z.string()).optional(),
   /** Match mode pros required signals. Default OR pra v0. */
   match_mode: TransitionMatchMode.optional(),
+  /**
+   * BUG-KT-01 (ops#1141): quando definido (>=1), os required_signals devem
+   * matchar em N turns CONSECUTIVOS finais (não apenas em qualquer turn da
+   * janela). Recupera DT-A01-03 (regressões exigem persistência).
+   * Quando set, caller deve passar signalsPerTurn pra evaluateTransition.
+   */
+  consecutive_turns: z.number().int().positive().optional(),
 });
 export type TransitionRule = z.infer<typeof TransitionRuleSchema>;
 
@@ -74,12 +87,16 @@ export interface TransitionEvaluationResult {
  * @param rule Regra da transição
  * @param signalsObserved Lista única de signals presentes (concatenada das últimas N turns)
  * @param turnsSinceLastTransition Janela de turns no estado atual
+ * @param signalsPerTurn (opcional) Signals por turno em ordem cronológica
+ *   (último é o turno mais recente). Necessário quando rule.consecutive_turns
+ *   está definido. Quando ausente e a rule exige consecutive_turns, fired=false.
  */
 export function evaluateTransition(
   transitionName: string,
   rule: TransitionRule,
   signalsObserved: string[],
   turnsSinceLastTransition: number,
+  signalsPerTurn?: string[][],
 ): TransitionEvaluationResult {
   const observed = new Set(signalsObserved);
   const requiredMatched = rule.required_signals.filter((s) => observed.has(s));
@@ -92,10 +109,39 @@ export function evaluateTransition(
 
   // Match required: AND vs OR
   const matchMode = rule.match_mode ?? "OR";
-  const requiredOk =
-    matchMode === "AND"
-      ? requiredMatched.length === rule.required_signals.length
-      : requiredMatched.length > 0;
+  const matchedInTurnSignals = (turnSignals: string[]): boolean => {
+    const turnSet = new Set(turnSignals);
+    const matchedInTurn = rule.required_signals.filter((s) => turnSet.has(s));
+    return matchMode === "AND"
+      ? matchedInTurn.length === rule.required_signals.length
+      : matchedInTurn.length > 0;
+  };
+
+  // BUG-KT-01: consecutive_turns check (DT-A01-03)
+  let requiredOk: boolean;
+  let consecutiveReason: string | null = null;
+  const consecN = rule.consecutive_turns ?? 0;
+  if (consecN > 0) {
+    if (!signalsPerTurn) {
+      requiredOk = false;
+      consecutiveReason = `consecutive_turns=${consecN} requires signalsPerTurn (not provided)`;
+    } else if (signalsPerTurn.length < consecN) {
+      requiredOk = false;
+      consecutiveReason = `consecutive_turns=${consecN} requires at least ${consecN} turns observed (got ${signalsPerTurn.length})`;
+    } else {
+      const lastN = signalsPerTurn.slice(-consecN);
+      requiredOk = lastN.every(matchedInTurnSignals);
+      if (!requiredOk) {
+        consecutiveReason = `required_signals not present in ${consecN} consecutive trailing turns`;
+      }
+    }
+  } else {
+    // Legacy: flat observed
+    requiredOk =
+      matchMode === "AND"
+        ? requiredMatched.length === rule.required_signals.length
+        : requiredMatched.length > 0;
+  }
 
   // Janela ok?
   const windowOk = turnsSinceLastTransition >= rule.minimum_window_turns;
@@ -103,21 +149,29 @@ export function evaluateTransition(
   // Sem regression?
   const noRegression = regressionPresent.length === 0;
 
-  const fired = requiredOk && windowOk && noRegression;
+  // BUG-KT-01: confirmatory_min check (DT-A01-02)
+  const confMin = rule.confirmatory_min ?? 0;
+  const confirmatoryOk = confirmatoryMatched.length >= confMin;
+
+  const fired = requiredOk && windowOk && noRegression && confirmatoryOk;
 
   let reason: string;
   if (!requiredOk) {
-    reason = `required_signals not matched (${matchMode}, got ${requiredMatched.length}/${rule.required_signals.length})`;
+    reason =
+      consecutiveReason ??
+      `required_signals not matched (${matchMode}, got ${requiredMatched.length}/${rule.required_signals.length})`;
   } else if (!windowOk) {
     reason = `minimum_window_turns not reached (${turnsSinceLastTransition} < ${rule.minimum_window_turns})`;
   } else if (!noRegression) {
     reason = `regression signals present: ${regressionPresent.join(", ")}`;
+  } else if (!confirmatoryOk) {
+    reason = `confirmatory_min not met (need ${confMin}, got ${confirmatoryMatched.length})`;
   } else {
     reason = `fired — required matched (${requiredMatched.join(", ")})${
       confirmatoryMatched.length > 0
         ? ` + confirmatory (${confirmatoryMatched.join(", ")})`
         : ""
-    }`;
+    }${consecN > 0 ? ` × ${consecN} consecutive turns` : ""}`;
   }
 
   return {

--- a/shared/tests/transitions-schema.test.ts
+++ b/shared/tests/transitions-schema.test.ts
@@ -128,3 +128,194 @@ describe("evaluateTransition — match_mode AND", () => {
     expect(both.fired).toBe(true);
   });
 });
+
+// ─── BUG-KT-01 fix (ops#1141) — confirmatory_min + consecutive_turns ───────
+
+describe("evaluateTransition — confirmatory_min (DT-A01-02)", () => {
+  const rule: TransitionRule = {
+    required_signals: ["frame_synthesis"],
+    minimum_window_turns: 5,
+    confirmatory_signals: ["meta_cognitive_observation", "voluntary_topic_deepening"],
+    confirmatory_min: 1,
+    match_mode: "AND",
+  };
+
+  it("fired=false quando required match mas confirmatory_min=1 não atingido", () => {
+    const r = evaluateTransition("baia_to_pasto", rule, ["frame_synthesis"], 6);
+    expect(r.fired).toBe(false);
+    expect(r.reason).toContain("confirmatory_min");
+  });
+
+  it("fired=true quando required match + 1 confirmatory presente", () => {
+    const r = evaluateTransition(
+      "baia_to_pasto",
+      rule,
+      ["frame_synthesis", "meta_cognitive_observation"],
+      6,
+    );
+    expect(r.fired).toBe(true);
+    expect(r.confirmatory_matched).toContain("meta_cognitive_observation");
+  });
+
+  it("fired=true quando required match + qualquer 1 dos 2 confirmatory", () => {
+    const r1 = evaluateTransition(
+      "baia_to_pasto",
+      rule,
+      ["frame_synthesis", "voluntary_topic_deepening"],
+      6,
+    );
+    expect(r1.fired).toBe(true);
+  });
+
+  it("confirmatory_min default = 0 (backward compat — confirmatory não bloqueia)", () => {
+    const ruleNoMin: TransitionRule = {
+      required_signals: ["a"],
+      minimum_window_turns: 0,
+      confirmatory_signals: ["c"],
+      // confirmatory_min not set
+    };
+    const r = evaluateTransition("t", ruleNoMin, ["a"], 0);
+    expect(r.fired).toBe(true);
+  });
+
+  it("confirmatory_min=2 exige 2 of N confirmatory", () => {
+    const ruleStrict: TransitionRule = {
+      required_signals: ["a"],
+      minimum_window_turns: 0,
+      confirmatory_signals: ["c1", "c2", "c3"],
+      confirmatory_min: 2,
+    };
+    const oneOnly = evaluateTransition("t", ruleStrict, ["a", "c1"], 0);
+    expect(oneOnly.fired).toBe(false);
+    const twoOk = evaluateTransition("t", ruleStrict, ["a", "c1", "c2"], 0);
+    expect(twoOk.fired).toBe(true);
+  });
+});
+
+describe("evaluateTransition — consecutive_turns (DT-A01-03)", () => {
+  const rule: TransitionRule = {
+    required_signals: ["distress_marker_high", "gatekeeper_resistance"],
+    minimum_window_turns: 0,
+    confirmatory_signals: [],
+    match_mode: "OR",
+    consecutive_turns: 2,
+  };
+
+  it("fired=false quando signal aparece em 1 turn apenas (flat — sem signalsPerTurn)", () => {
+    const r = evaluateTransition(
+      "regression_pasto_to_baia",
+      rule,
+      ["distress_marker_high"],
+      0,
+    );
+    expect(r.fired).toBe(false);
+    expect(r.reason).toContain("consecutive_turns");
+  });
+
+  it("fired=false quando signalsPerTurn tem distress em apenas 1 dos últimos 2 turns", () => {
+    const r = evaluateTransition(
+      "regression_pasto_to_baia",
+      rule,
+      ["distress_marker_high"],
+      0,
+      [["mood_drift_up"], ["distress_marker_high"]],
+    );
+    expect(r.fired).toBe(false);
+    expect(r.reason).toContain("consecutive");
+  });
+
+  it("fired=true quando signal aparece em 2 turns CONSECUTIVOS no final", () => {
+    const r = evaluateTransition(
+      "regression_pasto_to_baia",
+      rule,
+      ["distress_marker_high"],
+      0,
+      [["mood_drift_up"], ["distress_marker_high"], ["gatekeeper_resistance"]],
+    );
+    expect(r.fired).toBe(true);
+  });
+
+  it("fired=false quando signalsPerTurn tem menos turns que consecutive_turns", () => {
+    const r = evaluateTransition(
+      "regression_pasto_to_baia",
+      rule,
+      ["distress_marker_high"],
+      0,
+      [["distress_marker_high"]],
+    );
+    expect(r.fired).toBe(false);
+  });
+
+  it("consecutive_turns NÃO definido = comportamento legacy (signal em qualquer turn)", () => {
+    const ruleLegacy: TransitionRule = {
+      required_signals: ["a"],
+      minimum_window_turns: 0,
+      confirmatory_signals: [],
+      // consecutive_turns not set
+    };
+    const r = evaluateTransition("t", ruleLegacy, ["a"], 0);
+    expect(r.fired).toBe(true);
+  });
+});
+
+describe("parseTransitionsConfig — novos campos opcionais (BUG-KT-01)", () => {
+  it("aceita confirmatory_min como number", () => {
+    const c = parseTransitionsConfig({
+      profile_id: "kids",
+      schema_version: "v0.3",
+      transitions: {
+        baia_to_pasto: {
+          required_signals: ["frame_synthesis"],
+          minimum_window_turns: 5,
+          confirmatory_signals: ["meta_cognitive_observation"],
+          confirmatory_min: 1,
+          match_mode: "AND",
+        },
+      },
+    });
+    expect(c.transitions.baia_to_pasto!.confirmatory_min).toBe(1);
+  });
+
+  it("aceita consecutive_turns como number positivo", () => {
+    const c = parseTransitionsConfig({
+      profile_id: "kids",
+      schema_version: "v0.3",
+      transitions: {
+        regression_pasto_to_baia: {
+          required_signals: ["distress_marker_high"],
+          minimum_window_turns: 0,
+          consecutive_turns: 2,
+        },
+      },
+    });
+    expect(c.transitions.regression_pasto_to_baia!.consecutive_turns).toBe(2);
+  });
+
+  it("rejeita consecutive_turns negativo ou zero", () => {
+    expect(() =>
+      parseTransitionsConfig({
+        profile_id: "kids",
+        schema_version: "v0.3",
+        transitions: {
+          bad: {
+            required_signals: ["a"],
+            minimum_window_turns: 0,
+            consecutive_turns: 0,
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("backward compat — config sem novos campos ainda parseia", () => {
+    const c = parseTransitionsConfig({
+      profile_id: "test",
+      schema_version: "v0",
+      transitions: {
+        t1: { required_signals: ["a"], minimum_window_turns: 0 },
+      },
+    });
+    expect(c.transitions.t1!.confirmatory_min).toBe(0);
+    expect(c.transitions.t1!.consecutive_turns).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes ascendimacy/ascendimacy-ops#1141

## O que faz

Recupera **DT-A01-02** e **DT-A01-03** da spec original do handoff `2026-04-26-cc-motor-pre-piloto-strategic-gaps.md §motor#25`, que estavam não-implementadas no schema v0.2 do \`kids.transitions.yaml\`.

### Schema extension (\`shared/src/transitions-schema.ts\`)

- **`confirmatory_min: number`** (default 0) — exige N confirmatory matches pra transição firar. Recupera DT-A01-02 (combinar `required` + `confirmatory` groups, sem nested schema).
- **`consecutive_turns: number` positive** (optional) — `required_signals` devem matchar em N turnos **CONSECUTIVOS finais**. Recupera DT-A01-03 (regressões exigem persistência, não pico isolado).
- \`evaluateTransition()\` agora aceita \`signalsPerTurn?: string[][]\` opcional.

### Trigger-evaluator extension

- \`collectRecentSignalsPerTurn(eventLog, lookbackTurns): string[][]\` — variante per-turn de \`collectRecentSignals\`, preserva estrutura cronológica.
- \`evaluateAllTransitions()\` propaga \`signalsPerTurn\` quando fornecido.
- \`plan.ts\` passa \`signalsPerTurn\` em todas as chamadas.

### YAML update (v0.2 → v0.3)

- \`baia_to_pasto\`: \`confirmatory_min: 1\`. Exige \`frame_synthesis\` AND 1 of \`[meta_cognitive_observation, voluntary_topic_deepening]\`.
- \`regression_baia_to_brejo\`: \`consecutive_turns: 2\`.
- \`regression_pasto_to_baia\`: \`consecutive_turns: 2\`.

## Desvio do P14 spec ratificada (#1141)

A spec dizia \`confirmatory_min: 2 de [dyad_inteligent, recall_positive, mood_stable, engagement_high, sacrifice_accepted]\` (lista ilustrativa).

**Implementado:** \`confirmatory_min: 1\` com signals atuais (\`meta_cog\`, \`voluntary_topic\`) — alinha **exatamente** com DT-A01-02 original que pedia \`required_signals_any\` (1+ de 2). Mais conservador + traceable. Novos signals do P14 podem ser adicionados em PR futuro se calibração do piloto pedir mais rigor.

## Tests

- \`shared/tests/transitions-schema.test.ts\`: **+14 tests** novos (confirmatory_min ×5, consecutive_turns ×5, schema parsing ×4)
- \`planejador/tests/trigger-evaluator.test.ts\`: **+5 tests** (3 legacy refatorados pra novo behavior; 1 não-fired-com-signal-isolado; 1 confirmatory_min em baia_to_pasto)

\`\`\`
Test Files  71 passed | 2 skipped (73)
     Tests  1208 passed | 8 skipped (1216)
\`\`\`

(12 falhas pré-existentes em \`orchestrator/\` e \`packages/ebrota-console-ui/\` são resolução de package/build, não relacionadas a este PR.)

## Critério de aceitação do P14

- [x] \`baia_to_pasto\` com required + confirmatory min satisfeito
- [x] Regressões em ocorrência única → NOT trigger
- [x] Regressões em 2 turnos consecutivos → trigger
- [x] Test \"só_frame_synthesis\" → NOT trigger
- [x] Test \"frame_synthesis + 1_confirmatory\" → trigger
- [x] Test regressão isolada → NOT trigger
- [x] Test regressão 2 consecutivos → trigger

## Disciplina (CLAUDE.md)

- ✅ Worktree isolada (\`.cc-worktrees/motor-issue1141\`)
- ✅ \`lane:execution\` aplicada na issue antes de começar (#1141)
- ✅ TDD audit → red → green
- ✅ Backward compat preservado (campos novos opcionais; default 0/undefined)
- ✅ Cross-repo \`Closes\` ascendimacy/ascendimacy-ops#1141