### PR TITLE
[feat ops#1150] S1: contrato unificado S1.read → LearnerSummary

### DIFF
--- a/planejador/src/s1-read.ts
+++ b/planejador/src/s1-read.ts
@@ -1,0 +1,80 @@
+/**
+ * S1.read — contrato unificado de leitura do estado do aprendiz.
+ *
+ * Agrega 3 fontes (kids_casel_history, kids_tree_nodes, kids_helix_state)
+ * e retorna LearnerSummary com cache in-memory TTL 60s.
+ *
+ * Spec: ascendimacy-ops#1150. Decisões:
+ *  - D-P41-01: TTL = 60s
+ *  - D-P41-02: cache em memória (in-process Map)
+ */
+
+import type { LearnerSummary } from "@ascendimacy/shared";
+
+export const S1_CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  data: LearnerSummary;
+  cachedAt: number;
+}
+
+const _cache = new Map<string, CacheEntry>();
+
+/**
+ * Injectable data sources — permite testes sem DB real.
+ * Produção: motor-execucao fornece implementação concreta.
+ */
+export interface S1DataSources {
+  getCaselLevels(persona: string): Promise<Record<string, number>>;
+  getTreeZones(persona: string): Promise<string[]>;
+  getHelixPosition(persona: string): Promise<string | null>;
+  getLastSession(persona: string): Promise<string | null>;
+}
+
+const defaultSources: S1DataSources = {
+  getCaselLevels: async () => ({}),
+  getTreeZones: async () => [],
+  getHelixPosition: async () => null,
+  getLastSession: async () => null,
+};
+
+export const S1 = {
+  async read(
+    { persona }: { persona: string },
+    sources: S1DataSources = defaultSources,
+  ): Promise<LearnerSummary> {
+    const now = Date.now();
+    const cached = _cache.get(persona);
+    if (cached !== undefined && now - cached.cachedAt < S1_CACHE_TTL_MS) {
+      return cached.data;
+    }
+
+    const [casel_levels, tree_zones, helix_position, last_session] =
+      await Promise.all([
+        sources.getCaselLevels(persona),
+        sources.getTreeZones(persona),
+        sources.getHelixPosition(persona),
+        sources.getLastSession(persona),
+      ]);
+
+    const summary: LearnerSummary = {
+      persona,
+      casel_levels,
+      tree_zones,
+      helix_position,
+      last_session,
+      cached_at: now,
+    };
+
+    _cache.set(persona, { data: summary, cachedAt: now });
+    return summary;
+  },
+
+  clearCache(persona?: string): void {
+    if (persona !== undefined) {
+      _cache.delete(persona);
+    } else {
+      _cache.clear();
+    }
+  },
+};

--- a/planejador/tests/s1-read.unit.test.ts
+++ b/planejador/tests/s1-read.unit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { S1, S1_CACHE_TTL_MS, type S1DataSources } from "../src/s1-read.js";
+
+const mockSources: S1DataSources = {
+  getCaselLevels: async (persona) => (persona === "ryo" ? { SA: 3, SM: 2 } : { SA: 1 }),
+  getTreeZones: async () => ["raiz", "tronco"],
+  getHelixPosition: async () => "active",
+  getLastSession: async () => "2026-05-26T10:00:00.000Z",
+};
+
+describe("S1.read", () => {
+  beforeEach(() => {
+    S1.clearCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns merged LearnerSummary from 3 sources", async () => {
+    const result = await S1.read({ persona: "ryo" }, mockSources);
+    expect(result.persona).toBe("ryo");
+    expect(result.casel_levels).toEqual({ SA: 3, SM: 2 });
+    expect(result.tree_zones).toEqual(["raiz", "tronco"]);
+    expect(result.helix_position).toBe("active");
+    expect(result.last_session).toBe("2026-05-26T10:00:00.000Z");
+    expect(result.cached_at).toBeGreaterThan(0);
+  });
+
+  it("second call returns cached result without re-fetching", async () => {
+    let callCount = 0;
+    const countingSources: S1DataSources = {
+      ...mockSources,
+      getCaselLevels: async (p) => {
+        callCount++;
+        return mockSources.getCaselLevels(p);
+      },
+    };
+
+    const first = await S1.read({ persona: "kei" }, countingSources);
+    const second = await S1.read({ persona: "kei" }, countingSources);
+
+    expect(callCount).toBe(1);
+    expect(second.cached_at).toBe(first.cached_at);
+    expect(second).toStrictEqual(first);
+  });
+
+  it("re-fetches after TTL expires", async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const countingSources: S1DataSources = {
+      ...mockSources,
+      getCaselLevels: async (p) => {
+        callCount++;
+        return mockSources.getCaselLevels(p);
+      },
+    };
+
+    await S1.read({ persona: "saki" }, countingSources);
+    expect(callCount).toBe(1);
+
+    vi.advanceTimersByTime(S1_CACHE_TTL_MS + 1);
+
+    await S1.read({ persona: "saki" }, countingSources);
+    expect(callCount).toBe(2);
+  });
+
+  it("cache hit still within TTL does not re-fetch", async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const countingSources: S1DataSources = {
+      ...mockSources,
+      getCaselLevels: async (p) => {
+        callCount++;
+        return mockSources.getCaselLevels(p);
+      },
+    };
+
+    await S1.read({ persona: "saki" }, countingSources);
+    vi.advanceTimersByTime(S1_CACHE_TTL_MS - 1);
+    await S1.read({ persona: "saki" }, countingSources);
+
+    expect(callCount).toBe(1);
+  });
+
+  it("isolates cache per persona", async () => {
+    const ryo = await S1.read({ persona: "ryo" }, mockSources);
+    const kei = await S1.read({ persona: "kei" }, mockSources);
+    expect(ryo.casel_levels["SA"]).toBe(3);
+    expect(kei.casel_levels["SA"]).toBe(1);
+    expect(ryo.persona).toBe("ryo");
+    expect(kei.persona).toBe("kei");
+  });
+
+  it("handles null helix_position and last_session", async () => {
+    const nullSources: S1DataSources = {
+      ...mockSources,
+      getHelixPosition: async () => null,
+      getLastSession: async () => null,
+    };
+    const result = await S1.read({ persona: "ryo" }, nullSources);
+    expect(result.helix_position).toBeNull();
+    expect(result.last_session).toBeNull();
+  });
+
+  it("clearCache for specific persona leaves others intact", async () => {
+    let ryoFetches = 0;
+    const countingSources: S1DataSources = {
+      ...mockSources,
+      getCaselLevels: async (p) => {
+        if (p === "ryo") ryoFetches++;
+        return mockSources.getCaselLevels(p);
+      },
+    };
+
+    await S1.read({ persona: "ryo" }, countingSources);
+    await S1.read({ persona: "kei" }, countingSources);
+    S1.clearCache("ryo");
+    await S1.read({ persona: "ryo" }, countingSources);
+    await S1.read({ persona: "kei" }, countingSources); // should still be cached
+
+    expect(ryoFetches).toBe(2); // fetched twice (second after clearCache)
+  });
+});

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -79,6 +79,12 @@ export {
   type CaselDimensionPair,
 } from "./kids-helix-state.js";
 
+// S1 unified read contract (ops#1150) — LearnerSummary schema + type.
+export {
+  LearnerSummarySchema,
+  type LearnerSummary,
+} from "./learner-summary.js";
+
 // Trio runtime engine (ops#1086) — types puros; lógica em
 // orchestrator/src/trio-runtime.ts. Doctrine §10 + §11 dinamicas-grupo.
 export {

--- a/shared/src/contracts/learner-summary.ts
+++ b/shared/src/contracts/learner-summary.ts
@@ -1,0 +1,23 @@
+/**
+ * LearnerSummary — contrato unificado de leitura do estado do aprendiz.
+ *
+ * S1.read({ persona }) agrega 3 fontes (kids_casel_history,
+ * kids_tree_nodes, kids_helix_state) e retorna este shape com cache TTL 60s.
+ *
+ * Spec: ascendimacy-ops#1150. Decisões aplicadas:
+ *  - D-P41-01: TTL = 60s
+ *  - D-P41-02: cache em memória (in-process Map)
+ */
+
+import { z } from "zod";
+
+export const LearnerSummarySchema = z.object({
+  persona: z.string().min(1),
+  casel_levels: z.record(z.string(), z.number()),
+  tree_zones: z.array(z.string()),
+  helix_position: z.string().nullable(),
+  last_session: z.string().nullable(),
+  cached_at: z.number(),
+});
+
+export type LearnerSummary = z.infer<typeof LearnerSummarySchema>;

--- a/shared/tests/contracts/learner-summary.unit.test.ts
+++ b/shared/tests/contracts/learner-summary.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { LearnerSummarySchema } from "../../src/contracts/learner-summary.js";
+
+const valid = {
+  persona: "ryo",
+  casel_levels: { SA: 2, SM: 1 },
+  tree_zones: ["raiz", "tronco"],
+  helix_position: "active",
+  last_session: "2026-05-26T10:00:00.000Z",
+  cached_at: 1716720000000,
+};
+
+describe("LearnerSummarySchema", () => {
+  it("accepts valid shape", () => {
+    const result = LearnerSummarySchema.parse(valid);
+    expect(result.persona).toBe("ryo");
+    expect(result.casel_levels).toEqual({ SA: 2, SM: 1 });
+    expect(result.tree_zones).toEqual(["raiz", "tronco"]);
+  });
+
+  it("accepts null helix_position and last_session", () => {
+    const result = LearnerSummarySchema.parse({
+      ...valid,
+      helix_position: null,
+      last_session: null,
+    });
+    expect(result.helix_position).toBeNull();
+    expect(result.last_session).toBeNull();
+  });
+
+  it("accepts empty casel_levels and tree_zones", () => {
+    expect(() =>
+      LearnerSummarySchema.parse({ ...valid, casel_levels: {}, tree_zones: [] }),
+    ).not.toThrow();
+  });
+
+  it("rejects missing persona field", () => {
+    const { persona: _, ...rest } = valid;
+    expect(() => LearnerSummarySchema.parse(rest)).toThrow();
+  });
+
+  it("rejects empty persona string", () => {
+    expect(() =>
+      LearnerSummarySchema.parse({ ...valid, persona: "" }),
+    ).toThrow();
+  });
+
+  it("rejects non-number casel_levels values", () => {
+    expect(() =>
+      LearnerSummarySchema.parse({ ...valid, casel_levels: { SA: "high" } }),
+    ).toThrow();
+  });
+
+  it("rejects non-string tree_zones elements", () => {
+    expect(() =>
+      LearnerSummarySchema.parse({ ...valid, tree_zones: [1, 2] }),
+    ).toThrow();
+  });
+
+  it("rejects undefined helix_position (must be string | null)", () => {
+    expect(() =>
+      LearnerSummarySchema.parse({ ...valid, helix_position: undefined }),
+    ).toThrow();
+  });
+
+  it("rejects missing cached_at", () => {
+    const { cached_at: _, ...rest } = valid;
+    expect(() => LearnerSummarySchema.parse(rest)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes ascendimacy/ascendimacy-ops#1150

## O que muda
- `LearnerSummarySchema` (Zod v4) em `shared/src/contracts/learner-summary.ts`
- `LearnerSummary` type exportado via `shared/src/contracts/index.ts`
- `S1.read({ persona })` em `planejador/src/s1-read.ts` — agrega `kids_casel_history` + `kids_tree_nodes` + `kids_helix_state`
- Cache in-memory TTL 60s (module-level `Map`)
- `S1DataSources` interface injetável — testes puros sem DB

## Testes
- `shared/tests/contracts/learner-summary.unit.test.ts` — 9 testes (schema valida/rejeita shapes)
- `planejador/tests/s1-read.unit.test.ts` — 7 testes (merge das 3 fontes, cache hit 2ª chamada, miss após TTL via `vi.useFakeTimers()`, isolamento por persona, clearCache parcial)
- Regressão: shared 863/863 pass + planejador 344/344 pass

## Decisões aplicadas
- D-P41-01: TTL=60s ✅
- D-P41-02: cache em memória ✅