### PR TITLE
[feat ops#1136] TV2-4: handleSimplifiedPipeline agrega EngineTraceV2

### DIFF
--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -17,12 +17,18 @@
 
 import type {
   ContentItem,
+  EngineStateSnapshot,
+  EngineTraceV2,
   EvaluateAndSelectInput,
   EvaluateAndSelectOutput,
   ScoredContentItem,
   SubjectKnowledgeEntry,
+  SubjectKnowledgeWriteTrace,
+  SubjectKnowledgeWriter,
 } from "@ascendimacy/shared";
 import {
+  computeStateDiff,
+  createLlmTraceCollector,
   extractDiscoveries,
   extractBoundaryEvents,
   extractPresentedConcepts,
@@ -33,6 +39,75 @@ import {
   type StrategyPlan,
   type SubjectKnowledgeEntry as SkEntry,
 } from "@ascendimacy/shared";
+
+// ─────────────────────────────────────────────────────────────────────────
+// TV2-4 helpers — state snapshot + SK write annotation
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mapeia o `type` da SubjectKnowledgeEntry para o `writer` que a emitiu.
+ * Inferência heurística — fonte da verdade são os writers, mas como
+ * extract*() funções não anotam writer, derivamos do tipo.
+ */
+function inferWriter(type: string): SubjectKnowledgeWriter {
+  if (type === "presented_concept") return "concept_ledger";
+  if (type === "boundary_event") return "boundary";
+  if (type === "recall_check_attempt") return "recall_check";
+  if (type === "axis_attempt_outcome") return "axis_attempt_outcome";
+  if (type === "vertical_affinity_signal") return "vertical_affinity";
+  if (type === "interest" || type === "value" || type === "need" || type === "discovery") {
+    return "discovery";
+  }
+  return "other";
+}
+
+/**
+ * Constrói EngineStateSnapshot a partir do input.state + contextHints.
+ * Apenas campos disponíveis no contexto motor-drota; STS forwarder
+ * (TV2-5) pode enriquecer com dados extras (parental_profile etc).
+ */
+function buildStateSnapshot(
+  input: EvaluateAndSelectInput,
+  budgetRemaining: number,
+  journeyStage: JourneyStage,
+  phase?: SessionPhase,
+): EngineStateSnapshot {
+  const snapshot: EngineStateSnapshot = {
+    trust_level: input.state.trustLevel ?? 0.5,
+    budget_remaining: budgetRemaining,
+    journey_state: {
+      stage: journeyStage,
+      discoveries_count: 0,
+      families_covered: [],
+    },
+  };
+  if (phase) snapshot.current_session_phase = phase;
+  const helix = input.state.kidsHelixState;
+  if (helix) {
+    // KidsHelixState não tem activeLevel explícito — derivamos como 1
+    // (Dreyfus level 1 = novice). cycle_progress aproximamos via current_day
+    // / 17 (ciclo 0-17 dias). active_pair[0] como dim primária.
+    const activeDimension = helix.active_pair?.[0] ?? "SA";
+    const cycleDay = helix.current_day ?? 0;
+    snapshot.helix_state = {
+      activeDimension,
+      activeLevel: 1,
+      cycleDay,
+      progress: Math.min(Math.max(cycleDay / 17, 0), 1),
+    };
+  }
+  const proposedHint = input.contextHints?.["subject_proposed"] as
+    | { axes_active: number[] }
+    | undefined;
+  if (proposedHint) {
+    snapshot.subject_proposed = {
+      version: 1,
+      axes_active: proposedHint.axes_active ?? [],
+      ratified_at: null,
+    };
+  }
+  return snapshot;
+}
 
 /** PR 2 tracer — confidence threshold por fase pro DiscoveryWriter. */
 const DISCOVERY_MIN_CONFIDENCE_BY_PHASE: Record<SessionPhase, number> = {
@@ -47,10 +122,21 @@ import { selectAction } from "./pragmatic-selector.js";
 import { materialize } from "./constrained-materializer.js";
 import { resolveInauguralTemplate } from "./inaugural-template.js";
 
+export interface SimplifiedPipelineOpts {
+  /** TV2-4 (spec ops#1136): captura engine trace v2 no output. Default true. */
+  captureTrace?: boolean;
+}
+
 export async function handleSimplifiedPipeline(
   input: EvaluateAndSelectInput,
   ranked: ScoredContentItem[],
+  opts: SimplifiedPipelineOpts = {},
 ): Promise<EvaluateAndSelectOutput> {
+  const captureTrace = opts.captureTrace ?? true;
+  const turnStartedAt = new Date().toISOString();
+  const collector = captureTrace ? createLlmTraceCollector() : undefined;
+  const warnings: EngineTraceV2["warnings"] = [];
+
   // Mensagem do sujeito vem em contextHints.last_user_message; fallback
   // pra instruction_addition se ausente; se ambos vazios, assess opera com
   // string vazia (mood=5 conservador via rule-based).
@@ -64,14 +150,17 @@ export async function handleSimplifiedPipeline(
       | undefined) ?? [];
 
   // 1. Unified Assessor — extrai mood + signals + engagement em 1 chamada.
-  const assessment = await assess({
-    message: lastUserMessage,
-    recentTurns,
-    personaName: input.persona.name,
-    personaAge: input.persona.age,
-    trustLevel: input.state.trustLevel,
-    run_id: input.sessionId,
-  });
+  const assessment = await assess(
+    {
+      message: lastUserMessage,
+      recentTurns,
+      personaName: input.persona.name,
+      personaAge: input.persona.age,
+      trustLevel: input.state.trustLevel,
+      run_id: input.sessionId,
+    },
+    collector ? { collector } : undefined,
+  );
 
   // Assessment snapshot pro EvaluateAndSelectOutput (compat opt-in).
   const assessmentForOutput = {
@@ -160,11 +249,14 @@ export async function handleSimplifiedPipeline(
   );
 
   // 2. Pragmatic Selector — determinístico, zero LLM.
-  const selectionResult = selectAction({
-    candidates: ranked,
-    assessment,
-    state: input.state,
-  });
+  const selectionResult = selectAction(
+    {
+      candidates: ranked,
+      assessment,
+      state: input.state,
+    },
+    captureTrace ? { captureTrace: true } : undefined,
+  );
 
   // Escalação: pool sem viáveis ou budget exausto → fallback conversacional.
   if (!selectionResult.selected || selectionResult.escalate_to !== null) {
@@ -244,21 +336,24 @@ export async function handleSimplifiedPipeline(
     | undefined;
 
   // 3b. Constrained Materializer — texto final com FALLBACK handling.
-  const matResult = await materialize({
-    action: selectionResult.selected,
-    subjectNameForm: input.persona.name,
-    mood: assessment.mood,
-    engagement: assessment.engagement,
-    turnCount: input.state.turn,
-    budgetRemaining: input.state.budgetRemaining,
-    jurisdictionActive:
-      ((input.contextHints?.["jurisdiction_active"] as string | undefined) ??
-        "br") as "br" | "jp" | "ch",
-    run_id: input.sessionId,
-    incomingMessage: lastUserMessage,
-    recentTurns,
-    ...(recallCheckCandidate ? { recallCheckCandidate } : {}),
-  });
+  const matResult = await materialize(
+    {
+      action: selectionResult.selected,
+      subjectNameForm: input.persona.name,
+      mood: assessment.mood,
+      engagement: assessment.engagement,
+      turnCount: input.state.turn,
+      budgetRemaining: input.state.budgetRemaining,
+      jurisdictionActive:
+        ((input.contextHints?.["jurisdiction_active"] as string | undefined) ??
+          "br") as "br" | "jp" | "ch",
+      run_id: input.sessionId,
+      incomingMessage: lastUserMessage,
+      recentTurns,
+      ...(recallCheckCandidate ? { recallCheckCandidate } : {}),
+    },
+    collector ? { collector } : undefined,
+  );
 
   // ── Fase 3: ConceptLedgerWriter — após materializar o Fact, emite
   // presented_concept (+1pt) se item está taggeado com axis_id/family/
@@ -303,6 +398,50 @@ export async function handleSimplifiedPipeline(
     });
   }
 
+  let engineTrace: EngineTraceV2 | undefined;
+  if (captureTrace) {
+    const preState = buildStateSnapshot(
+      input,
+      input.state.budgetRemaining,
+      journeyStage,
+      sessionState.phase,
+    );
+    const postState = buildStateSnapshot(
+      input,
+      selectionResult.newState.budgetRemaining,
+      journeyStage,
+      sessionState.phase,
+    );
+    const skWrites: SubjectKnowledgeWriteTrace[] = subjectKnowledgeEvents.map(
+      (e) => ({
+        type: e.type,
+        payload: e.payload as unknown as Record<string, unknown>,
+        writer: inferWriter(e.type),
+        triggered_by: e.confirmed_at ?? "motor_inferred",
+      }),
+    );
+    engineTrace = {
+      schema_version: 2,
+      turn_started_at: turnStartedAt,
+      turn_completed_at: new Date().toISOString(),
+      pre_state: preState,
+      post_state: postState,
+      state_diff: computeStateDiff(preState, postState, skWrites.length),
+      components: {
+        ...(assessment._trace ? { unified_assessor: assessment._trace } : {}),
+        ...(selectionResult._trace
+          ? { pragmatic_selector: selectionResult._trace }
+          : {}),
+        ...(matResult._trace
+          ? { constrained_materializer: matResult._trace }
+          : {}),
+      },
+      llm_calls: collector?.drain() ?? [],
+      subject_knowledge_writes: skWrites,
+      warnings,
+    };
+  }
+
   return {
     selectedContent: selectionResult.selected,
     selectionRationale: selectionResult.decision_path,
@@ -314,5 +453,6 @@ export async function handleSimplifiedPipeline(
     ...(matResult.fallback_triggered
       ? { skipReason: "materializer_fallback" }
       : {}),
+    ...(engineTrace ? { engineTrace } : {}),
   };
 }

--- a/motor-drota/tests/pipeline-engine-trace.test.ts
+++ b/motor-drota/tests/pipeline-engine-trace.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests TV2-4 — handleSimplifiedPipeline emite engineTrace v2 completo.
+ *
+ * Foca no aggregator: pre/post state + components + llm_calls +
+ * sk writes + state_diff. Mocks callGateway + callGatewayWithTracing
+ * via vi.mock.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  ContentItem,
+  EvaluateAndSelectInput,
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+  PersonaDef,
+  ScoredContentItem,
+} from "@ascendimacy/shared";
+
+const mockCallCount = { n: 0 };
+const responses: GatewayChatCompletionOutput[] = [];
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: vi.fn(async (_req: GatewayChatCompletionInput) => {
+      const r = responses[mockCallCount.n] ?? responses[responses.length - 1];
+      mockCallCount.n += 1;
+      if (!r) throw new Error("no mock response");
+      return r;
+    }),
+    callGatewayWithTracing: vi.fn(async (req, role, collector) => {
+      const r = responses[mockCallCount.n] ?? responses[responses.length - 1];
+      mockCallCount.n += 1;
+      if (!r) throw new Error("no mock response");
+      collector?.push({
+        id: `llm-mock-${role}-${mockCallCount.n}`,
+        role,
+        provider: "local",
+        model: r.model,
+        prompt: `[SYSTEM]\n${req.systemPrompt}\n\n[USER]\n${req.userMessage}`,
+        response: r.content,
+        duration_ms: r.latency_ms,
+        input_tokens: r.tokens.in,
+        output_tokens: r.tokens.out,
+      });
+      return r;
+    }),
+  };
+});
+
+import { handleSimplifiedPipeline } from "../src/simplified-pipeline-handler.js";
+
+function llmResponse(content: string): GatewayChatCompletionOutput {
+  return {
+    content,
+    tokens: { in: 100, out: 50, reasoning: 0 },
+    provider: "local",
+    model: "qwen14b",
+    latency_ms: 200,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
+function stubItem(id: string, cost = 3): ScoredContentItem {
+  return {
+    item: {
+      id,
+      type: "curiosity_hook",
+      domain: "biology",
+      casel_target: ["SA"],
+      age_range: [7, 14],
+      surprise: 7,
+      verified: true,
+      base_score: 7,
+      fact: "f",
+      bridge: "b",
+      quest: "q",
+      sacrifice_type: "reflect",
+      sacrifice_amount: cost,
+    } as ContentItem,
+    score: 8,
+    reasons: [],
+  };
+}
+
+function stubInput(overrides: Partial<EvaluateAndSelectInput> = {}): EvaluateAndSelectInput {
+  return {
+    sessionId: "test-session",
+    contentPool: [stubItem("a", 3), stubItem("b", 5)],
+    state: {
+      sessionId: "test-session",
+      trustLevel: 0.5,
+      budgetRemaining: 15,
+      eventLog: [],
+      turn: 2,
+    },
+    persona: {
+      id: "ryo-001",
+      name: "Ryo",
+      age: 13,
+      profile: {},
+    } as PersonaDef,
+    strategicRationale: "",
+    contextHints: { last_user_message: "tô legal" },
+    ...overrides,
+  } as EvaluateAndSelectInput;
+}
+
+beforeEach(() => {
+  mockCallCount.n = 0;
+  responses.length = 0;
+});
+
+describe("handleSimplifiedPipeline — TV2-4 engineTrace", () => {
+  it("emite engineTrace v2 com schema_version=2 quando default (captureTrace=true)", async () => {
+    // 1 LLM response = unified-assessor (haiku); selector é zero-LLM;
+    // materializer faz 1 chamada. Mas no rule-path do assessor com
+    // mensagem clara "tô legal" pode resolver rule-only.
+    // Garantimos 2 responses pra cobrir os 2 paths possíveis.
+    responses.push(
+      llmResponse('{"mood":7,"signals":[],"engagement":"medium","mood_confidence":"high","rationale":"ok"}'),
+      llmResponse("Lagarta quando dissolve, vira borboleta."),
+    );
+    const result = await handleSimplifiedPipeline(stubInput(), [stubItem("a", 3)]);
+    expect(result.engineTrace).toBeDefined();
+    expect(result.engineTrace?.schema_version).toBe(2);
+  });
+
+  it("popula pre_state + post_state + state_diff coerentes", async () => {
+    responses.push(
+      llmResponse('{"mood":7,"signals":[],"engagement":"medium","mood_confidence":"high","rationale":"ok"}'),
+      llmResponse("Texto materializado."),
+    );
+    const input = stubInput();
+    const result = await handleSimplifiedPipeline(input, [stubItem("a", 3)]);
+    const t = result.engineTrace!;
+    expect(t.pre_state.budget_remaining).toBe(15);
+    expect(t.post_state.budget_remaining).toBeLessThanOrEqual(15);
+    expect(t.state_diff.budget_delta).toBe(
+      t.post_state.budget_remaining - t.pre_state.budget_remaining,
+    );
+    expect(t.state_diff.trust_delta).toBe(0); // motor não muda trust aqui
+  });
+
+  it("agrega trace seções dos 3 componentes em components", async () => {
+    responses.push(
+      llmResponse('{"mood":7,"signals":[],"engagement":"medium","mood_confidence":"high","rationale":"ok"}'),
+      llmResponse("texto"),
+    );
+    const result = await handleSimplifiedPipeline(stubInput(), [stubItem("a", 3)]);
+    const components = result.engineTrace!.components;
+    expect(components.unified_assessor).toBeDefined();
+    expect(components.pragmatic_selector).toBeDefined();
+    expect(components.constrained_materializer).toBeDefined();
+  });
+
+  it("captura llm_calls do collector (assessor + materializer)", async () => {
+    responses.push(
+      llmResponse('{"mood":4,"signals":["positive_engagement"],"engagement":"medium","mood_confidence":"medium","rationale":"ok"}'),
+      llmResponse("texto materializado"),
+    );
+    // mensagem ambígua pra forçar caminho LLM (não rule-high)
+    const result = await handleSimplifiedPipeline(
+      stubInput({ contextHints: { last_user_message: "talvez sim, sei lá" } }),
+      [stubItem("a", 3)],
+    );
+    const calls = result.engineTrace!.llm_calls;
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    // pelo menos o materializer call deve estar lá
+    expect(calls.some((c) => c.role === "materializer")).toBe(true);
+  });
+
+  it("annotates subject_knowledge_writes com writer correto", async () => {
+    responses.push(
+      llmResponse('{"mood":7,"signals":["positive_engagement"],"engagement":"medium","mood_confidence":"high","rationale":"ok"}'),
+      llmResponse("texto"),
+    );
+    // Item taggeado com axis_id pra gerar presented_concept
+    const taggedItem: ScoredContentItem = {
+      ...stubItem("tagged_x"),
+      item: {
+        ...stubItem("tagged_x").item,
+        axis_id: 11,
+        family: "carater",
+        lineage_anchor: "estoica/dicotomia_controle",
+        extracted_keywords: ["transformação"],
+      } as ContentItem,
+    };
+    const result = await handleSimplifiedPipeline(
+      stubInput(),
+      [taggedItem],
+    );
+    const writes = result.engineTrace!.subject_knowledge_writes;
+    const presented = writes.find((w) => w.type === "presented_concept");
+    if (presented) {
+      expect(presented.writer).toBe("concept_ledger");
+    }
+  });
+
+  it("captureTrace=false NÃO emite engineTrace", async () => {
+    responses.push(
+      llmResponse('{"mood":7,"signals":[],"engagement":"medium","mood_confidence":"high","rationale":"ok"}'),
+      llmResponse("texto"),
+    );
+    const result = await handleSimplifiedPipeline(
+      stubInput(),
+      [stubItem("a", 3)],
+      { captureTrace: false },
+    );
+    expect(result.engineTrace).toBeUndefined();
+  });
+
+  it("turn_started_at < turn_completed_at", async () => {
+    responses.push(
+      llmResponse('{"mood":7,"signals":[],"engagement":"medium","mood_confidence":"high","rationale":"ok"}'),
+      llmResponse("texto"),
+    );
+    const result = await handleSimplifiedPipeline(stubInput(), [stubItem("a", 3)]);
+    const t = result.engineTrace!;
+    expect(
+      new Date(t.turn_completed_at).getTime() >=
+        new Date(t.turn_started_at).getTime(),
+    ).toBe(true);
+  });
+
+  it("estado helix snapshot populado quando kidsHelixState presente", async () => {
+    responses.push(
+      llmResponse('{"mood":7,"signals":[],"engagement":"medium","mood_confidence":"high","rationale":"ok"}'),
+      llmResponse("texto"),
+    );
+    const input = stubInput({
+      state: {
+        sessionId: "test-session",
+        trustLevel: 0.6,
+        budgetRemaining: 20,
+        eventLog: [],
+        turn: 3,
+        kidsHelixState: {
+          persona_id: "ryo-001",
+          active_pair: ["SA", "SM"],
+          cycle_started_at: "2026-05-01T00:00:00Z",
+          current_day: 4,
+          mode: "active",
+          previous_pair: null,
+          cycles_completed: 0,
+          queue: ["SOC", "REL", "DM"],
+          completed: [],
+          deferred: [],
+        },
+      } as never,
+    });
+    const result = await handleSimplifiedPipeline(input, [stubItem("a", 3)]);
+    const helix = result.engineTrace!.pre_state.helix_state;
+    expect(helix).toBeDefined();
+    expect(helix?.activeDimension).toBe("SA");
+    expect(helix?.cycleDay).toBe(4);
+  });
+});

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -129,6 +129,12 @@ export interface EvaluateAndSelectOutput {
    * mesmo plan via session_id.
    */
   strategyPlan?: import("./strategy-plan.js").StrategyPlan;
+  /**
+   * TV2-4 (spec ops#1136): trace v2 completo do turn. Presente quando
+   * handleSimplifiedPipeline cria collector + agrega. STS forwarder
+   * (TV2-5) pega daqui e injeta em turn.engineTrace no trace.json.
+   */
+  engineTrace?: import("./engine-trace-v2.js").EngineTraceV2;
 }
 
 export interface ExecutePlaybookInput {


### PR DESCRIPTION
Aggregator central junta tudo: collector + componentes + state snapshots + diff + SK writes. `EvaluateAndSelectOutput.engineTrace` opcional. Default `captureTrace=true`.

## Aggregator

- `createLlmTraceCollector()` no entry; passado pra `assess()` + `materialize()`. Selector recebe `captureTrace=true`.
- `buildStateSnapshot()`: trust, budget, journey_state, helix_state, subject_proposed, phase.
- KidsHelixState → activeDimension (active_pair[0]) + cycleDay + progress (day/17).
- `inferWriter(type)` annota SubjectKnowledgeWriteTrace.writer.
- `computeStateDiff()` → transitions + deltas.

## Test plan

- [x] 8 novos casos em `pipeline-engine-trace.test.ts` — schema, snapshots, components, llm_calls, sk writes annotation, off path, timestamps, helix snapshot
- [x] 854 shared + 373 motor + 337 planejador = 1564 verdes
- [x] Build limpo

## Próximas

- **TV2-5**: STS trace-writer inclui `turn.engineTrace`
- **TV2-6**: UI Replay v2 estende ReplayTurnDetail
- **TV2-7**: LLM x-ray panel
- **TV2-8**: docs/migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)