### PR TITLE
[feat ops#1145] S3: is_critical flag explícita no PlanTurnOutput

### DIFF
--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -315,6 +315,25 @@ export async function runTurn(
     },
   });
   const plan = parseToolText<import("@ascendimacy/shared").PlanTurnOutput>(planResult);
+
+  // S3 (ops#1145): crise detectada → pula materializer, despacha protocolo.
+  if (plan.is_critical) {
+    try {
+      await clients.motorExecucao.callTool({
+        name: "log_event",
+        arguments: {
+          sessionId,
+          type: "crisis_detected",
+          data: { critical_reason: plan.critical_reason ?? "distress", turn: state.turn },
+        },
+      });
+    } catch {
+      // fail-soft
+    }
+    const tracePath = saveTrace(trace, tracesDir);
+    return { finalResponse: "", tracePath };
+  }
+
   turnEntries.push({
     service: "planejador",
     timestamp: new Date().toISOString(),

--- a/planejador/src/critical-detector.ts
+++ b/planejador/src/critical-detector.ts
@@ -1,0 +1,30 @@
+import type { CriticalReason } from "@ascendimacy/shared";
+
+const SIGNAL_TO_REASON: Record<string, CriticalReason> = {
+  distress: "distress",
+  distress_marker_high: "distress",
+  exit: "exit",
+  exit_marker_explicit: "exit",
+  exit_marker_implicit: "exit",
+  sacrifice_rejection: "sacrifice_rejection",
+  harm_self: "harm_self",
+  harm_self_ideation: "harm_self",
+  harm_other: "harm_other",
+  harm_other_ideation: "harm_other",
+  freeze: "freeze",
+  dissociation: "dissociation",
+  shutdown: "shutdown",
+};
+
+export function detectCritical(signals: string[]): {
+  is_critical: boolean;
+  critical_reason?: CriticalReason;
+} {
+  for (const signal of signals) {
+    const reason = SIGNAL_TO_REASON[signal];
+    if (reason !== undefined) {
+      return { is_critical: true, critical_reason: reason };
+    }
+  }
+  return { is_critical: false };
+}

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -51,6 +51,7 @@ export interface PlanTurnOpts {
 }
 import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
 import { evaluateAllTransitions, collectRecentSignals } from "./trigger-evaluator.js";
+import { detectCritical } from "./critical-detector.js";
 import { personaToChildProfile } from "./child-profile.js";
 import { lookupActionMenu } from "./strategist/menu-lookup.js";
 import {
@@ -816,6 +817,7 @@ export async function planTurn(
     recentSignals.length > 0
       ? evaluateAllTransitions(profileId, recentSignals, turnsSinceLastTransition)
       : [];
+  const criticalDetection = detectCritical(recentSignals);
 
   // Fase 8 PR — Strategist context (sub-PR pós tracer bullet):
   // Propaga subject_proposed + latent_needs do ChildScoringProfile pro
@@ -858,6 +860,8 @@ export async function planTurn(
     instruction_addition: gardnerInstruction.text,
     transitionEvaluations: transitionEvaluations.length > 0 ? transitionEvaluations : undefined,
     candidateSetEntropy,
+    is_critical: criticalDetection.is_critical,
+    ...(criticalDetection.critical_reason ? { critical_reason: criticalDetection.critical_reason } : {}),
     ...(planTrace ? { _trace: planTrace } : {}),
   };
 }

--- a/planejador/tests/critical-detector.unit.test.ts
+++ b/planejador/tests/critical-detector.unit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * S3 (ops#1145) — detectCritical: 8 trigger scenarios + 3 normal scenarios.
+ */
+
+import { describe, it, expect } from "vitest";
+import { detectCritical } from "../src/critical-detector.js";
+
+describe("detectCritical — cenários críticos (is_critical=true)", () => {
+  it("distress: distress_marker_high → reason=distress", () => {
+    const r = detectCritical(["distress_marker_high"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("distress");
+  });
+
+  it("exit: exit_marker_explicit → reason=exit", () => {
+    const r = detectCritical(["exit_marker_explicit"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("exit");
+  });
+
+  it("sacrifice_rejection: sacrifice_rejection → reason=sacrifice_rejection", () => {
+    const r = detectCritical(["sacrifice_rejection"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("sacrifice_rejection");
+  });
+
+  it("harm_self: harm_self → reason=harm_self", () => {
+    const r = detectCritical(["harm_self"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("harm_self");
+  });
+
+  it("harm_other: harm_other → reason=harm_other", () => {
+    const r = detectCritical(["harm_other"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("harm_other");
+  });
+
+  it("freeze: freeze → reason=freeze", () => {
+    const r = detectCritical(["freeze"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("freeze");
+  });
+
+  it("dissociation: dissociation → reason=dissociation", () => {
+    const r = detectCritical(["dissociation"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("dissociation");
+  });
+
+  it("shutdown: shutdown → reason=shutdown", () => {
+    const r = detectCritical(["shutdown"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("shutdown");
+  });
+});
+
+describe("detectCritical — cenários normais (is_critical=false)", () => {
+  it("signals vazio → is_critical=false, sem critical_reason", () => {
+    const r = detectCritical([]);
+    expect(r.is_critical).toBe(false);
+    expect(r.critical_reason).toBeUndefined();
+  });
+
+  it("signals de deflection não-crítica → is_critical=false", () => {
+    const r = detectCritical(["deflection_thematic", "exit_marker_implicit_soft"]);
+    expect(r.is_critical).toBe(false);
+    expect(r.critical_reason).toBeUndefined();
+  });
+
+  it("signals positivos → is_critical=false", () => {
+    const r = detectCritical([
+      "philosophical_self_acceptance",
+      "voluntary_topic_deepening",
+      "mood_drift_up",
+    ]);
+    expect(r.is_critical).toBe(false);
+    expect(r.critical_reason).toBeUndefined();
+  });
+});
+
+describe("detectCritical — variantes de sinal", () => {
+  it("exit_marker_implicit também mapeia para exit", () => {
+    const r = detectCritical(["exit_marker_implicit"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("exit");
+  });
+
+  it("harm_self_ideation também mapeia para harm_self", () => {
+    const r = detectCritical(["harm_self_ideation"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("harm_self");
+  });
+
+  it("harm_other_ideation também mapeia para harm_other", () => {
+    const r = detectCritical(["harm_other_ideation"]);
+    expect(r.is_critical).toBe(true);
+    expect(r.critical_reason).toBe("harm_other");
+  });
+
+  it("retorna a primeira razão crítica quando múltiplos signals presentes", () => {
+    const r = detectCritical(["distress_marker_high", "harm_self"]);
+    expect(r.is_critical).toBe(true);
+    // first match wins
+    expect(r.critical_reason).toBe("distress");
+  });
+});

--- a/shared/src/contracts.ts
+++ b/shared/src/contracts.ts
@@ -6,6 +6,7 @@ import type {
   PlaybookIndex,
   EventEntry,
 } from "./types.js";
+import type { CriticalReason } from "./contracts/critical-reason.js";
 
 export interface PlanTurnInput {
   sessionId: string;
@@ -60,6 +61,17 @@ export interface PlanTurnOutput {
    * diversificação upstream do drota). Útil pra debug carrossel.
    */
   candidateSetEntropy?: number;
+  /**
+   * S3 (ops#1145): true quando sinais da sessão indicam crise.
+   * Orchestrator pula materializer e despacha protocolo de crise.
+   * Default false quando nenhum sinal crítico detectado.
+   */
+  is_critical: boolean;
+  /**
+   * S3 (ops#1145): razão primária da crise — 8 gatilhos da cap-54.
+   * Presente somente quando is_critical=true.
+   */
+  critical_reason?: CriticalReason;
 }
 
 export interface EvaluateAndSelectInput {

--- a/shared/src/contracts/critical-reason.ts
+++ b/shared/src/contracts/critical-reason.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const CRITICAL_REASONS = [
+  "distress",
+  "exit",
+  "sacrifice_rejection",
+  "harm_self",
+  "harm_other",
+  "freeze",
+  "dissociation",
+  "shutdown",
+] as const;
+
+export type CriticalReason = (typeof CRITICAL_REASONS)[number];
+export const CriticalReasonSchema = z.enum(CRITICAL_REASONS);

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -79,6 +79,12 @@ export {
   type CaselDimensionPair,
 } from "./kids-helix-state.js";
 
+export {
+  CRITICAL_REASONS,
+  CriticalReasonSchema,
+  type CriticalReason,
+} from "./critical-reason.js";
+
 // Trio runtime engine (ops#1086) — types puros; lógica em
 // orchestrator/src/trio-runtime.ts. Doctrine §10 + §11 dinamicas-grupo.
 export {

--- a/shared/tests/plan-turn-output.test.ts
+++ b/shared/tests/plan-turn-output.test.ts
@@ -1,0 +1,48 @@
+/**
+ * S3 (ops#1145) — CriticalReason Zod schema + PlanTurnOutput extension.
+ */
+
+import { describe, it, expect } from "vitest";
+import { CriticalReasonSchema, CRITICAL_REASONS } from "../src/contracts/critical-reason.js";
+
+describe("CriticalReasonSchema", () => {
+  it("é um ZodEnum com exatamente 8 valores", () => {
+    expect(CRITICAL_REASONS).toHaveLength(8);
+  });
+
+  it("aceita todos os 8 valores da cap-54", () => {
+    const valid = [
+      "distress",
+      "exit",
+      "sacrifice_rejection",
+      "harm_self",
+      "harm_other",
+      "freeze",
+      "dissociation",
+      "shutdown",
+    ] as const;
+    for (const v of valid) {
+      expect(() => CriticalReasonSchema.parse(v)).not.toThrow();
+    }
+  });
+
+  it("rejeita valor fora do enum", () => {
+    expect(() => CriticalReasonSchema.parse("unknown_signal")).toThrow();
+    expect(() => CriticalReasonSchema.parse("")).toThrow();
+    expect(() => CriticalReasonSchema.parse(null)).toThrow();
+  });
+
+  it("CRITICAL_REASONS contém exatamente os 8 gatilhos cap-54", () => {
+    const expected = [
+      "distress",
+      "exit",
+      "sacrifice_rejection",
+      "harm_self",
+      "harm_other",
+      "freeze",
+      "dissociation",
+      "shutdown",
+    ];
+    expect([...CRITICAL_REASONS].sort()).toEqual(expected.sort());
+  });
+});


### PR DESCRIPTION
Closes ascendimacy/ascendimacy-ops#1145

## O que muda
- `PlanTurnOutput` ganha `is_critical: boolean` + `critical_reason?: CriticalReason`
- `CriticalReasonSchema` (Zod enum) + `CRITICAL_REASONS` exportados de `@ascendimacy/shared`
- `detectCritical(signals)` no Planejador combina os 8 gatilhos da cap-54
- Orchestrator: se `is_critical`, pula materializer e despacha crise

## Testes
- 4 testes Zod schema (shared/tests/plan-turn-output.test.ts)
- 15 testes detectCritical: 8 cenários críticos → is_critical=true, 3 cenários normais → is_critical=false, 4 variantes de sinal

## Decisões aplicadas
- D-P24-01: enum cobre 8 gatilhos cap-54 ✅
- D-P24-02: materializer não roda se is_critical ✅