### PR TITLE
[feat ops#1152] S1: MilestoneEvent schema + detector V0

### DIFF
--- a/motor-execucao/src/executor.ts
+++ b/motor-execucao/src/executor.ts
@@ -4,6 +4,7 @@ import type {
   ExecutePlaybookInput,
   ExecutePlaybookOutput,
   InquiryChoice,
+  MilestoneEvent,
 } from "@ascendimacy/shared";
 import { parseRepetitionAnswer } from "@ascendimacy/shared";
 import { getState, updateState, logEvent, getDbInstance } from "./state-manager.js";
@@ -135,6 +136,16 @@ export function executePlaybook(
       timestamp: getNow(),
       type: "repetition_inquiry_suppressed",
       data: { reason: suppressedReason },
+    });
+  }
+
+  // ops#1152 S1: log milestone_detected event when planejador detected one.
+  const milestone = contextHints?.["milestone_detected"] as MilestoneEvent | undefined;
+  if (milestone) {
+    logEvent(sessionId, {
+      timestamp: getNow(),
+      type: "milestone_detected",
+      data: milestone as unknown as Record<string, unknown>,
     });
   }
 

--- a/planejador/src/milestone-detector.ts
+++ b/planejador/src/milestone-detector.ts
@@ -1,0 +1,85 @@
+import type { MilestoneEvent, MilestoneEventType } from "@ascendimacy/shared";
+
+interface Rule {
+  type: MilestoneEventType;
+  axis: string;
+  /** Lowercase Portuguese phrases to match in message. */
+  phrases: string[];
+  /** Semantic signal keys that also trigger this milestone (checked in signals[]). */
+  signalKeys?: string[];
+}
+
+// Rules ordered from most specific to most generic to avoid false positives.
+// repair_initiated and regression_recognized must precede virtue_practiced
+// because generic phrases like "fiz" and "consegui" appear in repair/regression
+// contexts too.
+const RULES: Rule[] = [
+  {
+    type: "first_avowal",
+    axis: "autoconhecimento",
+    phrases: ["eu sei", "eu aprendi", "eu entendo agora"],
+  },
+  {
+    type: "fear_named",
+    axis: "coragem",
+    phrases: ["tenho medo", "me assusta", "fico com medo"],
+  },
+  {
+    type: "conflict_resolved",
+    axis: "justiça",
+    phrases: ["resolvemos", "chegamos a um acordo", "ficou resolvido"],
+    signalKeys: ["resolution", "agreement", "conflict_resolved"],
+  },
+  {
+    type: "value_articulated",
+    axis: "honestidade",
+    phrases: ["é importante", "eu acredito", "o que mais importa"],
+  },
+  {
+    type: "regression_recognized",
+    axis: "prudência",
+    phrases: ["errei de novo", "voltei a", "não consegui"],
+  },
+  {
+    type: "sacrifice_chosen",
+    axis: "temperança",
+    phrases: ["prefiro", "escolho", "mesmo que seja difícil"],
+  },
+  {
+    type: "repair_initiated",
+    axis: "justiça",
+    phrases: ["desculpa", "quero consertar", "fiz errado e"],
+  },
+  {
+    type: "virtue_practiced",
+    axis: "temperança",
+    phrases: ["consegui", "fiz", "terminei"],
+  },
+];
+
+export function detectMilestone(
+  message: string,
+  signals: string[],
+  persona: string,
+): MilestoneEvent | null {
+  const lower = message.toLowerCase();
+
+  for (const rule of RULES) {
+    const phraseMatch = rule.phrases.some((p) => lower.includes(p));
+    const signalMatch =
+      rule.signalKeys !== undefined &&
+      signals.some((s) => rule.signalKeys!.includes(s));
+
+    if (phraseMatch || signalMatch) {
+      return {
+        type: rule.type,
+        axis: rule.axis,
+        evidence: message.slice(0, 200),
+        persona,
+        timestamp: new Date().toISOString(),
+      };
+    }
+  }
+
+  return null;
+}

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -43,6 +43,7 @@ import {
   isExhausted,
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku, type LlmCallResult } from "./llm-client.js";
+import { detectMilestone } from "./milestone-detector.js";
 import type { LlmTraceCollector, PlanejadorTrace } from "@ascendimacy/shared";
 
 export interface PlanTurnOpts {
@@ -827,6 +828,14 @@ export async function planTurn(
   }
   if (child.latent_needs && child.latent_needs.length > 0) {
     contextHints["latent_needs"] = child.latent_needs;
+  }
+
+  // ops#1152 S1: milestone detector V0 rule-based (sem LLM).
+  // Detecta no incomingMessage + recentSignals; propaga via contextHints
+  // pra executor.ts logar como "milestone_detected" event no event_log.
+  const milestone = detectMilestone(input.incomingMessage, recentSignals, input.persona.id);
+  if (milestone) {
+    contextHints["milestone_detected"] = milestone;
   }
 
   // motor#25 (handoff #25 B5): Shannon entropy do candidate set antes de retornar.

--- a/planejador/tests/milestone-detector.test.ts
+++ b/planejador/tests/milestone-detector.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { detectMilestone } from "../src/milestone-detector.js";
+
+describe("detectMilestone — positivos (8 tipos)", () => {
+  it("first_avowal: detecta 'eu aprendi'", () => {
+    const r = detectMilestone("Eu aprendi que posso ser mais paciente", [], "ryo");
+    expect(r?.type).toBe("first_avowal");
+    expect(r?.persona).toBe("ryo");
+    expect(r?.axis).toBe("autoconhecimento");
+    expect(r?.evidence).toContain("aprendi");
+    expect(r?.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("fear_named: detecta 'tenho medo'", () => {
+    const r = detectMilestone("Tenho medo de errar na frente de todo mundo", [], "kei");
+    expect(r?.type).toBe("fear_named");
+    expect(r?.persona).toBe("kei");
+  });
+
+  it("conflict_resolved: detecta via signal 'resolution'", () => {
+    const r = detectMilestone("ok", ["resolution", "mood_drift_up"], "ryo");
+    expect(r?.type).toBe("conflict_resolved");
+  });
+
+  it("conflict_resolved: detecta via frase 'resolvemos'", () => {
+    const r = detectMilestone("Resolvemos a briga com minha irmã", [], "ryo");
+    expect(r?.type).toBe("conflict_resolved");
+  });
+
+  it("value_articulated: detecta 'o que mais importa'", () => {
+    const r = detectMilestone("O que mais importa é ser honesto", [], "saki");
+    expect(r?.type).toBe("value_articulated");
+    expect(r?.axis).toBe("honestidade");
+  });
+
+  it("virtue_practiced: detecta 'consegui'", () => {
+    const r = detectMilestone("Consegui terminar o dever de casa hoje", [], "ryo");
+    expect(r?.type).toBe("virtue_practiced");
+    expect(r?.axis).toBe("temperança");
+  });
+
+  it("regression_recognized: detecta 'errei de novo'", () => {
+    const r = detectMilestone("Errei de novo com meu irmão, fui grosso", [], "kei");
+    expect(r?.type).toBe("regression_recognized");
+    expect(r?.axis).toBe("prudência");
+  });
+
+  it("sacrifice_chosen: detecta 'prefiro'", () => {
+    const r = detectMilestone("Prefiro ficar em casa do que ir à festa", [], "ryo");
+    expect(r?.type).toBe("sacrifice_chosen");
+  });
+
+  it("repair_initiated: detecta 'desculpa'", () => {
+    const r = detectMilestone("Desculpa pelo que fiz ontem, foi errado", [], "saki");
+    expect(r?.type).toBe("repair_initiated");
+    expect(r?.axis).toBe("justiça");
+  });
+});
+
+describe("detectMilestone — negativos (sem milestone)", () => {
+  it("retorna null para mensagem neutra", () => {
+    expect(detectMilestone("tudo bem por aqui", [], "ryo")).toBeNull();
+  });
+
+  it("retorna null para mensagem vazia", () => {
+    expect(detectMilestone("", [], "ryo")).toBeNull();
+  });
+
+  it("retorna null para mensagem sem padrão e sem signals", () => {
+    expect(detectMilestone("ok legal", [], "ryo")).toBeNull();
+  });
+});
+
+describe("detectMilestone — evidence truncation", () => {
+  it("trunca evidence em 200 chars", () => {
+    const long = "eu aprendi " + "x".repeat(300);
+    const r = detectMilestone(long, [], "ryo");
+    expect(r?.type).toBe("first_avowal");
+    expect(r?.evidence.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -99,3 +99,11 @@ export {
   type NextSpeakerTarget,
   type TrioDecision,
 } from "./trio-runtime.js";
+
+export {
+  MilestoneEventSchema,
+  MilestoneEventTypeSchema,
+  MILESTONE_EVENT_TYPES,
+  type MilestoneEvent,
+  type MilestoneEventType,
+} from "./milestone-event.js";

--- a/shared/src/contracts/milestone-event.ts
+++ b/shared/src/contracts/milestone-event.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { Iso8601DateTime } from "./iso8601.js";
+
+export const MilestoneEventTypeSchema = z.enum([
+  "first_avowal",
+  "fear_named",
+  "conflict_resolved",
+  "value_articulated",
+  "virtue_practiced",
+  "regression_recognized",
+  "sacrifice_chosen",
+  "repair_initiated",
+]);
+
+export const MILESTONE_EVENT_TYPES = MilestoneEventTypeSchema.options;
+export type MilestoneEventType = z.infer<typeof MilestoneEventTypeSchema>;
+
+export const MilestoneEventSchema = z.object({
+  type: MilestoneEventTypeSchema,
+  axis: z.string().min(1),
+  evidence: z.string().min(1),
+  persona: z.string().min(1),
+  timestamp: Iso8601DateTime,
+});
+
+export type MilestoneEvent = z.infer<typeof MilestoneEventSchema>;

--- a/shared/tests/milestone-event.test.ts
+++ b/shared/tests/milestone-event.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { MilestoneEventSchema, MilestoneEventTypeSchema, MILESTONE_EVENT_TYPES } from "../src/contracts/milestone-event.js";
+
+const validEvent = {
+  type: "first_avowal" as const,
+  axis: "autoconhecimento",
+  evidence: "eu sei que errei",
+  persona: "ryo",
+  timestamp: "2026-05-26T10:00:00.000Z",
+};
+
+describe("MilestoneEventTypeSchema — enum dos 8 tipos", () => {
+  it("aceita todos os 8 tipos válidos", () => {
+    for (const t of MILESTONE_EVENT_TYPES) {
+      expect(MilestoneEventTypeSchema.safeParse(t).success).toBe(true);
+    }
+  });
+
+  it("REJEITA tipo desconhecido", () => {
+    expect(MilestoneEventTypeSchema.safeParse("unknown_type").success).toBe(false);
+  });
+
+  it("REJEITA string vazia", () => {
+    expect(MilestoneEventTypeSchema.safeParse("").success).toBe(false);
+  });
+
+  it("REJEITA null", () => {
+    expect(MilestoneEventTypeSchema.safeParse(null).success).toBe(false);
+  });
+
+  it("exporta exatamente 8 tipos", () => {
+    expect(MILESTONE_EVENT_TYPES).toHaveLength(8);
+  });
+});
+
+describe("MilestoneEventSchema — validação de objeto completo", () => {
+  it("aceita evento válido", () => {
+    expect(MilestoneEventSchema.safeParse(validEvent).success).toBe(true);
+  });
+
+  it("aceita todos os 8 tipos como type", () => {
+    for (const t of MILESTONE_EVENT_TYPES) {
+      expect(MilestoneEventSchema.safeParse({ ...validEvent, type: t }).success).toBe(true);
+    }
+  });
+
+  it("REJEITA sem campo type", () => {
+    const { type: _, ...rest } = validEvent;
+    expect(MilestoneEventSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("REJEITA sem campo axis", () => {
+    const { axis: _, ...rest } = validEvent;
+    expect(MilestoneEventSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("REJEITA sem campo evidence", () => {
+    const { evidence: _, ...rest } = validEvent;
+    expect(MilestoneEventSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("REJEITA sem campo persona", () => {
+    const { persona: _, ...rest } = validEvent;
+    expect(MilestoneEventSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("REJEITA sem campo timestamp", () => {
+    const { timestamp: _, ...rest } = validEvent;
+    expect(MilestoneEventSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("REJEITA timestamp não-ISO", () => {
+    expect(MilestoneEventSchema.safeParse({ ...validEvent, timestamp: "ontem" }).success).toBe(false);
+  });
+
+  it("REJEITA axis vazio", () => {
+    expect(MilestoneEventSchema.safeParse({ ...validEvent, axis: "" }).success).toBe(false);
+  });
+
+  it("REJEITA evidence vazio", () => {
+    expect(MilestoneEventSchema.safeParse({ ...validEvent, evidence: "" }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes ascendimacy/ascendimacy-ops#1152

## O que muda
- `MilestoneEventSchema` em `shared/src/contracts/milestone-event.ts` — 8 tipos enum
- `detectMilestone()` rule-based V0 em `planejador/src/milestone-detector.ts` (sem LLM, defer para follow-up)
- Hook no `event_log` pós-turno: `plan.ts` detecta → `contextHints["milestone_detected"]` → `executor.ts` loga `milestone_detected` event

## Fora de escopo neste PR
- LLM judge (Haiku) — follow-up S-P43-02
- Painel longitudinal — follow-up S-P43-03/04

## Testes
- 28 testes novos: 5 enum + 10 schema (shared) + 9 positivos + 3 negativos + 1 truncation (planejador)
- 0 regressões (2243 testes passando)

## Decisões aplicadas
- D-P43-01: enum 8 categorias ✅
- Regras ordenadas do mais específico ao mais genérico (repair/regression antes de virtue_practiced) para evitar falsos positivos com frases curtas como "fiz"