### PR TITLE
[feat ops#1136] TV2-6: Replay UI consome engineTrace v2

### DIFF
--- a/packages/ebrota-console-ui/src/components/Replay.svelte
+++ b/packages/ebrota-console-ui/src/components/Replay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { replaySessionId, globalError } from "../lib/stores.js";
   import type { ApiClient, ReplayTrace } from "../lib/api.js";
+  import ReplayTurnDetail from "./ReplayTurnDetail.svelte";
 
   export let api: ApiClient;
 
@@ -113,6 +114,7 @@
                     <p>{turn.finalResponse}</p>
                   </div>
                 {/if}
+                <ReplayTurnDetail {turn} />
               </li>
             {/each}
           </ol>

--- a/packages/ebrota-console-ui/src/components/ReplayTurnDetail.svelte
+++ b/packages/ebrota-console-ui/src/components/ReplayTurnDetail.svelte
@@ -29,13 +29,34 @@
   $: skEvents = (turn.subjectKnowledgeEvents ??
     drota.subjectKnowledgeEvents ??
     []) as Array<Record<string, unknown>>;
+
+  // ─── v2 engine trace (sub-fase TV2-6) ──────────────────────────────────
+  $: engineV2 = turn.engineTrace;
+  $: hasV2 = engineV2 !== undefined;
+  $: v2StateDiff = engineV2?.state_diff;
+  $: v2Components = engineV2?.components ?? {};
+  $: v2SkWrites = engineV2?.subject_knowledge_writes ?? [];
+  $: v2Warnings = engineV2?.warnings ?? [];
+
   $: hasEngineData =
+    hasV2 ||
     pool.length > 0 ||
     selected !== null ||
     skEvents.length > 0 ||
     plan.strategicRationale !== undefined ||
     plan.instruction_addition !== undefined ||
     exec.eventLogged !== undefined;
+
+  function fmtDelta(d: number | undefined): string {
+    if (typeof d !== "number") return "?";
+    const sign = d > 0 ? "+" : "";
+    return `${sign}${d.toFixed(2)}`;
+  }
+
+  function joinSignals(s: string[] | undefined): string {
+    if (!s || s.length === 0) return "(none)";
+    return s.join(", ");
+  }
 
   function fmtScore(s: number | undefined): string {
     if (typeof s !== "number") return "?";
@@ -101,11 +122,247 @@
         {#if pool.length > 0}
           <span class="badge pool">{pool.length} pool</span>
         {/if}
+        {#if hasV2}
+          <span class="badge v2" data-testid="v2-badge">v2</span>
+        {/if}
       </span>
     </button>
 
     {#if expanded}
       <div class="sections">
+        {#if hasV2}
+          <section class="v2" data-testid="v2-section">
+            <h4>🆕 v2 engine trace</h4>
+            {#if turn.motorTrace !== undefined}
+              <p class="v2-note" data-testid="v2-coexist-note">
+                v2 engine trace available — v1 motorTrace abaixo permanece como fallback.
+              </p>
+            {/if}
+
+            {#if v2StateDiff}
+              <div class="v2-state-diff" data-testid="v2-state-diff">
+                <strong>state diff:</strong>
+                <span class="badges">
+                  {#if v2StateDiff.trust_delta !== undefined && v2StateDiff.trust_delta !== 0}
+                    <span class="badge" data-testid="v2-trust-delta"
+                      >Δtrust={fmtDelta(v2StateDiff.trust_delta)}</span
+                    >
+                  {/if}
+                  {#if v2StateDiff.budget_delta !== undefined && v2StateDiff.budget_delta !== 0}
+                    <span class="badge" data-testid="v2-budget-delta"
+                      >Δbudget={fmtDelta(v2StateDiff.budget_delta)}</span
+                    >
+                  {/if}
+                  {#if v2StateDiff.journey_stage_transition}
+                    <span class="badge journey" data-testid="v2-journey-transition">
+                      journey: {v2StateDiff.journey_stage_transition.from} →
+                      {v2StateDiff.journey_stage_transition.to}
+                    </span>
+                  {/if}
+                  {#if v2StateDiff.helix_advance}
+                    <span class="badge helix" data-testid="v2-helix-advance">
+                      helix
+                      {#if v2StateDiff.helix_advance.dimension_changed}·dim{/if}
+                      {#if v2StateDiff.helix_advance.level_changed}·lvl{/if}
+                      {#if v2StateDiff.helix_advance.cycle_completed}·cycle{/if}
+                    </span>
+                  {/if}
+                  {#if v2StateDiff.session_phase_transition}
+                    <span class="badge phase" data-testid="v2-phase-transition">
+                      phase: {v2StateDiff.session_phase_transition.from} →
+                      {v2StateDiff.session_phase_transition.to}
+                    </span>
+                  {/if}
+                  {#if v2StateDiff.subject_knowledge_added_count !== undefined && v2StateDiff.subject_knowledge_added_count > 0}
+                    <span class="badge sk" data-testid="v2-sk-added"
+                      >+{v2StateDiff.subject_knowledge_added_count} sk</span
+                    >
+                  {/if}
+                </span>
+              </div>
+            {/if}
+
+            {#if v2Components.unified_assessor}
+              {@const a = v2Components.unified_assessor}
+              <details class="v2-comp" data-testid="v2-comp-assessor">
+                <summary>🧪 assessor</summary>
+                <div class="v2-comp-body">
+                  {#if a.outputs?.mood !== undefined}
+                    <p><strong>mood:</strong> <code>{a.outputs.mood.toFixed(2)}</code></p>
+                  {/if}
+                  {#if a.mood_method}
+                    <p><strong>method:</strong> <code>{a.mood_method}</code></p>
+                  {/if}
+                  {#if a.outputs?.engagement}
+                    <p><strong>engagement:</strong> <code>{a.outputs.engagement}</code></p>
+                  {/if}
+                  <p><strong>signals:</strong> {joinSignals(a.outputs?.signals)}</p>
+                  {#if a.duration_ms !== undefined}
+                    <p class="muted-row"><code>{fmtMs(a.duration_ms)}</code></p>
+                  {/if}
+                </div>
+              </details>
+            {/if}
+
+            {#if v2Components.planejador}
+              {@const p = v2Components.planejador}
+              <details class="v2-comp" data-testid="v2-comp-planejador">
+                <summary>🧠 planejador</summary>
+                <div class="v2-comp-body">
+                  {#if p.outputs?.strategicRationale}
+                    <p><strong>rationale:</strong> {p.outputs.strategicRationale}</p>
+                  {/if}
+                  {#if p.outputs?.candidateSetEntropy !== undefined}
+                    <p>
+                      <strong>entropy:</strong>
+                      <code>{p.outputs.candidateSetEntropy.toFixed(3)}</code>
+                    </p>
+                  {/if}
+                  {#if p.triageDecision}
+                    <p>
+                      <strong>triage:</strong>
+                      <code>{p.triageDecision.route ?? "?"}</code>
+                      — {p.triageDecision.reason ?? ""}
+                    </p>
+                  {/if}
+                  {#if p.duration_ms !== undefined}
+                    <p class="muted-row"><code>{fmtMs(p.duration_ms)}</code></p>
+                  {/if}
+                </div>
+              </details>
+            {/if}
+
+            {#if v2Components.strategist}
+              {@const s = v2Components.strategist}
+              <details class="v2-comp" data-testid="v2-comp-strategist">
+                <summary>🎯 strategist</summary>
+                <div class="v2-comp-body">
+                  {#if s.inputs?.journey_stage}
+                    <p>
+                      <strong>journey_stage:</strong>
+                      <code>{s.inputs.journey_stage}</code>
+                    </p>
+                  {/if}
+                  <p>
+                    <strong>target_demos:</strong>
+                    {(s.outputs?.target_demonstrations ?? []).length}
+                  </p>
+                  {#if s.composition_method}
+                    <p>
+                      <strong>method:</strong>
+                      <code>{s.composition_method}</code>
+                    </p>
+                  {/if}
+                  {#if s.duration_ms !== undefined}
+                    <p class="muted-row"><code>{fmtMs(s.duration_ms)}</code></p>
+                  {/if}
+                </div>
+              </details>
+            {/if}
+
+            {#if v2Components.pragmatic_selector}
+              {@const sel = v2Components.pragmatic_selector}
+              <details class="v2-comp" data-testid="v2-comp-selector">
+                <summary>🎲 pragmatic_selector</summary>
+                <div class="v2-comp-body">
+                  {#if sel.outputs?.selected_id}
+                    <p>
+                      <strong>selected:</strong>
+                      <code>{sel.outputs.selected_id}</code>
+                    </p>
+                  {/if}
+                  {#if sel.filters_applied && sel.filters_applied.length > 0}
+                    <p><strong>filters_applied:</strong></p>
+                    <ul class="v2-filters">
+                      {#each sel.filters_applied as f}
+                        <li>
+                          <code>{f.name}</code>
+                          {#if f.items_removed && f.items_removed.length > 0}
+                            — removed {f.items_removed.length}
+                          {/if}
+                          {#if f.reason}<span class="muted-row"> ({f.reason})</span>{/if}
+                        </li>
+                      {/each}
+                    </ul>
+                  {/if}
+                  {#if sel.duration_ms !== undefined}
+                    <p class="muted-row"><code>{fmtMs(sel.duration_ms)}</code></p>
+                  {/if}
+                </div>
+              </details>
+            {/if}
+
+            {#if v2Components.constrained_materializer}
+              {@const m = v2Components.constrained_materializer}
+              <details class="v2-comp" data-testid="v2-comp-materializer">
+                <summary>✍️ constrained_materializer</summary>
+                <div class="v2-comp-body">
+                  {#if m.inputs?.selected_item_id}
+                    <p>
+                      <strong>item_id:</strong>
+                      <code>{m.inputs.selected_item_id}</code>
+                    </p>
+                  {/if}
+                  {#if m.stable_prefix_hash}
+                    <p>
+                      <strong>stable_prefix_hash:</strong>
+                      <code class="hash">{m.stable_prefix_hash}</code>
+                    </p>
+                  {/if}
+                  {#if m.llm_call_ref}
+                    <p>
+                      <strong>llm_call_ref:</strong>
+                      <code>{m.llm_call_ref}</code>
+                    </p>
+                  {/if}
+                  {#if m.duration_ms !== undefined}
+                    <p class="muted-row"><code>{fmtMs(m.duration_ms)}</code></p>
+                  {/if}
+                </div>
+              </details>
+            {/if}
+
+            {#if v2SkWrites.length > 0}
+              <div class="v2-sk-writes" data-testid="v2-sk-writes">
+                <h5>🔍 Subject Knowledge writes ({v2SkWrites.length})</h5>
+                <ul>
+                  {#each v2SkWrites as w}
+                    <li>
+                      <span
+                        class="badge"
+                        style="background: {eventBadge(w.type)}; color: white"
+                        >{w.type}</span
+                      >
+                      {#if w.writer}
+                        <span class="muted-row">writer=<code>{w.writer}</code></span>
+                      {/if}
+                      {#if w.triggered_by}
+                        <span class="muted-row"
+                          >triggered_by=<code>{w.triggered_by}</code></span
+                        >
+                      {/if}
+                    </li>
+                  {/each}
+                </ul>
+              </div>
+            {/if}
+
+            {#if v2Warnings.length > 0}
+              <div class="v2-warnings" data-testid="v2-warnings">
+                <h5>⚠️ warnings ({v2Warnings.length})</h5>
+                <ul>
+                  {#each v2Warnings as w}
+                    <li>
+                      <span class="badge warn">{w.component}</span>
+                      <span class="warn-msg">{w.message}</span>
+                    </li>
+                  {/each}
+                </ul>
+              </div>
+            {/if}
+          </section>
+        {/if}
+
         {#if plan.strategicRationale || plan.instruction_addition || plan.candidateSetEntropy !== undefined}
           <section class="plan">
             <h4>🧠 Plan</h4>
@@ -368,5 +625,103 @@
   .card-skip {
     color: #b00020;
     font-size: 0.75rem;
+  }
+  /* ── v2 engine trace (TV2-6) ──────────────────────────────────────── */
+  .badge.v2 {
+    background: rgba(0, 121, 107, 0.25);
+    color: #00695c;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .badge.journey { background: rgba(123, 31, 162, 0.22); }
+  .badge.helix { background: rgba(245, 124, 0, 0.22); }
+  .badge.phase { background: rgba(46, 125, 50, 0.22); }
+  .badge.warn {
+    background: rgba(183, 28, 28, 0.18);
+    color: #b71c1c;
+    font-weight: 600;
+  }
+  .v2 .v2-note {
+    font-style: italic;
+    opacity: 0.75;
+    font-size: 0.72rem;
+    margin: 0 0 0.3rem 0;
+  }
+  .v2-state-diff {
+    margin: 0.2rem 0 0.5rem 0;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .v2-state-diff .badges {
+    margin-left: 0;
+  }
+  .v2-comp {
+    margin: 0.2rem 0;
+    padding: 0.15rem 0;
+  }
+  .v2-comp > summary {
+    cursor: pointer;
+    font-size: 0.78rem;
+    opacity: 0.85;
+  }
+  .v2-comp-body {
+    padding: 0.2rem 0 0.2rem 1rem;
+  }
+  .v2-comp-body p {
+    margin: 0.1rem 0;
+    font-size: 0.78rem;
+  }
+  .v2-filters {
+    list-style: none;
+    margin: 0.15rem 0;
+    padding: 0 0 0 1rem;
+    font-size: 0.75rem;
+  }
+  .v2-filters li {
+    padding: 0.1rem 0;
+  }
+  .muted-row {
+    opacity: 0.6;
+    font-size: 0.7rem;
+  }
+  .hash {
+    font-size: 0.7rem;
+    word-break: break-all;
+  }
+  .v2-sk-writes,
+  .v2-warnings {
+    margin-top: 0.5rem;
+  }
+  .v2-sk-writes h5,
+  .v2-warnings h5 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.78rem;
+  }
+  .v2-sk-writes ul,
+  .v2-warnings ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .v2-sk-writes li,
+  .v2-warnings li {
+    padding: 0.15rem 0;
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    flex-wrap: wrap;
+    font-size: 0.75rem;
+  }
+  .v2-sk-writes .badge {
+    padding: 0.05rem 0.4rem;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+  .warn-msg {
+    color: #b71c1c;
   }
 </style>

--- a/packages/ebrota-console-ui/src/components/ReplayTurnDetail.svelte
+++ b/packages/ebrota-console-ui/src/components/ReplayTurnDetail.svelte
@@ -1,0 +1,372 @@
+<script lang="ts">
+  /**
+   * ReplayTurnDetail — engine x-ray expansível por turn no Replay.
+   *
+   * Surfaces o que já existe em trace.json (motorTrace.{plan, drota, exec}
+   * + subjectKnowledgeEvents + flags do turn). Não busca dados extras do
+   * BFF — render puro do trace.
+   *
+   * Out of scope (v1): LLM calls raw (entries vazias nos STS traces), Journey
+   * snapshots por turn (não capturados — necessitaria estender writers).
+   */
+  import type { ReplayTraceTurn, ReplayScoredItemLike } from "../lib/api.js";
+
+  export let turn: ReplayTraceTurn;
+
+  let expanded = false;
+
+  $: motor = turn.motorTrace ?? {};
+  $: plan = motor.plan ?? {};
+  $: drota = motor.drota ?? {};
+  $: exec = motor.exec ?? {};
+  $: pool = (plan.contentPool ?? []) as ReplayScoredItemLike[];
+  $: selected = drota.selectedContent ?? null;
+  $: selectedId =
+    selected?.item && typeof selected.item.id === "string"
+      ? selected.item.id
+      : null;
+  // Subject Knowledge events: turn-level OR drota nested (legacy)
+  $: skEvents = (turn.subjectKnowledgeEvents ??
+    drota.subjectKnowledgeEvents ??
+    []) as Array<Record<string, unknown>>;
+  $: hasEngineData =
+    pool.length > 0 ||
+    selected !== null ||
+    skEvents.length > 0 ||
+    plan.strategicRationale !== undefined ||
+    plan.instruction_addition !== undefined ||
+    exec.eventLogged !== undefined;
+
+  function fmtScore(s: number | undefined): string {
+    if (typeof s !== "number") return "?";
+    return s.toFixed(2);
+  }
+
+  function fmtMs(ms: number | undefined): string {
+    if (typeof ms !== "number") return "?";
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+
+  function eventBadge(type: string): string {
+    if (type === "interest") return "#1976d2";
+    if (type === "value") return "#388e3c";
+    if (type === "need") return "#f57c00";
+    if (type === "discovery") return "#7b1fa2";
+    if (type === "boundary_event") return "#b00020";
+    if (type === "presented_concept") return "#00897b";
+    if (type === "recall_check_attempt") return "#ef6c00";
+    if (type === "axis_attempt_outcome") return "#5d4037";
+    return "#666";
+  }
+
+  function eventLabel(e: Record<string, unknown>): string {
+    const payload = (e["payload"] ?? {}) as Record<string, unknown>;
+    if (typeof payload["label"] === "string") return payload["label"];
+    if (typeof payload["concept_id"] === "string") return payload["concept_id"];
+    if (typeof payload["item_id"] === "string") return String(payload["item_id"]);
+    if (typeof payload["topic_category"] === "string")
+      return `topic=${payload["topic_category"]}`;
+    return JSON.stringify(payload).slice(0, 80);
+  }
+</script>
+
+{#if hasEngineData || turn.trustLevel !== undefined}
+  <div class="engine-detail" data-testid="engine-detail">
+    <button
+      type="button"
+      class="toggle"
+      on:click={() => (expanded = !expanded)}
+      aria-expanded={expanded}
+      data-testid="engine-toggle"
+    >
+      <span class="caret">{expanded ? "▼" : "▶"}</span>
+      Engine x-ray
+      <span class="badges">
+        {#if turn.trustLevel !== undefined}
+          <span class="badge">trust={turn.trustLevel.toFixed(2)}</span>
+        {/if}
+        {#if turn.budgetRemaining !== undefined}
+          <span class="badge">budget={turn.budgetRemaining}</span>
+        {/if}
+        {#if turn.playbookId}
+          <span class="badge mono">{turn.playbookId}</span>
+        {/if}
+        {#if turn.durationMs !== undefined}
+          <span class="badge">{fmtMs(turn.durationMs)}</span>
+        {/if}
+        {#if skEvents.length > 0}
+          <span class="badge sk">{skEvents.length} sk</span>
+        {/if}
+        {#if pool.length > 0}
+          <span class="badge pool">{pool.length} pool</span>
+        {/if}
+      </span>
+    </button>
+
+    {#if expanded}
+      <div class="sections">
+        {#if plan.strategicRationale || plan.instruction_addition || plan.candidateSetEntropy !== undefined}
+          <section class="plan">
+            <h4>🧠 Plan</h4>
+            {#if plan.strategicRationale}
+              <p><strong>rationale:</strong> {plan.strategicRationale}</p>
+            {/if}
+            {#if plan.instruction_addition}
+              <p><strong>instruction:</strong> {plan.instruction_addition}</p>
+            {/if}
+            {#if plan.candidateSetEntropy !== undefined}
+              <p>
+                <strong>entropy:</strong>
+                <code>{plan.candidateSetEntropy.toFixed(3)}</code>
+              </p>
+            {/if}
+            {#if plan.contextHints}
+              <details class="raw">
+                <summary>contextHints (JSON)</summary>
+                <pre>{JSON.stringify(plan.contextHints, null, 2)}</pre>
+              </details>
+            {/if}
+          </section>
+        {/if}
+
+        {#if pool.length > 0}
+          <section class="pool" data-testid="pool-section">
+            <h4>🎯 Pool top-{Math.min(pool.length, 5)} (selected ↗)</h4>
+            <ol>
+              {#each pool.slice(0, 5) as scored}
+                {@const id =
+                  typeof scored.item?.["id"] === "string"
+                    ? scored.item["id"]
+                    : "?"}
+                <li class:selected={id === selectedId}>
+                  <span class="iid">{id}</span>
+                  <span class="score">score={fmtScore(scored.score)}</span>
+                  {#if id === selectedId}<span class="picked">↗ SELECTED</span>{/if}
+                  {#if scored.reasons && scored.reasons.length > 0}
+                    <details class="reasons">
+                      <summary>reasons ({scored.reasons.length})</summary>
+                      <ul>
+                        {#each scored.reasons as r}
+                          <li><code>{r}</code></li>
+                        {/each}
+                      </ul>
+                    </details>
+                  {/if}
+                </li>
+              {/each}
+            </ol>
+            {#if drota.selectionRationale}
+              <p class="sel-rationale">
+                <strong>selectionRationale:</strong> {drota.selectionRationale}
+              </p>
+            {/if}
+          </section>
+        {/if}
+
+        {#if skEvents.length > 0}
+          <section class="sk" data-testid="sk-section">
+            <h4>🔍 Subject Knowledge writes ({skEvents.length})</h4>
+            <ul>
+              {#each skEvents as e}
+                {@const type =
+                  typeof e["type"] === "string" ? e["type"] : "unknown"}
+                <li>
+                  <span
+                    class="badge"
+                    style="background: {eventBadge(type)}; color: white">{type}</span
+                  >
+                  <span class="ev-label">{eventLabel(e)}</span>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/if}
+
+        {#if exec.eventLogged || exec.newState}
+          <section class="exec">
+            <h4>⚙️ Exec</h4>
+            {#if exec.eventLogged}
+              <details class="raw">
+                <summary>eventLogged</summary>
+                <pre>{JSON.stringify(exec.eventLogged, null, 2)}</pre>
+              </details>
+            {/if}
+            {#if exec.newState}
+              <details class="raw">
+                <summary>newState</summary>
+                <pre>{JSON.stringify(exec.newState, null, 2)}</pre>
+              </details>
+            {/if}
+          </section>
+        {/if}
+
+        {#if turn.cardEmissionSkipReason}
+          <p class="card-skip">
+            <strong>card emission skipped:</strong> {turn.cardEmissionSkipReason}
+          </p>
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .engine-detail {
+    margin-top: 0.4rem;
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-radius: 4px;
+    background: rgba(127, 127, 127, 0.04);
+    font-size: 0.8rem;
+  }
+  .toggle {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.4rem 0.6rem;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .toggle:hover {
+    background: rgba(127, 127, 127, 0.1);
+  }
+  .caret {
+    opacity: 0.6;
+    width: 0.8rem;
+  }
+  .badges {
+    display: inline-flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+    margin-left: auto;
+  }
+  .badge {
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    background: rgba(127, 127, 127, 0.15);
+    font-size: 0.7rem;
+  }
+  .badge.mono {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  }
+  .badge.sk { background: rgba(123, 31, 162, 0.2); }
+  .badge.pool { background: rgba(25, 118, 210, 0.2); }
+  .sections {
+    padding: 0.5rem 0.7rem;
+    border-top: 1px solid rgba(127, 127, 127, 0.2);
+  }
+  .sections section {
+    margin-bottom: 0.7rem;
+  }
+  .sections h4 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.8rem;
+  }
+  .sections p {
+    margin: 0.15rem 0;
+    line-height: 1.4;
+  }
+  .pool ol {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .pool li {
+    padding: 0.2rem 0;
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.4rem;
+    align-items: baseline;
+  }
+  .pool li.selected {
+    background: rgba(76, 175, 80, 0.12);
+    border-left: 2px solid #388e3c;
+    padding-left: 0.3rem;
+  }
+  .iid {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    word-break: break-all;
+  }
+  .score {
+    font-size: 0.75rem;
+    opacity: 0.75;
+  }
+  .picked {
+    color: #388e3c;
+    font-weight: 600;
+    font-size: 0.7rem;
+  }
+  .reasons {
+    grid-column: 1 / -1;
+    margin-left: 0.8rem;
+  }
+  .reasons summary {
+    cursor: pointer;
+    font-size: 0.7rem;
+    opacity: 0.7;
+  }
+  .reasons ul {
+    list-style: none;
+    padding: 0.2rem 0 0.2rem 1rem;
+    margin: 0;
+  }
+  .reasons code {
+    font-size: 0.7rem;
+  }
+  .sel-rationale {
+    margin-top: 0.4rem;
+    font-style: italic;
+    opacity: 0.85;
+  }
+  .sk ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .sk li {
+    padding: 0.15rem 0;
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+  }
+  .sk .badge {
+    padding: 0.05rem 0.4rem;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+  .ev-label {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    word-break: break-all;
+  }
+  .raw {
+    margin-top: 0.3rem;
+  }
+  .raw summary {
+    cursor: pointer;
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+  .raw pre {
+    background: rgba(127, 127, 127, 0.08);
+    padding: 0.4rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    overflow-x: auto;
+    margin: 0.2rem 0 0 0;
+    max-height: 200px;
+  }
+  .card-skip {
+    color: #b00020;
+    font-size: 0.75rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -106,6 +106,33 @@ export interface SessionLibraryEntry {
   tracePath: string | null;
 }
 
+export interface ReplayScoredItemLike {
+  item?: { id?: string; type?: string; domain?: string; axis_id?: number } & Record<string, unknown>;
+  score?: number;
+  reasons?: string[];
+}
+
+export interface ReplayMotorTraceLike {
+  plan?: {
+    contextHints?: unknown;
+    instruction_addition?: string;
+    strategicRationale?: string;
+    candidateSetEntropy?: number;
+    contentPool?: ReplayScoredItemLike[];
+  };
+  drota?: {
+    selectedContent?: ReplayScoredItemLike;
+    selectionRationale?: string;
+    linguisticMaterialization?: string;
+    subjectKnowledgeEvents?: unknown[];
+  };
+  exec?: {
+    eventLogged?: unknown;
+    newState?: unknown;
+    success?: boolean;
+  };
+}
+
 export interface ReplayTraceTurn {
   turnNumber?: number;
   sessionId?: string;
@@ -113,6 +140,26 @@ export interface ReplayTraceTurn {
   finalResponse?: string;
   timestamp?: string;
   entries?: Array<Record<string, unknown>>;
+
+  // ─── engine x-ray (S-OC-22 follow-up) — read straight from raw trace ────
+  /** Trust level pós-turn (0..1). */
+  trustLevel?: number;
+  /** Budget restante pra sessão (qualquer escala). */
+  budgetRemaining?: number;
+  playbookId?: string;
+  durationMs?: number;
+  /** Razão de skip de card emission, quando aplicável. */
+  cardEmissionSkipReason?: string;
+
+  /** Trace estruturado do motor pipeline (plan / drota / exec). */
+  motorTrace?: ReplayMotorTraceLike;
+
+  /**
+   * Subject Knowledge events emitidos por writers neste turn. Pode estar
+   * no nível do turn (preferido) OU em motorTrace.drota.subjectKnowledgeEvents
+   * (legacy STS schema).
+   */
+  subjectKnowledgeEvents?: unknown[];
 }
 
 export interface ReplayTrace {

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -133,6 +133,125 @@ export interface ReplayMotorTraceLike {
   };
 }
 
+// ─── EngineTraceV2Like — TV2 (sub-fase TV2-6) ────────────────────────────
+//
+// Shape duck-typed que mirrora `EngineTraceV2` de shared/src/engine-trace-v2.ts.
+// Duplicado aqui pra não importar shared no bundle browser. Mantém apenas
+// os campos consumidos pela UI; campos não-renderizados ficam `unknown`.
+//
+// Coexiste com `motorTrace` (v1) — se ambos presentes, UI prioriza v2.
+
+export interface EngineTraceStateDiffLike {
+  journey_stage_transition?: { from: string; to: string; trigger?: string };
+  helix_advance?: {
+    dimension_changed?: boolean;
+    level_changed?: boolean;
+    cycle_completed?: boolean;
+  };
+  subject_knowledge_added_count?: number;
+  trust_delta?: number;
+  budget_delta?: number;
+  session_phase_transition?: { from: string; to: string };
+}
+
+export interface EngineTraceAssessorLike {
+  inputs?: { user_message?: string; turn_history_window?: number };
+  outputs?: {
+    mood?: number;
+    signals?: string[];
+    engagement?: string;
+  };
+  mood_method?: "rule" | "llm" | "fallback";
+  duration_ms?: number;
+  llm_call_ref?: string;
+}
+
+export interface EngineTracePlanejadorLike {
+  inputs?: Record<string, unknown>;
+  outputs?: {
+    contentPool?: ReplayScoredItemLike[];
+    strategicRationale?: string;
+    candidateSetEntropy?: number;
+    instruction_addition?: string;
+    contextHints?: unknown;
+  };
+  triageDecision?: { route?: string; reason?: string };
+  triggerEvaluation?: { transitions_checked?: string[]; fired?: string };
+  llm_call_ref?: string;
+  duration_ms?: number;
+}
+
+export interface EngineTraceStrategistLike {
+  inputs?: {
+    journey_stage?: string;
+    latent_needs?: string[];
+    current_objectives?: Array<Record<string, unknown>>;
+  };
+  outputs?: {
+    plan_id?: string;
+    target_demonstrations?: Array<Record<string, unknown>>;
+    playbook_composition?: Array<Record<string, unknown>>;
+  };
+  composition_method?: "template_v1" | "llm";
+  duration_ms?: number;
+}
+
+export interface EngineTraceSelectorLike {
+  inputs?: { pool_size?: number; mood?: number; budget?: number };
+  filters_applied?: Array<{
+    name: string;
+    items_removed?: string[];
+    reason?: string;
+  }>;
+  outputs?: { selected_id?: string; pool_remaining?: string[] };
+  duration_ms?: number;
+}
+
+export interface EngineTraceMaterializerLike {
+  inputs?: {
+    selected_item_id?: string;
+    instruction_addition?: string;
+    user_message?: string;
+  };
+  stable_prefix_hash?: string;
+  user_message_constructed?: string;
+  outputs?: { raw_response?: string; final_text?: string };
+  llm_call_ref?: string;
+  duration_ms?: number;
+}
+
+export interface EngineTraceSkWriteLike {
+  type: string;
+  payload?: Record<string, unknown>;
+  writer?: string;
+  triggered_by?: string;
+}
+
+export interface EngineTraceWarningLike {
+  component: string;
+  message: string;
+  recoverable?: boolean;
+}
+
+export interface EngineTraceV2Like {
+  schema_version?: number;
+  turn_started_at?: string;
+  turn_completed_at?: string;
+  pre_state?: Record<string, unknown>;
+  post_state?: Record<string, unknown>;
+  state_diff?: EngineTraceStateDiffLike;
+  components?: {
+    unified_assessor?: EngineTraceAssessorLike;
+    planejador?: EngineTracePlanejadorLike;
+    strategist?: EngineTraceStrategistLike;
+    pragmatic_selector?: EngineTraceSelectorLike;
+    constrained_materializer?: EngineTraceMaterializerLike;
+  };
+  llm_calls?: unknown[];
+  subject_knowledge_writes?: EngineTraceSkWriteLike[];
+  warnings?: EngineTraceWarningLike[];
+}
+
 export interface ReplayTraceTurn {
   turnNumber?: number;
   sessionId?: string;
@@ -153,6 +272,13 @@ export interface ReplayTraceTurn {
 
   /** Trace estruturado do motor pipeline (plan / drota / exec). */
   motorTrace?: ReplayMotorTraceLike;
+
+  /**
+   * Engine Trace v2 (sub-fase TV2-6) — full engine telemetry per turn.
+   * Convive com motorTrace v1: quando ambos presentes, UI prioriza v2.
+   * Quando ausente, UI cai pra v1 (motorTrace) sem mudança comportamental.
+   */
+  engineTrace?: EngineTraceV2Like;
 
   /**
    * Subject Knowledge events emitidos por writers neste turn. Pode estar

--- a/packages/ebrota-console-ui/tests/components/DiscoveriesPanel.test.ts
+++ b/packages/ebrota-console-ui/tests/components/DiscoveriesPanel.test.ts
@@ -1,0 +1,116 @@
+/**
+ * DiscoveriesPanel smoke tests — verifica consumo de /subjects/:id/discoveries
+ * + /boundaries-summary.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import DiscoveriesPanel from "../../src/components/DiscoveriesPanel.svelte";
+import { discoveriesPanelOpen, tracerSubjectId } from "../../src/lib/stores.js";
+import type {
+  ApiClient,
+  SubjectKnowledgeEntryLike,
+  BoundarySummary,
+} from "../../src/lib/api.js";
+
+const buildApi = (
+  discoveries: SubjectKnowledgeEntryLike[] | Error,
+  summary: BoundarySummary[] = [],
+): ApiClient =>
+  ({
+    listSubjectDiscoveries: vi.fn(async () => {
+      if (discoveries instanceof Error) throw discoveries;
+      return { discoveries };
+    }),
+    getBoundariesSummary: vi.fn(async () => ({ summary })),
+  }) as never;
+
+beforeEach(() => {
+  discoveriesPanelOpen.set(false);
+  tracerSubjectId.set("test-subject");
+});
+
+const entry = (
+  type: string,
+  label: string,
+  confidence = 0.8,
+): SubjectKnowledgeEntryLike => ({
+  id: `${type}-${label}`,
+  type,
+  source: "motor_inferred",
+  confidence,
+  payload: { label },
+  turn_ref: "t1",
+  session_id: "s1",
+  created_at: "2026-05-26T10:00:00Z",
+});
+
+describe("DiscoveriesPanel", () => {
+  it("não renderiza quando fechado", () => {
+    render(DiscoveriesPanel, { api: buildApi([]) });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("mostra empty state quando 0 descobertas", async () => {
+    render(DiscoveriesPanel, { api: buildApi([]) });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Nenhuma descoberta pra este sujeito ainda/),
+      ).toBeDefined();
+    });
+  });
+
+  it("renderiza timeline de descobertas com badges por type", async () => {
+    render(DiscoveriesPanel, {
+      api: buildApi([
+        entry("interest", "tênis", 0.9),
+        entry("value", "persistência", 0.7),
+        entry("boundary_event", "corpo", 0.85),
+      ]),
+    });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText("tênis")).toBeDefined();
+    });
+    expect(screen.getByText("persistência")).toBeDefined();
+    // "interest"/"value" aparecem como option do select filter + badge na lista
+    expect(screen.getAllByText("interest").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("value").length).toBeGreaterThan(0);
+    expect(screen.getByText(/conf=0\.90/)).toBeDefined();
+  });
+
+  it("renderiza boundaries summary agregado", async () => {
+    render(DiscoveriesPanel, {
+      api: buildApi(
+        [entry("interest", "tênis")],
+        [
+          {
+            topic_category: "corpo",
+            count: 5,
+            high_intensity_count: 2,
+            last_seen_at: "2026-05-26T10:00:00Z",
+          },
+        ],
+      ),
+    });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/Boundaries/)).toBeDefined();
+    });
+    expect(screen.getByText("corpo")).toBeDefined();
+    expect(screen.getByText(/5×/)).toBeDefined();
+    expect(screen.getByText(/high 2/)).toBeDefined();
+  });
+
+  it("mostra erro quando API falha", async () => {
+    render(DiscoveriesPanel, {
+      api: buildApi(new Error("DB locked")),
+    });
+    discoveriesPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/DB locked/)).toBeDefined();
+    });
+  });
+});

--- a/packages/ebrota-console-ui/tests/components/JourneyPanel.test.ts
+++ b/packages/ebrota-console-ui/tests/components/JourneyPanel.test.ts
@@ -1,0 +1,88 @@
+/**
+ * JourneyPanel smoke tests — verifica que UI consome /subjects/:id/journey-state
+ * corretamente em cenários vazio, populado e com override parental.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import JourneyPanel from "../../src/components/JourneyPanel.svelte";
+import { journeyPanelOpen, tracerSubjectId } from "../../src/lib/stores.js";
+import type { ApiClient, JourneyStateLike } from "../../src/lib/api.js";
+
+const buildApi = (state: JourneyStateLike | Error): ApiClient =>
+  ({
+    getJourneyState: vi.fn(async () => {
+      if (state instanceof Error) throw state;
+      return { state };
+    }),
+    setJourneyOverride: vi.fn(async (_id, stage, reason) => ({
+      state: {
+        ...(state as JourneyStateLike),
+        stage: stage as JourneyStateLike["stage"],
+        override_by_parent: { forced_stage: stage, reason, timestamp: "now" },
+      },
+    })),
+    clearJourneyOverride: vi.fn(async () => ({ state: state as JourneyStateLike })),
+  }) as never;
+
+beforeEach(() => {
+  journeyPanelOpen.set(false);
+  tracerSubjectId.set("test-subject");
+});
+
+describe("JourneyPanel", () => {
+  it("não renderiza modal quando fechado", () => {
+    render(JourneyPanel, { api: buildApi(makeState("discovery_only")) });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("mostra stage atual quando populado", async () => {
+    render(JourneyPanel, {
+      api: buildApi(makeState("applied_double_helix", 18, ["carater", "disposicao"])),
+    });
+    journeyPanelOpen.set(true);
+    await waitFor(() => {
+      // applied_double_helix aparece no select option + no badge → vários matches
+      expect(screen.getAllByText("applied_double_helix").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText(/18/)).toBeDefined();
+  });
+
+  it("mostra override parental quando presente", async () => {
+    const state = makeState("mapping_ready", 5, ["carater"]);
+    state.override_by_parent = {
+      forced_stage: "mapping_ready",
+      reason: "ainda sentindo cedo",
+      timestamp: "2026-05-26T10:00:00Z",
+    };
+    render(JourneyPanel, { api: buildApi(state) });
+    journeyPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/ainda sentindo cedo/)).toBeDefined();
+    });
+  });
+
+  it("mostra erro quando API falha", async () => {
+    render(JourneyPanel, { api: buildApi(new Error("BFF offline")) });
+    journeyPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/BFF offline/)).toBeDefined();
+    });
+  });
+});
+
+function makeState(
+  stage: JourneyStateLike["stage"],
+  discoveries = 0,
+  families: string[] = [],
+): JourneyStateLike {
+  return {
+    subject_id: "test-subject",
+    stage,
+    stage_entered_at: "2026-05-20T10:00:00Z",
+    discoveries_count: discoveries,
+    families_covered: families,
+    last_updated_at: "2026-05-26T10:00:00Z",
+  };
+}

--- a/packages/ebrota-console-ui/tests/components/MapsPanel.test.ts
+++ b/packages/ebrota-console-ui/tests/components/MapsPanel.test.ts
@@ -1,0 +1,110 @@
+/**
+ * MapsPanel smoke tests — verifica consumo de /frameworks + /subjects/:id/maps.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import MapsPanel from "../../src/components/MapsPanel.svelte";
+import { mapsPanelOpen, tracerSubjectId } from "../../src/lib/stores.js";
+import type {
+  ApiClient,
+  FrameworkMeta,
+  SubjectMapLike,
+} from "../../src/lib/api.js";
+
+const frameworks = (): FrameworkMeta[] => [
+  {
+    id: "valores_classicos",
+    display_name: "Valores clássicos",
+    dimensions: ["axis_1", "axis_2", "axis_11"],
+    render_hint: "radar",
+  },
+  {
+    id: "gardner",
+    display_name: "Gardner",
+    dimensions: ["intrapersonal", "interpersonal"],
+    render_hint: "bar",
+  },
+];
+
+const buildApi = (
+  fws: FrameworkMeta[] | Error,
+  maps: SubjectMapLike | Error,
+): ApiClient =>
+  ({
+    listFrameworks: vi.fn(async () => {
+      if (fws instanceof Error) throw fws;
+      return { frameworks: fws };
+    }),
+    getSubjectMaps: vi.fn(async () => {
+      if (maps instanceof Error) throw maps;
+      return { maps };
+    }),
+  }) as never;
+
+beforeEach(() => {
+  mapsPanelOpen.set(false);
+  tracerSubjectId.set("test-subject");
+});
+
+describe("MapsPanel", () => {
+  it("não renderiza modal quando fechado", () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), {
+        subject_id: "test-subject",
+        computed_at: "2026-05-26",
+        positions: {},
+      }),
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("mostra tabs de frameworks + dimensões com valor > 0", async () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), {
+        subject_id: "test-subject",
+        computed_at: "2026-05-26T10:00:00Z",
+        positions: {
+          valores_classicos: { axis_1: 3, axis_2: 0, axis_11: 5 },
+          gardner: { intrapersonal: 2, interpersonal: 0 },
+        },
+      }),
+    });
+    mapsPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText("Valores clássicos")).toBeDefined();
+    });
+    expect(screen.getByText("Gardner")).toBeDefined();
+    // Default tab = valores_classicos; axis_1 e axis_11 visíveis (axis_2 = 0)
+    expect(screen.getByText("axis_1")).toBeDefined();
+    expect(screen.getByText("axis_11")).toBeDefined();
+    expect(screen.queryByText("axis_2")).toBeNull();
+  });
+
+  it("mostra empty state quando nenhuma posição > 0", async () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), {
+        subject_id: "test-subject",
+        computed_at: "2026-05-26",
+        positions: { valores_classicos: { axis_1: 0, axis_2: 0 } },
+      }),
+    });
+    mapsPanelOpen.set(true);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Nenhuma posição com valor > 0/),
+      ).toBeDefined();
+    });
+  });
+
+  it("mostra erro quando getSubjectMaps falha", async () => {
+    render(MapsPanel, {
+      api: buildApi(frameworks(), new Error("maps endpoint 500")),
+    });
+    mapsPanelOpen.set(true);
+    await waitFor(() => {
+      expect(screen.getByText(/maps endpoint 500/)).toBeDefined();
+    });
+  });
+});

--- a/packages/ebrota-console-ui/tests/components/ReplayTurnDetail.test.ts
+++ b/packages/ebrota-console-ui/tests/components/ReplayTurnDetail.test.ts
@@ -1,0 +1,165 @@
+/**
+ * ReplayTurnDetail smoke tests — engine x-ray per turn.
+ *
+ * Cobre cenários: motor data ausente (não renderiza nada),
+ * trace completo (pool + selected + SK events + plan).
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/svelte";
+
+afterEach(() => cleanup());
+import ReplayTurnDetail from "../../src/components/ReplayTurnDetail.svelte";
+import type { ReplayTraceTurn } from "../../src/lib/api.js";
+
+const emptyTurn = (): ReplayTraceTurn => ({
+  turnNumber: 1,
+});
+
+const richTurn = (): ReplayTraceTurn => ({
+  turnNumber: 4,
+  trustLevel: 0.42,
+  budgetRemaining: 96,
+  playbookId: "helix-rapport-v1",
+  durationMs: 12345,
+  motorTrace: {
+    plan: {
+      strategicRationale: "explorar autoconhecimento via metáfora natural",
+      instruction_addition: "tom suave, evitar conceitos abstratos",
+      candidateSetEntropy: 2.41,
+      contextHints: { stage: "applied_double_helix" },
+      contentPool: [
+        {
+          item: { id: "bio_caterpillar_dissolve", axis_id: 11 },
+          score: 14.5,
+          reasons: ["base_score=10", "multidim_bonus=+6", "surprise_bonus=+3"],
+        },
+        {
+          item: { id: "bio_dolphin_names", axis_id: 11 },
+          score: 12.0,
+          reasons: ["base_score=10", "multidim_bonus=+4"],
+        },
+        {
+          item: { id: "myth_kintsugi_philosophy", axis_id: 3 },
+          score: 10.5,
+          reasons: ["base_score=10", "surprise_bonus=+1"],
+        },
+      ],
+    },
+    drota: {
+      selectedContent: {
+        item: { id: "bio_caterpillar_dissolve", axis_id: 11 },
+        score: 14.5,
+        reasons: ["base_score=10"],
+      },
+      selectionRationale: "highest score + matches casel_focus",
+      linguisticMaterialization: "Lagarta quando dissolve...",
+    },
+    exec: {
+      eventLogged: { kind: "presented_concept_logged" },
+      success: true,
+    },
+  },
+  subjectKnowledgeEvents: [
+    {
+      type: "presented_concept",
+      payload: { concept_id: "bio_caterpillar_dissolve", axis_id: 11 },
+    },
+    {
+      type: "boundary_event",
+      payload: { topic_category: "corpo" },
+    },
+  ],
+});
+
+describe("ReplayTurnDetail", () => {
+  it("não renderiza nada quando turn sem motor data", () => {
+    const { container } = render(ReplayTurnDetail, { turn: emptyTurn() });
+    expect(container.querySelector(".engine-detail")).toBeNull();
+  });
+
+  it("renderiza colapsado com badges quando trace tem motor data", () => {
+    render(ReplayTurnDetail, { turn: richTurn() });
+    expect(screen.getByText(/Engine x-ray/)).toBeDefined();
+    expect(screen.getByText(/trust=0\.42/)).toBeDefined();
+    expect(screen.getByText(/budget=96/)).toBeDefined();
+    expect(screen.getByText("helix-rapport-v1")).toBeDefined();
+    expect(screen.getByText(/2 sk/)).toBeDefined();
+    expect(screen.getByText(/3 pool/)).toBeDefined();
+  });
+
+  it("expande ao clicar e mostra todas as seções", async () => {
+    render(ReplayTurnDetail, { turn: richTurn() });
+    const toggle = screen.getByTestId("engine-toggle");
+    await fireEvent.click(toggle);
+
+    // Plan section
+    expect(
+      screen.getByText(/explorar autoconhecimento via metáfora natural/),
+    ).toBeDefined();
+    expect(screen.getByText(/tom suave/)).toBeDefined();
+    expect(screen.getByText("2.410")).toBeDefined(); // entropy
+
+    // Pool section
+    expect(screen.getByTestId("pool-section")).toBeDefined();
+    // bio_caterpillar_dissolve aparece no pool list — pode renderizar 1+ vezes
+    // dependendo do estado expand interno
+    expect(screen.getAllByText("bio_caterpillar_dissolve").length).toBeGreaterThan(0);
+    expect(screen.getByText("bio_dolphin_names")).toBeDefined();
+    expect(screen.getByText(/SELECTED/)).toBeDefined();
+    expect(screen.getByText(/highest score \+ matches casel_focus/)).toBeDefined();
+
+    // SK section
+    expect(screen.getByTestId("sk-section")).toBeDefined();
+    expect(screen.getByText("presented_concept")).toBeDefined();
+    expect(screen.getByText("boundary_event")).toBeDefined();
+  });
+
+  it("destaca o item selected dentro do pool", async () => {
+    const { container } = render(ReplayTurnDetail, { turn: richTurn() });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+    const selectedLi = container.querySelector("li.selected");
+    expect(selectedLi).not.toBeNull();
+    expect(selectedLi?.textContent).toContain("bio_caterpillar_dissolve");
+  });
+
+  it("renderiza só badges quando flags do turn presentes mas sem motorTrace", () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 1,
+      trustLevel: 0.55,
+      budgetRemaining: 80,
+      playbookId: "warmup",
+    };
+    render(ReplayTurnDetail, { turn });
+    expect(screen.getByText(/trust=0\.55/)).toBeDefined();
+    expect(screen.getByText("warmup")).toBeDefined();
+  });
+
+  it("fallback pra subjectKnowledgeEvents em motorTrace.drota (legacy STS)", async () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 2,
+      motorTrace: {
+        drota: {
+          subjectKnowledgeEvents: [
+            { type: "interest", payload: { label: "tênis" } },
+          ],
+        },
+      },
+    };
+    render(ReplayTurnDetail, { turn });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+    expect(screen.getByText("interest")).toBeDefined();
+    expect(screen.getByText("tênis")).toBeDefined();
+  });
+
+  it("mostra cardEmissionSkipReason quando presente", async () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 3,
+      trustLevel: 0.4,
+      cardEmissionSkipReason: "trust_below_threshold",
+      motorTrace: { plan: { strategicRationale: "x" } },
+    };
+    render(ReplayTurnDetail, { turn });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+    expect(screen.getByText(/trust_below_threshold/)).toBeDefined();
+  });
+});

--- a/packages/ebrota-console-ui/tests/components/ReplayTurnDetail.test.ts
+++ b/packages/ebrota-console-ui/tests/components/ReplayTurnDetail.test.ts
@@ -162,4 +162,232 @@ describe("ReplayTurnDetail", () => {
     await fireEvent.click(screen.getByTestId("engine-toggle"));
     expect(screen.getByText(/trust_below_threshold/)).toBeDefined();
   });
+
+  // ─── TV2-6: v2 engine trace coverage ─────────────────────────────────
+  // Quando turn.engineTrace presente, render v2 sections; v1 fica como
+  // fallback. Quando ambos presentes, v2 vem primeiro + nota de coexistência.
+
+  it("[v2] engineTrace ausente → v1 motorTrace continua renderizando (regressão)", async () => {
+    render(ReplayTurnDetail, { turn: richTurn() });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+    // v2 section NÃO aparece quando engineTrace ausente
+    expect(screen.queryByTestId("v2-section")).toBeNull();
+    expect(screen.queryByTestId("v2-badge")).toBeNull();
+    // v1 sections continuam funcionando
+    expect(screen.getByTestId("pool-section")).toBeDefined();
+    expect(screen.getByTestId("sk-section")).toBeDefined();
+  });
+
+  it("[v2] engineTrace presente → renderiza state_diff badges, components by name, sk_writes e warnings", async () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 5,
+      trustLevel: 0.5,
+      engineTrace: {
+        schema_version: 2,
+        turn_started_at: "2026-05-26T15:00:00Z",
+        turn_completed_at: "2026-05-26T15:00:08Z",
+        state_diff: {
+          trust_delta: 0.08,
+          budget_delta: -3,
+          subject_knowledge_added_count: 2,
+          journey_stage_transition: {
+            from: "discovery_only",
+            to: "mapping_ready",
+            trigger: "auto",
+          },
+          helix_advance: { level_changed: true },
+          session_phase_transition: {
+            from: "ice_breaker",
+            to: "challenge_explain",
+          },
+        },
+        components: {
+          unified_assessor: {
+            outputs: { mood: 0.72, signals: ["curious", "open"], engagement: "high" },
+            mood_method: "rule",
+            duration_ms: 12,
+          },
+          planejador: {
+            outputs: {
+              strategicRationale: "ancorar em metáfora natural",
+              candidateSetEntropy: 1.85,
+            },
+            triageDecision: { route: "drota", reason: "no_parental_signal" },
+            duration_ms: 1450,
+          },
+          strategist: {
+            inputs: { journey_stage: "mapping_ready" },
+            outputs: {
+              target_demonstrations: [{ id: "demo1" }, { id: "demo2" }, { id: "demo3" }],
+              playbook_composition: [],
+            },
+            composition_method: "template_v1",
+            duration_ms: 8,
+          },
+          pragmatic_selector: {
+            inputs: { pool_size: 5, mood: 0.72 },
+            filters_applied: [
+              {
+                name: "mood_gate",
+                items_removed: ["heavy_item_a"],
+                reason: "mood>0.5 prunes heavy",
+              },
+            ],
+            outputs: { selected_id: "bio_caterpillar_dissolve", pool_remaining: [] },
+            duration_ms: 3,
+          },
+          constrained_materializer: {
+            inputs: {
+              selected_item_id: "bio_caterpillar_dissolve",
+              user_message: "...",
+            },
+            stable_prefix_hash: "sha256:abc12345",
+            user_message_constructed: "...",
+            outputs: { raw_response: "...", final_text: "..." },
+            llm_call_ref: "llm-call-001",
+            duration_ms: 8200,
+          },
+        },
+        llm_calls: [],
+        subject_knowledge_writes: [
+          {
+            type: "discovery",
+            payload: { label: "interesse: lagartas" },
+            writer: "discovery",
+            triggered_by: "unified_assessor.signals",
+          },
+          {
+            type: "presented_concept",
+            payload: { concept_id: "bio_caterpillar_dissolve" },
+            writer: "concept_ledger",
+            triggered_by: "constrained_materializer.execute",
+          },
+        ],
+        warnings: [
+          {
+            component: "strategist",
+            message: "no current_objectives — falling back to default",
+            recoverable: true,
+          },
+        ],
+      },
+    };
+    render(ReplayTurnDetail, { turn });
+
+    // v2 badge no toggle
+    expect(screen.getByTestId("v2-badge")).toBeDefined();
+
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+
+    // v2 section + state diff
+    expect(screen.getByTestId("v2-section")).toBeDefined();
+    expect(screen.getByTestId("v2-state-diff")).toBeDefined();
+    expect(screen.getByTestId("v2-trust-delta")).toBeDefined();
+    expect(screen.getByTestId("v2-budget-delta")).toBeDefined();
+    expect(screen.getByTestId("v2-journey-transition")).toBeDefined();
+    expect(screen.getByTestId("v2-helix-advance")).toBeDefined();
+    expect(screen.getByTestId("v2-phase-transition")).toBeDefined();
+    expect(screen.getByTestId("v2-sk-added")).toBeDefined();
+
+    // Components present
+    expect(screen.getByTestId("v2-comp-assessor")).toBeDefined();
+    expect(screen.getByTestId("v2-comp-planejador")).toBeDefined();
+    expect(screen.getByTestId("v2-comp-strategist")).toBeDefined();
+    expect(screen.getByTestId("v2-comp-selector")).toBeDefined();
+    expect(screen.getByTestId("v2-comp-materializer")).toBeDefined();
+
+    // Subject Knowledge writes show writer + triggered_by
+    const skWrites = screen.getByTestId("v2-sk-writes");
+    expect(skWrites).toBeDefined();
+    expect(skWrites.textContent).toContain("discovery");
+    expect(skWrites.textContent).toContain("concept_ledger");
+    expect(skWrites.textContent).toContain("unified_assessor.signals");
+
+    // Warnings
+    expect(screen.getByTestId("v2-warnings")).toBeDefined();
+    expect(screen.getByText(/no current_objectives/)).toBeDefined();
+  });
+
+  it("[v2] subset de components (só assessor) → outras sections omitidas", async () => {
+    const turn: ReplayTraceTurn = {
+      turnNumber: 6,
+      engineTrace: {
+        schema_version: 2,
+        turn_started_at: "2026-05-26T15:00:00Z",
+        turn_completed_at: "2026-05-26T15:00:01Z",
+        state_diff: {
+          trust_delta: 0,
+          budget_delta: 0,
+          subject_knowledge_added_count: 0,
+        },
+        components: {
+          unified_assessor: {
+            outputs: { mood: 0.3, signals: [], engagement: "low" },
+            mood_method: "fallback",
+            duration_ms: 5,
+          },
+        },
+        llm_calls: [],
+        subject_knowledge_writes: [],
+        warnings: [],
+      },
+    };
+    render(ReplayTurnDetail, { turn });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+
+    expect(screen.getByTestId("v2-comp-assessor")).toBeDefined();
+    expect(screen.queryByTestId("v2-comp-planejador")).toBeNull();
+    expect(screen.queryByTestId("v2-comp-strategist")).toBeNull();
+    expect(screen.queryByTestId("v2-comp-selector")).toBeNull();
+    expect(screen.queryByTestId("v2-comp-materializer")).toBeNull();
+    expect(screen.queryByTestId("v2-sk-writes")).toBeNull();
+    expect(screen.queryByTestId("v2-warnings")).toBeNull();
+    // Sem journey/helix/phase transitions, badges desses não aparecem
+    expect(screen.queryByTestId("v2-journey-transition")).toBeNull();
+    expect(screen.queryByTestId("v2-helix-advance")).toBeNull();
+  });
+
+  it("[v2] engineTrace + motorTrace ambos presentes → v2 vem primeiro + nota de coexistência", async () => {
+    const v1 = richTurn();
+    const turn: ReplayTraceTurn = {
+      ...v1,
+      engineTrace: {
+        schema_version: 2,
+        turn_started_at: "2026-05-26T15:00:00Z",
+        turn_completed_at: "2026-05-26T15:00:02Z",
+        state_diff: {
+          trust_delta: 0.02,
+          budget_delta: -1,
+          subject_knowledge_added_count: 0,
+        },
+        components: {
+          unified_assessor: {
+            outputs: { mood: 0.5, signals: ["x"], engagement: "medium" },
+            mood_method: "llm",
+            duration_ms: 100,
+          },
+        },
+        llm_calls: [],
+        subject_knowledge_writes: [],
+        warnings: [],
+      },
+    };
+    const { container } = render(ReplayTurnDetail, { turn });
+    await fireEvent.click(screen.getByTestId("engine-toggle"));
+
+    expect(screen.getByTestId("v2-section")).toBeDefined();
+    expect(screen.getByTestId("v2-coexist-note")).toBeDefined();
+    // v1 sections still rendered abaixo
+    expect(screen.getByTestId("pool-section")).toBeDefined();
+
+    // Ordem DOM: v2 vem antes de v1 pool-section
+    const v2 = screen.getByTestId("v2-section");
+    const pool = screen.getByTestId("pool-section");
+    const positionRel = v2.compareDocumentPosition(pool);
+    // DOCUMENT_POSITION_FOLLOWING = 4
+    expect(positionRel & 4).toBe(4);
+
+    // Sanidade — extra para garantir que renderizou todo o trace
+    expect(container.querySelectorAll(".v2-comp").length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Estende `ReplayTurnDetail.svelte` com seção **🆕 v2 engine trace** que consome `turn.engineTrace` (EngineTraceV2) quando presente: state_diff badges (Δtrust, Δbudget, journey transition, helix advance, session phase transition, sk_added), 5 components collapsible (assessor, planejador, strategist, pragmatic_selector, constrained_materializer), Subject Knowledge writes enhanced (writer + triggered_by por entry), warnings (red badges).
- Adiciona `EngineTraceV2Like` em `api.ts` (duck-typed, sem importar `shared/src/engine-trace-v2.ts` — UI bundle browser-only). Campo `engineTrace?` no `ReplayTraceTurn`.
- Backward 100%: `engineTrace` ausente → v1 (`motorTrace`) renderiza igual. Ambos presentes → v2 vem primeiro + nota "v2 engine trace available" + v1 segue como fallback.
- LLM calls **não** renderizados aqui — TV2-7 (painel LlmXrayPanel separado).

## Files changed

- `packages/ebrota-console-ui/src/lib/api.ts` — +126 (tipos v2 duck-typed)
- `packages/ebrota-console-ui/src/components/ReplayTurnDetail.svelte` — +355 (nova section + CSS)
- `packages/ebrota-console-ui/tests/components/ReplayTurnDetail.test.ts` — +228 (4 novos tests)

## Notes

- Não tocou `App.svelte`, `Status.svelte`, `stores.ts` (TV2-7 paralelo)
- Não tocou motor/shared/ops (escopo só UI)
- PR inclui cherry-pick do commit base v1 (PR #226 ainda aberto) — quando #226 mergeia, rebase é trivial pois o commit é idêntico

## Test plan

- [x] `npm run build --workspace packages/ebrota-console-ui` → ok
- [x] `npm test --workspace packages/ebrota-console-ui` → 122/122 pass (118 baseline + 4 new)
- [x] Regressão coberta: `engineTrace` ausente → v1 sections renderizam (test "engineTrace ausente → v1 motorTrace continua renderizando")
- [x] Cenário completo coberto: state_diff todas as transições + 5 components + sk_writes com writer/triggered_by + warnings
- [x] Subset coberto: só assessor → outras sections omitidas
- [x] Coexistência coberta: v1+v2 ambos presentes, v2 primeiro no DOM, nota visível

🤖 Generated with [Claude Code](https://claude.com/claude-code)