### PR TITLE
[fix ops#1122] SessionLibrary: auto-refresh interval 5s + onDestroy cleanup

### DIFF
--- a/packages/ebrota-console-ui/src/components/SessionLibrary.svelte
+++ b/packages/ebrota-console-ui/src/components/SessionLibrary.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import {
     libraryOpen,
     replaySessionId,
@@ -20,6 +20,9 @@
   let q = "";
   let hasOverrides = false;
   let lastFetch = Date.now();
+  let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+  const LIBRARY_REFRESH_MS = 5000;
 
   $: open = $libraryOpen;
 
@@ -47,10 +50,27 @@
 
   $: if (open) {
     void refresh();
+    if (refreshInterval === null) {
+      refreshInterval = setInterval(() => {
+        void refresh();
+      }, LIBRARY_REFRESH_MS);
+    }
+  } else {
+    if (refreshInterval !== null) {
+      clearInterval(refreshInterval);
+      refreshInterval = null;
+    }
   }
 
   onMount(() => {
     if (open) void refresh();
+  });
+
+  onDestroy(() => {
+    if (refreshInterval !== null) {
+      clearInterval(refreshInterval);
+      refreshInterval = null;
+    }
   });
 
   function openReplay(sessionId: string): void {


### PR DESCRIPTION
## Problema
SessionLibrary não atualizava automaticamente enquanto aberta — o usuário precisava clicar manualmente em "Aplicar" pra ver novas sessões.

## Fix
- Adiciona `onDestroy` ao import de `svelte`
- Timer de 5s (`LIBRARY_REFRESH_MS`) iniciado quando painel abre (`open` torna-se true)
- Timer cancelado quando painel fecha ou componente desmontado (sem leak)

## Testes
- 141/141 UI tests passando
- Sem mudança de contrato público

Closes ops#1122