### PR TITLE
[feat ops#1123] BFF: stdio daemon client + /sessions/active endpoint + App auto-connect

### DIFF
--- a/packages/ebrota-console-bff/src/cli.ts
+++ b/packages/ebrota-console-bff/src/cli.ts
@@ -22,7 +22,10 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { initDb } from "./db.js";
 import { createBffServer } from "./server.js";
-import { createMockDaemonClient } from "./daemon-client.js";
+import {
+  createMockDaemonClient,
+  createStdioDaemonClient,
+} from "./daemon-client.js";
 import { scanTraces } from "./traces-scanner.js";
 import type { ConsoleMode } from "./types.js";
 
@@ -41,6 +44,12 @@ const initialMode: ConsoleMode =
 const useMockDaemon =
   (process.env["EBROTA_BFF_USE_MOCK_DAEMON"] ?? "true") !== "false";
 
+// Caminho pro binary do daemon (C-MX-07). Pode ser sobrescrito via env var.
+// Default: ../motor-daemon/dist/cli.js relativo ao BFF dist/.
+const daemonBin =
+  process.env["EBROTA_BFF_DAEMON_BIN"] ??
+  resolve(join(__dirname, "../../motor-daemon/dist/cli.js"));
+
 const log = (msg: string): void => {
   process.stderr.write(`[ebrota-console-bff] ${msg}\n`);
 };
@@ -53,20 +62,14 @@ log(`mode: ${initialMode}`);
 if (useMockDaemon) {
   log("⚠️  EBROTA_BFF_USE_MOCK_DAEMON=true — using in-memory mock daemon");
   log("   (set EBROTA_BFF_USE_MOCK_DAEMON=false when C-MX-07 daemon merged)");
+} else {
+  log(`daemon bin: ${daemonBin}`);
 }
 
 const db = initDb({ dbPath });
 const daemon = useMockDaemon
   ? createMockDaemonClient()
-  : (() => {
-      // Production stdio impl vira PR seguinte. Pra V0.1 PR2, sai com
-      // erro explícito se EBROTA_BFF_USE_MOCK_DAEMON=false ainda.
-      throw new Error(
-        "Stdio daemon client não implementado em PR2 — ship em PR seguinte " +
-          "após C-MX-07 mergeado. Use EBROTA_BFF_USE_MOCK_DAEMON=true ou " +
-          "deixe unset (default mock).",
-      );
-    })();
+  : createStdioDaemonClient(daemonBin);
 
 const server = createBffServer({
   daemon,

--- a/packages/ebrota-console-bff/src/daemon-client.ts
+++ b/packages/ebrota-console-bff/src/daemon-client.ts
@@ -14,6 +14,9 @@
  *  evitar dependência circular entre workspaces. Mantido em sync
  *  manualmente. */
 
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
 export interface ScoredContentItemShape {
   item: {
     id: string;
@@ -151,6 +154,126 @@ export interface MockDaemonClient extends OrchestratorDaemonClient {
     sessionId: string;
     decision: ApprovalDecision;
   }>;
+}
+
+/**
+ * Production stdio daemon client — spawna o binary `motor-daemon`
+ * como subprocesso e comunica via stdio MCP (C-MX-07).
+ *
+ * @param daemonBin - caminho absoluto pro binary `motor-daemon`
+ *                    (tipicamente `dist/cli.js` do orchestrator workspace)
+ */
+export function createStdioDaemonClient(
+  daemonBin: string,
+): OrchestratorDaemonClient {
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [daemonBin],
+    stderr: "inherit",
+  });
+
+  const client = new Client(
+    { name: "ebrota-console-bff", version: "0.1.0" },
+    { capabilities: {} },
+  );
+
+  let connected = false;
+
+  const ensureConnected = async (): Promise<void> => {
+    if (!connected) {
+      await client.connect(transport);
+      connected = true;
+    }
+  };
+
+  const callTool = async <T>(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<T> => {
+    await ensureConnected();
+    const result = await client.callTool({ name: toolName, arguments: args });
+    // MCP tools retornam content array; extraímos o primeiro item de texto
+    const content = result.content;
+    if (!Array.isArray(content) || content.length === 0) {
+      throw new Error(`Tool ${toolName} retornou content vazio`);
+    }
+    const first = content[0];
+    if (first.type !== "text" || typeof first.text !== "string") {
+      throw new Error(
+        `Tool ${toolName} retornou content inesperado: ${JSON.stringify(first)}`,
+      );
+    }
+    return JSON.parse(first.text) as T;
+  };
+
+  return {
+    async startCardSession(input) {
+      return callTool<StartCardSessionOutput>("startCardSession", {
+        cardId: input.cardId,
+        conversationId: input.conversationId,
+        from: input.from,
+        pkg: input.pkg,
+        ...(input.personaId !== undefined
+          ? { personaId: input.personaId }
+          : {}),
+      });
+    },
+
+    async subscribeTurnState(sessionId, sinceIndex = 0) {
+      return callTool<TurnEventsSnapshot>("subscribe_turn_state", {
+        sessionId,
+        sinceIndex,
+      });
+    },
+
+    async listOptions(sessionId) {
+      return callTool<{ contentPool: ScoredContentItemShape[] }>(
+        "list_options",
+        { sessionId },
+      );
+    },
+
+    async overrideSelection(sessionId, contentItemId) {
+      return callTool<OverrideSelectionResult>("override_selection", {
+        sessionId,
+        contentItemId,
+      });
+    },
+
+    async approveOrEdit(sessionId, decision) {
+      return callTool<ApproveOrEditResult>("approve_or_edit", {
+        sessionId,
+        approved: decision.approved,
+        ...(decision.editedText !== undefined
+          ? { editedText: decision.editedText }
+          : {}),
+        ...(decision.rationale !== undefined
+          ? { rationale: decision.rationale }
+          : {}),
+      });
+    },
+
+    async getPendingApproval(sessionId) {
+      return callTool<PendingApproval | null>("get_pending_approval", {
+        sessionId,
+      });
+    },
+
+    async daemonStatus() {
+      return callTool<DaemonStatus>("daemon.status", {});
+    },
+
+    async endSession(sessionId) {
+      return callTool<{ closed: boolean }>("endSession", { sessionId });
+    },
+
+    async close() {
+      if (connected) {
+        await transport.close();
+        connected = false;
+      }
+    },
+  };
 }
 
 export function createMockDaemonClient(

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -13,6 +13,7 @@
  *   GET  /mode                                  → { mode }
  *   POST /mode { mode }                         → { mode }
  *   POST /sessions/start-card                   → startCardSession output
+ *   GET  /sessions/active                       → { sessionIds: string[] }
  *   GET  /sessions/:id/turn-state               → SSE stream (polling)
  *   GET  /sessions/:id/options                  → { contentPool }
  *   POST /sessions/:id/override { contentItemId } → OverrideSelectionResult
@@ -117,6 +118,11 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   const debugEvents = createDebugEventsStore();
   let mode: ConsoleMode = opts.initialMode ?? "auto";
 
+  // In-memory set de sessionIds ativos (iniciados via /sessions/start-card,
+  // removidos via /sessions/:id/end). Permite que App.svelte faça polling
+  // em GET /sessions/active e auto-conecte ao live stream (Fix 3 / S-OC-05).
+  const activeSessions = new Set<string>();
+
   // GET /status — health + observabilidade
   fastify.get("/status", async () => {
     const daemonStatus = await opts.daemon.daemonStatus();
@@ -173,8 +179,16 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
         .code(400)
         .send({ error: "campos obrigatórios: cardId, conversationId, from, pkg" });
     }
-    return opts.daemon.startCardSession(body);
+    const result = await opts.daemon.startCardSession(body);
+    activeSessions.add(result.sessionId);
+    return result;
   });
+
+  // GET /sessions/active — lista sessionIds ativos (iniciados, não encerrados).
+  // App.svelte faz polling aqui pra auto-conectar ao live stream (Fix 3).
+  fastify.get("/sessions/active", async () => ({
+    sessionIds: [...activeSessions],
+  }));
 
   // GET /sessions/:id/turn-state — SSE stream polling subscribeTurnState
   fastify.get<{ Params: { id: string } }>(
@@ -495,7 +509,10 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   // POST /sessions/:id/end — endSession
   fastify.post<{ Params: { id: string } }>(
     "/sessions/:id/end",
-    async (req) => opts.daemon.endSession(req.params.id),
+    async (req) => {
+      activeSessions.delete(req.params.id);
+      return opts.daemon.endSession(req.params.id);
+    },
   );
 
   // ── Subject Knowledge endpoints (Fase 2) ─────────────────────────

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -30,7 +30,9 @@
 
   const api = createApiClient();
   const STATUS_POLL_INTERVAL_MS = 2000;
+  const ACTIVE_SESSIONS_POLL_MS = 3000;
   let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let activeSessionsPollTimer: ReturnType<typeof setInterval> | undefined;
   let streamManager: TurnStateStreamManager | undefined;
 
   async function refreshStatus(): Promise<void> {
@@ -44,6 +46,26 @@
       globalError.set(
         `BFF offline: ${err instanceof Error ? err.message : String(err)}`,
       );
+    }
+  }
+
+  /**
+   * Verifica sessões ativas no BFF — se existir uma sessão ativa e nenhuma
+   * sessão corrente estiver definida na UI, auto-conecta ao live stream
+   * (Fix 3 / S-OC-05). Usa a mais recente (última no array).
+   */
+  async function checkActiveSessions(): Promise<void> {
+    try {
+      const { sessionIds } = await api.getActiveSessions();
+      const currentId = $currentSessionId;
+      if (sessionIds.length > 0 && currentId === null) {
+        const latest = sessionIds[sessionIds.length - 1];
+        if (latest !== undefined) {
+          currentSessionId.set(latest);
+        }
+      }
+    } catch {
+      // silencioso — polling não crítico
     }
   }
 
@@ -68,14 +90,20 @@
   onMount(() => {
     applyUrlParams();
     void refreshStatus();
+    void checkActiveSessions();
     pollTimer = setInterval(() => {
       void refreshStatus();
     }, STATUS_POLL_INTERVAL_MS);
+    activeSessionsPollTimer = setInterval(() => {
+      void checkActiveSessions();
+    }, ACTIVE_SESSIONS_POLL_MS);
     streamManager = startTurnStateStream(api);
   });
 
   onDestroy(() => {
     if (pollTimer !== undefined) clearInterval(pollTimer);
+    if (activeSessionsPollTimer !== undefined)
+      clearInterval(activeSessionsPollTimer);
     streamManager?.stop();
   });
 </script>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -347,6 +347,8 @@ export interface ApiClient {
   startCardSession(
     input: StartCardSessionRequest,
   ): Promise<StartCardSessionOutput>;
+  /** Retorna sessionIds de sessões atualmente ativas no BFF (Fix 3). */
+  getActiveSessions(): Promise<{ sessionIds: string[] }>;
   listOptions(
     sessionId: string,
   ): Promise<{ contentPool: ScoredContentItemSummary[] }>;
@@ -501,6 +503,8 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     setMode: (mode) => post<{ mode: ConsoleMode }>("/mode", { mode }),
     startCardSession: (input) =>
       post<StartCardSessionOutput>("/sessions/start-card", input),
+    getActiveSessions: () =>
+      get<{ sessionIds: string[] }>("/sessions/active"),
     listOptions: (sessionId) =>
       get<{ contentPool: ScoredContentItemSummary[] }>(
         `/sessions/${encodeURIComponent(sessionId)}/options`,


### PR DESCRIPTION
## Problema
Três root causes para sessões realtime não aparecerem no eBrota Console:
1. **Fix 1**: `EBROTA_BFF_USE_MOCK_DAEMON=false` lançava erro imediato — stdio client não implementado
2. **Fix 3a**: BFF não tinha endpoint `GET /sessions/active` — UI não sabia quais sessões estavam ativas
3. **Fix 3b**: `App.svelte` só conectava ao live stream via URL param `?live=ID` — sem auto-detect

## Solução

### Fix 1 — `createStdioDaemonClient` em `daemon-client.ts`
- Spawna `motor-daemon` como subprocesso via `@modelcontextprotocol/sdk` StdioClientTransport
- Mapeia todos os 8 MCP tools: `startCardSession`, `endSession`, `daemon.status`, `subscribe_turn_state`, `list_options`, `override_selection`, `approve_or_edit`, `get_pending_approval`
- Lazy connect (conecta no primeiro tool call)
- Caminho do binary configurável via `EBROTA_BFF_DAEMON_BIN` env var (default: `../../motor-daemon/dist/cli.js`)

### Fix 3a — `GET /sessions/active` em `server.ts`
- `activeSessions: Set<string>` rastreia sessões abertas em memória
- `POST /sessions/start-card` → adiciona ao set
- `POST /sessions/:id/end` → remove do set
- `GET /sessions/active` → retorna `{ sessionIds: string[] }`

### Fix 3b — polling em `App.svelte`
- `checkActiveSessions()` polling a cada 3s
- Se sessão ativa encontrada e nenhuma sessão corrente na UI, auto-seta `currentSessionId`

## Testes
- BFF: 150/150 testes passando
- UI: 141/141 testes passando
- `tsc --noEmit --project tsconfig.build.json`: sem erros

Closes ops#1123