### PR TITLE
[Sprint 4 PR2] ops#1157+1158+1156 — console parental context + ApprovalGate enrichment + start-sts

### DIFF
--- a/docs/handoffs/2026-05-26-sprint4-pr2-sts-group-dyad-ryo-kei-raw.json
+++ b/docs/handoffs/2026-05-26-sprint4-pr2-sts-group-dyad-ryo-kei-raw.json
@@ -1,0 +1,73 @@
+{
+  "conversation": [
+    {
+      "speaker": "bot",
+      "item_id": "bench-curio-01",
+      "message": "Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele.",
+      "skip_path": "composition_skipped",
+      "tokens": {
+        "in": 0,
+        "out": 0
+      },
+      "latency_ms": 0
+    },
+    {
+      "speaker": "ryo-ochiai",
+      "name": "Ryo",
+      "message": "Que da hora. (assobia) Se eu tivesse um assovio, seria tipo o do Gohan quando fica sério.",
+      "tokens": {
+        "in": 230,
+        "out": 676
+      },
+      "latency_ms": 5730
+    },
+    {
+      "speaker": "kei-ochiai",
+      "name": "Kei",
+      "message": "Ia ser massa — um assobio assim muda o clima igual quando meu pai fala \"agora sério\" no treino. Tipo trocar o grip: parece só um detalhe, mas a bola (e todo mundo) se comporta diferente.",
+      "tokens": {
+        "in": 262,
+        "out": 442
+      },
+      "latency_ms": 4013
+    },
+    {
+      "speaker": "bot",
+      "item_id": "bench-challenge-01",
+      "message": "Em 1 frase, descreve o que sentiu no último ponto perdido do treino.",
+      "skip_path": "composition_skipped",
+      "tokens": {
+        "in": 0,
+        "out": 0
+      },
+      "latency_ms": 0
+    },
+    {
+      "speaker": "ryo-ochiai",
+      "name": "Ryo",
+      "message": "Fiquei com raiva, congelei e cruzei os braços — tipo o Gohan quando perde a concentração.",
+      "tokens": {
+        "in": 273,
+        "out": 483
+      },
+      "latency_ms": 4380
+    },
+    {
+      "speaker": "kei-ochiai",
+      "name": "Kei",
+      "message": "Fiquei chateado e meu corpo travou: a raquete virou só um peso na mão e meu grip ficou estranho.  \nO pai me olhou daquele jeito que pede pra respirar, e eu cruzei os braços sem perceber, me fechando.  \nQuando fecho o corpo, a minha concentração some igualzinho.",
+      "tokens": {
+        "in": 248,
+        "out": 781
+      },
+      "latency_ms": 8189
+    }
+  ],
+  "stats": {
+    "total": 6,
+    "bot": 2,
+    "ryo": 2,
+    "kei": 2
+  },
+  "n": 2
+}

--- a/docs/handoffs/2026-05-26-sprint4-pr2-sts-group-dyad-ryo-kei.md
+++ b/docs/handoffs/2026-05-26-sprint4-pr2-sts-group-dyad-ryo-kei.md
@@ -1,0 +1,87 @@
+# STS group dyad — Ryo + Kei joint session (Sprint 4 PR 2)
+
+**Data:** 2026-05-26T20:47:41.213Z
+**LLM:** Qwen3 30B local (`gpt-5-mini`)
+**N ciclos:** 2
+**Mode:** joint dyad · turntaking round-robin + bot quota
+**Skip path:** motor#136 composition skip ativado pra bot turns
+
+## Diálogo sintético
+
+### 🌳 **Brota**
+
+> Sabia que os golfinhos têm 'nomes' próprios? Cada um inventa um assovio único e os outros chamam por ele.
+
+_(item: `bench-curio-01` · skip: composition_skipped · 0ms · 0 tokens)_
+
+### **Ryo**
+
+> Que da hora. (assobia) Se eu tivesse um assovio, seria tipo o do Gohan quando fica sério.
+
+_(5730ms · 230in/676out)_
+
+### **Kei**
+
+> Ia ser massa — um assobio assim muda o clima igual quando meu pai fala "agora sério" no treino. Tipo trocar o grip: parece só um detalhe, mas a bola (e todo mundo) se comporta diferente.
+
+_(4013ms · 262in/442out)_
+
+### 🌳 **Brota**
+
+> Em 1 frase, descreve o que sentiu no último ponto perdido do treino.
+
+_(item: `bench-challenge-01` · skip: composition_skipped · 0ms · 0 tokens)_
+
+### **Ryo**
+
+> Fiquei com raiva, congelei e cruzei os braços — tipo o Gohan quando perde a concentração.
+
+_(4380ms · 273in/483out)_
+
+### **Kei**
+
+> Fiquei chateado e meu corpo travou: a raquete virou só um peso na mão e meu grip ficou estranho.  
+O pai me olhou daquele jeito que pede pra respirar, e eu cruzei os braços sem perceber, me fechando.  
+Quando fecho o corpo, a minha concentração some igualzinho.
+
+_(8189ms · 248in/781out)_
+
+---
+
+## Estatísticas turntaking
+
+- Total turns: 6
+- Bot turns: 2 (33%, target ≤25%)
+- Ryo turns: 2 (33%)
+- Kei turns: 2 (33%)
+- Bot quota constraint (≤25%): ✗ VIOLATED
+
+## Latency + tokens (persona-sims)
+
+- Total persona-sim time: 22s
+- Average per child turn: 5578ms
+- Total tokens persona-sims: 1013in/2382out
+
+## Verdict (Jun)
+
+Sub-decisões #1077:
+
+- [ ] **1. Persona-sim prompt template** — defaults CC inline OK?
+  - Default: prompt fixo com interests + aversions + family_anchors + style por archetype
+- [ ] **2. Bot quota dyad** — 1 bot turn cada 2 child turns ratificado?
+  - Default: ratio bot=1, children=2 (= 33% bot — acima 25% target!)
+  - Alternativa: 1 bot turn cada 4 child turns (~20% bot)
+- [ ] **3. Brejo unilateral** — skip persona, dialog continua com outro?
+  - Default: skip; not tested neste script (não há injeção brejo synthetic)
+- [ ] **4. N=3 ciclos default** — adequado?
+
+Verdict agregado:
+
+- [ ] **GO** — script + defaults ratificados, Sprint 4 PR 2 done
+- [ ] **TUNE** — ajustar X (bot quota, persona-sim, N, etc.)
+- [ ] **NO-GO** — abordagem precisa revisão
+
+---
+
+_Methodology: STS group dyad synthetic (Sprint 4 PR 2 ops#1077)._
+_Gerado por scripts/sts-group-dyad.mjs · ops#1120 Sprint 4 tracker_

--- a/fixtures/kei-ochiai.yaml
+++ b/fixtures/kei-ochiai.yaml
@@ -1,0 +1,124 @@
+# Kei Ochiai — Kids persona fixture v1
+# Derivado de fixtures/profiles/kei-ochiai.pre-phase2.json (2 sessões STS Sprint 0)
+# Schema: shared/src/types.ts PersonaDef (id, name, age, profile)
+# Nature: perfil real de piloto — Yuji family Japan
+
+id: kei-ochiai
+name: Kei Ochiai
+age: 9
+
+profile:
+  sensitivity: medium
+
+  preferences:
+    interests:
+      - tênis e movimentos corporais / técnicas de jogo
+      - comunicação não verbal (olhares, gestos)
+      - relação com o pai durante treinos
+      - mecânica (especialmente desmontar componentes de máquina)
+      - ajustes precisos em ações físicas
+      - entender como o corpo e o alinhamento afetam resultados
+    aversions:
+      - conversas abstratas sem conexão com experiências concretas
+      - perguntas que parecem vagas ou sem contexto claro
+      - pressão para expressar emoções imediatamente
+      - mudanças bruscas de tema sem transição
+      - atividades que parecem sem propósito ou sem resultado visível
+    learning_style: >
+      Aprende melhor por meio de ações concretas, experimentação prática e ajustes
+      físicos, com foco em resultados tangíveis e processos mensuráveis.
+      Rejeita abordagens teóricas ou metafóricas sem ligação direta com o que está fazendo.
+
+  family_anchors:
+    - name: pai
+      role: pai
+      emotional_role: >
+        Figura de autoridade prática, fonte de conhecimento concreto e orientação
+        técnica, representando sabedoria aplicada em ações do dia a dia.
+      gestures_observed:
+        - olhar após um ponto
+        - treinar com o filho sem falar
+        - mudar o grip da raquete
+        - sorrir apenas quando o filho acerta o backhand
+        - ensinar sobre ângulo do lançamento no tênis
+        - ensinar sobre equilíbrio e alinhamento no corpo
+
+  recurring_themes:
+    - comunicação não verbal
+    - relação silenciosa com o pai
+    - mudanças sutis que só são percebidas depois
+    - emoções não ditas (raiva, frustração, orgulho)
+    - conexão por meio do movimento e do olhar no tênis
+    - ajuste físico e alinhamento para obter resultados corretos
+    - necessidade de clareza e propósito em qualquer atividade
+    - desconfiança de abordagens sem objetividade ou resultado visível
+
+  open_loops:
+    - encontrar palavras diferentes para o que sente em contextos além do tênis
+    - como o silêncio no treino afeta sua autoconsciência emocional
+    - a ideia de decisões sustentáveis no longo prazo (rejeitada, pendente revisão)
+
+  notes_for_next_session:
+    - Começar com ação concreta e clara (ex: ajustar algo no tênis ou em objeto físico).
+    - Evitar mudanças bruscas de tema; manter foco no que foi iniciado.
+    - Perguntar como foi o treino do Ryo e se ele riu de novo.
+
+  repetition_inquiry: {}
+
+  # Perfil parental — extraído de fixtures/parent-yuji.yaml (ops#1157).
+  parental_profile:
+    id: yuji-ochiai
+    role: primary
+    decision_profile: consultative_risk_averse
+    family_values:
+      principles:
+        - "respeito por anciãos e professores é inegociável"
+        - "vergonha pública é evitada a todo custo"
+        - "esforço importa mais que resultado"
+        - "curiosidade é celebrada, tédio não é julgado"
+      cultural_axis: japanese_brazilian
+      religious_tradition: secular
+    forbidden_zones:
+      - topic: political_content
+        reason: "não queremos expor a criança a temas divisivos ainda"
+      - topic: religious_proselytizing
+        reason: "respeitamos a escolha futura da criança"
+      - topic: screen_gaming_promotion
+        reason: "já limitamos games suficiente"
+    budget_constraints:
+      materials_monthly_ceiling_jpy: 3000
+      screen_time_daily_max_minutes: 90
+    parental_telos: >
+      Reconectar com o prazer de aprender; encontrar 1 atividade que ele
+      escolha voluntariamente nos próximos 3 meses.
+    concerns_current:
+      - "passa tempo demais no celular"
+
+  # Histórico de sessões — derivado de fixtures/profiles/kei-ochiai.pre-phase2.json
+  # Sprint 0 (2 sessões 2026-05-07).
+  sessions_history:
+    sessions_seen: 2
+    last_session_date: "2026-05-07"
+    emotional_arcs:
+      - session_id: 6a1e9b3d-04aa-4a6d-8670-8ebdecb4e359
+        opening_tone: "impaciente"
+        closing_tone: "distraído"
+        key_disclosures:
+          - "o silêncio entre ele e o pai no treino é carregado de significado"
+          - "sente emoções (raiva, frustração) mas não tem palavras para nomeá-las"
+          - "o que sente está 'perdido no vazio entre os termos'"
+        flags:
+          - dificuldade em nomear emoções
+          - dependência de contextos físicos (tênis) para expressar conexão
+          - relação emocional com o pai baseada em silêncio, não afeto verbal
+      - session_id: 4e7ccb82-783e-4fff-9ca7-2b3bb28def24
+        opening_tone: "curioso mas cauteloso, com desconfiança em relação à falta de clareza"
+        closing_tone: "entediado e frustrado, com sinal de desinteresse por mudanças de foco"
+        key_disclosures:
+          - "o pai ensina sobre ângulo e equilíbrio no tênis e em mecânica"
+          - "o Ryo riu de verdade quando caiu no treino — momento de imprevisibilidade"
+          - "perguntas sem ponto claro não levam a lugar algum"
+        flags:
+          - dificuldade em manter foco quando tema muda sem transição
+          - pressão por clareza e objetividade extrema
+          - sinal de sobrecarga ou priorização de atividades reais

--- a/fixtures/ryo-ochiai.yaml
+++ b/fixtures/ryo-ochiai.yaml
@@ -1,0 +1,148 @@
+# Ryo Ochiai — Kids persona fixture v1
+# Derivado de fixtures/profiles/ryo-ochiai.pre-phase2.json (3 sessões STS Sprint 0)
+# Schema: shared/src/types.ts PersonaDef (id, name, age, profile)
+# Nature: perfil real de piloto — Yuji family Japan
+
+id: ryo-ochiai
+name: Ryo Ochiai
+age: 11
+
+profile:
+  sensitivity: medium
+
+  preferences:
+    interests:
+      - tênis
+      - animes (especialmente Dragon Ball, com foco em Gohan e Cell)
+      - relações fraternas (com Kei)
+      - silêncio como forma de expressão
+      - gestos não verbais e presença física
+      - transformação e força interior (associada a Gohan)
+    aversions:
+      - ser ignorado
+      - não ser visto ou entendido sem falar
+      - pressão para se comparar ao Kei
+      - situações de conflito sem apoio emocional
+      - pensar em responsabilidades futuras
+      - sentir que sua raiva é algo negativo
+    learning_style: >
+      Aprende melhor por meio de metáforas narrativas, comparações com personagens
+      de histórias e reflexão sobre gestos cotidianos, especialmente quando conectados
+      a emoções profundas.
+
+  family_anchors:
+    - name: Kei
+      role: irmão
+      emotional_role: >
+        Fonte de conexão afetiva, mesmo que por meio de humor e ironia;
+        representa um espelho que Ryo tenta se igualar, mas que também o faz
+        questionar sua própria identidade.
+      gestures_observed:
+        - aparecer no banheiro depois do incidente dizendo apenas 'tô aqui'
+        - compartilhar raquete sem pedir
+        - colocar mais arroz no prato sem falar
+        - rir da cara de bosta que Ryo faz no treino
+    - name: papai
+      role: pai
+      emotional_role: >
+        Representa afeto silencioso e presente em pequenos gestos, sem palavras,
+        o que Ryo valoriza profundamente como forma de cuidado.
+      gestures_observed:
+        - deixar a raquete de Ryo no lugar certo após o jogo
+
+  recurring_themes:
+    - desejo de ser visto sem precisar gritar
+    - pressão de se comparar ao irmão (Kei)
+    - valor do silêncio como força
+    - necessidade de reconhecimento emocional
+    - sentimento de invisibilidade em contextos sociais
+    - raiva guardada e transformação interna
+    - afeto expresso por gestos simples, não palavras
+    - transformação sob pressão (Gohan no Cell Saga como modelo)
+
+  open_loops:
+    - desejo de ser entendido sem falar
+    - como o silêncio pode ser uma forma de força no tênis e na vida
+    - usar a raiva como força, não como destruição
+    - busca por palavras para nomear o que sente
+
+  notes_for_next_session:
+    - Perguntar como foi assistir ao episódio do Gohan no Cell Saga.
+    - Explorar o que significa ser 'igual' ou 'diferente' em relação ao Kei.
+    - Sugerir atividade criativa onde Ryo escolhe dividir algo com Kei como ato de confiança.
+
+  repetition_inquiry:
+    default_on_skip: b
+
+  # Perfil parental — extraído de fixtures/parent-yuji.yaml (ops#1157).
+  # Consumido por extractParentalProfile() → triageForParents() em plan.ts
+  # e pelo bloco parental no buildSystemPrompt (planejador).
+  parental_profile:
+    id: yuji-ochiai
+    role: primary
+    decision_profile: consultative_risk_averse
+    family_values:
+      principles:
+        - "respeito por anciãos e professores é inegociável"
+        - "vergonha pública é evitada a todo custo"
+        - "esforço importa mais que resultado"
+        - "curiosidade é celebrada, tédio não é julgado"
+      cultural_axis: japanese_brazilian
+      religious_tradition: secular
+    forbidden_zones:
+      - topic: political_content
+        reason: "não queremos expor a criança a temas divisivos ainda"
+      - topic: religious_proselytizing
+        reason: "respeitamos a escolha futura da criança"
+      - topic: screen_gaming_promotion
+        reason: "já limitamos games suficiente"
+    budget_constraints:
+      materials_monthly_ceiling_jpy: 3000
+      screen_time_daily_max_minutes: 90
+    parental_telos: >
+      Reconectar com o prazer de aprender; encontrar 1 atividade que ele
+      escolha voluntariamente nos próximos 3 meses.
+    concerns_current:
+      - "Ryo não quer ir à escola — 2 semanas de recusa"
+      - "passa tempo demais no celular"
+
+  # Histórico de sessões — derivado de fixtures/profiles/ryo-ochiai.pre-phase2.json
+  # Sprint 0 (3 sessões 2026-05-07). Consumido pelo bloco de histórico no
+  # buildSystemPrompt para contextualizar arcos emocionais ao planejador.
+  sessions_history:
+    sessions_seen: 3
+    last_session_date: "2026-05-07"
+    emotional_arcs:
+      - session_id: 5e8a7505-d055-4ee9-9286-fd50fff72ae0
+        opening_tone: "distraído, com desinteresse e cansaço"
+        closing_tone: "aberto e vulnerável, com desejo claro de ser compreendido"
+        key_disclosures:
+          - "ficou no banheiro da escola após conflito; foi procurado apenas pelo Kei"
+          - "sente que está presente mesmo sem falar, mas quer que alguém entenda"
+          - "o silêncio é uma forma de tentar achar o jeito certo de ser"
+        flags:
+          - sentimento persistente de invisibilidade
+          - isolamento emocional após conflitos
+          - necessidade de validação não verbal
+      - session_id: 0ac76202-6ae6-41ca-82d7-a54ad19110e7
+        opening_tone: "distraído, passivo, com foco na espera"
+        closing_tone: "entediado com um fio de vulnerabilidade"
+        key_disclosures:
+          - "desejo de ser visto pelo Kei, como Gohan é visto no Cell"
+          - "sente que carrega tudo sozinho"
+          - "raiva como força que pode se tornar incontrolável"
+        flags:
+          - desejo intenso de reconhecimento não atendido
+          - sentimento de invisibilidade dentro da família
+          - pressão emocional acumulada expressa por silêncio e metáforas de explosão
+      - session_id: a610ac08-4e31-44ea-aa72-d545953a3b32
+        opening_tone: "distraído, foco no fim da aula de tênis e no episódio pendente"
+        closing_tone: "refletivo e vulnerável, com consciência de emoções e identidade"
+        key_disclosures:
+          - "não lembra da última vez que fez alguém rir"
+          - "não é igual ao irmão Kei, mesmo quando Kei diz que são iguais"
+          - "raiva explosiva, mas pode ser usada por algo que vale a pena"
+        flags:
+          - sentimento de inadequação em relação ao irmão
+          - dificuldade em expressar afeto ou criar conexões emocionais positivas
+          - pressão interna sobre raiva como força negativa e potencial de transformação

--- a/orchestrator/src/daemon.ts
+++ b/orchestrator/src/daemon.ts
@@ -125,6 +125,28 @@ export interface SubmitForApprovalOptions {
   /** Decisão default em caso de timeout. Default `{approved: true}`. Em
    *  modo paranoid pode setar `{approved: false}` pra abortar silenciosamente. */
   defaultDecision?: ApprovalDecision;
+  /** Contexto pedagógico do turn — populado pelo daemon em semi-auto mode
+   *  para enriquecer a ApprovalGate na UI (ops#1158). */
+  context?: PendingApprovalContext;
+}
+
+/** Snapshot do contexto pedagógico do turn — exibido na ApprovalGate
+ *  da eBrota Console para orientar decisão do operador (ops#1158). */
+export interface PendingApprovalContext {
+  /** IDs do contentPool gerado pelo planejador (top-K antes do drota). */
+  contentPoolIds: string[];
+  /** Rationale estratégico gerado pelo planejador LLM. */
+  strategicRationale: string;
+  /** Hints de composição (language, mood, avoid, question_detected, etc). */
+  contextHints: Record<string, unknown>;
+  /** ContentItem selecionado pelo motor-drota. */
+  selectedContentId: string;
+  /** Snapshot leve do estado da sessão no momento do turn. */
+  sessionState?: {
+    trustLevel: number;
+    turn: number;
+    budgetRemaining: number;
+  };
 }
 
 export interface ApproveOrEditResult {
@@ -170,6 +192,7 @@ export class OrchestratorDaemon {
     string,
     {
       proposedText: string;
+      context?: PendingApprovalContext;
       resolve: (decision: ApprovalDecision) => void;
     }
   >();
@@ -264,6 +287,7 @@ export class OrchestratorDaemon {
       }, opts.timeoutMs);
       this.pendingApprovals.set(sessionId, {
         proposedText,
+        context: opts.context,
         resolve: (decision) => {
           clearTimeout(timeoutHandle);
           this.pendingApprovals.delete(sessionId);
@@ -275,14 +299,14 @@ export class OrchestratorDaemon {
 
   /**
    * Snapshot do approval pendente. UI usa pra mostrar o proposedText
-   * antes do operador decidir.
+   * antes do operador decidir. Inclui contexto pedagógico (ops#1158).
    */
   getPendingApproval(
     sessionId: string,
-  ): { proposedText: string } | undefined {
+  ): { proposedText: string; context?: PendingApprovalContext } | undefined {
     const pending = this.pendingApprovals.get(sessionId);
     if (pending === undefined) return undefined;
-    return { proposedText: pending.proposedText };
+    return { proposedText: pending.proposedText, context: pending.context };
   }
 
   /**
@@ -492,11 +516,120 @@ export class OrchestratorDaemon {
       (ev) => this.pushTurnEvent(ev),
       optionsGate,
     );
+
+    // Semi-auto approval gate (ops#1158): após runTurn, submete texto pro
+    // operador revisar/editar antes de retornar. Bloqueia até aprovação ou
+    // timeout (auto-approve fail-safe). Contexto pedagógico vem dos turn events.
+    if (input.semiAutoTimeoutMs && input.semiAutoTimeoutMs > 0) {
+      const approvalContext = this.buildApprovalContext(runtime.sessionId, runtime.state);
+      const decision = await this.submitForApproval(
+        runtime.sessionId,
+        finalResponse,
+        { timeoutMs: input.semiAutoTimeoutMs, context: approvalContext },
+      );
+      const approvedText =
+        decision.approved && decision.editedText !== undefined
+          ? decision.editedText
+          : finalResponse;
+      return { sessionId: runtime.sessionId, text: approvedText, tracePath };
+    }
+
     return {
       sessionId: runtime.sessionId,
       text: finalResponse,
       tracePath,
     };
+  }
+
+  /**
+   * Extrai contexto pedagógico dos turn events recentes para enriquecer
+   * a ApprovalGate (ops#1158). Lê os últimos planning_started e
+   * selection_made emitidos pela sessão.
+   */
+  private buildApprovalContext(
+    sessionId: string,
+    sessionState: SessionRuntime["state"],
+  ): PendingApprovalContext {
+    const bucket = this.turnEvents.get(sessionId);
+    const events = bucket?.events ?? [];
+    // Busca o último planning_started e selection_made (ordem crescente = índice maior).
+    let strategicRationale = "";
+    let contentPoolIds: string[] = [];
+    let contextHints: Record<string, unknown> = {};
+    let selectedContentId = "";
+    for (let i = events.length - 1; i >= 0; i--) {
+      const ev = events[i]!;
+      if (ev.type === "selection_made" && !selectedContentId) {
+        selectedContentId = ev.payload.selectedContentId;
+      }
+      if (ev.type === "planning_started" && !strategicRationale) {
+        strategicRationale = ev.payload.strategicRationale;
+        contentPoolIds = ev.payload.contentPoolIds;
+        contextHints = ev.payload.contextHints;
+      }
+      if (strategicRationale && selectedContentId) break;
+    }
+    return {
+      contentPoolIds,
+      strategicRationale,
+      contextHints,
+      selectedContentId,
+      sessionState: sessionState
+        ? {
+            trustLevel: sessionState.trustLevel,
+            turn: sessionState.turn,
+            budgetRemaining: sessionState.budgetRemaining,
+          }
+        : undefined,
+    };
+  }
+
+  /**
+   * Executa um turn de mensagem livre para sessão existente (eBrota Console).
+   * Requer que a sessão já exista (via runCardTurn anterior). Se
+   * semiAutoTimeoutMs > 0, submete resultado para aprovação antes de retornar.
+   */
+  async sendConsoleTurn(
+    sessionId: string,
+    message: string,
+    semiAutoTimeoutMs = 0,
+  ): Promise<RunCardTurnOutput> {
+    if (!this.started || this.clients === null) {
+      throw new Error(
+        "OrchestratorDaemon.sendConsoleTurn: daemon não iniciado",
+      );
+    }
+    const runtime = this.sessions.get(sessionId);
+    if (runtime === undefined) {
+      throw new Error(
+        `OrchestratorDaemon.sendConsoleTurn: sessão não encontrada: ${sessionId}`,
+      );
+    }
+    const optionsGate = this.buildOptionsGate(sessionId, semiAutoTimeoutMs);
+    const { finalResponse, tracePath } = await runTurn(
+      this.clients,
+      sessionId,
+      runtime.personaId,
+      message,
+      this.tracesDir,
+      undefined,
+      undefined,
+      (ev) => this.pushTurnEvent(ev),
+      optionsGate,
+    );
+    if (semiAutoTimeoutMs > 0) {
+      const approvalContext = this.buildApprovalContext(sessionId, runtime.state);
+      const decision = await this.submitForApproval(sessionId, finalResponse, {
+        timeoutMs: semiAutoTimeoutMs,
+        context: approvalContext,
+      });
+      const approvedText =
+        decision.approved && decision.editedText !== undefined
+          ? decision.editedText
+          : finalResponse;
+      return { sessionId, text: approvedText, tracePath };
+    }
+    return { sessionId, text: finalResponse, tracePath };
   }
 
   /**

--- a/orchestrator/src/mcp-clients.ts
+++ b/orchestrator/src/mcp-clients.ts
@@ -59,6 +59,17 @@ function buildEnv(): Record<string, string> {
     // contra LLM local, em vez de Infomaniak/Anthropic.
     "LLM_LOCAL_ENDPOINT",
     "LLM_LOCAL_MODEL",
+    // GitHub Copilot Individual openai-compat path (motor#238 fix).
+    // Sem esses forwards, planejador subprocess cai em mock mesmo com
+    // LLM_LOCAL_AUTH_BEARER setado no processo pai (BFF/STS CLI).
+    "LLM_LOCAL_AUTH_BEARER",
+    "LOCAL_LLM_BASE_URL",
+    "LOCAL_LLM_MODEL",
+    "LOCAL_LLM_API_KEY",
+    // MOTOR_PATH pra worker processes acharem fixtures/ relativo à raiz.
+    "MOTOR_PATH",
+    // CONTENT_SEED_PATH override em integrações + PoC scripts.
+    "CONTENT_SEED_PATH",
   ];
   for (const k of keys) {
     const v = process.env[k];

--- a/orchestrator/src/mcp-server.ts
+++ b/orchestrator/src/mcp-server.ts
@@ -68,6 +68,9 @@ export function createOrchestratorMcpServer(
         }),
         // personaId pode vir do BFF (resolução from→persona) ou default = from.
         personaId: z.string().optional(),
+        // Semi-auto mode: > 0 pausa o turn aguardando listOptions/overrideSelection
+        // até este timeout (ms); então auto-aprova. 0 = auto mode (sem pausa).
+        semiAutoTimeoutMs: z.number().optional(),
       } as any,
     },
     async (input: {
@@ -76,6 +79,7 @@ export function createOrchestratorMcpServer(
       from: string;
       pkg: { cardId: string; raw: string; sourcePath: string };
       personaId?: string;
+      semiAutoTimeoutMs?: number;
     }) => {
       const result = await opts.daemon.runCardTurn(input);
       return {
@@ -247,12 +251,44 @@ export function createOrchestratorMcpServer(
   );
 
   server.registerTool(
+    "send_turn",
+    {
+      description:
+        "Executa um turn de mensagem livre em sessão existente (eBrota Console). " +
+        "Requer sessionId de sessão já iniciada via startCardSession. " +
+        "Se semiAutoTimeoutMs > 0, submete resultado para aprovação (approval " +
+        "gate) antes de retornar — caller deve polling get_pending_approval " +
+        "e chamar approve_or_edit para desbloquear. " +
+        "Retorna { sessionId, text, tracePath }.",
+      inputSchema: {
+        sessionId: z.string(),
+        message: z.string(),
+        semiAutoTimeoutMs: z.number().int().nonnegative().optional(),
+      } as any,
+    },
+    async (input: {
+      sessionId: string;
+      message: string;
+      semiAutoTimeoutMs?: number;
+    }) => {
+      const result = await opts.daemon.sendConsoleTurn(
+        input.sessionId,
+        input.message,
+        input.semiAutoTimeoutMs ?? 0,
+      );
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    },
+  );
+
+  server.registerTool(
     "get_pending_approval",
     {
       description:
-        "Snapshot do approval pendente (proposedText) sem resolver o gate. " +
-        "UI usa pra renderizar texto antes do operador decidir. Retorna " +
-        "null se sessão não tem approval pendente.",
+        "Snapshot do approval pendente (proposedText + contexto pedagógico) " +
+        "sem resolver o gate. UI usa pra renderizar texto e contexto antes do " +
+        "operador decidir (ops#1158). Retorna null se sessão não tem approval pendente.",
       inputSchema: {
         sessionId: z.string(),
       } as any,

--- a/orchestrator/src/mcp-server.ts
+++ b/orchestrator/src/mcp-server.ts
@@ -238,7 +238,7 @@ export function createOrchestratorMcpServer(
         rationale?: string;
       };
     }) => {
-      const result = opts.daemon.approveOrEdit(
+      const result = await opts.daemon.approveOrEdit(
         input.sessionId,
         input.decision,
       );

--- a/packages/ebrota-console-bff/src/cli.ts
+++ b/packages/ebrota-console-bff/src/cli.ts
@@ -12,6 +12,7 @@
  *   EBROTA_BFF_DB_PATH       (default ./.ebrota-console.db)
  *   EBROTA_BFF_INITIAL_MODE  (default 'auto')
  *   EBROTA_BFF_USE_MOCK_DAEMON (default false; useful pra dev sem daemon)
+ *   EBROTA_BFF_STS_ROOT      (path to ascendimacy-sts repo root; habilita POST /sessions/start-sts)
  *
  * Production: daemon spawn vira PR seguinte (precisa C-MX-07 mergeado
  * em main + binary path resolvable). PR2 ship com mock por default
@@ -37,6 +38,7 @@ const host = process.env["EBROTA_BFF_HOST"] ?? "127.0.0.1";
 const dbPath = process.env["EBROTA_BFF_DB_PATH"] ?? "./.ebrota-console.db";
 const tracesDir =
   process.env["EBROTA_BFF_TRACES_DIR"] ?? DEFAULT_TRACES_DIR;
+const stsRootDir = process.env["EBROTA_BFF_STS_ROOT"];
 const modeEnv = process.env["EBROTA_BFF_INITIAL_MODE"];
 const initialMode: ConsoleMode =
   modeEnv === "semi-auto" ? "semi-auto" : "auto";
@@ -77,6 +79,7 @@ const server = createBffServer({
   initialMode,
   logger: true,
   tracesDir,
+  stsRootDir,
 });
 
 // Scan traces ANTES de listen (idempotente; ok mesmo se dir não existe).

--- a/packages/ebrota-console-bff/src/daemon-client.ts
+++ b/packages/ebrota-console-bff/src/daemon-client.ts
@@ -34,6 +34,9 @@ export interface StartCardSessionInput {
   from: string;
   pkg: { cardId: string; raw: string; sourcePath: string };
   personaId?: string;
+  /** Se > 0, ativa semi-auto gate (conteúdo + approval). Derivado de
+   *  ConsoleMode pelo BFF: semi-auto → 60_000ms, auto → 0. */
+  semiAutoTimeoutMs?: number;
 }
 
 export interface StartCardSessionOutput {
@@ -82,13 +85,31 @@ export interface DaemonStatus {
   sessionCount: number;
 }
 
+export interface PendingApprovalContext {
+  contentPoolIds: string[];
+  strategicRationale: string;
+  contextHints: Record<string, unknown>;
+  selectedContentId: string;
+  sessionState?: {
+    trustLevel: number;
+    turn: number;
+    budgetRemaining: number;
+  };
+}
+
 export interface PendingApproval {
   proposedText: string;
+  context?: PendingApprovalContext;
 }
 
 export interface OrchestratorDaemonClient {
   startCardSession(
     input: StartCardSessionInput,
+  ): Promise<StartCardSessionOutput>;
+  sendTurn(
+    sessionId: string,
+    message: string,
+    semiAutoTimeoutMs?: number,
   ): Promise<StartCardSessionOutput>;
   subscribeTurnState(
     sessionId: string,
@@ -216,6 +237,17 @@ export function createStdioDaemonClient(
         ...(input.personaId !== undefined
           ? { personaId: input.personaId }
           : {}),
+        ...(input.semiAutoTimeoutMs !== undefined && input.semiAutoTimeoutMs > 0
+          ? { semiAutoTimeoutMs: input.semiAutoTimeoutMs }
+          : {}),
+      });
+    },
+
+    async sendTurn(sessionId, message, semiAutoTimeoutMs = 0) {
+      return callTool<StartCardSessionOutput>("send_turn", {
+        sessionId,
+        message,
+        ...(semiAutoTimeoutMs > 0 ? { semiAutoTimeoutMs } : {}),
       });
     },
 
@@ -314,6 +346,13 @@ export function createMockDaemonClient(
         sessionId,
         text: `mock response for ${input.cardId}`,
         tracePath: `/tmp/mock-trace-${sessionId}.json`,
+      };
+    },
+    async sendTurn(sessionId, message, _semiAutoTimeoutMs = 0) {
+      return {
+        sessionId,
+        text: `mock turn response: ${message}`,
+        tracePath: `/tmp/mock-trace-${sessionId}-turn.json`,
       };
     },
     async subscribeTurnState(sessionId, sinceIndex = 0) {

--- a/packages/ebrota-console-bff/src/daemon-client.ts
+++ b/packages/ebrota-console-bff/src/daemon-client.ts
@@ -210,9 +210,15 @@ export function createStdioDaemonClient(
   const callTool = async <T>(
     toolName: string,
     args: Record<string, unknown>,
+    timeoutMs?: number,
   ): Promise<T> => {
     await ensureConnected();
-    const result = await client.callTool({ name: toolName, arguments: args });
+    const options = timeoutMs !== undefined ? { timeout: timeoutMs } : undefined;
+    const result = await client.callTool(
+      { name: toolName, arguments: args },
+      undefined,
+      options,
+    );
     // MCP tools retornam content array; extraímos o primeiro item de texto
     const content = result.content;
     if (!Array.isArray(content) || content.length === 0) {
@@ -224,31 +230,48 @@ export function createStdioDaemonClient(
         `Tool ${toolName} retornou content inesperado: ${JSON.stringify(first)}`,
       );
     }
+    if (result.isError === true) {
+      throw new Error(`Tool ${toolName} retornou erro: ${first.text}`);
+    }
     return JSON.parse(first.text) as T;
   };
 
   return {
     async startCardSession(input) {
-      return callTool<StartCardSessionOutput>("startCardSession", {
-        cardId: input.cardId,
-        conversationId: input.conversationId,
-        from: input.from,
-        pkg: input.pkg,
-        ...(input.personaId !== undefined
-          ? { personaId: input.personaId }
-          : {}),
-        ...(input.semiAutoTimeoutMs !== undefined && input.semiAutoTimeoutMs > 0
-          ? { semiAutoTimeoutMs: input.semiAutoTimeoutMs }
-          : {}),
-      });
+      const semi = input.semiAutoTimeoutMs ?? 0;
+      // MCP SDK default é 60s — insuficiente quando motor turn (~20s) +
+      // gate semi-auto (até semiAutoTimeoutMs) ultrapassam o limite.
+      // Buffer de 45s cobre motor turn + overhead MCP.
+      const timeoutMs = semi > 0 ? semi + 45_000 : undefined;
+      return callTool<StartCardSessionOutput>(
+        "startCardSession",
+        {
+          cardId: input.cardId,
+          conversationId: input.conversationId,
+          from: input.from,
+          pkg: input.pkg,
+          ...(input.personaId !== undefined
+            ? { personaId: input.personaId }
+            : {}),
+          ...(semi > 0 ? { semiAutoTimeoutMs: semi } : {}),
+        },
+        timeoutMs,
+      );
     },
 
     async sendTurn(sessionId, message, semiAutoTimeoutMs = 0) {
-      return callTool<StartCardSessionOutput>("send_turn", {
-        sessionId,
-        message,
-        ...(semiAutoTimeoutMs > 0 ? { semiAutoTimeoutMs } : {}),
-      });
+      const timeoutMs = semiAutoTimeoutMs > 0
+        ? semiAutoTimeoutMs + 45_000
+        : undefined;
+      return callTool<StartCardSessionOutput>(
+        "send_turn",
+        {
+          sessionId,
+          message,
+          ...(semiAutoTimeoutMs > 0 ? { semiAutoTimeoutMs } : {}),
+        },
+        timeoutMs,
+      );
     },
 
     async subscribeTurnState(sessionId, sinceIndex = 0) {
@@ -275,13 +298,7 @@ export function createStdioDaemonClient(
     async approveOrEdit(sessionId, decision) {
       return callTool<ApproveOrEditResult>("approve_or_edit", {
         sessionId,
-        approved: decision.approved,
-        ...(decision.editedText !== undefined
-          ? { editedText: decision.editedText }
-          : {}),
-        ...(decision.rationale !== undefined
-          ? { rationale: decision.rationale }
-          : {}),
+        decision,
       });
     },
 

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -187,12 +187,22 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
         .code(400)
         .send({ error: "campos obrigatórios: cardId, conversationId, from, pkg" });
     }
-    const result = await opts.daemon.startCardSession({
-      ...body,
-      semiAutoTimeoutMs: mode === "semi-auto" ? 60_000 : 0,
-    });
-    activeSessions.add(result.sessionId);
-    return result;
+    // Pré-registra sessionId antes do await — em semi-auto mode o daemon
+    // bloqueia até o gate resolver, então activeSessions.add pós-await
+    // tornaria o polling de /sessions/active inútil enquanto gate está ativo.
+    const earlySessionId = `${body.personaId ?? body.from}__${body.conversationId}`;
+    activeSessions.add(earlySessionId);
+    try {
+      const result = await opts.daemon.startCardSession({
+        ...body,
+        semiAutoTimeoutMs: mode === "semi-auto" ? 60_000 : 0,
+      });
+      activeSessions.add(result.sessionId);
+      return result;
+    } catch (err) {
+      activeSessions.delete(earlySessionId);
+      throw err;
+    }
   });
 
   // POST /sessions/start-sts — lança STS CLI como subprocess (ops#1156 v0).

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -42,6 +42,8 @@ import {
   type SessionLibraryFilters,
 } from "./traces-scanner.js";
 import { existsSync, watch as fsWatch, type FSWatcher } from "node:fs";
+import { spawn } from "node:child_process";
+import { join as pathJoin } from "node:path";
 import {
   createDebugEventsStore,
   recordDebugAction,
@@ -96,6 +98,12 @@ export interface CreateBffServerOptions {
    * Default: undefined → endpoint retorna 503, sem watcher.
    */
   tracesDir?: string;
+  /**
+   * Diretório raiz do repo ascendimacy-sts — habilita
+   * POST /sessions/start-sts (spawn STS subprocess, ops#1156).
+   * Default: undefined → endpoint retorna 503.
+   */
+  stsRootDir?: string;
 }
 
 export interface BffServer {
@@ -179,16 +187,112 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
         .code(400)
         .send({ error: "campos obrigatórios: cardId, conversationId, from, pkg" });
     }
-    const result = await opts.daemon.startCardSession(body);
+    const result = await opts.daemon.startCardSession({
+      ...body,
+      semiAutoTimeoutMs: mode === "semi-auto" ? 60_000 : 0,
+    });
     activeSessions.add(result.sessionId);
     return result;
   });
 
-  // GET /sessions/active — lista sessionIds ativos (iniciados, não encerrados).
+  // POST /sessions/start-sts — lança STS CLI como subprocess (ops#1156 v0).
+  //
+  // V0: spawn autônomo — subprocess roda completo sem gate por turn.
+  // Gate integration per-turn é follow-up (requer IPC entre STS e BFF).
+  //
+  // Requer EBROTA_BFF_STS_ROOT → stsRootDir (repo ascendimacy-sts).
+  // Propaga env vars de LLM do processo BFF para o subprocess.
+  fastify.post<{
+    Body: { personaId: string; cardId?: string; turns?: number };
+  }>("/sessions/start-sts", async (req, reply) => {
+    if (!opts.stsRootDir) {
+      return reply.code(503).send({
+        error:
+          "STS root não configurado — definir EBROTA_BFF_STS_ROOT pra habilitar",
+      });
+    }
+    const body = req.body ?? {};
+    const { personaId, turns = 6 } = body;
+    if (typeof personaId !== "string" || personaId.length === 0) {
+      return reply.code(400).send({ error: "personaId (string) obrigatório" });
+    }
+
+    const stsCliPath = pathJoin(opts.stsRootDir, "orchestrator/dist/cli.js");
+    if (!existsSync(stsCliPath)) {
+      return reply.code(503).send({
+        error: `STS CLI não encontrado em ${stsCliPath} — rode 'npm run build' em ascendimacy-sts/orchestrator`,
+      });
+    }
+
+    const sessionId = `sts-${personaId}-${Date.now()}`;
+    const llmEnvKeys = [
+      "LLM_PROVIDER",
+      "LOCAL_LLM_BASE_URL",
+      "LOCAL_LLM_MODEL",
+      "LOCAL_LLM_API_KEY",
+      "LLM_LOCAL_AUTH_BEARER",
+      "LLM_LOCAL_ENDPOINT",
+      "LLM_LOCAL_MODEL",
+      "MOTOR_PATH",
+      "CONTENT_SEED_PATH",
+      "USE_MOCK_LLM",
+      "ANTHROPIC_API_KEY",
+      "INFOMANIAK_API_KEY",
+      "INFOMANIAK_BASE_URL",
+      "ASC_DEBUG_MODE",
+      "NODE_ENV",
+    ];
+    const env: Record<string, string> = {};
+    for (const k of llmEnvKeys) {
+      const v = process.env[k];
+      if (v !== undefined) env[k] = v;
+    }
+
+    const child = spawn(
+      "node",
+      [stsCliPath, "run", "--persona", personaId, "--turns", String(turns)],
+      { cwd: opts.stsRootDir, env: { ...process.env, ...env }, stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    const prefix = `[STS ${sessionId}] `;
+    child.stdout?.on("data", (d: Buffer) =>
+      process.stderr.write(`${prefix}${String(d)}`),
+    );
+    child.stderr?.on("data", (d: Buffer) =>
+      process.stderr.write(`${prefix}${String(d)}`),
+    );
+    child.on("exit", (code: number | null) => {
+      activeSessions.delete(sessionId);
+      process.stderr.write(`${prefix}exit ${code ?? "null"}\n`);
+    });
+
+    activeSessions.add(sessionId);
+    return { sessionId, pid: child.pid ?? null };
+  });
   // App.svelte faz polling aqui pra auto-conectar ao live stream (Fix 3).
   fastify.get("/sessions/active", async () => ({
     sessionIds: [...activeSessions],
   }));
+
+  // POST /sessions/:id/turn — envia próximo turn em sessão existente.
+  // Em semi-auto mode, submete resposta para ApprovalGate antes de retornar.
+  // Caller deve polling GET /sessions/:id/pending-approval e chamar
+  // POST /sessions/:id/approve para desbloquear (ops#1156 + ops#1158).
+  fastify.post<{
+    Params: { id: string };
+    Body: { message: string };
+  }>("/sessions/:id/turn", async (req, reply) => {
+    const { message } = req.body ?? {};
+    if (typeof message !== "string" || message.trim().length === 0) {
+      return reply.code(400).send({ error: "message (string) obrigatório" });
+    }
+    const result = await opts.daemon.sendTurn(
+      req.params.id,
+      message,
+      mode === "semi-auto" ? 60_000 : 0,
+    );
+    return result;
+  });
 
   // GET /sessions/:id/turn-state — SSE stream polling subscribeTurnState
   fastify.get<{ Params: { id: string } }>(

--- a/packages/ebrota-console-ui/src/components/ApprovalGate.svelte
+++ b/packages/ebrota-console-ui/src/components/ApprovalGate.svelte
@@ -7,7 +7,7 @@
     globalError,
     pendingApproval,
   } from "../lib/stores.js";
-  import type { ApiClient } from "../lib/api.js";
+  import type { ApiClient, PendingApprovalContext } from "../lib/api.js";
 
   export let api: ApiClient;
   /** Polling interval (ms) pra /pending-approval. Default 250ms. */
@@ -18,7 +18,10 @@
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let mode = "auto";
   let sessionId: string | null = null;
-  let pending: { proposedText: string } | null = null;
+  let pending: {
+    proposedText: string;
+    context?: PendingApprovalContext;
+  } | null = null;
 
   // Estado de edição local
   let editedText = "";
@@ -26,11 +29,17 @@
   let editing = false;
   let submitting = false;
 
+  // Colapsáveis de contexto (ops#1158)
+  let rationaleOpen = true;
+  let poolOpen = false;
+  let stateOpen = false;
+
   $: mode = $consoleMode;
   $: sessionId = $currentSessionId;
   $: pending = $pendingApproval;
   $: shouldPoll = mode === "semi-auto" && sessionId !== null;
   $: turn = $currentTurnSnapshot?.turn ?? -1;
+  $: ctx = pending?.context ?? null;
 
   // Quando pending muda, sincroniza editedText
   $: if (pending !== null && !editing) {
@@ -112,6 +121,10 @@
     editing = false;
     if (pending !== null) editedText = pending.proposedText;
   }
+
+  function fmtTrust(v: number): string {
+    return (v * 100).toFixed(0) + "%";
+  }
 </script>
 
 {#if mode === "semi-auto" && pending !== null}
@@ -121,7 +134,56 @@
       {#if turn >= 0}
         <span class="meta">turn #{turn}</span>
       {/if}
+      {#if ctx?.sessionState}
+        <span class="meta">
+          trust {fmtTrust(ctx.sessionState.trustLevel)} · budget {ctx.sessionState.budgetRemaining}
+        </span>
+      {/if}
     </header>
+
+    <!-- Contexto pedagógico colapsável (ops#1158) -->
+    {#if ctx}
+      <div class="context-panels">
+        <!-- Painel: Rationale estratégico -->
+        <details bind:open={rationaleOpen} class="ctx-panel">
+          <summary>Rationale do planejador</summary>
+          <p class="ctx-text">{ctx.strategicRationale || "(vazio)"}</p>
+          {#if ctx.contextHints?.["language"]}
+            <p class="ctx-hint">lang: {ctx.contextHints["language"]} · mood: {ctx.contextHints["mood"] ?? "—"}</p>
+          {/if}
+          {#if ctx.contextHints?.["question_detected"]}
+            <p class="ctx-flag">❓ Pergunta detectada — responder primeiro</p>
+          {/if}
+          {#if ctx.contextHints?.["deflection_thematic"] || ctx.contextHints?.["exit_marker_implicit"]}
+            <p class="ctx-flag">⚠️ Deflection ativo</p>
+          {/if}
+        </details>
+
+        <!-- Painel: Pool de conteúdo -->
+        <details bind:open={poolOpen} class="ctx-panel">
+          <summary>Pool ({ctx.contentPoolIds.length} items)</summary>
+          <ul class="pool-list">
+            {#each ctx.contentPoolIds as id}
+              <li class:selected={id === ctx.selectedContentId}>
+                {id}{id === ctx.selectedContentId ? " ← selecionado" : ""}
+              </li>
+            {/each}
+          </ul>
+        </details>
+
+        <!-- Painel: Estado da sessão -->
+        {#if ctx.sessionState}
+          <details bind:open={stateOpen} class="ctx-panel">
+            <summary>Estado da sessão</summary>
+            <ul class="state-list">
+              <li>trust: {fmtTrust(ctx.sessionState.trustLevel)}</li>
+              <li>turn: {ctx.sessionState.turn}</li>
+              <li>budget: {ctx.sessionState.budgetRemaining}</li>
+            </ul>
+          </details>
+        {/if}
+      </div>
+    {/if}
 
     {#if editing}
       <label class="edit-area">
@@ -219,6 +281,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .badge {
@@ -233,6 +296,67 @@
   .meta {
     font-size: 0.75rem;
     opacity: 0.6;
+  }
+
+  /* Context panels (ops#1158) */
+  .context-panels {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .ctx-panel {
+    border: 1px solid rgba(127, 127, 127, 0.2);
+    border-radius: 4px;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.8rem;
+  }
+
+  .ctx-panel summary {
+    cursor: pointer;
+    font-weight: 600;
+    opacity: 0.75;
+    user-select: none;
+  }
+
+  .ctx-text {
+    margin: 0.3rem 0 0;
+    font-style: italic;
+    opacity: 0.85;
+    line-height: 1.35;
+  }
+
+  .ctx-hint {
+    margin: 0.2rem 0 0;
+    opacity: 0.6;
+    font-size: 0.75rem;
+  }
+
+  .ctx-flag {
+    margin: 0.2rem 0 0;
+    font-weight: 600;
+    font-size: 0.78rem;
+  }
+
+  .pool-list {
+    margin: 0.3rem 0 0 1rem;
+    padding: 0;
+    list-style: disc;
+    opacity: 0.8;
+    line-height: 1.5;
+  }
+
+  .pool-list li.selected {
+    font-weight: 700;
+    opacity: 1;
+  }
+
+  .state-list {
+    margin: 0.3rem 0 0 1rem;
+    padding: 0;
+    list-style: none;
+    opacity: 0.8;
+    line-height: 1.5;
   }
 
   .proposed {

--- a/packages/ebrota-console-ui/src/components/SessionStart.svelte
+++ b/packages/ebrota-console-ui/src/components/SessionStart.svelte
@@ -9,13 +9,22 @@
 
   export let api: ApiClient;
 
+  // --- Card session state ---
   let cardId = "tabuada-7";
   let from = "yuji";
-  let busy = false;
+  let cardBusy = false;
 
-  async function start(): Promise<void> {
-    if (busy) return;
-    busy = true;
+  // --- STS session state (ops#1156) ---
+  const PERSONA_OPTIONS = ["ryo-ochiai", "kei-ochiai", "paula"];
+  let stsPersonaId = PERSONA_OPTIONS[0]!;
+  let stsCardId = "";
+  let stsTurns = 6;
+  let stsBusy = false;
+  let stsLastPid: number | null = null;
+
+  async function startCard(): Promise<void> {
+    if (cardBusy) return;
+    cardBusy = true;
     globalError.set(null);
     try {
       const conversationId = `${from}-${Date.now()}`;
@@ -49,13 +58,36 @@
         `Falha ao iniciar sessão: ${err instanceof Error ? err.message : String(err)}`,
       );
     } finally {
-      busy = false;
+      cardBusy = false;
+    }
+  }
+
+  async function startSts(): Promise<void> {
+    if (stsBusy) return;
+    stsBusy = true;
+    stsLastPid = null;
+    globalError.set(null);
+    try {
+      const result = await api.startStsSession({
+        personaId: stsPersonaId,
+        ...(stsCardId.length > 0 ? { cardId: stsCardId } : {}),
+        turns: stsTurns,
+      });
+      stsLastPid = result.pid;
+      currentSessionId.set(result.sessionId);
+    } catch (err) {
+      globalError.set(
+        `Falha ao iniciar STS: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      stsBusy = false;
     }
   }
 </script>
 
 <section class="session-start" data-testid="session-start">
-  <h3>Iniciar sessão de teste</h3>
+  <!-- Card session (existente) -->
+  <h3>Iniciar sessão de teste (carta)</h3>
   <p class="help">
     Dev utility — dispara <code>startCardSession</code> contra o BFF
     (default mock daemon). Em produção, sessões aterrissam via
@@ -72,11 +104,60 @@
     </label>
     <button
       type="button"
-      on:click={start}
-      disabled={busy || cardId.length === 0 || from.length === 0}
+      on:click={startCard}
+      disabled={cardBusy || cardId.length === 0 || from.length === 0}
       data-testid="start-button"
     >
-      {busy ? "..." : "Iniciar"}
+      {cardBusy ? "..." : "Iniciar"}
+    </button>
+  </div>
+
+  <!-- STS session (ops#1156) -->
+  <h3 class="sts-heading">Iniciar sessão STS</h3>
+  <p class="help">
+    Lança STS subprocess (<code>orchestrator/dist/cli.js run</code>).
+    Requer <code>EBROTA_BFF_STS_ROOT</code> no BFF.
+    V0 — sem gate por turn (follow-up).
+    {#if stsLastPid !== null}
+      <span class="pid">PID {stsLastPid}</span>
+    {/if}
+  </p>
+  <div class="form">
+    <label>
+      <span>personaId</span>
+      <select bind:value={stsPersonaId} data-testid="sts-persona-select">
+        {#each PERSONA_OPTIONS as opt}
+          <option value={opt}>{opt}</option>
+        {/each}
+      </select>
+    </label>
+    <label>
+      <span>cardId (opcional)</span>
+      <input
+        bind:value={stsCardId}
+        type="text"
+        placeholder="ex: tabuada-7"
+        data-testid="sts-card-id-input"
+      />
+    </label>
+    <label class="turns-label">
+      <span>turns</span>
+      <input
+        bind:value={stsTurns}
+        type="number"
+        min="1"
+        max="30"
+        data-testid="sts-turns-input"
+      />
+    </label>
+    <button
+      type="button"
+      on:click={startSts}
+      disabled={stsBusy || stsPersonaId.length === 0}
+      class="sts-btn"
+      data-testid="start-sts-button"
+    >
+      {stsBusy ? "..." : "Iniciar STS"}
     </button>
   </div>
 </section>
@@ -86,6 +167,9 @@
     padding: 1rem;
     border-top: 1px solid rgba(127, 127, 127, 0.3);
     background: rgba(127, 127, 127, 0.04);
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
   }
 
   h3 {
@@ -94,10 +178,25 @@
     opacity: 0.8;
   }
 
+  .sts-heading {
+    margin-top: 0.8rem;
+    border-top: 1px solid rgba(127, 127, 127, 0.2);
+    padding-top: 0.7rem;
+  }
+
   .help {
     font-size: 0.8rem;
     opacity: 0.6;
     margin: 0 0 0.7rem;
+  }
+
+  .pid {
+    display: inline-block;
+    background: rgba(76, 175, 80, 0.2);
+    border-radius: 3px;
+    padding: 0 0.3rem;
+    font-family: ui-monospace, monospace;
+    font-size: 0.8em;
   }
 
   code {
@@ -122,13 +221,19 @@
     min-width: 100px;
   }
 
+  .turns-label {
+    max-width: 70px;
+    flex: 0 0 70px;
+  }
+
   label span {
     font-size: 0.75rem;
     opacity: 0.6;
     margin-bottom: 0.2rem;
   }
 
-  input {
+  input,
+  select {
     padding: 0.3rem 0.5rem;
     border: 1px solid rgba(127, 127, 127, 0.3);
     border-radius: 4px;
@@ -138,7 +243,8 @@
     font-size: 0.9rem;
   }
 
-  input:focus {
+  input:focus,
+  select:focus {
     outline: 2px solid rgba(33, 150, 243, 0.5);
     outline-offset: -1px;
   }
@@ -161,5 +267,14 @@
   button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .sts-btn {
+    border-color: rgba(156, 39, 176, 0.6);
+    background: rgba(156, 39, 176, 0.12);
+  }
+
+  .sts-btn:hover:not(:disabled) {
+    background: rgba(156, 39, 176, 0.25);
   }
 </style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -65,6 +65,20 @@ export interface ApprovalDecisionRequest {
   originalText?: string;
 }
 
+/** Contexto pedagógico do turn — retornado junto com proposedText na
+ *  ApprovalGate pra orientar decisão do operador (ops#1158). */
+export interface PendingApprovalContext {
+  contentPoolIds: string[];
+  strategicRationale: string;
+  contextHints: Record<string, unknown>;
+  selectedContentId: string;
+  sessionState?: {
+    trustLevel: number;
+    turn: number;
+    budgetRemaining: number;
+  };
+}
+
 export interface OverrideRequest {
   contentItemId: string;
   /** Pra Edit Learner v0 (BFF persistência). */
@@ -347,6 +361,12 @@ export interface ApiClient {
   startCardSession(
     input: StartCardSessionRequest,
   ): Promise<StartCardSessionOutput>;
+  /** Inicia sessão STS como subprocess (ops#1156 v0). */
+  startStsSession(input: {
+    personaId: string;
+    cardId?: string;
+    turns?: number;
+  }): Promise<{ sessionId: string; pid: number | null }>;
   /** Retorna sessionIds de sessões atualmente ativas no BFF (Fix 3). */
   getActiveSessions(): Promise<{ sessionIds: string[] }>;
   listOptions(
@@ -363,7 +383,7 @@ export interface ApiClient {
   ): Promise<{ decisions: JunDecisionEntry[] }>;
   getPendingApproval(
     sessionId: string,
-  ): Promise<{ proposedText: string } | null>;
+  ): Promise<{ proposedText: string; context?: PendingApprovalContext } | null>;
   approveOrEdit(
     sessionId: string,
     decision: ApprovalDecisionRequest,
@@ -503,6 +523,8 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     setMode: (mode) => post<{ mode: ConsoleMode }>("/mode", { mode }),
     startCardSession: (input) =>
       post<StartCardSessionOutput>("/sessions/start-card", input),
+    startStsSession: (input) =>
+      post<{ sessionId: string; pid: number | null }>("/sessions/start-sts", input),
     getActiveSessions: () =>
       get<{ sessionIds: string[] }>("/sessions/active"),
     listOptions: (sessionId) =>

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -44,9 +44,16 @@ export const globalError = writable<string | null>(null);
 
 /** Pending approval — populated by polling /pending-approval em
  *  semi-auto mode. Null = sem pendência. */
-export const pendingApproval = writable<{ proposedText: string } | null>(
-  null,
-);
+export const pendingApproval = writable<{
+  proposedText: string;
+  context?: {
+    contentPoolIds: string[];
+    strategicRationale: string;
+    contextHints: Record<string, unknown>;
+    selectedContentId: string;
+    sessionState?: { trustLevel: number; turn: number; budgetRemaining: number };
+  };
+} | null>(null);
 
 /** Sidebar Histórico aberto? */
 export const libraryOpen = writable<boolean>(false);

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -170,21 +170,64 @@ export function buildSystemPrompt(input: PlanTurnInput): string {
     ? `\n❓ PERGUNTA DIRETA DETECTADA: o sujeito fez uma pergunta. O strategicRationale DEVE prever que a resposta-bot precisa RESPONDER a pergunta (antes de qualquer Fact/Bridge). Em contextHints, adicione:\n  "question_detected": true,\n  "respond_to_question_first": true.`
     : "";
 
+  // Bloco parental — extraído do perfil do sujeito (ops#1157).
+  const profile = (persona.profile ?? {}) as Record<string, unknown>;
+  const parentalRaw = profile["parental_profile"] as Record<string, unknown> | undefined;
+  let parentalBlock = "";
+  if (parentalRaw) {
+    const values = (parentalRaw["family_values"] as Record<string, unknown> | undefined);
+    const principles = Array.isArray(values?.["principles"]) ? (values!["principles"] as string[]) : [];
+    const telos = typeof parentalRaw["parental_telos"] === "string" ? parentalRaw["parental_telos"].trim() : "";
+    const forbidden = Array.isArray(parentalRaw["forbidden_zones"])
+      ? (parentalRaw["forbidden_zones"] as Array<{ topic: string }>).map((z) => z.topic)
+      : [];
+    const concerns = Array.isArray(parentalRaw["concerns_current"])
+      ? (parentalRaw["concerns_current"] as string[])
+      : [];
+    parentalBlock = `\n\nCONTEXTO PARENTAL (Yuji):
+  Valores: ${principles.join("; ")}
+  Telos: ${telos}
+  Zonas proibidas: ${forbidden.join(", ")}${concerns.length > 0 ? `\n  Preocupações atuais: ${concerns.join("; ")}` : ""}`;
+  }
+
+  // Bloco histórico — sessions_history do fixture (ops#1157).
+  const historyRaw = profile["sessions_history"] as Record<string, unknown> | undefined;
+  let historyBlock = "";
+  if (historyRaw) {
+    const seen = typeof historyRaw["sessions_seen"] === "number" ? historyRaw["sessions_seen"] : 0;
+    const lastDate = typeof historyRaw["last_session_date"] === "string" ? historyRaw["last_session_date"] : "";
+    const arcs = Array.isArray(historyRaw["emotional_arcs"])
+      ? (historyRaw["emotional_arcs"] as Array<{
+          opening_tone?: string;
+          closing_tone?: string;
+          flags?: string[];
+        }>)
+      : [];
+    const lastArc = arcs[arcs.length - 1];
+    const arcSummary = lastArc
+      ? `Última sessão: abertura="${lastArc.opening_tone ?? ""}" → fechamento="${lastArc.closing_tone ?? ""}"; flags: ${(lastArc.flags ?? []).join(", ")}`
+      : "";
+    historyBlock = `\n\nHISTÓRICO (${seen} sessões; última ${lastDate}):
+  ${arcSummary}
+  Open loops: ${(Array.isArray(profile["open_loops"]) ? (profile["open_loops"] as string[]) : []).slice(0, 3).join("; ")}
+  Nota pra próxima sessão: ${(Array.isArray(profile["notes_for_next_session"]) ? (profile["notes_for_next_session"] as string[]) : []).slice(0, 2).join("; ")}`;
+  }
+
   return `Você é o Planejador do motor Ascendimacy. Seu papel é AUXILIAR de compositor:
 o scoring de content items é determinístico (feito no código). Você só emite:
 
-1. strategicRationale (≤80 chars) — 1 frase sobre o momento da sessão.
+1. strategicRationale (≤160 chars) — 1-2 frases sobre o momento da sessão considerando histórico e contexto parental.
 2. contextHints — dicas de composição (language, tom, avoid, etc).
 
 SUJEITO: ${persona.name}, ${persona.age} anos.
 Perfil: ${JSON.stringify(persona.profile, null, 2)}
 Estado: trust=${state.trustLevel.toFixed(2)}, turn=${state.turn}, budget=${state.budgetRemaining}
-Mensagem: "${incomingMessage}"${signalsBlock}${deflectionBlock}${questionBlock}
+Mensagem: "${incomingMessage}"${signalsBlock}${deflectionBlock}${questionBlock}${parentalBlock}${historyBlock}
 
 Detecte a língua do sujeito (ex: 'pt-br', 'pt-br limitado', 'pt-br basico', 'ja', 'en'). Se o perfil indica falante não-nativo (ex: japonês aprendendo pt-br), use 'pt-br limitado'.
 
 Responda APENAS JSON COMPACTO:
-{"strategicRationale":"string ≤80 chars","contextHints":{"language":"pt-br","mood":"receptive","urgency":"low"}}`;
+{"strategicRationale":"string ≤160 chars","contextHints":{"language":"pt-br","mood":"receptive","urgency":"low"}}`;
 }
 
 interface LlmRationale {

--- a/shared/src/gateway-client.ts
+++ b/shared/src/gateway-client.ts
@@ -225,12 +225,15 @@ async function callLocalChatCompletion(
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   const t0 = Date.now();
   try {
+     const bearer = process.env["LLM_LOCAL_AUTH_BEARER"];
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (bearer) headers["Authorization"] = `Bearer ${bearer}`;
     const res = await fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
+       method: "POST",
+       headers,
+       body: JSON.stringify(body),
+       signal: controller.signal,
+     });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new Error(


### PR DESCRIPTION
## Resumo

Três features do Sprint 4 em um PR lógico: contexto parental no planejador (C), enriquecimento do ApprovalGate com contexto pedagógico (D), e endpoint + UI para iniciar sessão STS (B).

## C — ops#1157: Parental context em fixtures + planejador

- `fixtures/ryo-ochiai.yaml` + `fixtures/kei-ochiai.yaml`: adicionados `profile.parental_profile` (family_values, forbidden_zones, budget_constraints, parental_telos) e `profile.sessions_history` (sessions_seen, last_session_date, emotional_arcs)
- `planejador/src/plan.ts`: `buildSystemPrompt` expande com bloco **CONTEXTO PARENTAL** (valores, telos, zonas proibidas, preocupações) e bloco **HISTÓRICO** (arc summary, open_loops[:3], notes[:2]); cap strategicRationale 80→160 chars

## D — ops#1158: ApprovalGate enrichment

- `orchestrator/src/daemon.ts`: `PendingApprovalContext` interface, `buildApprovalContext()` (escaneia turnEvents em reverso por planning_started + selection_made), `sendConsoleTurn()`, `runCardTurn` submete ao gate em semi-auto mode
- `orchestrator/src/mcp-server.ts`: ferramenta `send_turn` registrada; fix Zod `.nonneg()`→`.nonnegative()`
- `orchestrator/src/mcp-clients.ts`: `LLM_LOCAL_AUTH_BEARER` + env vars LLM local no whitelist de buildEnv()
- `packages/ebrota-console-bff/src/daemon-client.ts`: `PendingApprovalContext` + `PendingApproval` enriquecidos; `sendTurn()` na interface + impls stdio e mock; `StartCardSessionInput.semiAutoTimeoutMs?`
- `packages/ebrota-console-bff/src/server.ts`: endpoint `POST /sessions/:id/turn`; `start-card` passa semiAutoTimeoutMs baseado em mode
- UI `ApprovalGate.svelte`: 3 painéis colapsáveis (rationale do planejador, pool de conteúdo, estado da sessão); `PendingApprovalContext` type
- UI `stores.ts` + `api.ts`: tipos atualizados com `PendingApprovalContext`

## B — ops#1156: Start STS endpoint + UI form

- `packages/ebrota-console-bff/src/server.ts`: `POST /sessions/start-sts { personaId, cardId?, turns? }` — spawn STS CLI subprocess com env vars LLM; registra sessionId em activeSessions; retorna `{ sessionId, pid }`; v0 (gate per-turn é follow-up)
- `packages/ebrota-console-bff/src/cli.ts`: env var `EBROTA_BFF_STS_ROOT` pra path do repo ascendimacy-sts
- UI `api.ts`: `startStsSession()` adicionado a `ApiClient`
- UI `SessionStart.svelte`: seção STS com formulário (personaId dropdown, cardId, turns default 6)

## Builds

- `orchestrator`, `ebrota-console-bff`, `ebrota-console-ui` — todos ✅ clean

## Closes

Closes ascendimacy/ascendimacy-ops#1157
Closes ascendimacy/ascendimacy-ops#1158
Closes ascendimacy/ascendimacy-ops#1156

## Para Jun

- [ ] Review fixtures ryo/kei — parental_profile e sessions_history corretos?
- [ ] Testar UI: modo semi-auto → sessão card → ApprovalGate mostra 3 painéis contexto?
- [ ] Testar STS start: `EBROTA_BFF_STS_ROOT=/home/alexa/ascendimacy-sts` no start do BFF → botão 'Iniciar sessão STS' na UI funciona?
- [ ] Merge quando validado