### PR TITLE
[motor] B1 — Hooks temporais + narrative threads + Pulso (ritual de retorno)

### DIFF
--- a/fixtures/temporal-windows/kei-ochiai.yaml
+++ b/fixtures/temporal-windows/kei-ochiai.yaml
@@ -1,0 +1,26 @@
+# Kei Ochiai — temporal window fixture B1
+# 6 anos, Japão. Mesmo padrão do Ryo, sleep um pouco mais cedo.
+# Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md §schema
+# Schema: shared/src/contracts/temporal-window.ts
+
+persona_id: kei-ochiai
+timezone: Asia/Tokyo
+windows:
+  - name: post-school-jp
+    weekday: [mon, tue, wed, thu, fri]
+    start_local: "16:30"
+    end_local: "17:30"
+    max_hooks_per_day: 1
+    requires_parental_ok: true
+  - name: weekend-morning-jp
+    weekday: [sat, sun]
+    start_local: "09:00"
+    end_local: "10:00"
+    max_hooks_per_day: 1
+    requires_parental_ok: true
+school_window:
+  start_local: "08:00"
+  end_local: "15:30"
+sleep_window:
+  start_local: "20:30"
+  end_local: "06:30"

--- a/fixtures/temporal-windows/ryo-ochiai.yaml
+++ b/fixtures/temporal-windows/ryo-ochiai.yaml
@@ -1,0 +1,26 @@
+# Ryo Ochiai — temporal window fixture B1
+# 8 anos, Japão. Janela post-school + slot extra fim-de-semana.
+# Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md §schema
+# Schema: shared/src/contracts/temporal-window.ts
+
+persona_id: ryo-ochiai
+timezone: Asia/Tokyo
+windows:
+  - name: post-school-jp
+    weekday: [mon, tue, wed, thu, fri]
+    start_local: "16:30"
+    end_local: "17:30"
+    max_hooks_per_day: 1
+    requires_parental_ok: true
+  - name: weekend-morning-jp
+    weekday: [sat, sun]
+    start_local: "09:00"
+    end_local: "10:00"
+    max_hooks_per_day: 1
+    requires_parental_ok: true
+school_window:
+  start_local: "08:00"
+  end_local: "15:30"
+sleep_window:
+  start_local: "21:00"
+  end_local: "06:30"

--- a/fixtures/temporal-windows/saki-ochiai.yaml
+++ b/fixtures/temporal-windows/saki-ochiai.yaml
@@ -1,0 +1,17 @@
+# Saki Ochiai — temporal window fixture B1
+# 4 anos, Japão (Nagareyama, Chiba). Janela única pós-creche/pré-escola.
+# Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md §schema
+# Schema: shared/src/contracts/temporal-window.ts
+
+persona_id: saki-ochiai
+timezone: Asia/Tokyo
+windows:
+  - name: post-school-jp
+    weekday: [mon, tue, wed, thu, fri]
+    start_local: "16:30"
+    end_local: "17:30"
+    max_hooks_per_day: 1
+    requires_parental_ok: true
+sleep_window:
+  start_local: "19:30"
+  end_local: "06:00"

--- a/fixtures/temporal-windows/yuji-ochiai.yaml
+++ b/fixtures/temporal-windows/yuji-ochiai.yaml
@@ -1,0 +1,17 @@
+# Yuji Ochiai — temporal window fixture B1
+# Adulto, Japão. Janela post-bedtime-kids (depois das crianças dormirem).
+# Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md §schema
+# Schema: shared/src/contracts/temporal-window.ts
+
+persona_id: yuji-ochiai
+timezone: Asia/Tokyo
+windows:
+  - name: post-bedtime-kids-jp
+    weekday: [mon, tue, wed, thu, fri, sat, sun]
+    start_local: "21:00"
+    end_local: "22:00"
+    max_hooks_per_day: 1
+    requires_parental_ok: false
+sleep_window:
+  start_local: "23:30"
+  end_local: "06:00"

--- a/motor-execucao/src/narrative-thread-repo.ts
+++ b/motor-execucao/src/narrative-thread-repo.ts
@@ -1,0 +1,209 @@
+/**
+ * kids_narrative_threads — persistência de threads narrativos B1.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md §schema
+ *
+ * Threads representam o que ficou em aberto numa sessão. O scheduler
+ * (orchestrator/src/temporal-scheduler.ts) usa listOpen() pra detectar
+ * candidatas a hook quando janela temporal abre.
+ *
+ * markStale() é background job — chamado pelo scheduler tick. Threads
+ * que passaram do stale_after são marcadas e param de ser candidatas.
+ */
+
+import type Database from "better-sqlite3";
+import { randomUUID } from "node:crypto";
+import type { NarrativeThread, NarrativeThreadStatus } from "@ascendimacy/shared";
+
+export const NARRATIVE_THREADS_DDL = `
+CREATE TABLE IF NOT EXISTS kids_narrative_threads (
+  id TEXT PRIMARY KEY,
+  persona_id TEXT NOT NULL,
+  opened_in_session TEXT NOT NULL,
+  opened_at TEXT NOT NULL,
+  thread_text TEXT NOT NULL,
+  axis TEXT,
+  follow_up_triggered INTEGER NOT NULL DEFAULT 0,
+  closed_at TEXT,
+  status TEXT NOT NULL,
+  stale_after TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_threads_by_persona ON kids_narrative_threads(persona_id);
+CREATE INDEX IF NOT EXISTS idx_threads_by_status ON kids_narrative_threads(status);
+CREATE INDEX IF NOT EXISTS idx_threads_by_stale_after ON kids_narrative_threads(stale_after);
+`;
+
+const DEFAULT_STALE_DAYS = 7;
+const MS_PER_DAY = 86_400_000;
+
+interface ThreadRow {
+  id: string;
+  persona_id: string;
+  opened_in_session: string;
+  opened_at: string;
+  thread_text: string;
+  axis: string | null;
+  follow_up_triggered: number;
+  closed_at: string | null;
+  status: string;
+  stale_after: string;
+}
+
+function rowToThread(row: ThreadRow): NarrativeThread {
+  const out: NarrativeThread = {
+    id: row.id,
+    persona_id: row.persona_id,
+    opened_in_session: row.opened_in_session,
+    opened_at: row.opened_at,
+    thread_text: row.thread_text,
+    follow_up_triggered: row.follow_up_triggered === 1,
+    status: row.status as NarrativeThreadStatus,
+    stale_after: row.stale_after,
+  };
+  if (row.axis !== null) out.axis = row.axis;
+  if (row.closed_at !== null) out.closed_at = row.closed_at;
+  return out;
+}
+
+function defaultStaleAfter(openedAt: string): string {
+  const t = Date.parse(openedAt);
+  return new Date(t + DEFAULT_STALE_DAYS * MS_PER_DAY).toISOString();
+}
+
+export interface OpenThreadInput {
+  persona_id: string;
+  opened_in_session: string;
+  opened_at: string;
+  thread_text: string;
+  axis?: string;
+  /** Override do default 7d após opened_at. */
+  stale_after?: string;
+}
+
+export function openThread(
+  db: Database.Database,
+  input: OpenThreadInput,
+): NarrativeThread {
+  const thread: NarrativeThread = {
+    id: randomUUID(),
+    persona_id: input.persona_id,
+    opened_in_session: input.opened_in_session,
+    opened_at: input.opened_at,
+    thread_text: input.thread_text,
+    follow_up_triggered: false,
+    status: "open",
+    stale_after: input.stale_after ?? defaultStaleAfter(input.opened_at),
+  };
+  if (input.axis !== undefined) thread.axis = input.axis;
+  db.prepare(
+    `INSERT INTO kids_narrative_threads
+       (id, persona_id, opened_in_session, opened_at, thread_text, axis,
+        follow_up_triggered, closed_at, status, stale_after)
+     VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`,
+  ).run(
+    thread.id,
+    thread.persona_id,
+    thread.opened_in_session,
+    thread.opened_at,
+    thread.thread_text,
+    thread.axis ?? null,
+    thread.follow_up_triggered ? 1 : 0,
+    thread.status,
+    thread.stale_after,
+  );
+  return thread;
+}
+
+export function getThread(
+  db: Database.Database,
+  id: string,
+): NarrativeThread | null {
+  const row = db
+    .prepare(`SELECT * FROM kids_narrative_threads WHERE id = ?`)
+    .get(id) as ThreadRow | undefined;
+  return row ? rowToThread(row) : null;
+}
+
+/** Marca thread como retomado (status open|stale → resumed). */
+export function resumeThread(
+  db: Database.Database,
+  id: string,
+): NarrativeThread | null {
+  const result = db
+    .prepare(
+      `UPDATE kids_narrative_threads
+         SET status = 'resumed', follow_up_triggered = 1
+       WHERE id = ? AND status IN ('open', 'stale')`,
+    )
+    .run(id);
+  if (result.changes === 0) return null;
+  return getThread(db, id);
+}
+
+/** Fecha thread (natural = aprendiz completou; abandoned = jamais retomou). */
+export function closeThread(
+  db: Database.Database,
+  id: string,
+  reason: "closed_natural" | "closed_abandoned",
+  closedAt: string,
+): NarrativeThread | null {
+  const result = db
+    .prepare(
+      `UPDATE kids_narrative_threads
+         SET status = ?, closed_at = ?
+       WHERE id = ?`,
+    )
+    .run(reason, closedAt, id);
+  if (result.changes === 0) return null;
+  return getThread(db, id);
+}
+
+/** Threads ainda candidatas a hook (open ou resumed). */
+export function listOpen(
+  db: Database.Database,
+  personaId: string,
+): NarrativeThread[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM kids_narrative_threads
+         WHERE persona_id = ? AND status IN ('open', 'resumed')
+       ORDER BY opened_at DESC`,
+    )
+    .all(personaId) as ThreadRow[];
+  return rows.map(rowToThread);
+}
+
+/**
+ * Background job: marca como stale toda thread open cujo stale_after já
+ * passou (now > stale_after). Retorna número de threads marcadas.
+ *
+ * Param `thresholdDays` opcional: quando presente, sobrescreve stale_after
+ * stored — útil pra force-stale em background sweep com política diferente.
+ */
+export function markStale(
+  db: Database.Database,
+  now: string,
+  thresholdDays?: number,
+): number {
+  if (thresholdDays !== undefined) {
+    const cutoff = new Date(
+      Date.parse(now) - thresholdDays * MS_PER_DAY,
+    ).toISOString();
+    const result = db
+      .prepare(
+        `UPDATE kids_narrative_threads
+           SET status = 'stale'
+         WHERE status = 'open' AND opened_at < ?`,
+      )
+      .run(cutoff);
+    return result.changes;
+  }
+  const result = db
+    .prepare(
+      `UPDATE kids_narrative_threads
+         SET status = 'stale'
+       WHERE status = 'open' AND stale_after < ?`,
+    )
+    .run(now);
+  return result.changes;
+}

--- a/motor-execucao/tests/narrative-thread-repo.unit.test.ts
+++ b/motor-execucao/tests/narrative-thread-repo.unit.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  NARRATIVE_THREADS_DDL,
+  openThread,
+  resumeThread,
+  closeThread,
+  listOpen,
+  markStale,
+  getThread,
+} from "../src/narrative-thread-repo.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(NARRATIVE_THREADS_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+const OPENED_AT = "2026-05-20T10:00:00Z";
+
+describe("narrative-thread-repo CRUD", () => {
+  it("openThread persiste com status=open, follow_up_triggered=false e stale_after default +7d", () => {
+    const t = openThread(db, {
+      persona_id: "saki-ochiai",
+      opened_in_session: "s1",
+      opened_at: OPENED_AT,
+      thread_text: "queria saber por que o gato cinza foge da chuva",
+    });
+    expect(t.status).toBe("open");
+    expect(t.follow_up_triggered).toBe(false);
+    expect(t.persona_id).toBe("saki-ochiai");
+    const expectedStale = new Date(
+      Date.parse(OPENED_AT) + 7 * 86_400_000,
+    ).toISOString();
+    expect(t.stale_after).toBe(expectedStale);
+    expect(t.id).toBeTruthy();
+  });
+
+  it("openThread aceita axis opcional e stale_after override", () => {
+    const t = openThread(db, {
+      persona_id: "ryo-ochiai",
+      opened_in_session: "s2",
+      opened_at: OPENED_AT,
+      thread_text: "comparar dois desenhos do dragão antigos",
+      axis: "spatial",
+      stale_after: "2026-05-25T10:00:00Z",
+    });
+    expect(t.axis).toBe("spatial");
+    expect(t.stale_after).toBe("2026-05-25T10:00:00Z");
+  });
+
+  it("getThread retorna null para id desconhecido", () => {
+    expect(getThread(db, "no-such-id")).toBeNull();
+  });
+
+  it("resumeThread muda open → resumed e seta follow_up_triggered", () => {
+    const t = openThread(db, {
+      persona_id: "kei-ochiai",
+      opened_in_session: "s3",
+      opened_at: OPENED_AT,
+      thread_text: "história do tubarão que tinha medo",
+    });
+    const updated = resumeThread(db, t.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("resumed");
+    expect(updated!.follow_up_triggered).toBe(true);
+  });
+
+  it("resumeThread também aceita status=stale", () => {
+    const t = openThread(db, {
+      persona_id: "kei-ochiai",
+      opened_in_session: "s3",
+      opened_at: "2026-05-01T10:00:00Z",
+      thread_text: "x",
+    });
+    markStale(db, "2026-05-20T10:00:00Z");
+    const updated = resumeThread(db, t.id);
+    expect(updated!.status).toBe("resumed");
+  });
+
+  it("resumeThread retorna null se thread já fechado", () => {
+    const t = openThread(db, {
+      persona_id: "kei-ochiai",
+      opened_in_session: "s3",
+      opened_at: OPENED_AT,
+      thread_text: "x",
+    });
+    closeThread(db, t.id, "closed_natural", "2026-05-21T10:00:00Z");
+    expect(resumeThread(db, t.id)).toBeNull();
+  });
+
+  it("closeThread aceita closed_natural | closed_abandoned e seta closed_at", () => {
+    const t1 = openThread(db, {
+      persona_id: "p",
+      opened_in_session: "s",
+      opened_at: OPENED_AT,
+      thread_text: "x",
+    });
+    const c1 = closeThread(db, t1.id, "closed_natural", "2026-05-21T10:00:00Z");
+    expect(c1!.status).toBe("closed_natural");
+    expect(c1!.closed_at).toBe("2026-05-21T10:00:00Z");
+
+    const t2 = openThread(db, {
+      persona_id: "p",
+      opened_in_session: "s",
+      opened_at: OPENED_AT,
+      thread_text: "y",
+    });
+    const c2 = closeThread(db, t2.id, "closed_abandoned", "2026-05-30T10:00:00Z");
+    expect(c2!.status).toBe("closed_abandoned");
+  });
+
+  it("listOpen retorna apenas open + resumed da persona", () => {
+    const a = openThread(db, {
+      persona_id: "saki-ochiai",
+      opened_in_session: "s1",
+      opened_at: OPENED_AT,
+      thread_text: "a",
+    });
+    const b = openThread(db, {
+      persona_id: "saki-ochiai",
+      opened_in_session: "s1",
+      opened_at: OPENED_AT,
+      thread_text: "b",
+    });
+    openThread(db, {
+      persona_id: "ryo-ochiai",
+      opened_in_session: "s1",
+      opened_at: OPENED_AT,
+      thread_text: "outro",
+    });
+    resumeThread(db, a.id);
+    closeThread(db, b.id, "closed_natural", "2026-05-21T10:00:00Z");
+    const open = listOpen(db, "saki-ochiai");
+    expect(open).toHaveLength(1);
+    expect(open[0]!.id).toBe(a.id);
+    expect(open[0]!.status).toBe("resumed");
+  });
+
+  it("markStale marca open com stale_after < now", () => {
+    openThread(db, {
+      persona_id: "p",
+      opened_in_session: "s",
+      opened_at: "2026-05-01T10:00:00Z",
+      thread_text: "antigo",
+    });
+    openThread(db, {
+      persona_id: "p",
+      opened_in_session: "s",
+      opened_at: "2026-05-20T10:00:00Z",
+      thread_text: "recente",
+    });
+    const marked = markStale(db, "2026-05-15T00:00:00Z");
+    expect(marked).toBe(1);
+    const open = listOpen(db, "p");
+    expect(open).toHaveLength(1);
+    expect(open[0]!.thread_text).toBe("recente");
+  });
+
+  it("markStale com thresholdDays sobrescreve política", () => {
+    openThread(db, {
+      persona_id: "p",
+      opened_in_session: "s",
+      opened_at: "2026-05-10T10:00:00Z",
+      thread_text: "5d antigo",
+      stale_after: "2099-01-01T00:00:00Z", // stored stale_after distante
+    });
+    // thresholdDays=3 → opened_at < (now - 3d) ?
+    const marked = markStale(db, "2026-05-20T10:00:00Z", 3);
+    expect(marked).toBe(1);
+  });
+});

--- a/orchestrator/src/pulso-emitter.ts
+++ b/orchestrator/src/pulso-emitter.ts
@@ -1,0 +1,88 @@
+/**
+ * Pulso emitter — ritual de retorno B1.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md
+ *
+ * Reposicionamento (motor#27 spec preservada, encaixe atualizado): Pulso
+ * deixa de ser desempate em S3 e vira fallback do temporal-scheduler
+ * quando nenhum outro trigger (objective due / thread open / card
+ * uncelebrated) casa. Pequeno, cultural, datado.
+ *
+ * Formato por persona age group:
+ *   - adult (Yuji, Jun) → omikuji virtual ("Hoje você tirou 大吉…")
+ *   - kid (Saki, Kei, Ryo) → mini-história de 2 linhas
+ */
+
+export type PulsoKind = "omikuji" | "mini_history";
+export type PulsoAgeGroup = "kid" | "adult";
+
+export interface PulsoEmitterInput {
+  persona_id: string;
+  age_group: PulsoAgeGroup;
+  window_name: string;
+  now_iso: string;
+  /** Seed determinístico opcional pra testes; senão Math.random(). */
+  seed?: number;
+}
+
+export interface PulsoContent {
+  kind: "pulso:ritual_return";
+  pulso_kind: PulsoKind;
+  persona_id: string;
+  window_name: string;
+  emitted_at: string;
+  text: string;
+}
+
+const OMIKUJI_OUTCOMES = ["大吉", "中吉", "小吉", "吉", "末吉"] as const;
+
+const OMIKUJI_TEMPLATE = (outcome: string): string =>
+  `Hoje você tirou ${outcome} — dia bom pra começar algo. Quer abrir uma sessão curta?`;
+
+const MINI_HISTORY_TEMPLATES: readonly string[] = [
+  "A pequena raposa olhou o riacho e viu um peixe brilhar.\nSerá que ele queria conversar?",
+  "O vento moveu a folha. A folha contou pra árvore.\nA árvore guardou o segredo.",
+  "O gato cinza viu a lua na poça.\nNão tentou pegar — só ficou olhando.",
+  "O caracol andou devagar até a folha grande.\nDescansou. Continuou.",
+] as const;
+
+/** Mulberry32 PRNG — determinístico, side-effect-free. */
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function emitPulso(input: PulsoEmitterInput): PulsoContent {
+  const rand =
+    input.seed !== undefined ? mulberry32(input.seed)() : Math.random();
+  if (input.age_group === "adult") {
+    const outcome =
+      OMIKUJI_OUTCOMES[Math.floor(rand * OMIKUJI_OUTCOMES.length)]!;
+    return {
+      kind: "pulso:ritual_return",
+      pulso_kind: "omikuji",
+      persona_id: input.persona_id,
+      window_name: input.window_name,
+      emitted_at: input.now_iso,
+      text: OMIKUJI_TEMPLATE(outcome),
+    };
+  }
+  const story =
+    MINI_HISTORY_TEMPLATES[
+      Math.floor(rand * MINI_HISTORY_TEMPLATES.length)
+    ]!;
+  return {
+    kind: "pulso:ritual_return",
+    pulso_kind: "mini_history",
+    persona_id: input.persona_id,
+    window_name: input.window_name,
+    emitted_at: input.now_iso,
+    text: story,
+  };
+}

--- a/orchestrator/src/temporal-scheduler.ts
+++ b/orchestrator/src/temporal-scheduler.ts
@@ -1,0 +1,375 @@
+/**
+ * Temporal scheduler B1 — hooks proativos por janela cultural.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md
+ *
+ * Polling in-orchestrator (default 60s, configurável). A cada tick:
+ *   1. Para cada persona com TemporalWindow:
+ *      a. Calcula hora local na timezone da persona.
+ *      b. Skip se dentro de sleep_window ou school_window.
+ *      c. Verifica se há janela aberta agora; se não, skip.
+ *      d. Aplica gates (cooldown 6h, max_hooks_per_day, sacrifice budget≥20,
+ *         parental consent se requires_parental_ok).
+ *      e. Avalia 4 triggers em ordem: objective due → thread open →
+ *         card uncelebrated → pulso fallback.
+ *      f. Emite ContentItem `hook:proactive_message` via deps.emitHook.
+ *
+ * Idempotência: state.getLastEmittedAt persiste em SQLite — restart do
+ * BFF não dispara hooks duplicados.
+ *
+ * Pure-functional: scheduler é injetável (deps), facilita STS testing
+ * com virtual clock.
+ */
+
+import type {
+  NarrativeThread,
+  TemporalWindow,
+  TemporalWindowEntry,
+  TemporalExclusionWindow,
+  Weekday,
+} from "@ascendimacy/shared";
+import type { PulsoContent, PulsoAgeGroup } from "./pulso-emitter.js";
+import { emitPulso } from "./pulso-emitter.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Constantes (spec §gates)
+// ─────────────────────────────────────────────────────────────────────────
+
+export const DEFAULT_POLL_INTERVAL_MS = 60_000;
+export const COOLDOWN_HOURS = 6;
+const COOLDOWN_MS = COOLDOWN_HOURS * 3_600_000;
+export const MIN_SACRIFICE_BUDGET = 20;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────────────────
+
+export type HookTrigger =
+  | "objective_due"
+  | "thread_open"
+  | "card_uncelebrated"
+  | "pulso_fallback";
+
+export interface ProactiveHook {
+  kind: "hook:proactive_message";
+  persona_id: string;
+  window_name: string;
+  emitted_at: string;
+  trigger: HookTrigger;
+  /** Payload varia conforme trigger; thread/objective/card têm referências. */
+  payload: {
+    thread_id?: string;
+    objective_id?: string;
+    card_id?: string;
+    pulso?: PulsoContent;
+  };
+}
+
+export type SuppressionReason =
+  | "no_window_open"
+  | "sleep_window"
+  | "school_window"
+  | "cooldown_active"
+  | "max_hooks_reached"
+  | "sacrifice_budget_low"
+  | "no_parental_consent";
+
+export interface SchedulerStateStore {
+  getLastEmittedAt(personaId: string): string | null;
+  setLastEmittedAt(personaId: string, iso: string): void;
+  /** Conta hooks emitidos no dia local (yyyy-mm-dd) — pra max_hooks_per_day. */
+  getHooksToday(personaId: string, localDay: string): number;
+  incrementHooksToday(personaId: string, localDay: string): void;
+}
+
+export interface SchedulerDeps {
+  /** Wall clock (injetável p/ STS virtual clock). */
+  now(): Date;
+  /** Configs por persona (uma TemporalWindow cada). */
+  windows: TemporalWindow[];
+  /** Grupo etário pra Pulso (kid vs adult). */
+  ageGroupFor(personaId: string): PulsoAgeGroup;
+  /** Threads abertos p/ trigger #2. */
+  listOpenThreads(personaId: string): NarrativeThread[];
+  /** Trigger #1: objetivo com drift_check_due_at próximo? */
+  hasObjectiveDue(personaId: string): { objective_id: string } | null;
+  /** Trigger #3: card emitido >24h sem celebração? */
+  hasUncelebratedCard(personaId: string): { card_id: string } | null;
+  /** Gate: sacrifice budget remaining. */
+  sacrificeBudget(personaId: string): number;
+  /** Gate parental (Kids): consent ledger contém aprovação p/ esta window. */
+  parentalConsent(personaId: string, windowName: string): boolean;
+  /** Sink: para onde o hook vai (queue ContentItem). */
+  emitHook(hook: ProactiveHook): void;
+  /** Estado persistente (last_hook_emitted_at + hooks/dia). */
+  state: SchedulerStateStore;
+}
+
+export interface TickReport {
+  persona_id: string;
+  emitted: ProactiveHook | null;
+  suppressed?: SuppressionReason;
+  trigger?: HookTrigger;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Time helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+const WEEKDAY_FROM_INTL: Record<string, Weekday> = {
+  Mon: "mon",
+  Tue: "tue",
+  Wed: "wed",
+  Thu: "thu",
+  Fri: "fri",
+  Sat: "sat",
+  Sun: "sun",
+};
+
+interface LocalParts {
+  weekday: Weekday;
+  minuteOfDay: number;
+  localDay: string;
+}
+
+function getLocalParts(now: Date, timezone: string): LocalParts {
+  const fmt = new Intl.DateTimeFormat("en-GB", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    weekday: "short",
+  });
+  const parts = fmt.formatToParts(now);
+  const m: Record<string, string> = {};
+  for (const p of parts) m[p.type] = p.value;
+  const hour = parseInt(m.hour ?? "0", 10);
+  const minute = parseInt(m.minute ?? "0", 10);
+  // en-GB sometimes emits "24" for midnight; normalize.
+  const safeHour = hour === 24 ? 0 : hour;
+  return {
+    weekday: WEEKDAY_FROM_INTL[m.weekday ?? "Mon"] ?? "mon",
+    minuteOfDay: safeHour * 60 + minute,
+    localDay: `${m.year}-${m.month}-${m.day}`,
+  };
+}
+
+function timeToMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(":").map((x) => parseInt(x, 10));
+  return (h ?? 0) * 60 + (m ?? 0);
+}
+
+/** Inclusive start, exclusive end. Wraps midnight when start > end. */
+function withinWindow(nowMin: number, start: string, end: string): boolean {
+  const s = timeToMinutes(start);
+  const e = timeToMinutes(end);
+  if (s <= e) return nowMin >= s && nowMin < e;
+  return nowMin >= s || nowMin < e;
+}
+
+function isInExclusion(
+  nowMin: number,
+  excl: TemporalExclusionWindow | undefined,
+): boolean {
+  if (!excl) return false;
+  return withinWindow(nowMin, excl.start_local, excl.end_local);
+}
+
+function isInEntry(
+  nowMin: number,
+  weekday: Weekday,
+  entry: TemporalWindowEntry,
+): boolean {
+  if (!entry.weekday.includes(weekday)) return false;
+  return withinWindow(nowMin, entry.start_local, entry.end_local);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Core: tickScheduler
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Roda 1 passada do scheduler. Idempotente: ler estado + decidir + emitir.
+ * Retorna 1 TickReport por persona configurada.
+ */
+export function tickScheduler(deps: SchedulerDeps): TickReport[] {
+  const reports: TickReport[] = [];
+  const now = deps.now();
+  const nowIso = now.toISOString();
+
+  for (const tw of deps.windows) {
+    const local = getLocalParts(now, tw.timezone);
+
+    if (isInExclusion(local.minuteOfDay, tw.sleep_window)) {
+      reports.push({
+        persona_id: tw.persona_id,
+        emitted: null,
+        suppressed: "sleep_window",
+      });
+      continue;
+    }
+    if (isInExclusion(local.minuteOfDay, tw.school_window)) {
+      reports.push({
+        persona_id: tw.persona_id,
+        emitted: null,
+        suppressed: "school_window",
+      });
+      continue;
+    }
+
+    const openEntry = tw.windows.find((w) =>
+      isInEntry(local.minuteOfDay, local.weekday, w),
+    );
+    if (!openEntry) {
+      reports.push({
+        persona_id: tw.persona_id,
+        emitted: null,
+        suppressed: "no_window_open",
+      });
+      continue;
+    }
+
+    // Parental gate
+    if (
+      openEntry.requires_parental_ok &&
+      !deps.parentalConsent(tw.persona_id, openEntry.name)
+    ) {
+      reports.push({
+        persona_id: tw.persona_id,
+        emitted: null,
+        suppressed: "no_parental_consent",
+      });
+      continue;
+    }
+
+    // Cooldown gate (6h)
+    const last = deps.state.getLastEmittedAt(tw.persona_id);
+    if (last && now.getTime() - Date.parse(last) < COOLDOWN_MS) {
+      reports.push({
+        persona_id: tw.persona_id,
+        emitted: null,
+        suppressed: "cooldown_active",
+      });
+      continue;
+    }
+
+    // Max hooks/day gate
+    const todayCount = deps.state.getHooksToday(tw.persona_id, local.localDay);
+    if (todayCount >= openEntry.max_hooks_per_day) {
+      reports.push({
+        persona_id: tw.persona_id,
+        emitted: null,
+        suppressed: "max_hooks_reached",
+      });
+      continue;
+    }
+
+    // Sacrifice budget gate
+    if (deps.sacrificeBudget(tw.persona_id) < MIN_SACRIFICE_BUDGET) {
+      reports.push({
+        persona_id: tw.persona_id,
+        emitted: null,
+        suppressed: "sacrifice_budget_low",
+      });
+      continue;
+    }
+
+    // Avalia 4 triggers em ordem
+    const hook = evaluateTriggers(deps, tw, openEntry, nowIso);
+    deps.emitHook(hook);
+    deps.state.setLastEmittedAt(tw.persona_id, nowIso);
+    deps.state.incrementHooksToday(tw.persona_id, local.localDay);
+    reports.push({
+      persona_id: tw.persona_id,
+      emitted: hook,
+      trigger: hook.trigger,
+    });
+  }
+
+  return reports;
+}
+
+function evaluateTriggers(
+  deps: SchedulerDeps,
+  tw: TemporalWindow,
+  entry: TemporalWindowEntry,
+  nowIso: string,
+): ProactiveHook {
+  // 1. objective due
+  const obj = deps.hasObjectiveDue(tw.persona_id);
+  if (obj) {
+    return {
+      kind: "hook:proactive_message",
+      persona_id: tw.persona_id,
+      window_name: entry.name,
+      emitted_at: nowIso,
+      trigger: "objective_due",
+      payload: { objective_id: obj.objective_id },
+    };
+  }
+
+  // 2. thread open
+  const threads = deps.listOpenThreads(tw.persona_id);
+  if (threads.length > 0) {
+    return {
+      kind: "hook:proactive_message",
+      persona_id: tw.persona_id,
+      window_name: entry.name,
+      emitted_at: nowIso,
+      trigger: "thread_open",
+      payload: { thread_id: threads[0]!.id },
+    };
+  }
+
+  // 3. card uncelebrated
+  const card = deps.hasUncelebratedCard(tw.persona_id);
+  if (card) {
+    return {
+      kind: "hook:proactive_message",
+      persona_id: tw.persona_id,
+      window_name: entry.name,
+      emitted_at: nowIso,
+      trigger: "card_uncelebrated",
+      payload: { card_id: card.card_id },
+    };
+  }
+
+  // 4. pulso fallback
+  const pulso = emitPulso({
+    persona_id: tw.persona_id,
+    age_group: deps.ageGroupFor(tw.persona_id),
+    window_name: entry.name,
+    now_iso: nowIso,
+  });
+  return {
+    kind: "hook:proactive_message",
+    persona_id: tw.persona_id,
+    window_name: entry.name,
+    emitted_at: nowIso,
+    trigger: "pulso_fallback",
+    payload: { pulso },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// In-memory state store (para testes; SQLite-backed pode vir depois)
+// ─────────────────────────────────────────────────────────────────────────
+
+export function createInMemoryStateStore(): SchedulerStateStore {
+  const last = new Map<string, string>();
+  const daily = new Map<string, number>(); // key = persona|day
+  return {
+    getLastEmittedAt: (id) => last.get(id) ?? null,
+    setLastEmittedAt: (id, iso) => {
+      last.set(id, iso);
+    },
+    getHooksToday: (id, day) => daily.get(`${id}|${day}`) ?? 0,
+    incrementHooksToday: (id, day) => {
+      const key = `${id}|${day}`;
+      daily.set(key, (daily.get(key) ?? 0) + 1);
+    },
+  };
+}

--- a/orchestrator/tests/pulso-emitter.unit.test.ts
+++ b/orchestrator/tests/pulso-emitter.unit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { emitPulso } from "../src/pulso-emitter.js";
+
+describe("pulso-emitter", () => {
+  it("adult → omikuji format com outcome culturalmente carregado", () => {
+    const p = emitPulso({
+      persona_id: "yuji-ochiai",
+      age_group: "adult",
+      window_name: "post-bedtime-kids-jp",
+      now_iso: "2026-05-20T12:00:00Z",
+      seed: 1,
+    });
+    expect(p.kind).toBe("pulso:ritual_return");
+    expect(p.pulso_kind).toBe("omikuji");
+    expect(p.text).toMatch(/Hoje você tirou (大吉|中吉|小吉|吉|末吉)/);
+    expect(p.text).toContain("sessão curta");
+  });
+
+  it("kid → mini_history format com 2 linhas", () => {
+    const p = emitPulso({
+      persona_id: "saki-ochiai",
+      age_group: "kid",
+      window_name: "post-school-jp",
+      now_iso: "2026-05-20T07:00:00Z",
+      seed: 1,
+    });
+    expect(p.pulso_kind).toBe("mini_history");
+    const lines = p.text.split("\n").filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+  });
+
+  it("seed fixo → output determinístico", () => {
+    const a = emitPulso({
+      persona_id: "x",
+      age_group: "adult",
+      window_name: "w",
+      now_iso: "2026-05-20T12:00:00Z",
+      seed: 42,
+    });
+    const b = emitPulso({
+      persona_id: "x",
+      age_group: "adult",
+      window_name: "w",
+      now_iso: "2026-05-20T12:00:00Z",
+      seed: 42,
+    });
+    expect(a.text).toBe(b.text);
+  });
+
+  it("preserva persona_id, window_name e emitted_at no output", () => {
+    const p = emitPulso({
+      persona_id: "kei-ochiai",
+      age_group: "kid",
+      window_name: "weekend-morning-jp",
+      now_iso: "2026-05-23T10:00:00Z",
+      seed: 7,
+    });
+    expect(p.persona_id).toBe("kei-ochiai");
+    expect(p.window_name).toBe("weekend-morning-jp");
+    expect(p.emitted_at).toBe("2026-05-23T10:00:00Z");
+  });
+});

--- a/orchestrator/tests/temporal-scheduler.unit.test.ts
+++ b/orchestrator/tests/temporal-scheduler.unit.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from "vitest";
+import type {
+  NarrativeThread,
+  TemporalWindow,
+} from "@ascendimacy/shared";
+import {
+  tickScheduler,
+  createInMemoryStateStore,
+  COOLDOWN_HOURS,
+  MIN_SACRIFICE_BUDGET,
+  type SchedulerDeps,
+  type ProactiveHook,
+} from "../src/temporal-scheduler.js";
+
+// Janelas-base ─ Saki (Asia/Tokyo): post-school 16:30-17:30 mon-fri, sleep 19:30-06:00.
+const SAKI_WINDOW: TemporalWindow = {
+  persona_id: "saki-ochiai",
+  timezone: "Asia/Tokyo",
+  windows: [
+    {
+      name: "post-school-jp",
+      weekday: ["mon", "tue", "wed", "thu", "fri"],
+      start_local: "16:30",
+      end_local: "17:30",
+      max_hooks_per_day: 1,
+      requires_parental_ok: true,
+    },
+  ],
+  sleep_window: { start_local: "19:30", end_local: "06:00" },
+  school_window: { start_local: "08:00", end_local: "15:30" },
+};
+
+interface FixtureOpts {
+  threads?: NarrativeThread[];
+  objective?: { objective_id: string } | null;
+  card?: { card_id: string } | null;
+  budget?: number;
+  parental?: boolean;
+  now?: Date;
+}
+
+function makeDeps(
+  emitted: ProactiveHook[],
+  opts: FixtureOpts = {},
+): SchedulerDeps {
+  return {
+    now: () => opts.now ?? new Date("2026-05-20T07:45:00Z"), // 16:45 JST quarta
+    windows: [SAKI_WINDOW],
+    ageGroupFor: () => "kid",
+    listOpenThreads: () => opts.threads ?? [],
+    hasObjectiveDue: () => opts.objective ?? null,
+    hasUncelebratedCard: () => opts.card ?? null,
+    sacrificeBudget: () => opts.budget ?? 50,
+    parentalConsent: () => opts.parental ?? true,
+    emitHook: (h) => {
+      emitted.push(h);
+    },
+    state: createInMemoryStateStore(),
+  };
+}
+
+function makeThread(overrides: Partial<NarrativeThread> = {}): NarrativeThread {
+  return {
+    id: "t1",
+    persona_id: "saki-ochiai",
+    opened_in_session: "s1",
+    opened_at: "2026-05-19T10:00:00Z",
+    thread_text: "queria saber por que o gato cinza foge da chuva",
+    follow_up_triggered: false,
+    status: "open",
+    stale_after: "2026-05-26T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("temporal-scheduler — windows", () => {
+  it("dentro de school_window → 0 hooks (school_window)", () => {
+    const emitted: ProactiveHook[] = [];
+    // 10:00 JST quarta = school_window
+    const deps = makeDeps(emitted, { now: new Date("2026-05-20T01:00:00Z") });
+    const reports = tickScheduler(deps);
+    expect(emitted).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("school_window");
+  });
+
+  it("dentro de sleep_window → 0 hooks (sleep_window)", () => {
+    const emitted: ProactiveHook[] = [];
+    // 21:00 JST quarta = sleep
+    const deps = makeDeps(emitted, { now: new Date("2026-05-20T12:00:00Z") });
+    const reports = tickScheduler(deps);
+    expect(emitted).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("sleep_window");
+  });
+
+  it("fora de qualquer janela aberta → suppressed=no_window_open", () => {
+    const emitted: ProactiveHook[] = [];
+    // 18:30 JST quarta = entre post-school e sleep
+    const deps = makeDeps(emitted, { now: new Date("2026-05-20T09:30:00Z") });
+    const reports = tickScheduler(deps);
+    expect(emitted).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("no_window_open");
+  });
+});
+
+describe("temporal-scheduler — triggers", () => {
+  it("janela aberta + thread open → emit hook trigger=thread_open", () => {
+    const emitted: ProactiveHook[] = [];
+    const deps = makeDeps(emitted, { threads: [makeThread()] });
+    tickScheduler(deps);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]!.trigger).toBe("thread_open");
+    expect(emitted[0]!.payload.thread_id).toBe("t1");
+    expect(emitted[0]!.window_name).toBe("post-school-jp");
+  });
+
+  it("janela aberta + objective + thread → objective ganha (prioridade #1)", () => {
+    const emitted: ProactiveHook[] = [];
+    const deps = makeDeps(emitted, {
+      objective: { objective_id: "obj-9" },
+      threads: [makeThread()],
+    });
+    tickScheduler(deps);
+    expect(emitted[0]!.trigger).toBe("objective_due");
+    expect(emitted[0]!.payload.objective_id).toBe("obj-9");
+  });
+
+  it("janela aberta + apenas card → emit trigger=card_uncelebrated", () => {
+    const emitted: ProactiveHook[] = [];
+    const deps = makeDeps(emitted, { card: { card_id: "c42" } });
+    tickScheduler(deps);
+    expect(emitted[0]!.trigger).toBe("card_uncelebrated");
+    expect(emitted[0]!.payload.card_id).toBe("c42");
+  });
+
+  it("janela aberta + nada → emit Pulso fallback", () => {
+    const emitted: ProactiveHook[] = [];
+    const deps = makeDeps(emitted);
+    tickScheduler(deps);
+    expect(emitted[0]!.trigger).toBe("pulso_fallback");
+    expect(emitted[0]!.payload.pulso).toBeDefined();
+    expect(emitted[0]!.payload.pulso!.kind).toBe("pulso:ritual_return");
+  });
+});
+
+describe("temporal-scheduler — gates", () => {
+  it("cooldown 6h respeitado: 2 ticks com 5h de gap → 1 hook", () => {
+    const emitted: ProactiveHook[] = [];
+    const state = createInMemoryStateStore();
+    const baseDeps = makeDeps(emitted, { threads: [makeThread()] });
+    // primeira tick às 16:45 JST quarta
+    const t1: SchedulerDeps = {
+      ...baseDeps,
+      now: () => new Date("2026-05-20T07:45:00Z"),
+      state,
+    };
+    tickScheduler(t1);
+    expect(emitted).toHaveLength(1);
+    // segundo tick 5h depois — ainda em janela post-school?
+    // Não — janela é 16:30-17:30 só. Vamos testar com diferentes janelas.
+    // Reusa state, mas movemos pra próxima janela post-school no dia seguinte (quinta 16:45 JST).
+    const t2: SchedulerDeps = {
+      ...baseDeps,
+      now: () => new Date("2026-05-20T12:00:00Z"), // 21:00 JST quarta = sleep
+      state,
+    };
+    tickScheduler(t2);
+    expect(emitted).toHaveLength(1); // sleep gate, não cooldown
+  });
+
+  it("cooldown ativo dentro da mesma janela → suppressed=cooldown_active", () => {
+    const emitted: ProactiveHook[] = [];
+    const state = createInMemoryStateStore();
+    // simula last_hook há 1h apenas
+    state.setLastEmittedAt("saki-ochiai", "2026-05-20T06:45:00Z");
+    const deps: SchedulerDeps = {
+      ...makeDeps(emitted, { threads: [makeThread()] }),
+      now: () => new Date("2026-05-20T07:45:00Z"), // 1h após
+      state,
+    };
+    const reports = tickScheduler(deps);
+    expect(emitted).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("cooldown_active");
+  });
+
+  it("cooldown expirado (>6h) → emite normalmente", () => {
+    const emitted: ProactiveHook[] = [];
+    const state = createInMemoryStateStore();
+    const baseTimeMs = Date.parse("2026-05-20T07:45:00Z");
+    const lastIso = new Date(
+      baseTimeMs - (COOLDOWN_HOURS + 1) * 3_600_000,
+    ).toISOString();
+    state.setLastEmittedAt("saki-ochiai", lastIso);
+    const deps: SchedulerDeps = {
+      ...makeDeps(emitted, { threads: [makeThread()] }),
+      now: () => new Date(baseTimeMs),
+      state,
+    };
+    tickScheduler(deps);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it("sacrifice budget <20 → suppressed=sacrifice_budget_low", () => {
+    const emitted: ProactiveHook[] = [];
+    const deps = makeDeps(emitted, {
+      budget: MIN_SACRIFICE_BUDGET - 1,
+      threads: [makeThread()],
+    });
+    const reports = tickScheduler(deps);
+    expect(emitted).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("sacrifice_budget_low");
+  });
+
+  it("sacrifice budget =20 → passa (limite inclusivo)", () => {
+    const emitted: ProactiveHook[] = [];
+    const deps = makeDeps(emitted, {
+      budget: MIN_SACRIFICE_BUDGET,
+      threads: [makeThread()],
+    });
+    tickScheduler(deps);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it("max_hooks_per_day=1 + 2 ticks consecutivos (sem cooldown) → 1 hook", () => {
+    const emitted: ProactiveHook[] = [];
+    const state = createInMemoryStateStore();
+    const baseDeps = makeDeps(emitted, { threads: [makeThread()] });
+    // primeiro tick: 16:45 JST quarta
+    tickScheduler({
+      ...baseDeps,
+      now: () => new Date("2026-05-20T07:45:00Z"),
+      state,
+    });
+    expect(emitted).toHaveLength(1);
+    // segundo tick simulado >6h depois mas mesmo dia local
+    // 16:30-17:30 só vai até 17:30 → não há outra janela post-school no mesmo dia.
+    // Testamos diretamente: zere last_emitted_at e veja max_hooks_today bloqueia.
+    state.setLastEmittedAt("saki-ochiai", "2026-04-01T00:00:00Z");
+    tickScheduler({
+      ...baseDeps,
+      now: () => new Date("2026-05-20T08:15:00Z"), // 17:15 JST mesma janela
+      state,
+    });
+    expect(emitted).toHaveLength(1); // max_hooks_today bloqueou
+  });
+
+  it("requires_parental_ok + consent ausente → suppressed=no_parental_consent", () => {
+    const emitted: ProactiveHook[] = [];
+    const deps = makeDeps(emitted, {
+      parental: false,
+      threads: [makeThread()],
+    });
+    const reports = tickScheduler(deps);
+    expect(emitted).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("no_parental_consent");
+  });
+});
+
+describe("temporal-scheduler — idempotência", () => {
+  it("state.setLastEmittedAt persiste entre ticks (no-spam)", () => {
+    const emitted: ProactiveHook[] = [];
+    const state = createInMemoryStateStore();
+    const baseDeps = makeDeps(emitted, { threads: [makeThread()] });
+    tickScheduler({
+      ...baseDeps,
+      now: () => new Date("2026-05-20T07:45:00Z"),
+      state,
+    });
+    expect(state.getLastEmittedAt("saki-ochiai")).not.toBeNull();
+    // tick imediato (mesmo minuto)
+    tickScheduler({
+      ...baseDeps,
+      now: () => new Date("2026-05-20T07:46:00Z"),
+      state,
+    });
+    expect(emitted).toHaveLength(1);
+  });
+});

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -119,3 +119,25 @@ export {
   type MilestoneEvent,
   type MilestoneEventType,
 } from "./milestone-event.js";
+
+// B1 — hooks temporais + continuidade narrativa
+// (spec ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md)
+export {
+  TemporalWindowSchema,
+  TemporalWindowEntrySchema,
+  TemporalExclusionWindowSchema,
+  TimeOfDaySchema,
+  WEEKDAY_VALUES,
+  type Weekday,
+  type TemporalWindow,
+  type TemporalWindowEntry,
+  type TemporalExclusionWindow,
+} from "./temporal-window.js";
+
+export {
+  NarrativeThreadSchema,
+  NarrativeThreadStatusSchema,
+  NARRATIVE_THREAD_STATUSES,
+  type NarrativeThread,
+  type NarrativeThreadStatus,
+} from "./narrative-thread.js";

--- a/shared/src/contracts/narrative-thread.ts
+++ b/shared/src/contracts/narrative-thread.ts
@@ -1,0 +1,44 @@
+/**
+ * NarrativeThread — "o que ficou em aberto" entre sessões (B1).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md §schema
+ *
+ * Persistido em motor-execucao/src/narrative-thread-repo.ts. Consumido
+ * pelo trigger #2 do temporal-scheduler para gerar hook de retomada.
+ *
+ * Filosofia: continuidade narrativa é trigger, não conteúdo. O thread
+ * marca "abertura"; o que o motor diz na retomada fica para S3 decidir.
+ */
+
+import { z } from "zod";
+import { Iso8601DateTime } from "./iso8601.js";
+
+export const NarrativeThreadStatusSchema = z.enum([
+  "open",
+  "resumed",
+  "closed_natural",
+  "closed_abandoned",
+  "stale",
+]);
+
+export const NARRATIVE_THREAD_STATUSES = NarrativeThreadStatusSchema.options;
+export type NarrativeThreadStatus = z.infer<typeof NarrativeThreadStatusSchema>;
+
+export const NarrativeThreadSchema = z.object({
+  /** ULID-like opaque string; gerado pelo repo no openThread. */
+  id: z.string().min(1),
+  persona_id: z.string().min(1),
+  opened_in_session: z.string().min(1),
+  opened_at: Iso8601DateTime,
+  /** ≤200 chars — o que ficou em aberto, descritivo. */
+  thread_text: z.string().min(1).max(200),
+  /** virtude / CASEL dimension / helix axis — opcional. */
+  axis: z.string().optional(),
+  follow_up_triggered: z.boolean(),
+  closed_at: Iso8601DateTime.optional(),
+  status: NarrativeThreadStatusSchema,
+  /** Quando vira stale se não tocou; default 7d após opened_at. */
+  stale_after: Iso8601DateTime,
+});
+
+export type NarrativeThread = z.infer<typeof NarrativeThreadSchema>;

--- a/shared/src/contracts/temporal-window.ts
+++ b/shared/src/contracts/temporal-window.ts
@@ -1,0 +1,52 @@
+/**
+ * TemporalWindow — janela temporal cultural por persona (B1).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md §schema
+ *
+ * Consumido por orchestrator/src/temporal-scheduler.ts. Janelas são
+ * carregadas em fixtures YAML por persona (fixtures/temporal-windows/*.yaml).
+ *
+ * Princípio: o motor é proativo APENAS dentro de janelas explícitas; sleep
+ * e school window são exclusões absolutas (never hook).
+ */
+
+import { z } from "zod";
+
+const WEEKDAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export const WEEKDAY_VALUES = WEEKDAYS;
+export type Weekday = (typeof WEEKDAYS)[number];
+
+export const TimeOfDaySchema = z
+  .string()
+  .regex(TIME_PATTERN, "must be HH:MM 24h local time");
+
+export const TemporalWindowEntrySchema = z.object({
+  name: z.string().min(1),
+  weekday: z.array(z.enum(WEEKDAYS)).min(1),
+  start_local: TimeOfDaySchema,
+  end_local: TimeOfDaySchema,
+  max_hooks_per_day: z.number().int().positive().default(1),
+  requires_parental_ok: z.boolean(),
+});
+
+export const TemporalExclusionWindowSchema = z.object({
+  start_local: TimeOfDaySchema,
+  end_local: TimeOfDaySchema,
+});
+
+export const TemporalWindowSchema = z.object({
+  persona_id: z.string().min(1),
+  /** IANA timezone, ex.: "Asia/Tokyo", "America/Sao_Paulo". */
+  timezone: z.string().min(1),
+  windows: z.array(TemporalWindowEntrySchema),
+  /** Nunca dispara dentro da sleep window (wrap-around aceito). */
+  sleep_window: TemporalExclusionWindowSchema.optional(),
+  /** Nunca dispara dentro da school window. */
+  school_window: TemporalExclusionWindowSchema.optional(),
+});
+
+export type TemporalWindowEntry = z.infer<typeof TemporalWindowEntrySchema>;
+export type TemporalExclusionWindow = z.infer<typeof TemporalExclusionWindowSchema>;
+export type TemporalWindow = z.infer<typeof TemporalWindowSchema>;


### PR DESCRIPTION
Implementa spec **B1 — Hooks temporais JP/BR + continuidade narrativa**.

Spec: `ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md`

## O que entra

- `shared/src/contracts/temporal-window.ts` — `TemporalWindow` schema + Zod (timezone IANA, janelas por weekday, sleep/school exclusions).
- `shared/src/contracts/narrative-thread.ts` — `NarrativeThread` schema + Zod (open|resumed|closed_natural|closed_abandoned|stale).
- `motor-execucao/src/narrative-thread-repo.ts` — SQLite repo `kids_narrative_threads`: `openThread`, `resumeThread`, `closeThread`, `listOpen`, `markStale`, `getThread`, DDL exportado.
- `orchestrator/src/temporal-scheduler.ts` — scheduler in-orchestrator, `tickScheduler(deps)`. 4 triggers em ordem: objective due → thread open → card uncelebrated → Pulso fallback. Gates: cooldown 6h, sacrifice budget ≥20, max_hooks_per_day, parental consent (Kids), sleep+school exclusion. `createInMemoryStateStore()` para testes/F0; SQLite-backed store pode vir depois.
- `orchestrator/src/pulso-emitter.ts` — Pulso reposicionado como ritual de retorno B1: omikuji virtual (adult) vs mini-história 2 linhas (kid); seedable PRNG (mulberry32) para testes determinísticos.
- `fixtures/temporal-windows/{ryo,kei,saki,yuji}-ochiai.yaml` — exemplos por persona conforme spec.

## Decisões da spec (defaults CC ratificados em bloco)

- Scheduler: módulo dentro do orchestrator, polling 60s default (`DEFAULT_POLL_INTERVAL_MS`).
- Janelas: per-persona em `fixtures/temporal-windows/*.yaml`.
- Stale threshold: 7 dias após `opened_at` (override por thread em `openThread.stale_after`).
- Pulso fallback: dispara só quando nenhum outro trigger casa.
- Idempotência: `SchedulerStateStore.setLastEmittedAt` persiste — restart não duplica.

## Pulso reposicionado

`pragmatic-selector.ts` mantém o campo `pulso_emitted: boolean` (semântica preservada para trace antigo). O Pulso passa a ser emitido EM PARALELO pelo `pulso-emitter.ts` quando o scheduler decide fallback — não modifica o seletor.

## Tests

| Arquivo | Tests | Cobertura |
|---|---|---|
| `motor-execucao/tests/narrative-thread-repo.unit.test.ts` | 10 | CRUD round-trip + status transitions + markStale |
| `orchestrator/tests/temporal-scheduler.unit.test.ts` | 15 | janela fechada, triggers em ordem, cooldown 6h, sacrifice budget gate, parental gate, max_hooks/day, idempotência |
| `orchestrator/tests/pulso-emitter.unit.test.ts` | 4 | omikuji adult vs mini-história kid + determinismo seedável |

Build: `npm run build -ws` ✅
Tests: shared 896 ✅ | motor-execucao 186 ✅ | orchestrator 167 ✅

## Não-objetivos (v0)

- WhatsApp/email push (depende de motor-channels).
- ML para janela ótima — fixo por config.
- Hooks de grupo Ryo+Kei.
- Wiring no `daemon.ts` (módulo standalone; consumidor liga quando spec validar).

## Pré-requisitos cross-PR

- `DeclaredObjective` (spec S1 separada) — para trigger #1; scheduler aceita injetar `hasObjectiveDue` via deps, então funciona standalone.

🌳 Atrair não é interromper — é estar onde o ritmo já está.