### PR TITLE
[motor] B2 — Drilling primer + JP-PT vocab N5 (50 items)

### DIFF
--- a/fixtures/banks/ja-pt-vocab-n5.yaml
+++ b/fixtures/banks/ja-pt-vocab-n5.yaml
@@ -1,0 +1,401 @@
+# JLPT N5 — vocabulário básico JP → PT-BR (50 items)
+# Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+# Curado por Jun pra família Yuji (Ryo 8, Kei 6, Saki 4).
+# difficulty 1 = kana puro / katakana; difficulty 2 = kanji básico N5.
+bank_id: ja-pt-vocab-n5
+title: "Vocabulário básico JP-PT (JLPT N5)"
+curator: jun
+license: CC-BY-SA
+target_personas:
+  - ryo-ochiai
+  - kei-ochiai
+  - saki-ochiai
+items:
+  # ── Frutas / comidas (10) ───────────────────────────────────────────────
+  - id: jpv-001
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "りんご"
+      answer: "maçã"
+      accept_variants: ["maca"]
+  - id: jpv-002
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "バナナ"
+      answer: "banana"
+  - id: jpv-003
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "パン"
+      answer: "pão"
+      accept_variants: ["pao"]
+  - id: jpv-004
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "みかん"
+      answer: "tangerina"
+      accept_variants: ["mexerica"]
+  - id: jpv-005
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "いちご"
+      answer: "morango"
+  - id: jpv-006
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "ぶどう"
+      answer: "uva"
+  - id: jpv-007
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "すいか"
+      answer: "melancia"
+  - id: jpv-008
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "ごはん"
+      answer: "arroz"
+      accept_variants: ["comida"]
+  - id: jpv-009
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "みず"
+      answer: "água"
+      accept_variants: ["agua"]
+  - id: jpv-010
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "たまご"
+      answer: "ovo"
+
+  # ── Animais (10) ────────────────────────────────────────────────────────
+  - id: jpv-011
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "犬"
+      answer: "cachorro"
+      accept_variants: ["cão", "cao"]
+  - id: jpv-012
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "猫"
+      answer: "gato"
+  - id: jpv-013
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "鳥"
+      answer: "pássaro"
+      accept_variants: ["passaro"]
+  - id: jpv-014
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "魚"
+      answer: "peixe"
+  - id: jpv-015
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "うさぎ"
+      answer: "coelho"
+  - id: jpv-016
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "うま"
+      answer: "cavalo"
+  - id: jpv-017
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "ぞう"
+      answer: "elefante"
+  - id: jpv-018
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "ねずみ"
+      answer: "rato"
+  - id: jpv-019
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "くま"
+      answer: "urso"
+  - id: jpv-020
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "へび"
+      answer: "cobra"
+
+  # ── Família / pessoas (10) ──────────────────────────────────────────────
+  - id: jpv-021
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "お母さん"
+      answer: "mãe"
+      accept_variants: ["mae", "okaasan"]
+  - id: jpv-022
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "お父さん"
+      answer: "pai"
+      accept_variants: ["otousan"]
+  - id: jpv-023
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "おにいさん"
+      answer: "irmão mais velho"
+      accept_variants: ["irmao mais velho", "irmão", "irmao"]
+  - id: jpv-024
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "おねえさん"
+      answer: "irmã mais velha"
+      accept_variants: ["irma mais velha", "irmã", "irma"]
+  - id: jpv-025
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "おじいさん"
+      answer: "avô"
+      accept_variants: ["avo", "vovô", "vovo"]
+  - id: jpv-026
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "おばあさん"
+      answer: "avó"
+      accept_variants: ["avo", "vovó"]
+  - id: jpv-027
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "友達"
+      answer: "amigo"
+      accept_variants: ["amiga"]
+  - id: jpv-028
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "先生"
+      answer: "professor"
+      accept_variants: ["professora", "sensei"]
+  - id: jpv-029
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "子供"
+      answer: "criança"
+      accept_variants: ["crianca"]
+  - id: jpv-030
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "学生"
+      answer: "estudante"
+      accept_variants: ["aluno", "aluna"]
+
+  # ── Cores / números (10) ────────────────────────────────────────────────
+  - id: jpv-031
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "赤"
+      answer: "vermelho"
+      accept_variants: ["vermelha"]
+  - id: jpv-032
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "青"
+      answer: "azul"
+  - id: jpv-033
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "白"
+      answer: "branco"
+      accept_variants: ["branca"]
+  - id: jpv-034
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "黒"
+      answer: "preto"
+      accept_variants: ["preta"]
+  - id: jpv-035
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "黄色"
+      answer: "amarelo"
+      accept_variants: ["amarela"]
+  - id: jpv-036
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "一"
+      answer: "um"
+      accept_variants: ["uma", "1"]
+  - id: jpv-037
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "二"
+      answer: "dois"
+      accept_variants: ["duas", "2"]
+  - id: jpv-038
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "三"
+      answer: "três"
+      accept_variants: ["tres", "3"]
+  - id: jpv-039
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "四"
+      answer: "quatro"
+      accept_variants: ["4"]
+  - id: jpv-040
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 2
+    payload:
+      prompt: "五"
+      answer: "cinco"
+      accept_variants: ["5"]
+
+  # ── Verbos básicos hiragana (10) ────────────────────────────────────────
+  - id: jpv-041
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "たべる"
+      answer: "comer"
+  - id: jpv-042
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "のむ"
+      answer: "beber"
+  - id: jpv-043
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "みる"
+      answer: "ver"
+      accept_variants: ["olhar", "assistir"]
+  - id: jpv-044
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "きく"
+      answer: "ouvir"
+      accept_variants: ["escutar"]
+  - id: jpv-045
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "はなす"
+      answer: "falar"
+      accept_variants: ["conversar"]
+  - id: jpv-046
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "よむ"
+      answer: "ler"
+  - id: jpv-047
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "かく"
+      answer: "escrever"
+  - id: jpv-048
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "いく"
+      answer: "ir"
+  - id: jpv-049
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "くる"
+      answer: "vir"
+  - id: jpv-050
+    type: vocab
+    axis: language.jp_pt
+    difficulty: 1
+    payload:
+      prompt: "する"
+      answer: "fazer"

--- a/motor-drota/src/drill-fuzzy-match.ts
+++ b/motor-drota/src/drill-fuzzy-match.ts
@@ -1,0 +1,72 @@
+/**
+ * drill-fuzzy-match — validação de resposta para items B2 (Drilling).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ *
+ * Strictness default (Jun ratify 2026-05-26):
+ *  - Normaliza lowercase + remove acentos.
+ *  - Match contra `payload.answer` + `payload.accept_variants`.
+ *  - `slow_correct` quando latency > threshold (default 5s).
+ *
+ * Sem dependência de LLM — match local, determinístico.
+ */
+
+import type { DrillItem } from "@ascendimacy/shared";
+
+export interface FuzzyMatchResult {
+  correct: boolean;
+  latency_ms: number;
+  response_type: "correct" | "slow_correct" | "incorrect";
+}
+
+export interface FuzzyMatchOpts {
+  /** Acima deste limite, `correct` vira `slow_correct`. Default 5000ms. */
+  slowThresholdMs?: number;
+}
+
+const DEFAULT_SLOW_THRESHOLD_MS = 5000;
+
+/**
+ * Lowercase + strip Latin diacritics + collapse spaces.
+ *
+ * NFC re-compose ao final preserva caracteres não-latinos cujo NFD decompõe
+ * para `base + combining-mark` fora da faixa U+0300–U+036F (ex.: dakuten
+ * japonês U+3099 em `ご`).
+ */
+export function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .normalize("NFC")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function matchDrillAnswer(
+  item: DrillItem,
+  userResponse: string,
+  latencyMs: number,
+  opts: FuzzyMatchOpts = {},
+): FuzzyMatchResult {
+  const slow = opts.slowThresholdMs ?? DEFAULT_SLOW_THRESHOLD_MS;
+  const normUser = normalize(userResponse);
+  const candidates = [
+    item.payload.answer,
+    ...(item.payload.accept_variants ?? []),
+  ];
+  const correct = candidates.some((c) => normalize(c) === normUser);
+
+  if (!correct) {
+    return {
+      correct: false,
+      latency_ms: latencyMs,
+      response_type: "incorrect",
+    };
+  }
+  return {
+    correct: true,
+    latency_ms: latencyMs,
+    response_type: latencyMs > slow ? "slow_correct" : "correct",
+  };
+}

--- a/motor-drota/tests/drill-fuzzy-match.unit.test.ts
+++ b/motor-drota/tests/drill-fuzzy-match.unit.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchDrillAnswer,
+  normalize,
+} from "../src/drill-fuzzy-match.js";
+import type { DrillItem } from "@ascendimacy/shared";
+
+function makeItem(
+  answer: string,
+  accept_variants?: string[],
+): DrillItem {
+  return {
+    id: "test-001",
+    bank_id: "test-bank",
+    type: "vocab",
+    axis: "language.jp_pt",
+    difficulty: 1,
+    payload: { prompt: "りんご", answer, accept_variants },
+  };
+}
+
+describe("normalize", () => {
+  it("lowercase + remove acentos", () => {
+    expect(normalize("Maçã")).toBe("maca");
+    expect(normalize("PÃO")).toBe("pao");
+    expect(normalize("três")).toBe("tres");
+  });
+
+  it("colapsa espaços + trim", () => {
+    expect(normalize("  hello   world  ")).toBe("hello world");
+  });
+
+  it("preserva caracteres não-latinos", () => {
+    expect(normalize("りんご")).toBe("りんご");
+  });
+});
+
+describe("matchDrillAnswer", () => {
+  it("exact match → correct", () => {
+    const r = matchDrillAnswer(makeItem("maçã"), "maçã", 1000);
+    expect(r.correct).toBe(true);
+    expect(r.response_type).toBe("correct");
+  });
+
+  it("acento ignorado: 'maca' = 'maçã'", () => {
+    const r = matchDrillAnswer(makeItem("maçã"), "maca", 1000);
+    expect(r.correct).toBe(true);
+    expect(r.response_type).toBe("correct");
+  });
+
+  it("case-insensitive", () => {
+    const r = matchDrillAnswer(makeItem("Maçã"), "MAÇÃ", 1000);
+    expect(r.correct).toBe(true);
+  });
+
+  it("accept_variants match", () => {
+    const r = matchDrillAnswer(
+      makeItem("cachorro", ["cão", "cao"]),
+      "cão",
+      1000,
+    );
+    expect(r.correct).toBe(true);
+  });
+
+  it("variant normalizado também faz match", () => {
+    const r = matchDrillAnswer(
+      makeItem("cachorro", ["cão"]),
+      "cao",
+      1000,
+    );
+    expect(r.correct).toBe(true);
+  });
+
+  it("no match → incorrect", () => {
+    const r = matchDrillAnswer(makeItem("maçã"), "banana", 1000);
+    expect(r.correct).toBe(false);
+    expect(r.response_type).toBe("incorrect");
+  });
+
+  it("slow_correct quando latency > threshold default (5s)", () => {
+    const r = matchDrillAnswer(makeItem("maçã"), "maca", 6000);
+    expect(r.correct).toBe(true);
+    expect(r.response_type).toBe("slow_correct");
+  });
+
+  it("override slowThresholdMs", () => {
+    const fast = matchDrillAnswer(makeItem("maçã"), "maca", 2500, {
+      slowThresholdMs: 3000,
+    });
+    expect(fast.response_type).toBe("correct");
+
+    const slow = matchDrillAnswer(makeItem("maçã"), "maca", 3500, {
+      slowThresholdMs: 3000,
+    });
+    expect(slow.response_type).toBe("slow_correct");
+  });
+
+  it("latency preservada no result", () => {
+    const r = matchDrillAnswer(makeItem("x"), "x", 1234);
+    expect(r.latency_ms).toBe(1234);
+  });
+
+  it("trim leading/trailing spaces", () => {
+    const r = matchDrillAnswer(makeItem("maçã"), "  maca  ", 500);
+    expect(r.correct).toBe(true);
+  });
+});

--- a/motor-execucao/src/drill-repo.ts
+++ b/motor-execucao/src/drill-repo.ts
@@ -1,0 +1,288 @@
+/**
+ * drill-repo — persistência + carregamento de banks para B2 (Drilling).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ *
+ * Tabelas:
+ *  - `drill_states`  → estado per (persona_id, item_id), com SR + mastery.
+ *  - `drill_attempts` → log append-only por audit/análise.
+ *
+ * `loadBank(bankId)` lê fixture YAML e denormaliza `bank_id` em cada item.
+ */
+
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import yaml from "js-yaml";
+import type Database from "better-sqlite3";
+import {
+  DEFAULT_EASINESS,
+  DrillBankSchema,
+  isMastered,
+  nextInterval,
+  type DrillBank,
+  type DrillItem,
+  type DrillResponse,
+  type DrillState,
+  type SrResponse,
+} from "@ascendimacy/shared";
+import { getNow } from "./clock.js";
+
+export const DRILL_STATES_DDL = `
+CREATE TABLE IF NOT EXISTS drill_states (
+  persona_id TEXT NOT NULL,
+  item_id TEXT NOT NULL,
+  presented_count INTEGER NOT NULL DEFAULT 0,
+  correct_count INTEGER NOT NULL DEFAULT 0,
+  last_seen_at TEXT NOT NULL,
+  next_due_at TEXT NOT NULL,
+  current_interval_days REAL NOT NULL DEFAULT 0,
+  current_easiness REAL NOT NULL DEFAULT 2.5,
+  mastery_reached_at TEXT,
+  last_5_attempts_json TEXT NOT NULL DEFAULT '[]',
+  PRIMARY KEY (persona_id, item_id)
+);
+CREATE INDEX IF NOT EXISTS idx_drill_states_due ON drill_states(persona_id, next_due_at);
+CREATE INDEX IF NOT EXISTS idx_drill_states_mastery ON drill_states(persona_id, mastery_reached_at);
+
+CREATE TABLE IF NOT EXISTS drill_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  persona_id TEXT NOT NULL,
+  item_id TEXT NOT NULL,
+  response TEXT NOT NULL,
+  latency_ms INTEGER,
+  attempted_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_drill_attempts_persona ON drill_attempts(persona_id, attempted_at);
+CREATE INDEX IF NOT EXISTS idx_drill_attempts_item ON drill_attempts(persona_id, item_id, attempted_at);
+`;
+
+interface DrillStateRow {
+  persona_id: string;
+  item_id: string;
+  presented_count: number;
+  correct_count: number;
+  last_seen_at: string;
+  next_due_at: string;
+  current_interval_days: number;
+  current_easiness: number;
+  mastery_reached_at: string | null;
+  last_5_attempts_json: string;
+}
+
+export interface DrillAttemptRow {
+  id: number;
+  persona_id: string;
+  item_id: string;
+  response: DrillResponse;
+  latency_ms: number | null;
+  attempted_at: string;
+}
+
+const DEFAULT_BANKS_ROOT = "fixtures/banks";
+
+function rowToState(row: DrillStateRow): DrillState {
+  return {
+    persona_id: row.persona_id,
+    item_id: row.item_id,
+    presented_count: row.presented_count,
+    correct_count: row.correct_count,
+    last_seen_at: row.last_seen_at,
+    next_due_at: row.next_due_at,
+    current_interval_days: row.current_interval_days,
+    current_easiness: row.current_easiness,
+    mastery_reached_at: row.mastery_reached_at,
+    last_5_attempts: JSON.parse(row.last_5_attempts_json) as DrillResponse[],
+  };
+}
+
+function addDays(iso: string, days: number): string {
+  const t = new Date(iso).getTime();
+  return new Date(t + days * 86_400_000).toISOString();
+}
+
+/**
+ * Carrega banco YAML.
+ * - Se `bankIdOrPath` for absoluto → usa direto.
+ * - Se terminar em `.yaml` → resolve relativo a `opts.root` (default `fixtures/banks`).
+ * - Caso contrário → resolve `{root}/{bankId}.yaml`.
+ *
+ * Retorna `{bank, items}`. Items vêm com `bank_id` injetado (denormalizado).
+ */
+export function loadBank(
+  bankIdOrPath: string,
+  opts: { root?: string } = {},
+): { bank: DrillBank; items: DrillItem[] } {
+  const root = opts.root ?? DEFAULT_BANKS_ROOT;
+  const path = isAbsolute(bankIdOrPath)
+    ? bankIdOrPath
+    : bankIdOrPath.endsWith(".yaml")
+      ? resolve(root, bankIdOrPath)
+      : resolve(root, `${bankIdOrPath}.yaml`);
+  const raw = readFileSync(path, "utf-8");
+  const parsed = yaml.load(raw);
+  const bank = DrillBankSchema.parse(parsed);
+  const items: DrillItem[] = bank.items.map((it) => ({
+    ...it,
+    bank_id: bank.bank_id,
+  }));
+  return { bank, items };
+}
+
+export function getState(
+  db: Database.Database,
+  personaId: string,
+  itemId: string,
+): DrillState | null {
+  const row = db
+    .prepare("SELECT * FROM drill_states WHERE persona_id = ? AND item_id = ?")
+    .get(personaId, itemId) as DrillStateRow | undefined;
+  return row ? rowToState(row) : null;
+}
+
+function saveState(db: Database.Database, state: DrillState): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO drill_states
+      (persona_id, item_id, presented_count, correct_count,
+       last_seen_at, next_due_at, current_interval_days, current_easiness,
+       mastery_reached_at, last_5_attempts_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    state.persona_id,
+    state.item_id,
+    state.presented_count,
+    state.correct_count,
+    state.last_seen_at,
+    state.next_due_at,
+    state.current_interval_days,
+    state.current_easiness,
+    state.mastery_reached_at ?? null,
+    JSON.stringify(state.last_5_attempts),
+  );
+}
+
+/**
+ * Registra uma tentativa: insere em `drill_attempts` (audit log) e atualiza
+ * o `drill_states` correspondente via SM-2. Retorna o state pós-update.
+ *
+ * - `timeout` é mapeado para `incorrect` no algoritmo SR (intervalo reset).
+ * - `mastery_reached_at` é gravado uma única vez (evento, não estado).
+ */
+export function recordAttempt(
+  db: Database.Database,
+  args: {
+    personaId: string;
+    itemId: string;
+    response: DrillResponse;
+    latencyMs?: number;
+    nowIso?: string;
+  },
+): DrillState {
+  const ts = getNow(args.nowIso);
+
+  db.prepare(
+    `INSERT INTO drill_attempts (persona_id, item_id, response, latency_ms, attempted_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    args.personaId,
+    args.itemId,
+    args.response,
+    args.latencyMs ?? null,
+    ts,
+  );
+
+  const prior: DrillState = getState(db, args.personaId, args.itemId) ?? {
+    persona_id: args.personaId,
+    item_id: args.itemId,
+    presented_count: 0,
+    correct_count: 0,
+    last_seen_at: ts,
+    next_due_at: ts,
+    current_interval_days: 0,
+    current_easiness: DEFAULT_EASINESS,
+    mastery_reached_at: null,
+    last_5_attempts: [],
+  };
+
+  const srResponse: SrResponse =
+    args.response === "timeout" ? "incorrect" : args.response;
+  const { next_interval_days, next_easiness } = nextInterval(prior, srResponse);
+
+  const newLast5: DrillResponse[] = [
+    ...prior.last_5_attempts,
+    args.response,
+  ].slice(-5);
+
+  const wasCorrect =
+    args.response === "correct" || args.response === "slow_correct";
+
+  const updated: DrillState = {
+    ...prior,
+    presented_count: prior.presented_count + 1,
+    correct_count: prior.correct_count + (wasCorrect ? 1 : 0),
+    last_seen_at: ts,
+    next_due_at: addDays(ts, next_interval_days),
+    current_interval_days: next_interval_days,
+    current_easiness: next_easiness,
+    last_5_attempts: newLast5,
+  };
+
+  if (!updated.mastery_reached_at && isMastered(updated)) {
+    updated.mastery_reached_at = ts;
+  }
+
+  saveState(db, updated);
+  return updated;
+}
+
+export function listDue(
+  db: Database.Database,
+  personaId: string,
+  nowIso?: string,
+): DrillState[] {
+  const now = getNow(nowIso);
+  const rows = db
+    .prepare(
+      `SELECT * FROM drill_states
+       WHERE persona_id = ? AND next_due_at <= ?
+       ORDER BY next_due_at ASC`,
+    )
+    .all(personaId, now) as DrillStateRow[];
+  return rows.map(rowToState);
+}
+
+export function listMastered(
+  db: Database.Database,
+  personaId: string,
+): DrillState[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM drill_states
+       WHERE persona_id = ? AND mastery_reached_at IS NOT NULL
+       ORDER BY mastery_reached_at ASC`,
+    )
+    .all(personaId) as DrillStateRow[];
+  return rows.map(rowToState);
+}
+
+export function listAttempts(
+  db: Database.Database,
+  personaId: string,
+  itemId?: string,
+): DrillAttemptRow[] {
+  if (itemId !== undefined) {
+    return db
+      .prepare(
+        `SELECT * FROM drill_attempts
+         WHERE persona_id = ? AND item_id = ?
+         ORDER BY attempted_at ASC, id ASC`,
+      )
+      .all(personaId, itemId) as DrillAttemptRow[];
+  }
+  return db
+    .prepare(
+      `SELECT * FROM drill_attempts
+       WHERE persona_id = ?
+       ORDER BY attempted_at ASC, id ASC`,
+    )
+    .all(personaId) as DrillAttemptRow[];
+}

--- a/motor-execucao/tests/drill-repo.unit.test.ts
+++ b/motor-execucao/tests/drill-repo.unit.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import {
+  DRILL_STATES_DDL,
+  getState,
+  listAttempts,
+  listDue,
+  listMastered,
+  loadBank,
+  recordAttempt,
+} from "../src/drill-repo.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(DRILL_STATES_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+const PERSONA = "ryo-ochiai";
+const ITEM = "jpv-001";
+
+describe("drill-repo CRUD", () => {
+  it("getState retorna null quando não há estado", () => {
+    expect(getState(db, PERSONA, ITEM)).toBeNull();
+  });
+
+  it("recordAttempt cria estado novo na 1ª tentativa", () => {
+    const now = "2026-05-26T10:00:00.000Z";
+    const state = recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: ITEM,
+      response: "correct",
+      latencyMs: 1200,
+      nowIso: now,
+    });
+    expect(state.presented_count).toBe(1);
+    expect(state.correct_count).toBe(1);
+    expect(state.current_interval_days).toBe(1);
+    expect(state.current_easiness).toBeCloseTo(2.6, 5);
+    expect(state.last_seen_at).toBe(now);
+    expect(state.last_5_attempts).toEqual(["correct"]);
+
+    const persisted = getState(db, PERSONA, ITEM);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.presented_count).toBe(1);
+  });
+
+  it("recordAttempt incorrect reset interval + easiness cai", () => {
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: ITEM,
+      response: "correct",
+      nowIso: "2026-05-26T10:00:00.000Z",
+    });
+    const after = recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: ITEM,
+      response: "incorrect",
+      nowIso: "2026-05-27T10:00:00.000Z",
+    });
+    expect(after.current_interval_days).toBe(1);
+    expect(after.current_easiness).toBeCloseTo(2.4, 5); // 2.6 - 0.2
+    expect(after.presented_count).toBe(2);
+    expect(after.correct_count).toBe(1);
+  });
+
+  it("last_5_attempts mantém janela de 5", () => {
+    const responses = [
+      "correct",
+      "incorrect",
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+    ] as const;
+    for (const [i, r] of responses.entries()) {
+      recordAttempt(db, {
+        personaId: PERSONA,
+        itemId: ITEM,
+        response: r,
+        nowIso: `2026-05-${20 + i}T10:00:00.000Z`,
+      });
+    }
+    const final = getState(db, PERSONA, ITEM)!;
+    expect(final.last_5_attempts).toHaveLength(5);
+    // últimas 5 = correct, correct, correct, correct, correct
+    expect(final.last_5_attempts).toEqual([
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+    ]);
+  });
+
+  it("recordAttempt registra mastery_reached_at uma vez", () => {
+    // Sequência: 5 correct com intervals progressivos > 7d.
+    // Como cada correct multiplica intervalo, basta 4-5 corretos pra chegar lá.
+    let now = new Date("2026-05-01T10:00:00.000Z");
+    for (let i = 0; i < 5; i++) {
+      recordAttempt(db, {
+        personaId: PERSONA,
+        itemId: ITEM,
+        response: "correct",
+        nowIso: now.toISOString(),
+      });
+      now = new Date(now.getTime() + 30 * 86_400_000);
+    }
+    const state = getState(db, PERSONA, ITEM)!;
+    expect(state.mastery_reached_at).not.toBeNull();
+    expect(state.current_interval_days).toBeGreaterThanOrEqual(7);
+
+    // Próxima attempt não deve resetar mastery timestamp.
+    const masteryTs = state.mastery_reached_at;
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: ITEM,
+      response: "correct",
+      nowIso: now.toISOString(),
+    });
+    const after = getState(db, PERSONA, ITEM)!;
+    expect(after.mastery_reached_at).toBe(masteryTs);
+  });
+
+  it("listDue retorna apenas items com next_due_at <= now", () => {
+    // Item A: due imediatamente (incorrect = interval 1d)
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: "item-a",
+      response: "incorrect",
+      nowIso: "2026-05-01T10:00:00.000Z",
+    });
+    // Item B: muito no futuro (5 acertos seguidos → interval cresce)
+    let ts = new Date("2026-05-01T10:00:00.000Z");
+    for (let i = 0; i < 4; i++) {
+      recordAttempt(db, {
+        personaId: PERSONA,
+        itemId: "item-b",
+        response: "correct",
+        nowIso: ts.toISOString(),
+      });
+      ts = new Date(ts.getTime() + 30 * 86_400_000);
+    }
+
+    const due = listDue(db, PERSONA, "2026-05-03T10:00:00.000Z");
+    expect(due.map((s) => s.item_id)).toContain("item-a");
+    expect(due.map((s) => s.item_id)).not.toContain("item-b");
+  });
+
+  it("listDue isola por persona", () => {
+    recordAttempt(db, {
+      personaId: "ryo",
+      itemId: "x",
+      response: "incorrect",
+      nowIso: "2026-05-01T10:00:00.000Z",
+    });
+    recordAttempt(db, {
+      personaId: "kei",
+      itemId: "y",
+      response: "incorrect",
+      nowIso: "2026-05-01T10:00:00.000Z",
+    });
+    const ryoDue = listDue(db, "ryo", "2026-05-10T10:00:00.000Z");
+    expect(ryoDue).toHaveLength(1);
+    expect(ryoDue[0]!.item_id).toBe("x");
+  });
+
+  it("listMastered retorna apenas items com mastery_reached_at", () => {
+    // Item masterizado
+    let ts = new Date("2026-05-01T10:00:00.000Z");
+    for (let i = 0; i < 5; i++) {
+      recordAttempt(db, {
+        personaId: PERSONA,
+        itemId: "item-mastered",
+        response: "correct",
+        nowIso: ts.toISOString(),
+      });
+      ts = new Date(ts.getTime() + 30 * 86_400_000);
+    }
+    // Item ainda não masterizado
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: "item-fresh",
+      response: "correct",
+      nowIso: "2026-05-01T10:00:00.000Z",
+    });
+
+    const mastered = listMastered(db, PERSONA);
+    expect(mastered.map((s) => s.item_id)).toEqual(["item-mastered"]);
+  });
+
+  it("listAttempts retorna log na ordem (audit)", () => {
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: ITEM,
+      response: "incorrect",
+      latencyMs: 8000,
+      nowIso: "2026-05-01T10:00:00.000Z",
+    });
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: ITEM,
+      response: "correct",
+      latencyMs: 1500,
+      nowIso: "2026-05-02T10:00:00.000Z",
+    });
+    const log = listAttempts(db, PERSONA, ITEM);
+    expect(log).toHaveLength(2);
+    expect(log[0]!.response).toBe("incorrect");
+    expect(log[0]!.latency_ms).toBe(8000);
+    expect(log[1]!.response).toBe("correct");
+  });
+
+  it("listAttempts sem itemId retorna todos do persona", () => {
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: "a",
+      response: "correct",
+      nowIso: "2026-05-01T10:00:00.000Z",
+    });
+    recordAttempt(db, {
+      personaId: PERSONA,
+      itemId: "b",
+      response: "incorrect",
+      nowIso: "2026-05-02T10:00:00.000Z",
+    });
+    expect(listAttempts(db, PERSONA)).toHaveLength(2);
+  });
+});
+
+describe("loadBank — ja-pt-vocab-n5", () => {
+  const FIXTURE = resolve(
+    process.cwd(),
+    "../fixtures/banks/ja-pt-vocab-n5.yaml",
+  );
+  // motor-execucao roda testes com CWD = motor-execucao/, então sobe um nível.
+  // Tentamos ambos pra robustez quando vitest é executado da raiz.
+  const ALT_FIXTURE = resolve(
+    process.cwd(),
+    "fixtures/banks/ja-pt-vocab-n5.yaml",
+  );
+
+  function loadFixture() {
+    try {
+      return loadBank(FIXTURE);
+    } catch {
+      return loadBank(ALT_FIXTURE);
+    }
+  }
+
+  it("carrega 50 items válidos com bank_id denormalizado", () => {
+    const { bank, items } = loadFixture();
+    expect(bank.bank_id).toBe("ja-pt-vocab-n5");
+    expect(items).toHaveLength(50);
+    for (const item of items) {
+      expect(item.bank_id).toBe("ja-pt-vocab-n5");
+      expect(item.axis).toBe("language.jp_pt");
+      expect([1, 2]).toContain(item.difficulty);
+      expect(item.payload.prompt.length).toBeGreaterThan(0);
+      expect(item.payload.answer.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("ids são únicos no banco", () => {
+    const { items } = loadFixture();
+    const ids = new Set(items.map((it) => it.id));
+    expect(ids.size).toBe(items.length);
+  });
+});

--- a/orchestrator/src/drill-orchestrator.ts
+++ b/orchestrator/src/drill-orchestrator.ts
@@ -1,0 +1,63 @@
+/**
+ * drill-orchestrator — propõe candidatos B2 (Drilling) para o S3 decidir.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ *
+ * Filosofia: B2 propõe, S3 decide se cabe na sessão. Drill respeita
+ * sacrifice budget — não rouba tempo do núcleo S1-S5.
+ *
+ * `proposeDrillItem` é pura (sem DB). Caller carrega `listDue` + banks
+ * antes e passa o contexto. Mantém testabilidade + desacoplamento do
+ * motor-execucao (orchestrator não importa direto do workspace dele).
+ */
+
+import type { DrillItem, DrillState } from "@ascendimacy/shared";
+
+/** Hook descritor — usado pelo S3 quando aceita a proposta. */
+export const DRILL_WINDOW_HOOK = "drill_window_proposal" as const;
+export type DrillWindowHook = typeof DRILL_WINDOW_HOOK;
+
+/** Custo default por item em sacrifice points (spec default = 2). */
+export const DEFAULT_DRILL_COST = 2;
+
+export interface DrillProposalContext {
+  personaId: string;
+  /** States due ordenados por `next_due_at ASC` (saída de `listDue`). */
+  dueStates: DrillState[];
+  /** Lookup item_id → DrillItem dos banks já carregados na sessão. */
+  itemsById: Map<string, DrillItem>;
+  /** Sacrifice budget atual do aprendiz. */
+  budget: number;
+  /** Override do custo por item; default `DEFAULT_DRILL_COST`. */
+  costPerItem?: number;
+}
+
+export interface DrillProposal {
+  hook: DrillWindowHook;
+  item: DrillItem;
+  state: DrillState;
+  cost: number;
+}
+
+/**
+ * Retorna até 1 item due, respeitando sacrifice budget gate.
+ *
+ * Estratégia v0:
+ *  - Skip se budget < cost (gate explícito).
+ *  - Pega o mais atrasado (primeiro de `dueStates`, já ordenado por due).
+ *  - Skip items sem entrada em `itemsById` (banco não carregado).
+ *  - Retorna `null` se nenhum item match.
+ */
+export function proposeDrillItem(
+  ctx: DrillProposalContext,
+): DrillProposal | null {
+  const cost = ctx.costPerItem ?? DEFAULT_DRILL_COST;
+  if (ctx.budget < cost) return null;
+  for (const state of ctx.dueStates) {
+    const item = ctx.itemsById.get(state.item_id);
+    if (item) {
+      return { hook: DRILL_WINDOW_HOOK, item, state, cost };
+    }
+  }
+  return null;
+}

--- a/shared/src/contracts/drill-item.ts
+++ b/shared/src/contracts/drill-item.ts
@@ -1,0 +1,78 @@
+/**
+ * DrillItem — unidade atômica do subsistema B2 (Drilling).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ *
+ * B2 é paralelo a S1-S5. Items são declarativos, curados, agrupados em banks.
+ * LLM aqui não decide o item — apenas materializa variantes ao redor dele.
+ */
+
+import { z } from "zod";
+
+export const DRILL_ITEM_TYPES = ["vocab", "fact", "pattern"] as const;
+export const DrillItemTypeSchema = z.enum(DRILL_ITEM_TYPES);
+export type DrillItemType = z.infer<typeof DrillItemTypeSchema>;
+
+export const DrillDifficultySchema = z.union([
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5),
+]);
+export type DrillDifficulty = z.infer<typeof DrillDifficultySchema>;
+
+export const DRILL_REGISTERS = ["casual", "formal"] as const;
+export const DrillRegisterSchema = z.enum(DRILL_REGISTERS);
+export type DrillRegister = z.infer<typeof DrillRegisterSchema>;
+
+export const DrillItemPayloadSchema = z.object({
+  prompt: z.string().min(1),
+  answer: z.string().min(1),
+  accept_variants: z.array(z.string()).optional(),
+  hint: z.string().optional(),
+  audio_uri: z.string().optional(),
+});
+export type DrillItemPayload = z.infer<typeof DrillItemPayloadSchema>;
+
+export const DrillItemCulturalMetadataSchema = z.object({
+  register: DrillRegisterSchema,
+  domain: z.string().min(1),
+});
+export type DrillItemCulturalMetadata = z.infer<
+  typeof DrillItemCulturalMetadataSchema
+>;
+
+/**
+ * Shape comum a items em banco YAML (sem `bank_id`, herdado do header).
+ * `loadBank` denormaliza injetando `bank_id` em cada item resultante.
+ */
+export const DrillItemBaseSchema = z.object({
+  id: z.string().min(1),
+  type: DrillItemTypeSchema,
+  axis: z.string().min(1),
+  difficulty: DrillDifficultySchema,
+  payload: DrillItemPayloadSchema,
+  prerequisites: z.array(z.string()).optional(),
+  cultural_metadata: DrillItemCulturalMetadataSchema.optional(),
+});
+export type DrillItemBase = z.infer<typeof DrillItemBaseSchema>;
+
+export const DrillItemSchema = DrillItemBaseSchema.extend({
+  bank_id: z.string().min(1),
+});
+export type DrillItem = z.infer<typeof DrillItemSchema>;
+
+export const DrillBankSchema = z.object({
+  bank_id: z.string().min(1),
+  title: z.string().min(1),
+  curator: z.string().min(1),
+  license: z.string().min(1).optional(),
+  target_personas: z.array(z.string()).optional(),
+  items: z.array(DrillItemBaseSchema),
+});
+export type DrillBank = z.infer<typeof DrillBankSchema>;
+
+export function parseDrillBank(raw: unknown): DrillBank {
+  return DrillBankSchema.parse(raw);
+}

--- a/shared/src/contracts/drill-state.ts
+++ b/shared/src/contracts/drill-state.ts
@@ -1,0 +1,46 @@
+/**
+ * DrillState — estado per-aprendiz-per-item do subsistema B2.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ *
+ * Atualizado por `recordAttempt` (motor-execucao/drill-repo).
+ * Algoritmo SR em `shared/sr-algorithm.ts` (SM-2 simplificado).
+ */
+
+import { z } from "zod";
+import { Iso8601DateTime } from "./iso8601.js";
+
+export const DRILL_RESPONSES = [
+  "correct",
+  "incorrect",
+  "timeout",
+  "slow_correct",
+] as const;
+export const DrillResponseSchema = z.enum(DRILL_RESPONSES);
+export type DrillResponse = z.infer<typeof DrillResponseSchema>;
+
+export const DrillStateSchema = z.object({
+  persona_id: z.string().min(1),
+  item_id: z.string().min(1),
+  presented_count: z.number().int().nonnegative(),
+  correct_count: z.number().int().nonnegative(),
+  last_seen_at: Iso8601DateTime,
+  next_due_at: Iso8601DateTime,
+  current_interval_days: z.number().nonnegative(),
+  current_easiness: z.number().min(1.3),
+  mastery_reached_at: Iso8601DateTime.nullable().optional(),
+  last_5_attempts: z.array(DrillResponseSchema).max(5),
+});
+export type DrillState = z.infer<typeof DrillStateSchema>;
+
+/** SM-2 default — easiness inicial pra item novo (sem histórico). */
+export const DEFAULT_EASINESS = 2.5;
+/** Mínimo absoluto do SM-2 — abaixo daqui, o item vira "leech" no Anki tradicional. */
+export const MIN_EASINESS = 1.3;
+
+/** Mastery threshold — 4 de 5 corretos. */
+export const MASTERY_MIN_CORRECT = 4;
+/** Janela considerada pra mastery — últimas 5 attempts. */
+export const MASTERY_WINDOW_SIZE = 5;
+/** Mastery só conta se item já passou ≥7 dias de intervalo. */
+export const MASTERY_MIN_INTERVAL_DAYS = 7;

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -119,3 +119,40 @@ export {
   type MilestoneEvent,
   type MilestoneEventType,
 } from "./milestone-event.js";
+
+// B2 — Drilling primer (banco atômico + SR + mastery)
+// spec ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+export {
+  DRILL_ITEM_TYPES,
+  DRILL_REGISTERS,
+  DrillItemTypeSchema,
+  DrillDifficultySchema,
+  DrillRegisterSchema,
+  DrillItemPayloadSchema,
+  DrillItemCulturalMetadataSchema,
+  DrillItemBaseSchema,
+  DrillItemSchema,
+  DrillBankSchema,
+  parseDrillBank,
+  type DrillItem,
+  type DrillItemBase,
+  type DrillItemType,
+  type DrillDifficulty,
+  type DrillRegister,
+  type DrillItemPayload,
+  type DrillItemCulturalMetadata,
+  type DrillBank,
+} from "./drill-item.js";
+
+export {
+  DRILL_RESPONSES,
+  DrillResponseSchema,
+  DrillStateSchema,
+  DEFAULT_EASINESS,
+  MIN_EASINESS,
+  MASTERY_MIN_CORRECT,
+  MASTERY_WINDOW_SIZE,
+  MASTERY_MIN_INTERVAL_DAYS,
+  type DrillResponse,
+  type DrillState,
+} from "./drill-state.js";

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -47,3 +47,4 @@ export * from "./transitions-schema.js";
 export * from "./gateway-client.js";
 export * from "./contracts/index.js";
 export * from "./parse-repetition-answer.js";
+export * from "./sr-algorithm.js";

--- a/shared/src/sr-algorithm.ts
+++ b/shared/src/sr-algorithm.ts
@@ -1,0 +1,71 @@
+/**
+ * SM-2 simplificado — algoritmo SR para B2 (Drilling).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md §"Algoritmo SR"
+ *
+ * Battle-tested (Anki/SuperMemo), implementação <80 LOC, sem training data
+ * (vs FSRS). Mastery = janela 5 attempts com 4 corretos + intervalo ≥7d.
+ */
+
+import {
+  MIN_EASINESS,
+  MASTERY_MIN_CORRECT,
+  MASTERY_MIN_INTERVAL_DAYS,
+  MASTERY_WINDOW_SIZE,
+  type DrillResponse,
+  type DrillState,
+} from "./contracts/drill-state.js";
+
+export type SrResponse = "correct" | "incorrect" | "slow_correct";
+
+export interface SrResult {
+  next_interval_days: number;
+  next_easiness: number;
+}
+
+/**
+ * Calcula próximo intervalo + easiness dado o estado atual e a resposta.
+ *
+ * - `incorrect`: reset interval=1d, easiness -= 0.2 (floor MIN_EASINESS).
+ * - `correct` (q=5): easiness += 0.1; interval cresce 0→1→3→round(prev*ef).
+ * - `slow_correct` (q=3): easiness levemente cai; interval cresce.
+ */
+export function nextInterval(
+  state: Pick<DrillState, "current_interval_days" | "current_easiness">,
+  response: SrResponse,
+): SrResult {
+  if (response === "incorrect") {
+    return {
+      next_interval_days: 1,
+      next_easiness: Math.max(MIN_EASINESS, state.current_easiness - 0.2),
+    };
+  }
+  const q = response === "correct" ? 5 : 3;
+  const ef = Math.max(
+    MIN_EASINESS,
+    state.current_easiness + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02)),
+  );
+  const next =
+    state.current_interval_days === 0
+      ? 1
+      : state.current_interval_days === 1
+        ? 3
+        : Math.round(state.current_interval_days * ef);
+  return { next_interval_days: next, next_easiness: ef };
+}
+
+/**
+ * Mastery = evento, não estado. True quando a janela das últimas 5 attempts
+ * contém ≥4 corretas E o intervalo atual já é ≥7d (descarta acertos rasos).
+ */
+export function isMastered(
+  state: Pick<DrillState, "last_5_attempts" | "current_interval_days">,
+): boolean {
+  if (state.last_5_attempts.length < MASTERY_WINDOW_SIZE) return false;
+  const correctCount = state.last_5_attempts.filter(
+    (a: DrillResponse) => a === "correct" || a === "slow_correct",
+  ).length;
+  if (correctCount < MASTERY_MIN_CORRECT) return false;
+  if (state.current_interval_days < MASTERY_MIN_INTERVAL_DAYS) return false;
+  return true;
+}

--- a/shared/tests/sr-algorithm.unit.test.ts
+++ b/shared/tests/sr-algorithm.unit.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { nextInterval, isMastered } from "../src/sr-algorithm.js";
+import {
+  DEFAULT_EASINESS,
+  MIN_EASINESS,
+  type DrillResponse,
+  type DrillState,
+} from "../src/contracts/drill-state.js";
+
+const FRESH = {
+  current_interval_days: 0,
+  current_easiness: DEFAULT_EASINESS,
+};
+
+describe("nextInterval — SM-2 simplificado", () => {
+  it("fresh + correct → interval 1d, easiness 2.5 → 2.6", () => {
+    const { next_interval_days, next_easiness } = nextInterval(FRESH, "correct");
+    expect(next_interval_days).toBe(1);
+    expect(next_easiness).toBeCloseTo(2.6, 5);
+  });
+
+  it("fresh + incorrect → interval 1d, easiness 2.5 → 2.3", () => {
+    const { next_interval_days, next_easiness } = nextInterval(FRESH, "incorrect");
+    expect(next_interval_days).toBe(1);
+    expect(next_easiness).toBeCloseTo(2.3, 5);
+  });
+
+  it("interval=1 + correct → interval 3d (transição inicial)", () => {
+    const { next_interval_days } = nextInterval(
+      { current_interval_days: 1, current_easiness: 2.6 },
+      "correct",
+    );
+    expect(next_interval_days).toBe(3);
+  });
+
+  it("interval=3 + correct (ef=2.6) → 8d (round)", () => {
+    const { next_interval_days } = nextInterval(
+      { current_interval_days: 3, current_easiness: 2.6 },
+      "correct",
+    );
+    // 3 * (2.6 + 0.1) = 8.1 → 8
+    expect(next_interval_days).toBe(8);
+  });
+
+  it("easiness floored at MIN_EASINESS (1.3) após múltiplos incorrect", () => {
+    let easiness = DEFAULT_EASINESS;
+    for (let i = 0; i < 10; i++) {
+      ({ next_easiness: easiness } = nextInterval(
+        { current_interval_days: 5, current_easiness: easiness },
+        "incorrect",
+      ));
+    }
+    expect(easiness).toBe(MIN_EASINESS);
+    expect(easiness).toBeGreaterThanOrEqual(MIN_EASINESS);
+  });
+
+  it("incorrect sempre reseta intervalo para 1d", () => {
+    const r = nextInterval(
+      { current_interval_days: 30, current_easiness: 2.8 },
+      "incorrect",
+    );
+    expect(r.next_interval_days).toBe(1);
+  });
+
+  it("slow_correct sobe intervalo mas easiness cai um pouco", () => {
+    // q=3: ef + (0.1 - 2*(0.08 + 0.04)) = ef + (0.1 - 0.24) = ef - 0.14
+    const r = nextInterval(
+      { current_interval_days: 7, current_easiness: 2.5 },
+      "slow_correct",
+    );
+    expect(r.next_easiness).toBeCloseTo(2.36, 5);
+    // 7 * 2.36 = 16.52 → 17
+    expect(r.next_interval_days).toBe(17);
+  });
+
+  it("correct repetido eleva easiness gradualmente", () => {
+    let s = { current_interval_days: 0, current_easiness: DEFAULT_EASINESS };
+    for (let i = 0; i < 3; i++) {
+      const r = nextInterval(s, "correct");
+      s = {
+        current_interval_days: r.next_interval_days,
+        current_easiness: r.next_easiness,
+      };
+    }
+    expect(s.current_easiness).toBeGreaterThan(DEFAULT_EASINESS);
+  });
+
+  it("incorrect at MIN_EASINESS keeps it at MIN_EASINESS (no underflow)", () => {
+    const r = nextInterval(
+      { current_interval_days: 5, current_easiness: MIN_EASINESS },
+      "incorrect",
+    );
+    expect(r.next_easiness).toBe(MIN_EASINESS);
+  });
+});
+
+function makeAttempts(pattern: DrillResponse[]): DrillResponse[] {
+  return pattern;
+}
+
+describe("isMastered", () => {
+  it("retorna false com menos de 5 attempts", () => {
+    expect(
+      isMastered({
+        last_5_attempts: makeAttempts(["correct", "correct", "correct"]),
+        current_interval_days: 30,
+      }),
+    ).toBe(false);
+  });
+
+  it("retorna false com 5 attempts mas só 3 corretas", () => {
+    expect(
+      isMastered({
+        last_5_attempts: makeAttempts([
+          "correct",
+          "correct",
+          "incorrect",
+          "incorrect",
+          "correct",
+        ]),
+        current_interval_days: 30,
+      }),
+    ).toBe(false);
+  });
+
+  it("retorna false com 4 corretas mas interval < 7", () => {
+    expect(
+      isMastered({
+        last_5_attempts: makeAttempts([
+          "correct",
+          "correct",
+          "correct",
+          "correct",
+          "incorrect",
+        ]),
+        current_interval_days: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("retorna true com 4/5 corretas + interval ≥ 7", () => {
+    expect(
+      isMastered({
+        last_5_attempts: makeAttempts([
+          "correct",
+          "correct",
+          "incorrect",
+          "correct",
+          "correct",
+        ]),
+        current_interval_days: 7,
+      }),
+    ).toBe(true);
+  });
+
+  it("retorna true com 5/5 corretas + interval grande", () => {
+    expect(
+      isMastered({
+        last_5_attempts: makeAttempts([
+          "correct",
+          "correct",
+          "correct",
+          "correct",
+          "correct",
+        ]),
+        current_interval_days: 30,
+      }),
+    ).toBe(true);
+  });
+
+  it("slow_correct conta como acerto na contagem mastery", () => {
+    expect(
+      isMastered({
+        last_5_attempts: makeAttempts([
+          "correct",
+          "slow_correct",
+          "correct",
+          "slow_correct",
+          "incorrect",
+        ]),
+        current_interval_days: 14,
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Implementa B2 (Drilling) per spec [`2026-05-26-b2-drilling-primer-v0.md`](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-05-26-b2-drilling-primer-v0.md) em ascendimacy-ops.

Subsistema paralelo a S1–S5. **Pedagogia treina escolhas; drilling treina reflexos.**
B2 propõe candidatos; S3 decide se cabe na sessão (sacrifice budget gate, default 2 pts/item).

## Entregue (v0)

- **Schemas** (Zod): `DrillItem` + `DrillState` + `DrillBank`
- **Algoritmo SR**: SM-2 simplificado (`nextInterval`, `isMastered`), <80 LOC, easiness inicial 2.5 / mínimo 1.3
- **Persistência**: `drill-repo.ts` SQLite — tabelas `drill_states` + `drill_attempts`, `loadBank` YAML, mastery como evento (timestamp gravado uma vez)
- **Fuzzy match**: normalize NFD → strip Latin diacritics → NFC, `accept_variants`, slow_correct quando latency > 5s
- **Orchestrator**: `proposeDrillItem` puro (sem DB), hook `drill_window_proposal`, budget gate
- **Banco JP-PT v0**: 50 items JLPT N5 — 10 frutas, 10 animais, 10 família, 10 cores/números, 10 verbos hiragana

## Testes (40 passing)

| Arquivo | Casos |
|---|---|
| `shared/tests/sr-algorithm.unit.test.ts` | 15 — SM-2 + mastery edge cases |
| `motor-execucao/tests/drill-repo.unit.test.ts` | 12 — CRUD + listDue + listMastered + attempts log + bank loading |
| `motor-drota/tests/drill-fuzzy-match.unit.test.ts` | 13 — normalize (inclui dakuten JP) + variants + threshold |

## Build

Workspaces afetados (`shared`, `motor-execucao`, `motor-drota`, `orchestrator`) compilam clean.

## Defaults aplicados (Jun ratify em bloco)

- [x] SM-2 simplificado (FSRS quando ≥100 personas × 30 dias)
- [x] Fuzzy match aceita acento/case (PT-BR)
- [x] 50 items N5 v0
- [x] In-WhatsApp (QR cards físicos = v1 separado)
- [x] Hook `drill_window_proposal` — S3 elege
- [x] Cost 2 pts/item
- [x] Curador único = Jun (v0)
- [x] Worked → faded → independent fica v1 (só independent v0)

## Não-objetivos (v1)

- Worked → faded → independent scaffolding
- Múltiplos bancos por persona
- Audio prompts JP (TTS)
- Drill cooperativo (Ryo+Kei)
- FSRS migration

## Integração futura (out-of-scope desta PR)

- S3 elegibility check (hook listener)
- Subject Knowledge ledger → `drill_item_mastered` cria `mastery_anchor`
- Trace v2 `drill_attempts[]` por turn
- STS smoke `saki-drill-7d`

## Notas operacionais

- Branch original `feat/b2-drilling-primer` já existia no remoto com conteúdo não-relacionado (ops#1120); commit final foi cherry-picked para `feat/b2-drilling-impl` a partir de `origin/main` para garantir base limpa.
- Race condition observada durante implementação: working tree compartilhado entre agentes B1/B2/S1 levou ao commit inicial cair em branch errada — recovery via cherry-pick + resolução de conflito surgical (manteve apenas exports B2 no barrel).
- Diff do barrel `shared/src/contracts/index.ts` adiciona somente exports B2 (apêndice após `milestone-event`) — sem tocar exports B1/S1 que virão em PRs separadas.

Spec: `ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md`