### PR TITLE
[ui+bff] Parental Onboarding Wizard — 11 steps + BFF endpoints (US-PO-01..11)

### DIFF
--- a/packages/ebrota-console-bff/src/parental-onboarding-store.ts
+++ b/packages/ebrota-console-bff/src/parental-onboarding-store.ts
@@ -1,0 +1,144 @@
+/**
+ * Parental Onboarding Store (US-PO-01..11).
+ *
+ * Persiste o draft do wizard parental enquanto Yuji (ou outro adquirente)
+ * preenche. Idempotente — múltiplos POST /parental/onboarding/draft com
+ * mesmo `acquirerId` sobrescrevem.
+ *
+ * Source of truth final é `fixtures/parental-profile-<acquirerId>.yaml`
+ * escrito por `/parental/onboarding/complete`. SQLite serve só pro
+ * estado intermediário + retomada de sessão.
+ */
+
+import type { Database as DatabaseType } from "better-sqlite3";
+
+export const PARENTAL_ONBOARDING_SCHEMA = `
+CREATE TABLE IF NOT EXISTS parental_onboarding (
+  acquirer_id   TEXT PRIMARY KEY,
+  step          INTEGER NOT NULL DEFAULT 1,
+  status        TEXT NOT NULL DEFAULT 'in_progress' CHECK(status IN (
+    'in_progress', 'complete'
+  )),
+  state_json    TEXT NOT NULL,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  completed_at  TEXT
+);
+`;
+
+export interface OnboardingRecord {
+  acquirerId: string;
+  step: number;
+  status: "in_progress" | "complete";
+  state: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+interface OnboardingRow {
+  acquirer_id: string;
+  step: number;
+  status: "in_progress" | "complete";
+  state_json: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+export function initParentalOnboardingSchema(db: DatabaseType): void {
+  db.exec(PARENTAL_ONBOARDING_SCHEMA);
+}
+
+function deriveAcquirerId(state: Record<string, unknown>): string {
+  const family = (state.family ?? {}) as Record<string, unknown>;
+  const acquirer = (family.acquirer ?? {}) as Record<string, unknown>;
+  if (typeof acquirer.id === "string" && acquirer.id.length > 0) {
+    return acquirer.id;
+  }
+  if (typeof acquirer.name === "string" && acquirer.name.length > 0) {
+    return acquirer.name.toLowerCase().replace(/\s+/g, "-");
+  }
+  return "anonymous";
+}
+
+export function saveDraft(
+  db: DatabaseType,
+  state: Record<string, unknown>,
+): OnboardingRecord {
+  const acquirerId = deriveAcquirerId(state);
+  const step = typeof state.step === "number" ? state.step : 1;
+  const stateJson = JSON.stringify(state);
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO parental_onboarding (acquirer_id, step, status, state_json, created_at, updated_at)
+     VALUES (?, ?, 'in_progress', ?, ?, ?)
+     ON CONFLICT(acquirer_id) DO UPDATE SET
+       step = excluded.step,
+       state_json = excluded.state_json,
+       updated_at = excluded.updated_at`,
+  ).run(acquirerId, step, stateJson, now, now);
+  return readRecord(db, acquirerId)!;
+}
+
+export function markComplete(
+  db: DatabaseType,
+  state: Record<string, unknown>,
+): OnboardingRecord {
+  const acquirerId = deriveAcquirerId(state);
+  const stateJson = JSON.stringify({ ...state, readyForPilot: true });
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO parental_onboarding (acquirer_id, step, status, state_json, created_at, updated_at, completed_at)
+     VALUES (?, 11, 'complete', ?, ?, ?, ?)
+     ON CONFLICT(acquirer_id) DO UPDATE SET
+       step = 11,
+       status = 'complete',
+       state_json = excluded.state_json,
+       updated_at = excluded.updated_at,
+       completed_at = excluded.completed_at`,
+  ).run(acquirerId, stateJson, now, now, now);
+  return readRecord(db, acquirerId)!;
+}
+
+export function readRecord(
+  db: DatabaseType,
+  acquirerId: string,
+): OnboardingRecord | null {
+  const row = db
+    .prepare(
+      `SELECT acquirer_id, step, status, state_json, created_at, updated_at, completed_at
+       FROM parental_onboarding WHERE acquirer_id = ?`,
+    )
+    .get(acquirerId) as OnboardingRow | undefined;
+  if (!row) return null;
+  return {
+    acquirerId: row.acquirer_id,
+    step: row.step,
+    status: row.status,
+    state: JSON.parse(row.state_json) as Record<string, unknown>,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+/** Lista o registro mais recente (V0 — assume 1 adquirente ativo). */
+export function readLatest(db: DatabaseType): OnboardingRecord | null {
+  const row = db
+    .prepare(
+      `SELECT acquirer_id, step, status, state_json, created_at, updated_at, completed_at
+       FROM parental_onboarding ORDER BY updated_at DESC LIMIT 1`,
+    )
+    .get() as OnboardingRow | undefined;
+  if (!row) return null;
+  return {
+    acquirerId: row.acquirer_id,
+    step: row.step,
+    status: row.status,
+    state: JSON.parse(row.state_json) as Record<string, unknown>,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -72,6 +72,14 @@ import {
   getStrategyPlan,
   listStrategyPlansBySubject,
 } from "./strategy-plan-repo.js";
+import {
+  initParentalOnboardingSchema,
+  readLatest as readLatestOnboarding,
+  saveDraft as saveOnboardingDraft,
+  markComplete as markOnboardingComplete,
+} from "./parental-onboarding-store.js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -96,6 +104,12 @@ export interface CreateBffServerOptions {
    * Default: undefined → endpoint retorna 503, sem watcher.
    */
   tracesDir?: string;
+  /**
+   * Diretório de fixtures pra escrita do parental-profile.yaml ao
+   * finalizar onboarding (US-PO-11). Quando omitido, endpoint completa
+   * o draft no SQLite mas não escreve YAML em disco.
+   */
+  fixturesDir?: string;
 }
 
 export interface BffServer {
@@ -117,6 +131,8 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   const uiBaseUrl = opts.uiBaseUrl ?? "http://localhost:5173";
   const debugEvents = createDebugEventsStore();
   let mode: ConsoleMode = opts.initialMode ?? "auto";
+
+  initParentalOnboardingSchema(opts.db);
 
   // In-memory set de sessionIds ativos (iniciados via /sessions/start-card,
   // removidos via /sessions/:id/end). Permite que App.svelte faça polling
@@ -685,6 +701,159 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
     };
   });
 
+  // ── Parental Onboarding Wizard (US-PO-01..11) ────────────────────
+  // MC10 material — bullets + frases JP. V0 hardcoded a partir do spec
+  // 2026-05-19-mc10-onboarding-yuji.md §3. Versionamento via spec ID
+  // futura quando MC10 final ratificado.
+  fastify.get("/parental/mc10-material", async () => ({
+    beforeBullets: [
+      "Decida em qual cenário vai apresentar — ambos juntos ou um de cada vez (recomendação: um de cada vez).",
+    ],
+    duringBullets: [
+      "Diga o que você quiser sobre quem construiu — mas não minta. Se a criança perguntar, Brota confirma que é IA.",
+      'Diga que Brota vai mandar mensagem espontânea: "em breve, o Brota vai mandar mensagem pra você. Você não precisa responder se não quiser."',
+    ],
+    afterBullets: [
+      "Não pergunte sobre as conversas dele com o Brota. Deixe a criança contar por iniciativa.",
+      "Se reclamar do Brota, repassa pro Jun ANTES de mudar comportamento.",
+    ],
+    jpPhrases: [
+      {
+        pt: "Em breve, o Brota vai mandar mensagem. Você não precisa responder se não quiser.",
+        jp: "もうすぐ、ブロータからメッセージが来るよ。返事したくなかったらしなくていいよ。",
+      },
+    ],
+    escalationPath:
+      "Kid reclama do tom, JP soa estranho, loop ou tema difícil → escala pro Jun. Yuji não precisa virar professor do Brota.",
+  }));
+
+  // POST /parental/onboarding/draft — salva estado idempotente.
+  fastify.post<{ Body: Record<string, unknown> }>(
+    "/parental/onboarding/draft",
+    async (req, reply) => {
+      const state = req.body;
+      if (state === undefined || state === null || typeof state !== "object") {
+        return reply.code(400).send({ error: "body deve ser objeto WizardState" });
+      }
+      const record = saveOnboardingDraft(opts.db, state);
+      return {
+        acquirerId: record.acquirerId,
+        step: record.step,
+        status: record.status,
+        updatedAt: record.updatedAt,
+      };
+    },
+  );
+
+  // GET /parental/onboarding/status — retorna current step (retomada).
+  fastify.get("/parental/onboarding/status", async () => {
+    const record = readLatestOnboarding(opts.db);
+    if (!record) return { status: "not_started" };
+    return {
+      acquirerId: record.acquirerId,
+      step: record.step,
+      status: record.status,
+      updatedAt: record.updatedAt,
+      completedAt: record.completedAt,
+    };
+  });
+
+  // POST /parental/onboarding/complete — finaliza, escreve YAML +
+  // dispara evento persona_ready_for_pilot.
+  fastify.post<{ Body: Record<string, unknown> }>(
+    "/parental/onboarding/complete",
+    async (req, reply) => {
+      const state = req.body;
+      if (state === undefined || state === null || typeof state !== "object") {
+        return reply.code(400).send({ error: "body deve ser objeto WizardState" });
+      }
+      // Validação mínima: precisa de pelo menos 1 criança + telos.
+      const family = (state.family ?? {}) as Record<string, unknown>;
+      const children = (family.children ?? []) as unknown[];
+      if (!Array.isArray(children) || children.length === 0) {
+        return reply
+          .code(400)
+          .send({ error: "ao menos 1 criança obrigatória em family.children" });
+      }
+      const record = markOnboardingComplete(opts.db, state);
+
+      // YAML write — só se fixturesDir configurado.
+      let yamlPath: string | null = null;
+      if (opts.fixturesDir) {
+        yamlPath = `${opts.fixturesDir}/parental-profile-${record.acquirerId}.yaml`;
+        try {
+          mkdirSync(dirname(yamlPath), { recursive: true });
+          writeFileSync(yamlPath, serializeToYaml(state), "utf8");
+        } catch (err) {
+          return reply.code(500).send({
+            error: `falha ao escrever YAML: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        }
+      }
+
+      // Evento persona_ready_for_pilot — V0 só loga em debug_actions.
+      // Próximo PR pode wire pro orchestrator daemon notificar Jun.
+      try {
+        opts.db
+          .prepare(
+            `INSERT INTO debug_actions (session_id, action, rationale, recorded_at)
+             VALUES (?, 'persona_ready_for_pilot', ?, ?)`,
+          )
+          .run(
+            record.acquirerId,
+            `Family ${record.acquirerId} ready for pilot (${children.length} children)`,
+            new Date().toISOString(),
+          );
+      } catch {
+        // best-effort
+      }
+
+      return {
+        acquirerId: record.acquirerId,
+        status: "complete",
+        completedAt: record.completedAt,
+        yamlPath,
+        event: "persona_ready_for_pilot",
+      };
+    },
+  );
+
+  // POST /parental/mc1/preview — gera primeira mensagem customizada.
+  // V0 retorna template stub. Futuramente chama orchestrator daemon ou
+  // LLM gateway com persona context.
+  fastify.post<{
+    Body: {
+      personaId?: string;
+      childName?: string;
+      age?: number;
+      language?: string;
+      telos?: { text?: string; tags?: string[] };
+      virtues?: Array<{ axis: number; note?: string }>;
+    };
+  }>("/parental/mc1/preview", async (req, reply) => {
+    const body = req.body ?? {};
+    if (typeof body.childName !== "string" || body.childName.length === 0) {
+      return reply.code(400).send({ error: "childName obrigatório" });
+    }
+    const name = body.childName;
+    const lang = body.language ?? "pt";
+    const tags = body.telos?.tags ?? [];
+    const tagsStr = tags.length > 0 ? tags.slice(0, 2).join(" e ") : "curiosidade";
+
+    const ptText = `Oi, ${name}! Eu sou o Brota — uma plantinha que conversa. Estou aprendendo sobre ${tagsStr} e queria saber: o que você acha mais legal de explorar hoje? Você não precisa responder se não quiser.`;
+
+    const jpText =
+      lang === "jp"
+        ? `\n\n${name}くんへ\nぼくはブロータ。話せる小さな植物です。今日、何が一番おもしろいか教えてくれる？返事したくなかったらしなくていいよ。`
+        : "";
+
+    return {
+      personaId: body.personaId ?? "",
+      text: ptText + jpText,
+      generatedAt: new Date().toISOString(),
+    };
+  });
+
   // POST /rescan — re-indexa o tracesDir (manual trigger).
   // Útil quando STS roda em outro processo e deposita novos traces;
   // o BFF normalmente só scaneia no startup.
@@ -725,7 +894,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
     fastify,
     getMode: () => mode,
     debugEvents,
-    async listen(port, host = "127.0.0.1") {
+    async listen(port: number, host = "127.0.0.1") {
       await fastify.listen({ port, host });
     },
     async close() {
@@ -742,4 +911,100 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       opts.db.close();
     },
   };
+}
+
+/**
+ * Mini-YAML serializer pra parental-profile fixture. Não usa lib (yaml
+ * não está em deps). Cobre só os shapes do WizardState — strings, números,
+ * booleans, arrays e objetos aninhados. Strings com caracteres especiais
+ * são quotadas; chaves sempre nuas.
+ */
+function serializeToYaml(state: unknown): string {
+  const lines: string[] = ["# Parental Profile — gerado por Onboarding Wizard"];
+  lines.push(`# Gerado em ${new Date().toISOString()}`);
+  lines.push("");
+  emitNode(lines, "profile", state, 0);
+  return lines.join("\n") + "\n";
+}
+
+function emitNode(
+  lines: string[],
+  key: string | null,
+  value: unknown,
+  indent: number,
+): void {
+  const pad = "  ".repeat(indent);
+  if (value === null || value === undefined) {
+    if (key !== null) lines.push(`${pad}${key}: null`);
+    return;
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    const serialized = serializeScalar(value);
+    if (key !== null) lines.push(`${pad}${key}: ${serialized}`);
+    else lines.push(`${pad}${serialized}`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (key !== null) lines.push(`${pad}${key}:`);
+    if (value.length === 0) {
+      lines[lines.length - 1] = `${pad}${key !== null ? `${key}: ` : ""}[]`;
+      return;
+    }
+    for (const item of value) {
+      if (
+        item !== null &&
+        typeof item === "object" &&
+        !Array.isArray(item)
+      ) {
+        const entries = Object.entries(item as Record<string, unknown>);
+        if (entries.length === 0) {
+          lines.push(`${pad}- {}`);
+          continue;
+        }
+        lines.push(`${pad}-`);
+        for (const [k, v] of entries) {
+          emitNode(lines, k, v, indent + 1);
+        }
+      } else {
+        const scalar = serializeScalar(
+          item as string | number | boolean | null | undefined,
+        );
+        lines.push(`${pad}- ${scalar}`);
+      }
+    }
+    return;
+  }
+  if (typeof value === "object") {
+    if (key !== null) lines.push(`${pad}${key}:`);
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+      lines[lines.length - 1] = `${pad}${key !== null ? `${key}: ` : ""}{}`;
+      return;
+    }
+    for (const [k, v] of entries) {
+      emitNode(lines, k, v, key !== null ? indent + 1 : indent);
+    }
+  }
+}
+
+function serializeScalar(
+  value: string | number | boolean | null | undefined,
+): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  const s = value;
+  if (
+    s.length === 0 ||
+    /[:#\-?&*!|>'"%@`]|^\s|\s$|^(true|false|null|yes|no)$/i.test(s) ||
+    /\n/.test(s) ||
+    /^-?\d/.test(s)
+  ) {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return s;
 }

--- a/packages/ebrota-console-bff/tests/parental-onboarding.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/parental-onboarding.unit.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+let server: BffServer;
+let fixturesDir: string;
+
+const inject = async (
+  method: "GET" | "POST",
+  url: string,
+  payload?: unknown,
+) => {
+  const res = await server.fastify.inject({
+    method,
+    url,
+    ...(payload !== undefined ? { payload } : {}),
+  });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+beforeEach(() => {
+  const db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  fixturesDir = mkdtempSync(join(tmpdir(), "ebrota-parental-test-"));
+  server = createBffServer({
+    daemon,
+    db,
+    logger: false,
+    fixturesDir,
+  });
+});
+
+afterEach(async () => {
+  await server.close();
+  if (existsSync(fixturesDir)) {
+    rmSync(fixturesDir, { recursive: true, force: true });
+  }
+});
+
+const sampleState = (overrides?: Record<string, unknown>) => ({
+  step: 11,
+  mc10ReadAt: "2026-05-27T10:00:00.000Z",
+  family: {
+    acquirer: { id: "yuji-ochiai", name: "Yuji", relation: "pai" },
+    coParent: null,
+    children: [
+      { id: "ryo-ochiai", name: "Ryo", age: 8, primaryLanguage: "pt" },
+    ],
+  },
+  telos: {
+    text: "Queremos que cresçam bilíngues e curiosos.",
+    tags: ["bilinguismo", "curiosidade"],
+  },
+  forbiddenZones: [
+    { topic: "violência gráfica", policy: "never", reason: "default" },
+  ],
+  budget: {
+    sacrificeBudgetCap: 100,
+    offScreenRatio: 2,
+    sessionMinutesCap: 15,
+  },
+  virtuesByChild: {
+    "ryo-ochiai": [{ axis: 1 }, { axis: 5 }],
+  },
+  windowsByChild: {
+    "ryo-ochiai": { mon: "window1", tue: "window1" },
+  },
+  consents: {
+    storeTrace: true,
+    emitPhysicalCards: true,
+    activeHoursMessaging: true,
+    confirmIsAi: true,
+  },
+  dyad: null,
+  mc1Approvals: [
+    { childId: "ryo-ochiai", text: "Oi Ryo!", approved: true },
+  ],
+  readyForPilot: false,
+  ...overrides,
+});
+
+describe("GET /parental/mc10-material", () => {
+  it("retorna bullets + frases JP", async () => {
+    const res = await inject("GET", "/parental/mc10-material");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      beforeBullets: string[];
+      duringBullets: string[];
+      afterBullets: string[];
+      jpPhrases: Array<{ pt: string; jp: string }>;
+      escalationPath: string;
+    };
+    expect(body.beforeBullets.length).toBeGreaterThan(0);
+    expect(body.duringBullets.length).toBeGreaterThan(0);
+    expect(body.jpPhrases.length).toBeGreaterThan(0);
+    expect(typeof body.escalationPath).toBe("string");
+  });
+});
+
+describe("POST /parental/onboarding/draft (idempotente)", () => {
+  it("salva e atualiza idempotentemente", async () => {
+    const r1 = await inject("POST", "/parental/onboarding/draft", {
+      step: 3,
+      family: { acquirer: { id: "yuji-ochiai", name: "Yuji" } },
+    });
+    expect(r1.status).toBe(200);
+    expect((r1.body as { acquirerId: string }).acquirerId).toBe("yuji-ochiai");
+
+    // Re-save com step diferente — não cria novo registro.
+    const r2 = await inject("POST", "/parental/onboarding/draft", {
+      step: 5,
+      family: { acquirer: { id: "yuji-ochiai", name: "Yuji" } },
+    });
+    expect(r2.status).toBe(200);
+    expect((r2.body as { step: number }).step).toBe(5);
+  });
+
+  it("400 quando body inválido", async () => {
+    const res = await inject("POST", "/parental/onboarding/draft", null);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /parental/onboarding/status", () => {
+  it("retorna not_started quando vazio", async () => {
+    const res = await inject("GET", "/parental/onboarding/status");
+    expect(res.status).toBe(200);
+    expect((res.body as { status: string }).status).toBe("not_started");
+  });
+
+  it("retorna step + status após draft", async () => {
+    await inject("POST", "/parental/onboarding/draft", {
+      step: 4,
+      family: { acquirer: { id: "yuji-ochiai", name: "Yuji" } },
+    });
+    const res = await inject("GET", "/parental/onboarding/status");
+    expect((res.body as { step: number; status: string }).step).toBe(4);
+    expect((res.body as { status: string }).status).toBe("in_progress");
+  });
+});
+
+describe("POST /parental/onboarding/complete", () => {
+  it("escreve YAML + retorna status complete", async () => {
+    const res = await inject(
+      "POST",
+      "/parental/onboarding/complete",
+      sampleState(),
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      acquirerId: string;
+      status: string;
+      yamlPath: string | null;
+      event: string;
+    };
+    expect(body.status).toBe("complete");
+    expect(body.event).toBe("persona_ready_for_pilot");
+    expect(body.yamlPath).toMatch(/parental-profile-yuji-ochiai\.yaml$/);
+    expect(existsSync(body.yamlPath!)).toBe(true);
+
+    const yaml = readFileSync(body.yamlPath!, "utf8");
+    expect(yaml).toContain("Yuji");
+    expect(yaml).toContain("bilinguismo");
+    expect(yaml).toContain("Ryo");
+  });
+
+  it("400 quando não tem crianças", async () => {
+    const state = sampleState({ family: { acquirer: { id: "x", name: "X" }, children: [] } });
+    const res = await inject("POST", "/parental/onboarding/complete", state);
+    expect(res.status).toBe(400);
+  });
+
+  it("marca status como complete em /status após finalizar", async () => {
+    await inject("POST", "/parental/onboarding/complete", sampleState());
+    const status = await inject("GET", "/parental/onboarding/status");
+    expect((status.body as { status: string }).status).toBe("complete");
+    expect((status.body as { completedAt: string }).completedAt).toBeTruthy();
+  });
+});
+
+describe("POST /parental/mc1/preview", () => {
+  it("gera texto incluindo nome da criança", async () => {
+    const res = await inject("POST", "/parental/mc1/preview", {
+      personaId: "ryo-ochiai",
+      childName: "Ryo",
+      age: 8,
+      language: "pt",
+      telos: { text: "", tags: ["bilinguismo", "curiosidade"] },
+      virtues: [{ axis: 1 }],
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { text: string };
+    expect(body.text).toContain("Ryo");
+    expect(body.text.toLowerCase()).toContain("brota");
+  });
+
+  it("adiciona JP quando language=jp", async () => {
+    const res = await inject("POST", "/parental/mc1/preview", {
+      childName: "Kei",
+      language: "jp",
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { text: string };
+    expect(body.text).toMatch(/ブロータ/);
+  });
+
+  it("400 quando childName ausente", async () => {
+    const res = await inject("POST", "/parental/mc1/preview", {});
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -13,6 +13,7 @@
   import MapsPanel from "./components/MapsPanel.svelte";
   import DiscoveriesPanel from "./components/DiscoveriesPanel.svelte";
   import LlmXrayPanel from "./components/LlmXrayPanel.svelte";
+  import ParentalOnboardingWizard from "./components/ParentalOnboardingWizard.svelte";
   import { createApiClient } from "./lib/api.js";
   import {
     bffStatus,
@@ -34,6 +35,9 @@
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let activeSessionsPollTimer: ReturnType<typeof setInterval> | undefined;
   let streamManager: TurnStateStreamManager | undefined;
+  // US-PO-01..11 — quando ?onboarding=true na URL, mostra o wizard parental
+  // em vez do console operador. Default false.
+  let onboardingMode = false;
 
   async function refreshStatus(): Promise<void> {
     try {
@@ -79,6 +83,11 @@
     const { replaySessionId: r, liveSessionId: l } = parseUrlParams(
       window.location.search,
     );
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("onboarding") === "true") {
+      onboardingMode = true;
+      return;
+    }
     if (r !== null) {
       replaySessionId.set(r);
       libraryOpen.set(false);
@@ -89,6 +98,7 @@
 
   onMount(() => {
     applyUrlParams();
+    if (onboardingMode) return;
     void refreshStatus();
     void checkActiveSessions();
     pollTimer = setInterval(() => {
@@ -109,31 +119,40 @@
 </script>
 
 <div class="app">
-  <Status {api} />
+  {#if onboardingMode}
+    <header class="status-bar simple">
+      <h1>eBrota Console — Onboarding Parental</h1>
+    </header>
+    <main class="onboarding-main">
+      <ParentalOnboardingWizard />
+    </main>
+  {:else}
+    <Status {api} />
 
-  {#if $globalError !== null}
-    <div class="error-banner" data-testid="error-banner">
-      {$globalError}
-    </div>
+    {#if $globalError !== null}
+      <div class="error-banner" data-testid="error-banner">
+        {$globalError}
+      </div>
+    {/if}
+
+    <ApprovalGate {api} />
+
+    <main class="main-grid">
+      <ChatFeed />
+      <MotorView {api} />
+    </main>
+
+    <SessionStart {api} />
+
+    <SessionLibrary {api} />
+    <Replay {api} />
+    <DebugPanel {api} />
+    <Analytics {api} />
+    <JourneyPanel {api} />
+    <MapsPanel {api} />
+    <DiscoveriesPanel {api} />
+    <LlmXrayPanel />
   {/if}
-
-  <ApprovalGate {api} />
-
-  <main class="main-grid">
-    <ChatFeed />
-    <MotorView {api} />
-  </main>
-
-  <SessionStart {api} />
-
-  <SessionLibrary {api} />
-  <Replay {api} />
-  <DebugPanel {api} />
-  <Analytics {api} />
-  <JourneyPanel {api} />
-  <MapsPanel {api} />
-  <DiscoveriesPanel {api} />
-  <LlmXrayPanel />
 
   <footer>
     <p class="muted">
@@ -156,6 +175,23 @@
     padding: 0.5rem 1rem;
     font-size: 0.85rem;
     border-bottom: 1px solid rgba(176, 0, 32, 0.3);
+  }
+
+  .status-bar.simple {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+    background: rgba(127, 127, 127, 0.05);
+  }
+  .status-bar.simple h1 {
+    font-size: 1.1rem;
+    margin: 0;
+  }
+  .onboarding-main {
+    flex: 1;
+    padding: 1.5rem 1rem;
+    overflow-y: auto;
   }
 
   .main-grid {

--- a/packages/ebrota-console-ui/src/components/ParentalOnboardingWizard.svelte
+++ b/packages/ebrota-console-ui/src/components/ParentalOnboardingWizard.svelte
@@ -1,0 +1,348 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    emptyWizardState,
+    isStep8Complete,
+    isStep10Complete,
+    type WizardState,
+    type Mc10Material,
+  } from "../lib/wizard-types.js";
+  import Step01ReadMC10 from "./wizard-steps/Step01ReadMC10.svelte";
+  import Step02CadastrarFamilia from "./wizard-steps/Step02CadastrarFamilia.svelte";
+  import Step03DefinirTelos from "./wizard-steps/Step03DefinirTelos.svelte";
+  import Step04ForbiddenZones from "./wizard-steps/Step04ForbiddenZones.svelte";
+  import Step05BudgetConstraints from "./wizard-steps/Step05BudgetConstraints.svelte";
+  import Step06ProposedVirtues from "./wizard-steps/Step06ProposedVirtues.svelte";
+  import Step07JanelasTemporal from "./wizard-steps/Step07JanelasTemporal.svelte";
+  import Step08ConsentLedger from "./wizard-steps/Step08ConsentLedger.svelte";
+  import Step09DyadConfig from "./wizard-steps/Step09DyadConfig.svelte";
+  import Step10AprovarMC1 from "./wizard-steps/Step10AprovarMC1.svelte";
+  import Step11Ready from "./wizard-steps/Step11Ready.svelte";
+
+  export let baseUrl: string = "/api";
+  export let onComplete: (() => void) | undefined = undefined;
+  /** Fetch impl injetável pra testes — default globalThis.fetch. */
+  export let fetchImpl: typeof globalThis.fetch | undefined = undefined;
+  /** Material pré-carregado (testes) — quando setado, skipa fetch /mc10-material. */
+  export let initialMc10Material: Mc10Material | null = null;
+
+  function getFetch(): typeof globalThis.fetch {
+    if (fetchImpl) return fetchImpl;
+    return globalThis.fetch.bind(globalThis);
+  }
+
+  const STEP_TITLES = [
+    "Receber material MC10",
+    "Cadastrar família",
+    "Definir telos da família",
+    "Forbidden zones",
+    "Budget constraints",
+    "Virtudes propostas",
+    "Janelas temporais",
+    "Consent ledger",
+    "Configurar dyad",
+    "Aprovar primeira mensagem",
+    "Pronto para piloto",
+  ];
+
+  let state: WizardState = emptyWizardState();
+  let mc10Material: Mc10Material | null = initialMc10Material;
+  let mc10Loading = false;
+  let submitting = false;
+  let errorMsg: string | null = null;
+
+  async function fetchMc10(): Promise<void> {
+    mc10Loading = true;
+    try {
+      const f = getFetch();
+      const res = await f(`${baseUrl}/parental/mc10-material`);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      mc10Material = (await res.json()) as Mc10Material;
+    } catch (err) {
+      errorMsg = `Falha ao carregar MC10: ${err instanceof Error ? err.message : String(err)}`;
+    } finally {
+      mc10Loading = false;
+    }
+  }
+
+  async function saveDraft(): Promise<void> {
+    try {
+      const f = getFetch();
+      await f(`${baseUrl}/parental/onboarding/draft`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(state),
+      });
+    } catch {
+      // draft save é best-effort
+    }
+  }
+
+  async function completeOnboarding(): Promise<void> {
+    submitting = true;
+    errorMsg = null;
+    try {
+      const f = getFetch();
+      const res = await f(`${baseUrl}/parental/onboarding/complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(state),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error ?? `status ${res.status}`,
+        );
+      }
+      state.readyForPilot = true;
+      state = state;
+      if (onComplete) onComplete();
+    } catch (err) {
+      errorMsg = `Falha ao finalizar: ${err instanceof Error ? err.message : String(err)}`;
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function computeCanAdvance(s: WizardState): boolean {
+    switch (s.step) {
+      case 1:
+        return s.mc10ReadAt !== null;
+      case 2:
+        return (
+          s.family.acquirer.name.trim().length > 0 &&
+          s.family.children.length > 0 &&
+          s.family.children.every(
+            (c) => c.name.trim().length > 0 && c.age > 0,
+          )
+        );
+      case 3:
+        return s.telos.text.trim().length > 0;
+      case 4:
+        return true;
+      case 5:
+        return true;
+      case 6:
+        return s.family.children.every(
+          (c) => (s.virtuesByChild[c.id]?.length ?? 0) > 0,
+        );
+      case 7:
+        return true;
+      case 8:
+        return isStep8Complete(s.consents);
+      case 9:
+        return true;
+      case 10:
+        return isStep10Complete(s.mc1Approvals, s.family.children);
+      case 11:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  $: canAdvance = computeCanAdvance(state);
+
+  async function next(): Promise<void> {
+    if (!canAdvance) return;
+    if (state.step < 11) {
+      state.step += 1;
+      state = state;
+      void saveDraft();
+    }
+  }
+
+  function back(): void {
+    if (state.step > 1) {
+      state.step -= 1;
+      state = state;
+    }
+  }
+
+  async function finish(): Promise<void> {
+    await completeOnboarding();
+  }
+
+  $: progressPct = Math.round((state.step / 11) * 100);
+  $: title = STEP_TITLES[state.step - 1];
+
+  onMount(() => {
+    if (mc10Material === null) void fetchMc10();
+  });
+</script>
+
+<section
+  class="wizard"
+  data-testid="parental-onboarding-wizard"
+  aria-labelledby="wizard-title"
+>
+  <header class="wizard-header">
+    <h2 id="wizard-title">
+      Passo {state.step}/11 — {title}
+    </h2>
+    <div
+      class="progress"
+      role="progressbar"
+      aria-valuenow={state.step}
+      aria-valuemin="1"
+      aria-valuemax="11"
+    >
+      <div class="progress-fill" style="width: {progressPct}%" />
+    </div>
+  </header>
+
+  {#if errorMsg !== null}
+    <div class="error" data-testid="wizard-error">{errorMsg}</div>
+  {/if}
+
+  <main class="wizard-body">
+    {#if state.step === 1}
+      <Step01ReadMC10
+        bind:state
+        material={mc10Material}
+        loading={mc10Loading}
+      />
+    {:else if state.step === 2}
+      <Step02CadastrarFamilia bind:state />
+    {:else if state.step === 3}
+      <Step03DefinirTelos bind:state />
+    {:else if state.step === 4}
+      <Step04ForbiddenZones bind:state />
+    {:else if state.step === 5}
+      <Step05BudgetConstraints bind:state />
+    {:else if state.step === 6}
+      <Step06ProposedVirtues bind:state />
+    {:else if state.step === 7}
+      <Step07JanelasTemporal bind:state />
+    {:else if state.step === 8}
+      <Step08ConsentLedger bind:state />
+    {:else if state.step === 9}
+      <Step09DyadConfig bind:state />
+    {:else if state.step === 10}
+      <Step10AprovarMC1 bind:state {baseUrl} {fetchImpl} />
+    {:else if state.step === 11}
+      <Step11Ready bind:state />
+    {/if}
+  </main>
+
+  <footer class="wizard-footer">
+    <button
+      type="button"
+      class="btn btn-secondary"
+      on:click={back}
+      disabled={state.step === 1 || submitting}
+      data-testid="wizard-back"
+    >
+      Voltar
+    </button>
+    {#if state.step < 11}
+      <button
+        type="button"
+        class="btn btn-primary"
+        on:click={next}
+        disabled={!canAdvance || submitting}
+        data-testid="wizard-next"
+      >
+        Próximo
+      </button>
+    {:else}
+      <button
+        type="button"
+        class="btn btn-primary btn-finish"
+        on:click={finish}
+        disabled={submitting}
+        data-testid="wizard-finish"
+      >
+        {submitting ? "Finalizando..." : "Iniciar piloto"}
+      </button>
+    {/if}
+  </footer>
+</section>
+
+<style>
+  .wizard {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.5rem;
+    max-width: 720px;
+    margin: 0 auto;
+    background: rgba(127, 127, 127, 0.05);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 8px;
+  }
+
+  .wizard-header h2 {
+    font-size: 1.1rem;
+    margin: 0 0 0.5rem;
+  }
+
+  .progress {
+    width: 100%;
+    height: 8px;
+    background: rgba(127, 127, 127, 0.2);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: #4caf50;
+    transition: width 0.2s ease;
+  }
+
+  .error {
+    background: rgba(176, 0, 32, 0.15);
+    color: #b00020;
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  .wizard-body {
+    min-height: 280px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .wizard-footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border-top: 1px solid rgba(127, 127, 127, 0.2);
+    padding-top: 1rem;
+  }
+
+  .btn {
+    font-family: inherit;
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    background: rgba(127, 127, 127, 0.15);
+    color: inherit;
+  }
+
+  .btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .btn-primary {
+    background: rgba(33, 150, 243, 0.25);
+    border-color: rgba(33, 150, 243, 0.6);
+  }
+
+  .btn-finish {
+    background: rgba(76, 175, 80, 0.25);
+    border-color: rgba(76, 175, 80, 0.6);
+  }
+
+  @media (max-width: 600px) {
+    .wizard {
+      padding: 1rem;
+      border-radius: 0;
+    }
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step01ReadMC10.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step01ReadMC10.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import type { WizardState, Mc10Material } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+  export let material: Mc10Material | null;
+  export let loading: boolean;
+
+  function markRead(): void {
+    state.mc10ReadAt = new Date().toISOString();
+    state = state;
+  }
+</script>
+
+<div class="step" data-testid="step-01">
+  <p class="intro">
+    Antes de apresentar o Brota aos seus filhos, leia este material em ~1
+    minuto. Cada bullet é uma ação memorizável — não precisa decorar.
+  </p>
+
+  {#if loading}
+    <p class="muted">Carregando material...</p>
+  {:else if material === null}
+    <p class="muted">Material indisponível — verifique conexão BFF.</p>
+  {:else}
+    <section>
+      <h3>Antes de apresentar</h3>
+      <ul>
+        {#each material.beforeBullets as bullet}
+          <li>{bullet}</li>
+        {/each}
+      </ul>
+    </section>
+
+    <section>
+      <h3>Durante a apresentação</h3>
+      <ul>
+        {#each material.duringBullets as bullet}
+          <li>{bullet}</li>
+        {/each}
+      </ul>
+      {#if material.jpPhrases.length > 0}
+        <h4>Frases-chave JP sugeridas</h4>
+        <ul class="jp-list">
+          {#each material.jpPhrases as phrase}
+            <li>
+              <div class="jp">{phrase.jp}</div>
+              <div class="muted">{phrase.pt}</div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <section>
+      <h3>Depois</h3>
+      <ul>
+        {#each material.afterBullets as bullet}
+          <li>{bullet}</li>
+        {/each}
+      </ul>
+    </section>
+
+    <section class="escalation">
+      <strong>Escalation:</strong>
+      {material.escalationPath}
+    </section>
+  {/if}
+
+  <div class="confirm">
+    <button
+      type="button"
+      class="btn-confirm"
+      on:click={markRead}
+      disabled={loading || material === null}
+      data-testid="mc10-mark-read"
+    >
+      {state.mc10ReadAt !== null ? "✓ Li, entendi" : "Li, entendi"}
+    </button>
+    {#if state.mc10ReadAt !== null}
+      <span class="muted ts">Confirmado em {state.mc10ReadAt}</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  h3 {
+    font-size: 0.95rem;
+    margin: 0.5rem 0 0.25rem;
+  }
+  h4 {
+    font-size: 0.85rem;
+    margin: 0.5rem 0 0.25rem;
+    opacity: 0.8;
+  }
+  ul {
+    margin: 0;
+    padding-left: 1.25rem;
+  }
+  li {
+    margin: 0.25rem 0;
+    line-height: 1.4;
+  }
+  .jp-list li {
+    list-style: none;
+    margin-bottom: 0.5rem;
+  }
+  .jp {
+    font-size: 1rem;
+  }
+  .muted {
+    opacity: 0.65;
+    font-size: 0.85rem;
+  }
+  .escalation {
+    background: rgba(255, 193, 7, 0.1);
+    border-left: 3px solid rgba(255, 193, 7, 0.6);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
+  .confirm {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+  }
+  .btn-confirm {
+    background: rgba(76, 175, 80, 0.25);
+    border: 1px solid rgba(76, 175, 80, 0.6);
+    border-radius: 4px;
+    padding: 0.4rem 0.9rem;
+    cursor: pointer;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.9rem;
+  }
+  .btn-confirm:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .ts {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+    font-size: 0.75rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step02CadastrarFamilia.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step02CadastrarFamilia.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import type { WizardState, WizardChild } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  function addChild(): void {
+    const newChild: WizardChild = {
+      id: `child-${state.family.children.length + 1}-${Date.now()}`,
+      name: "",
+      age: 0,
+      primaryLanguage: "pt",
+    };
+    state.family.children = [...state.family.children, newChild];
+    state = state;
+  }
+
+  function removeChild(id: string): void {
+    state.family.children = state.family.children.filter((c) => c.id !== id);
+    state = state;
+  }
+
+  function toggleCoParent(): void {
+    if (state.family.coParent === null) {
+      state.family.coParent = {
+        name: "",
+        relation: "co-parent",
+        permissions: "full",
+      };
+    } else {
+      state.family.coParent = null;
+    }
+    state = state;
+  }
+</script>
+
+<div class="step" data-testid="step-02">
+  <section>
+    <h3>Adquirente (responsável principal)</h3>
+    <label>
+      <span>Nome</span>
+      <input
+        type="text"
+        bind:value={state.family.acquirer.name}
+        data-testid="acquirer-name"
+        placeholder="Yuji"
+      />
+    </label>
+    <label>
+      <span>Relação</span>
+      <input
+        type="text"
+        bind:value={state.family.acquirer.relation}
+        placeholder="pai"
+      />
+    </label>
+  </section>
+
+  <section>
+    <h3>Co-parental</h3>
+    <button
+      type="button"
+      class="btn-small"
+      on:click={toggleCoParent}
+      data-testid="toggle-coparent"
+    >
+      {state.family.coParent === null
+        ? "+ Adicionar co-parental"
+        : "Remover co-parental"}
+    </button>
+    {#if state.family.coParent !== null}
+      <label>
+        <span>Nome</span>
+        <input
+          type="text"
+          bind:value={state.family.coParent.name}
+          placeholder="Yuko"
+        />
+      </label>
+      <label>
+        <span>Relação</span>
+        <input
+          type="text"
+          bind:value={state.family.coParent.relation}
+          placeholder="mãe"
+        />
+      </label>
+      <label>
+        <span>Permissões</span>
+        <select bind:value={state.family.coParent.permissions}>
+          <option value="full">Acesso total</option>
+          <option value="view-only">Apenas visualização</option>
+        </select>
+      </label>
+    {/if}
+  </section>
+
+  <section>
+    <h3>Crianças</h3>
+    {#each state.family.children as child (child.id)}
+      <div class="child-row">
+        <input
+          type="text"
+          bind:value={child.name}
+          placeholder="Nome"
+          data-testid="child-name"
+        />
+        <input
+          type="number"
+          bind:value={child.age}
+          min="1"
+          max="18"
+          placeholder="Idade"
+          data-testid="child-age"
+        />
+        <select bind:value={child.primaryLanguage}>
+          <option value="pt">PT</option>
+          <option value="jp">JP</option>
+          <option value="en">EN</option>
+        </select>
+        <button
+          type="button"
+          class="btn-remove"
+          on:click={() => removeChild(child.id)}
+          aria-label="Remover criança"
+        >
+          ×
+        </button>
+      </div>
+    {/each}
+    <button
+      type="button"
+      class="btn-small"
+      on:click={addChild}
+      data-testid="add-child"
+    >
+      + Adicionar criança
+    </button>
+  </section>
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  h3 {
+    font-size: 0.95rem;
+    margin: 0;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+  }
+  label span {
+    opacity: 0.7;
+  }
+  input,
+  select {
+    padding: 0.35rem 0.5rem;
+    background: rgba(127, 127, 127, 0.1);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    font-family: inherit;
+    color: inherit;
+  }
+  .child-row {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .btn-small,
+  .btn-remove {
+    background: rgba(127, 127, 127, 0.15);
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 4px;
+    padding: 0.3rem 0.6rem;
+    cursor: pointer;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.85rem;
+    align-self: flex-start;
+  }
+  .btn-remove {
+    padding: 0.2rem 0.5rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step03DefinirTelos.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step03DefinirTelos.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import {
+    DEFAULT_TELOS_TAGS,
+    type WizardState,
+  } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  const MAX_LEN = 500;
+
+  function toggleTag(tag: string): void {
+    if (state.telos.tags.includes(tag)) {
+      state.telos.tags = state.telos.tags.filter((t) => t !== tag);
+    } else {
+      state.telos.tags = [...state.telos.tags, tag];
+    }
+    state = state;
+  }
+
+  $: remaining = MAX_LEN - state.telos.text.length;
+</script>
+
+<div class="step" data-testid="step-03">
+  <p class="intro">
+    O que importa pra esta família? O motor vai favorecer atividades que
+    refletem esses valores.
+  </p>
+
+  <label>
+    <span>Texto livre (≤500 caracteres)</span>
+    <textarea
+      bind:value={state.telos.text}
+      maxlength={MAX_LEN}
+      rows="5"
+      data-testid="telos-text"
+      placeholder="Ex: queremos que nossos filhos cresçam bilíngues, com curiosidade ativa e respeito por anciãos."
+    />
+    <span class="counter" class:warn={remaining < 50}>
+      {remaining} caracteres restantes
+    </span>
+  </label>
+
+  <section>
+    <h3>Tags estruturadas</h3>
+    <div class="chips">
+      {#each DEFAULT_TELOS_TAGS as tag}
+        <button
+          type="button"
+          class="chip"
+          class:active={state.telos.tags.includes(tag)}
+          on:click={() => toggleTag(tag)}
+          data-testid="telos-tag-{tag}"
+        >
+          {tag}
+        </button>
+      {/each}
+    </div>
+  </section>
+
+  {#if state.telos.text.trim().length > 0 || state.telos.tags.length > 0}
+    <section class="preview">
+      <strong>Preview:</strong>
+      Brota vai favorecer atividades alinhadas com
+      {state.telos.tags.length > 0
+        ? state.telos.tags.join(", ")
+        : "esses valores"}.
+    </section>
+  {/if}
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+  }
+  textarea {
+    padding: 0.5rem;
+    background: rgba(127, 127, 127, 0.1);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    font-family: inherit;
+    color: inherit;
+    resize: vertical;
+  }
+  .counter {
+    opacity: 0.6;
+    font-size: 0.75rem;
+    align-self: flex-end;
+  }
+  .counter.warn {
+    color: #ff9800;
+  }
+  h3 {
+    font-size: 0.9rem;
+    margin: 0 0 0.4rem;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .chip {
+    padding: 0.25rem 0.65rem;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    background: rgba(127, 127, 127, 0.1);
+    border-radius: 999px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.8rem;
+    color: inherit;
+  }
+  .chip.active {
+    background: rgba(33, 150, 243, 0.25);
+    border-color: rgba(33, 150, 243, 0.6);
+  }
+  .preview {
+    background: rgba(76, 175, 80, 0.08);
+    border-left: 3px solid rgba(76, 175, 80, 0.5);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step04ForbiddenZones.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step04ForbiddenZones.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import type {
+    WizardState,
+    WizardForbiddenZone,
+  } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  let newTopic = "";
+
+  function addZone(): void {
+    const topic = newTopic.trim();
+    if (topic.length === 0) return;
+    const zone: WizardForbiddenZone = {
+      topic,
+      policy: "never",
+      reason: "custom",
+    };
+    state.forbiddenZones = [...state.forbiddenZones, zone];
+    newTopic = "";
+    state = state;
+  }
+
+  function removeZone(idx: number): void {
+    state.forbiddenZones = state.forbiddenZones.filter((_, i) => i !== idx);
+    state = state;
+  }
+
+  function setPolicy(
+    idx: number,
+    policy: WizardForbiddenZone["policy"],
+  ): void {
+    state.forbiddenZones[idx].policy = policy;
+    state.forbiddenZones = state.forbiddenZones;
+    state = state;
+  }
+</script>
+
+<div class="step" data-testid="step-04">
+  <p class="intro">
+    Assuntos que Brota deve evitar. Defaults seguros já estão marcados como
+    "nunca abordar". Custom adicionados ficam abaixo.
+  </p>
+
+  <ul class="zones">
+    {#each state.forbiddenZones as zone, idx (zone.topic)}
+      <li class="zone">
+        <span class="topic">{zone.topic}</span>
+        <div class="policy-toggle">
+          {#each ["never", "soft", "open"] as p}
+            <button
+              type="button"
+              class="policy-btn"
+              class:active={zone.policy === p}
+              on:click={() =>
+                setPolicy(idx, p)}
+            >
+              {p === "never"
+                ? "Nunca"
+                : p === "soft"
+                  ? "Só se kid abordar"
+                  : "OK"}
+            </button>
+          {/each}
+        </div>
+        <button
+          type="button"
+          class="btn-remove"
+          on:click={() => removeZone(idx)}
+          aria-label="Remover"
+        >
+          ×
+        </button>
+      </li>
+    {/each}
+  </ul>
+
+  <div class="add-row">
+    <input
+      type="text"
+      bind:value={newTopic}
+      placeholder="Ex: discussão de divórcio"
+      data-testid="new-zone-topic"
+      on:keydown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          addZone();
+        }
+      }}
+    />
+    <button
+      type="button"
+      on:click={addZone}
+      class="btn-add"
+      data-testid="add-zone"
+    >
+      + Adicionar
+    </button>
+  </div>
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  .zones {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .zone {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.4rem 0.6rem;
+    background: rgba(127, 127, 127, 0.08);
+    border-radius: 4px;
+  }
+  .topic {
+    font-size: 0.9rem;
+  }
+  .policy-toggle {
+    display: flex;
+    gap: 0.2rem;
+  }
+  .policy-btn {
+    padding: 0.2rem 0.5rem;
+    font-size: 0.75rem;
+    background: rgba(127, 127, 127, 0.1);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    cursor: pointer;
+    color: inherit;
+    font-family: inherit;
+  }
+  .policy-btn.active {
+    background: rgba(176, 0, 32, 0.2);
+    border-color: rgba(176, 0, 32, 0.5);
+  }
+  .btn-remove {
+    background: transparent;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    padding: 0.15rem 0.45rem;
+    cursor: pointer;
+    color: inherit;
+  }
+  .add-row {
+    display: flex;
+    gap: 0.5rem;
+  }
+  .add-row input {
+    flex: 1;
+    padding: 0.35rem 0.5rem;
+    background: rgba(127, 127, 127, 0.1);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    font-family: inherit;
+    color: inherit;
+  }
+  .btn-add {
+    background: rgba(33, 150, 243, 0.2);
+    border: 1px solid rgba(33, 150, 243, 0.5);
+    border-radius: 3px;
+    padding: 0.35rem 0.7rem;
+    cursor: pointer;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.85rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step05BudgetConstraints.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step05BudgetConstraints.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import type { WizardState } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  $: minutesPerSession = state.budget.sessionMinutesCap;
+  $: sessionsPerDay = Math.max(
+    1,
+    Math.floor(
+      state.budget.sacrificeBudgetCap /
+        (state.budget.sessionMinutesCap * 2),
+    ),
+  );
+</script>
+
+<div class="step" data-testid="step-05">
+  <p class="intro">
+    Limites que protegem a criança do excesso. Valores se aplicam a todas as
+    crianças cadastradas; ajustes finos por kid acontecem no console depois.
+  </p>
+
+  <label class="slider-row">
+    <span class="label">Sacrifice budget cap diário</span>
+    <input
+      type="range"
+      min="20"
+      max="300"
+      step="10"
+      bind:value={state.budget.sacrificeBudgetCap}
+      data-testid="budget-cap"
+    />
+    <span class="value">{state.budget.sacrificeBudgetCap}</span>
+  </label>
+
+  <label class="slider-row">
+    <span class="label">Off-screen ratio (mínimo)</span>
+    <input
+      type="range"
+      min="1"
+      max="5"
+      step="0.5"
+      bind:value={state.budget.offScreenRatio}
+      data-testid="offscreen-ratio"
+    />
+    <span class="value">{state.budget.offScreenRatio}:1</span>
+  </label>
+
+  <label class="slider-row">
+    <span class="label">Tempo max por sessão (min)</span>
+    <input
+      type="range"
+      min="5"
+      max="60"
+      step="1"
+      bind:value={state.budget.sessionMinutesCap}
+      data-testid="session-cap"
+    />
+    <span class="value">{state.budget.sessionMinutesCap}</span>
+  </label>
+
+  <section class="preview">
+    <strong>Preview:</strong>
+    Cada criança terá ~{sessionsPerDay} sessões/dia, cada ≤{minutesPerSession} minutos.
+  </section>
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  .slider-row {
+    display: grid;
+    grid-template-columns: 1fr 2fr auto;
+    gap: 0.75rem;
+    align-items: center;
+    font-size: 0.85rem;
+  }
+  .label {
+    opacity: 0.8;
+  }
+  .value {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+    min-width: 3rem;
+    text-align: right;
+  }
+  .preview {
+    background: rgba(76, 175, 80, 0.08);
+    border-left: 3px solid rgba(76, 175, 80, 0.5);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step06ProposedVirtues.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step06ProposedVirtues.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import {
+    CARDINAL_AXES,
+    type WizardState,
+    type WizardChild,
+  } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  function getRecommendedAxes(child: WizardChild): number[] {
+    if (child.age <= 5) return [4, 5]; // temperança + curiosidade
+    if (child.age <= 9) return [1, 11, 5]; // justiça + criatividade + curiosidade
+    return [1, 8, 9]; // justiça + autonomia + disciplina
+  }
+
+  function toggleAxis(childId: string, axis: number): void {
+    const list = state.virtuesByChild[childId] ?? [];
+    const exists = list.some((v) => v.axis === axis);
+    if (exists) {
+      state.virtuesByChild[childId] = list.filter((v) => v.axis !== axis);
+    } else {
+      state.virtuesByChild[childId] = [...list, { axis }];
+    }
+    state.virtuesByChild = state.virtuesByChild;
+    state = state;
+  }
+
+  function isActive(childId: string, axis: number): boolean {
+    return (state.virtuesByChild[childId] ?? []).some((v) => v.axis === axis);
+  }
+
+  function applyRecommended(child: WizardChild): void {
+    const recommended = getRecommendedAxes(child);
+    state.virtuesByChild[child.id] = recommended.map((axis) => ({ axis }));
+    state.virtuesByChild = state.virtuesByChild;
+    state = state;
+  }
+</script>
+
+<div class="step" data-testid="step-06">
+  <p class="intro">
+    Eixos cardeais que esta família escolhe cultivar agora. Aceita a
+    recomendação por idade ou customize. Pelo menos 1 eixo por criança é
+    obrigatório.
+  </p>
+
+  {#if state.family.children.length === 0}
+    <p class="muted">
+      Nenhuma criança cadastrada — volte ao passo 2.
+    </p>
+  {/if}
+
+  {#each state.family.children as child (child.id)}
+    <section class="child-section">
+      <header class="child-header">
+        <h3>{child.name} ({child.age}a)</h3>
+        <button
+          type="button"
+          class="btn-small"
+          on:click={() => applyRecommended(child)}
+          data-testid="apply-recommended-{child.id}"
+        >
+          Usar recomendação por idade
+        </button>
+      </header>
+      <div class="grid">
+        {#each CARDINAL_AXES as axis}
+          <button
+            type="button"
+            class="axis-btn"
+            class:active={isActive(child.id, axis.id)}
+            on:click={() => toggleAxis(child.id, axis.id)}
+            data-testid="axis-{child.id}-{axis.id}"
+          >
+            <span class="axis-id">{axis.id}</span>
+            <span class="axis-label">{axis.label}</span>
+          </button>
+        {/each}
+      </div>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro,
+  .muted {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  .child-section {
+    border: 1px solid rgba(127, 127, 127, 0.2);
+    border-radius: 5px;
+    padding: 0.75rem;
+  }
+  .child-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+  .child-header h3 {
+    font-size: 0.95rem;
+    margin: 0;
+  }
+  .btn-small {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 3px;
+    cursor: pointer;
+    color: inherit;
+    font-family: inherit;
+    background: rgba(33, 150, 243, 0.15);
+    border: 1px solid rgba(33, 150, 243, 0.4);
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.4rem;
+  }
+  .axis-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.4rem;
+    background: rgba(127, 127, 127, 0.08);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 4px;
+    cursor: pointer;
+    color: inherit;
+    font-family: inherit;
+  }
+  .axis-btn.active {
+    background: rgba(76, 175, 80, 0.2);
+    border-color: rgba(76, 175, 80, 0.6);
+  }
+  .axis-id {
+    font-size: 0.7rem;
+    opacity: 0.6;
+  }
+  .axis-label {
+    font-size: 0.85rem;
+  }
+  @media (max-width: 600px) {
+    .grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step07JanelasTemporal.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step07JanelasTemporal.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import type {
+    WizardState,
+    DayKey,
+    WindowZone,
+  } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  const DAYS: ReadonlyArray<{ key: DayKey; label: string }> = [
+    { key: "mon", label: "Seg" },
+    { key: "tue", label: "Ter" },
+    { key: "wed", label: "Qua" },
+    { key: "thu", label: "Qui" },
+    { key: "fri", label: "Sex" },
+    { key: "sat", label: "Sáb" },
+    { key: "sun", label: "Dom" },
+  ];
+
+  const ZONES: ReadonlyArray<{
+    key: WindowZone;
+    label: string;
+    color: string;
+  }> = [
+    { key: "school", label: "Escola", color: "#9e9e9e" },
+    { key: "sleep", label: "Sono", color: "#3f51b5" },
+    { key: "window1", label: "Pós-escola", color: "#4caf50" },
+    { key: "window2", label: "Noite", color: "#ff9800" },
+    { key: "free", label: "Livre", color: "#03a9f4" },
+  ];
+
+  let selectedZone: WindowZone = "window1";
+
+  function setCell(childId: string, day: DayKey): void {
+    if (!state.windowsByChild[childId]) {
+      state.windowsByChild[childId] = {};
+    }
+    state.windowsByChild[childId][day] = selectedZone;
+    state.windowsByChild = state.windowsByChild;
+    state = state;
+  }
+
+  function getCellColor(childId: string, day: DayKey): string {
+    const zone = state.windowsByChild[childId]?.[day];
+    if (!zone) return "transparent";
+    return ZONES.find((z) => z.key === zone)?.color ?? "transparent";
+  }
+
+  function getCellLabel(childId: string, day: DayKey): string {
+    const zone = state.windowsByChild[childId]?.[day];
+    if (!zone) return "—";
+    return ZONES.find((z) => z.key === zone)?.label ?? "—";
+  }
+</script>
+
+<div class="step" data-testid="step-07">
+  <p class="intro">
+    Marque zones temporais por criança. Clique numa célula pra aplicar a zone
+    selecionada. Brota só envia mensagens em janelas <strong>livre</strong> ou
+    <strong>pós-escola/noite</strong>.
+  </p>
+
+  <div class="zone-palette">
+    {#each ZONES as zone}
+      <button
+        type="button"
+        class="zone-swatch"
+        class:active={selectedZone === zone.key}
+        style="--swatch-color: {zone.color}"
+        on:click={() => (selectedZone = zone.key)}
+      >
+        {zone.label}
+      </button>
+    {/each}
+  </div>
+
+  {#each state.family.children as child (child.id)}
+    <section class="child-cal">
+      <h3>{child.name}</h3>
+      <div class="grid">
+        {#each DAYS as day}
+          <div class="day-col">
+            <div class="day-label">{day.label}</div>
+            <button
+              type="button"
+              class="cell"
+              style="background: {getCellColor(child.id, day.key)}"
+              on:click={() => setCell(child.id, day.key)}
+              data-testid="cell-{child.id}-{day.key}"
+            >
+              {getCellLabel(child.id, day.key)}
+            </button>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  .zone-palette {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .zone-swatch {
+    padding: 0.3rem 0.7rem;
+    border-radius: 4px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    background: var(--swatch-color);
+    color: white;
+    font-family: inherit;
+    font-size: 0.8rem;
+  }
+  .zone-swatch.active {
+    border-color: white;
+    box-shadow: 0 0 0 2px var(--swatch-color);
+  }
+  .child-cal h3 {
+    font-size: 0.95rem;
+    margin: 0 0 0.4rem;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.25rem;
+  }
+  .day-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+  }
+  .day-label {
+    font-size: 0.7rem;
+    opacity: 0.6;
+  }
+  .cell {
+    width: 100%;
+    aspect-ratio: 1;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    color: white;
+    font-size: 0.7rem;
+    text-shadow: 0 0 2px rgba(0, 0, 0, 0.6);
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step08ConsentLedger.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step08ConsentLedger.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import type { WizardState } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  const CONSENTS: ReadonlyArray<{
+    key: keyof WizardState["consents"];
+    label: string;
+    detail: string;
+  }> = [
+    {
+      key: "storeTrace",
+      label: "Brota pode armazenar trace de conversas",
+      detail: "TTL configurável (default 90 dias). Pais podem solicitar deleção.",
+    },
+    {
+      key: "emitPhysicalCards",
+      label: "Brota pode emitir cards físicos (HMAC signed)",
+      detail: "Cards do baralho impresso; necessário pra modo offline.",
+    },
+    {
+      key: "activeHoursMessaging",
+      label: "Brota pode enviar mensagens em horário ativo",
+      detail: "Apenas dentro das janelas definidas no passo anterior.",
+    },
+    {
+      key: "confirmIsAi",
+      label: "Aceito que Brota confirma ser IA quando perguntado",
+      detail: "Conforme protocolo MC2 — Brota nunca mente sobre sua natureza.",
+    },
+  ];
+
+  function toggle(key: keyof WizardState["consents"]): void {
+    state.consents[key] = !state.consents[key];
+    state = state;
+  }
+</script>
+
+<div class="step" data-testid="step-08">
+  <p class="intro">
+    Todos os toggles abaixo são <strong>obrigatórios</strong> pra iniciar o
+    piloto. Cada um requer leitura + click explícito.
+  </p>
+
+  <ul class="consent-list">
+    {#each CONSENTS as item}
+      <li class="consent-row">
+        <label>
+          <input
+            type="checkbox"
+            checked={state.consents[item.key]}
+            on:change={() => toggle(item.key)}
+            data-testid="consent-{item.key}"
+          />
+          <div>
+            <div class="consent-label">{item.label}</div>
+            <div class="consent-detail">{item.detail}</div>
+          </div>
+        </label>
+      </li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  .consent-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .consent-row label {
+    display: flex;
+    gap: 0.6rem;
+    align-items: flex-start;
+    cursor: pointer;
+    padding: 0.5rem 0.6rem;
+    background: rgba(127, 127, 127, 0.08);
+    border-radius: 5px;
+  }
+  .consent-row input[type="checkbox"] {
+    margin-top: 0.2rem;
+    width: 1.1rem;
+    height: 1.1rem;
+  }
+  .consent-label {
+    font-size: 0.9rem;
+  }
+  .consent-detail {
+    font-size: 0.75rem;
+    opacity: 0.65;
+    margin-top: 0.2rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step09DyadConfig.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step09DyadConfig.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import type { WizardState } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  $: hasMultipleChildren = state.family.children.length > 1;
+
+  function togglePair(childId: string): void {
+    if (!state.dyad) {
+      state.dyad = {
+        pairChildIds: [childId],
+        playbookId: "kids.group.playbook",
+        includeYoungest: false,
+      };
+    } else if (state.dyad.pairChildIds.includes(childId)) {
+      state.dyad.pairChildIds = state.dyad.pairChildIds.filter(
+        (id) => id !== childId,
+      );
+      if (state.dyad.pairChildIds.length === 0) {
+        state.dyad = null;
+      }
+    } else {
+      state.dyad.pairChildIds = [...state.dyad.pairChildIds, childId];
+    }
+    state = state;
+  }
+
+  function isPaired(childId: string): boolean {
+    return state.dyad?.pairChildIds.includes(childId) ?? false;
+  }
+</script>
+
+<div class="step" data-testid="step-09">
+  {#if !hasMultipleChildren}
+    <p class="muted">
+      Apenas uma criança cadastrada — dyad não aplicável. Avance para o
+      próximo passo.
+    </p>
+  {:else}
+    <p class="intro">
+      Configure dyad (par cooperativo) entre crianças. Brota pode rodar
+      sessões conjuntas com playbook específico.
+    </p>
+
+    <section>
+      <h3>Selecione o par</h3>
+      <div class="children-list">
+        {#each state.family.children as child (child.id)}
+          <button
+            type="button"
+            class="child-pill"
+            class:active={isPaired(child.id)}
+            on:click={() => togglePair(child.id)}
+            data-testid="dyad-toggle-{child.id}"
+          >
+            {child.name} ({child.age}a)
+          </button>
+        {/each}
+      </div>
+    </section>
+
+    {#if state.dyad !== null && state.dyad.pairChildIds.length >= 2}
+      <section>
+        <label>
+          <span>Playbook ativo</span>
+          <input
+            type="text"
+            bind:value={state.dyad.playbookId}
+            data-testid="dyad-playbook"
+          />
+        </label>
+      </section>
+
+      <section class="preview">
+        <strong>Preview:</strong>
+        Bloco 6 (jogada cooperativa) ativado para o par selecionado.
+      </section>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro,
+  .muted {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  h3 {
+    font-size: 0.9rem;
+    margin: 0 0 0.4rem;
+  }
+  .children-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .child-pill {
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    background: rgba(127, 127, 127, 0.1);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+  }
+  .child-pill.active {
+    background: rgba(33, 150, 243, 0.25);
+    border-color: rgba(33, 150, 243, 0.6);
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+  }
+  label span {
+    opacity: 0.7;
+  }
+  input {
+    padding: 0.35rem 0.5rem;
+    background: rgba(127, 127, 127, 0.1);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 3px;
+    font-family: inherit;
+    color: inherit;
+  }
+  .preview {
+    background: rgba(76, 175, 80, 0.08);
+    border-left: 3px solid rgba(76, 175, 80, 0.5);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step10AprovarMC1.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step10AprovarMC1.svelte
@@ -1,0 +1,271 @@
+<script lang="ts">
+  import type {
+    WizardState,
+    WizardChild,
+    WizardMc1Approval,
+  } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+  export let baseUrl: string = "/api";
+  export let fetchImpl: typeof globalThis.fetch | undefined = undefined;
+
+  function getFetch(): typeof globalThis.fetch {
+    if (fetchImpl) return fetchImpl;
+    return globalThis.fetch.bind(globalThis);
+  }
+
+  let loadingChild: string | null = null;
+  let errorMsg: string | null = null;
+  let editingChild: string | null = null;
+
+  function getApproval(
+    childId: string,
+  ): WizardMc1Approval | undefined {
+    return state.mc1Approvals.find((a) => a.childId === childId);
+  }
+
+  function setApproval(approval: WizardMc1Approval): void {
+    const others = state.mc1Approvals.filter(
+      (a) => a.childId !== approval.childId,
+    );
+    state.mc1Approvals = [...others, approval];
+    state = state;
+  }
+
+  async function generate(child: WizardChild): Promise<void> {
+    loadingChild = child.id;
+    errorMsg = null;
+    try {
+      const f = getFetch();
+      const res = await f(`${baseUrl}/parental/mc1/preview`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          personaId: child.id,
+          childName: child.name,
+          age: child.age,
+          language: child.primaryLanguage,
+          telos: state.telos,
+          virtues: state.virtuesByChild[child.id] ?? [],
+        }),
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const body = (await res.json()) as { text: string };
+      setApproval({
+        childId: child.id,
+        text: body.text,
+        approved: false,
+      });
+    } catch (err) {
+      errorMsg = `Falha ao gerar MC1 para ${child.name}: ${err instanceof Error ? err.message : String(err)}`;
+    } finally {
+      loadingChild = null;
+    }
+  }
+
+  function approve(childId: string): void {
+    const a = getApproval(childId);
+    if (!a) return;
+    setApproval({ ...a, approved: true });
+  }
+
+  function startEdit(childId: string): void {
+    editingChild = childId;
+  }
+
+  function saveEdit(childId: string, newText: string): void {
+    const a = getApproval(childId);
+    if (!a) return;
+    setApproval({ ...a, text: newText, approved: false });
+    editingChild = null;
+  }
+
+  function onEditBlur(childId: string, event: FocusEvent): void {
+    const target = event.currentTarget as HTMLTextAreaElement;
+    saveEdit(childId, target.value);
+  }
+</script>
+
+<div class="step" data-testid="step-10">
+  <p class="intro">
+    Brota gerou uma primeira mensagem customizada para cada criança. Revise +
+    aprove (ou edite). Todas precisam estar aprovadas para finalizar.
+  </p>
+
+  {#if errorMsg !== null}
+    <div class="error">{errorMsg}</div>
+  {/if}
+
+  {#each state.family.children as child (child.id)}
+    {@const approval = getApproval(child.id)}
+    <section class="mc1-block" class:approved={approval?.approved}>
+      <header>
+        <h3>{child.name} ({child.age}a)</h3>
+        {#if approval?.approved}
+          <span class="badge ok">✓ Aprovado</span>
+        {:else if approval}
+          <span class="badge pending">Pendente</span>
+        {/if}
+      </header>
+
+      {#if !approval}
+        <button
+          type="button"
+          class="btn-primary"
+          on:click={() => generate(child)}
+          disabled={loadingChild === child.id}
+          data-testid="generate-mc1-{child.id}"
+        >
+          {loadingChild === child.id
+            ? "Gerando..."
+            : "Gerar MC1 customizada"}
+        </button>
+      {:else if editingChild === child.id}
+        <textarea
+          rows="5"
+          value={approval.text}
+          on:blur={(e) => onEditBlur(child.id, e)}
+          data-testid="edit-mc1-{child.id}"
+        />
+        <p class="hint">Clique fora pra salvar.</p>
+      {:else}
+        <pre class="mc1-text">{approval.text}</pre>
+        <div class="actions">
+          <button
+            type="button"
+            class="btn-approve"
+            on:click={() => approve(child.id)}
+            disabled={approval.approved}
+            data-testid="approve-mc1-{child.id}"
+          >
+            {approval.approved ? "Aprovado" : "Aprovar"}
+          </button>
+          <button
+            type="button"
+            class="btn-secondary"
+            on:click={() => startEdit(child.id)}
+          >
+            Editar
+          </button>
+          <button
+            type="button"
+            class="btn-secondary"
+            on:click={() => generate(child)}
+            disabled={loadingChild === child.id}
+          >
+            Regenerar
+          </button>
+        </div>
+      {/if}
+    </section>
+  {/each}
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .intro {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 0.9rem;
+  }
+  .error {
+    background: rgba(176, 0, 32, 0.15);
+    color: #b00020;
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+  .mc1-block {
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 5px;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .mc1-block.approved {
+    border-color: rgba(76, 175, 80, 0.5);
+    background: rgba(76, 175, 80, 0.05);
+  }
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  h3 {
+    font-size: 0.95rem;
+    margin: 0;
+  }
+  .badge {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 3px;
+  }
+  .badge.ok {
+    background: rgba(76, 175, 80, 0.2);
+    color: #2e7d32;
+  }
+  .badge.pending {
+    background: rgba(255, 193, 7, 0.2);
+    color: #f57c00;
+  }
+  .mc1-text {
+    background: rgba(127, 127, 127, 0.08);
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    margin: 0;
+  }
+  textarea {
+    background: rgba(127, 127, 127, 0.08);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 4px;
+    padding: 0.5rem;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    resize: vertical;
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.75rem;
+    opacity: 0.6;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .btn-primary,
+  .btn-approve,
+  .btn-secondary {
+    font-family: inherit;
+    font-size: 0.85rem;
+    padding: 0.35rem 0.7rem;
+    border-radius: 3px;
+    cursor: pointer;
+    color: inherit;
+  }
+  .btn-primary {
+    background: rgba(33, 150, 243, 0.25);
+    border: 1px solid rgba(33, 150, 243, 0.6);
+  }
+  .btn-approve {
+    background: rgba(76, 175, 80, 0.25);
+    border: 1px solid rgba(76, 175, 80, 0.6);
+  }
+  .btn-secondary {
+    background: rgba(127, 127, 127, 0.1);
+    border: 1px solid rgba(127, 127, 127, 0.3);
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/wizard-steps/Step11Ready.svelte
+++ b/packages/ebrota-console-ui/src/components/wizard-steps/Step11Ready.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import type { WizardState } from "../../lib/wizard-types.js";
+
+  export let state: WizardState;
+
+  $: checklist = [
+    {
+      label: `Família — ${state.family.children.length} criança(s)`,
+      done: state.family.children.length > 0,
+    },
+    {
+      label: `Telos — ${state.telos.tags.length} tags`,
+      done: state.telos.text.trim().length > 0,
+    },
+    {
+      label: `Forbidden zones — ${state.forbiddenZones.length}`,
+      done: true,
+    },
+    {
+      label: "Budget constraints",
+      done: true,
+    },
+    {
+      label: "Virtudes propostas",
+      done: state.family.children.every(
+        (c) => (state.virtuesByChild[c.id]?.length ?? 0) > 0,
+      ),
+    },
+    {
+      label: "Janelas temporais",
+      done: true,
+    },
+    {
+      label: "Consent ledger",
+      done:
+        state.consents.storeTrace &&
+        state.consents.emitPhysicalCards &&
+        state.consents.activeHoursMessaging &&
+        state.consents.confirmIsAi,
+    },
+    {
+      label: state.dyad === null
+        ? "Dyad — não aplicável"
+        : `Dyad — ${state.dyad.pairChildIds.length} crianças`,
+      done: true,
+    },
+    {
+      label: `MC1 aprovadas — ${state.mc1Approvals.filter((a) => a.approved).length}/${state.family.children.length}`,
+      done:
+        state.family.children.length > 0 &&
+        state.family.children.every((c) =>
+          state.mc1Approvals.some(
+            (a) => a.childId === c.id && a.approved,
+          ),
+        ),
+    },
+  ];
+
+  $: eta = "primeira mensagem agendada para próxima janela livre";
+</script>
+
+<div class="step" data-testid="step-11">
+  <h3>Resumo final</h3>
+
+  <ul class="checklist">
+    {#each checklist as item}
+      <li class:done={item.done}>
+        <span class="check">{item.done ? "✓" : "○"}</span>
+        {item.label}
+      </li>
+    {/each}
+  </ul>
+
+  {#if state.readyForPilot}
+    <div class="ready-banner" data-testid="ready-banner">
+      🌳 Família pronta! Brota foi notificado. {eta}.
+    </div>
+  {:else}
+    <p class="hint">
+      Clique em <strong>Iniciar piloto</strong> para criar o evento
+      <code>persona_ready_for_pilot</code> e notificar Jun.
+    </p>
+  {/if}
+</div>
+
+<style>
+  .step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  h3 {
+    font-size: 1rem;
+    margin: 0;
+  }
+  .checklist {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .checklist li {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.9rem;
+    opacity: 0.6;
+  }
+  .checklist li.done {
+    opacity: 1;
+  }
+  .check {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+    color: #4caf50;
+    width: 1rem;
+    text-align: center;
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.75;
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+    background: rgba(127, 127, 127, 0.15);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.85em;
+  }
+  .ready-banner {
+    background: rgba(76, 175, 80, 0.15);
+    border: 1px solid rgba(76, 175, 80, 0.5);
+    border-radius: 5px;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+    color: #2e7d32;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/lib/wizard-types.ts
+++ b/packages/ebrota-console-ui/src/lib/wizard-types.ts
@@ -1,0 +1,200 @@
+/**
+ * Parental Onboarding Wizard — state shape (US-PO-01..11).
+ *
+ * Mirrora subset relevante de `shared/src/parental-profile.ts` mas mantido
+ * separado pra não importar o módulo shared no bundle browser. BFF
+ * `/parental/onboarding/complete` é quem serializa pra YAML compatível.
+ */
+
+export interface WizardChild {
+  id: string;
+  name: string;
+  age: number;
+  primaryLanguage: string;
+}
+
+export interface WizardCoParent {
+  name: string;
+  relation: string;
+  permissions: "full" | "view-only";
+}
+
+export interface WizardFamily {
+  acquirer: { id: string; name: string; relation: string };
+  coParent: WizardCoParent | null;
+  children: WizardChild[];
+}
+
+export interface WizardForbiddenZone {
+  topic: string;
+  policy: "never" | "soft" | "open";
+  reason?: string;
+}
+
+export interface WizardBudget {
+  sacrificeBudgetCap: number;
+  offScreenRatio: number;
+  sessionMinutesCap: number;
+}
+
+/** axis id 1..12, com nota opcional. */
+export interface WizardVirtueChoice {
+  axis: number;
+  note?: string;
+}
+
+/** virtudes por criança (key = childId). */
+export type WizardVirtuesByChild = Record<string, WizardVirtueChoice[]>;
+
+export type DayKey =
+  | "mon"
+  | "tue"
+  | "wed"
+  | "thu"
+  | "fri"
+  | "sat"
+  | "sun";
+
+export type WindowZone = "school" | "sleep" | "free" | "window1" | "window2";
+
+/** Janelas por criança × dia. */
+export type WizardWindowsByChild = Record<
+  string,
+  Partial<Record<DayKey, WindowZone>>
+>;
+
+export interface WizardConsents {
+  storeTrace: boolean;
+  emitPhysicalCards: boolean;
+  activeHoursMessaging: boolean;
+  confirmIsAi: boolean;
+}
+
+export interface WizardDyad {
+  pairChildIds: string[];
+  playbookId: string;
+  includeYoungest: boolean;
+}
+
+export interface WizardMc1Approval {
+  childId: string;
+  text: string;
+  approved: boolean;
+}
+
+export interface WizardState {
+  /** Current step 1..11. */
+  step: number;
+  /** US-PO-01 — timestamp ISO quando "Li, entendi" foi clicado. */
+  mc10ReadAt: string | null;
+  /** US-PO-02. */
+  family: WizardFamily;
+  /** US-PO-03. */
+  telos: { text: string; tags: string[] };
+  /** US-PO-04. */
+  forbiddenZones: WizardForbiddenZone[];
+  /** US-PO-05 — orçamentos default aplicados a todas as crianças. */
+  budget: WizardBudget;
+  /** US-PO-06. */
+  virtuesByChild: WizardVirtuesByChild;
+  /** US-PO-07. */
+  windowsByChild: WizardWindowsByChild;
+  /** US-PO-08. */
+  consents: WizardConsents;
+  /** US-PO-09. */
+  dyad: WizardDyad | null;
+  /** US-PO-10 — uma aprovação por criança. */
+  mc1Approvals: WizardMc1Approval[];
+  /** US-PO-11 — finalizado. */
+  readyForPilot: boolean;
+}
+
+export interface Mc10Material {
+  beforeBullets: string[];
+  duringBullets: string[];
+  afterBullets: string[];
+  jpPhrases: Array<{ pt: string; jp: string }>;
+  escalationPath: string;
+}
+
+/** 12 eixos cardeais — labels curtas pra UI. */
+export const CARDINAL_AXES: ReadonlyArray<{ id: number; label: string }> = [
+  { id: 1, label: "Justiça" },
+  { id: 2, label: "Prudência" },
+  { id: 3, label: "Fortaleza" },
+  { id: 4, label: "Temperança" },
+  { id: 5, label: "Curiosidade" },
+  { id: 6, label: "Honestidade" },
+  { id: 7, label: "Generosidade" },
+  { id: 8, label: "Autonomia" },
+  { id: 9, label: "Disciplina" },
+  { id: 10, label: "Empatia" },
+  { id: 11, label: "Criatividade" },
+  { id: 12, label: "Perseverança" },
+];
+
+export const DEFAULT_TELOS_TAGS = [
+  "bilinguismo",
+  "autonomia",
+  "comunicação_emocional",
+  "criatividade",
+  "disciplina",
+  "conexão_natureza",
+  "respeito",
+  "curiosidade",
+];
+
+export const DEFAULT_FORBIDDEN_ZONES: ReadonlyArray<WizardForbiddenZone> = [
+  { topic: "violência gráfica", policy: "never", reason: "default seguro" },
+  { topic: "conteúdo sexual", policy: "never", reason: "default seguro" },
+  { topic: "drogas e álcool", policy: "never", reason: "default seguro" },
+];
+
+export function emptyWizardState(): WizardState {
+  return {
+    step: 1,
+    mc10ReadAt: null,
+    family: {
+      acquirer: { id: "", name: "", relation: "parent" },
+      coParent: null,
+      children: [],
+    },
+    telos: { text: "", tags: [] },
+    forbiddenZones: [...DEFAULT_FORBIDDEN_ZONES],
+    budget: {
+      sacrificeBudgetCap: 100,
+      offScreenRatio: 2,
+      sessionMinutesCap: 15,
+    },
+    virtuesByChild: {},
+    windowsByChild: {},
+    consents: {
+      storeTrace: false,
+      emitPhysicalCards: false,
+      activeHoursMessaging: false,
+      confirmIsAi: false,
+    },
+    dyad: null,
+    mc1Approvals: [],
+    readyForPilot: false,
+  };
+}
+
+export function isStep8Complete(consents: WizardConsents): boolean {
+  return (
+    consents.storeTrace &&
+    consents.emitPhysicalCards &&
+    consents.activeHoursMessaging &&
+    consents.confirmIsAi
+  );
+}
+
+export function isStep10Complete(
+  approvals: WizardMc1Approval[],
+  children: WizardChild[],
+): boolean {
+  if (children.length === 0) return false;
+  return children.every((c) =>
+    approvals.some((a) => a.childId === c.id && a.approved),
+  );
+}

--- a/packages/ebrota-console-ui/tests/parental-wizard.test.ts
+++ b/packages/ebrota-console-ui/tests/parental-wizard.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import ParentalOnboardingWizard from "../src/components/ParentalOnboardingWizard.svelte";
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+const MC10_RESPONSE = {
+  beforeBullets: ["bullet antes 1"],
+  duringBullets: ["bullet durante 1", "bullet durante 2"],
+  afterBullets: ["bullet depois 1", "bullet depois 2"],
+  jpPhrases: [{ pt: "test PT", jp: "テスト" }],
+  escalationPath: "escala pro Jun",
+};
+
+function buildFetchMock(): {
+  fn: typeof globalThis.fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fn = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    let body: unknown = undefined;
+    if (init?.body !== undefined) {
+      body = JSON.parse(init.body as string);
+    }
+    calls.push({ url, method, body });
+    if (url.endsWith("/parental/mc10-material") && method === "GET") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => MC10_RESPONSE,
+      } as Response;
+    }
+    if (url.endsWith("/parental/onboarding/draft") && method === "POST") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ acquirerId: "x", step: 1, status: "in_progress" }),
+      } as Response;
+    }
+    if (url.endsWith("/parental/onboarding/complete") && method === "POST") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ acquirerId: "x", status: "complete" }),
+      } as Response;
+    }
+    if (url.endsWith("/parental/mc1/preview") && method === "POST") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          personaId: "p1",
+          text: "Oi! Eu sou Brota.",
+          generatedAt: new Date().toISOString(),
+        }),
+      } as Response;
+    }
+    return {
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "not found" }),
+    } as Response;
+  };
+  return { fn: fn as unknown as typeof globalThis.fetch, calls };
+}
+
+let mock = buildFetchMock();
+
+beforeEach(() => {
+  mock = buildFetchMock();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderWizard(opts: { withMaterial?: boolean } = {}) {
+  return render(ParentalOnboardingWizard, {
+    fetchImpl: mock.fn,
+    initialMc10Material: opts.withMaterial === false ? null : MC10_RESPONSE,
+  });
+}
+
+describe("ParentalOnboardingWizard render + step 1", () => {
+  it("renderiza wizard com step 1 e progress 1/11", async () => {
+    renderWizard();
+    await tick();
+    expect(screen.getByTestId("parental-onboarding-wizard")).toBeDefined();
+    expect(
+      screen.getByText(/Passo 1\/11 — Receber material MC10/),
+    ).toBeDefined();
+  });
+
+  it("sem material pré-carregado, exibe 'Carregando' ou 'indisponível'", async () => {
+    // Quando fetchImpl não é wired e initialMc10Material=null, wizard
+    // tenta fetch real (jsdom não tem rede) → cai no catch → material
+    // permanece null e o estado de erro/indisponível é renderizado.
+    // O comportamento crítico (gate em step 1 disabled) é verificado em
+    // testes de unidade.
+    renderWizard({ withMaterial: false });
+    await tick();
+    const stepEl = screen.getByTestId("step-01");
+    expect(stepEl.textContent).toMatch(/Carregando|indisponível/);
+  });
+
+  it("botão Próximo disabled antes de marcar MC10 como lido", async () => {
+    renderWizard();
+    await waitFor(() => {
+      const btn = screen.getByTestId("mc10-mark-read") as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+    const nextBtn = screen.getByTestId("wizard-next") as HTMLButtonElement;
+    expect(nextBtn.disabled).toBe(true);
+  });
+
+  it("após click em 'Li, entendi', botão Próximo habilita", async () => {
+    renderWizard();
+    await waitFor(() => {
+      const btn = screen.getByTestId("mc10-mark-read") as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+    const markRead = screen.getByTestId("mc10-mark-read");
+    await fireEvent.click(markRead);
+    await tick();
+    const nextBtn = screen.getByTestId("wizard-next") as HTMLButtonElement;
+    expect(nextBtn.disabled).toBe(false);
+  });
+});
+
+describe("Navegação básica step 1 → step 2", () => {
+  it("após Próximo, step 2 aparece e MC10 timestamp persiste", async () => {
+    renderWizard();
+    await waitFor(() => {
+      const btn = screen.getByTestId("mc10-mark-read") as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+    await fireEvent.click(screen.getByTestId("mc10-mark-read"));
+    await tick();
+    await fireEvent.click(screen.getByTestId("wizard-next"));
+    await tick();
+    expect(screen.getByTestId("step-02")).toBeDefined();
+    expect(
+      screen.getByText(/Passo 2\/11 — Cadastrar família/),
+    ).toBeDefined();
+  });
+});
+
+describe("isStep8Complete + isStep10Complete (unit logic)", () => {
+  it("isStep8Complete só true com 4 consents", async () => {
+    const { isStep8Complete } = await import("../src/lib/wizard-types.js");
+    expect(
+      isStep8Complete({
+        storeTrace: false,
+        emitPhysicalCards: false,
+        activeHoursMessaging: false,
+        confirmIsAi: false,
+      }),
+    ).toBe(false);
+    expect(
+      isStep8Complete({
+        storeTrace: true,
+        emitPhysicalCards: true,
+        activeHoursMessaging: true,
+        confirmIsAi: false,
+      }),
+    ).toBe(false);
+    expect(
+      isStep8Complete({
+        storeTrace: true,
+        emitPhysicalCards: true,
+        activeHoursMessaging: true,
+        confirmIsAi: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("isStep10Complete exige aprovação per criança", async () => {
+    const { isStep10Complete } = await import("../src/lib/wizard-types.js");
+    const children = [
+      { id: "ryo", name: "Ryo", age: 8, primaryLanguage: "pt" },
+      { id: "kei", name: "Kei", age: 8, primaryLanguage: "pt" },
+    ];
+    expect(isStep10Complete([], children)).toBe(false);
+    expect(
+      isStep10Complete(
+        [{ childId: "ryo", text: "x", approved: true }],
+        children,
+      ),
+    ).toBe(false);
+    expect(
+      isStep10Complete(
+        [
+          { childId: "ryo", text: "x", approved: true },
+          { childId: "kei", text: "y", approved: true },
+        ],
+        children,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("emptyWizardState defaults", () => {
+  it("step inicia em 1 e tem 3 defaults de forbidden zones", async () => {
+    const { emptyWizardState } = await import("../src/lib/wizard-types.js");
+    const s = emptyWizardState();
+    expect(s.step).toBe(1);
+    expect(s.forbiddenZones.length).toBe(3);
+    expect(s.budget.sacrificeBudgetCap).toBe(100);
+    expect(s.consents.storeTrace).toBe(false);
+    expect(s.readyForPilot).toBe(false);
+  });
+});


### PR DESCRIPTION
Implementa US-PO-01..11 do spec `docs/specs/2026-05-26-console-ebrota-user-stories-v0.md` (Parental Journey — Navigation Flows). Pré-piloto Yuji blocker.

## UI

- `ParentalOnboardingWizard.svelte`: 11 steps lineares (forward + back) com progress bar `N/11`, gating reativo per step (`canAdvance`), `fetchImpl` + `initialMc10Material` props injetáveis para testes.
- 11 sub-componentes em `src/components/wizard-steps/`:
  - **Step01 ReadMC10** — bullets PT-BR + frases JP do spec MC10; botão *Li, entendi* marca timestamp.
  - **Step02 CadastrarFamilia** — adquirente + co-parental opcional + crianças (nome/idade/idioma).
  - **Step03 DefinirTelos** — textarea ≤500 + chips estruturadas.
  - **Step04 ForbiddenZones** — 3 defaults seguros + add custom + policy toggle (nunca/soft/open).
  - **Step05 BudgetConstraints** — sliders (sacrifice cap, off-screen ratio, session minutes) com preview.
  - **Step06 ProposedVirtues** — grid 12 eixos cardeais per criança + recomendação por idade.
  - **Step07 JanelasTemporal** — calendário 7×N por criança × 5 zones.
  - **Step08 ConsentLedger** — 4 toggles obrigatórios (gate hard).
  - **Step09 DyadConfig** — selector de pares + playbook (skipável se 1 criança).
  - **Step10 AprovarMC1** — gera + aprova/edita/regenera per kid via `/parental/mc1/preview`.
  - **Step11 Ready** — checklist final + botão *Iniciar piloto*.
- `wizard-types.ts` — `WizardState` shape + `isStep8Complete` / `isStep10Complete` / `emptyWizardState`.
- `App.svelte` — `?onboarding=true` na URL renderiza o wizard isolado (sem polling daemon/canal).

## BFF (`packages/ebrota-console-bff/src/server.ts`)

- `GET  /parental/mc10-material` — bullets PT-BR + frases JP hardcoded (V0 do spec MC10).
- `POST /parental/onboarding/draft` — idempotente por `acquirerId`, persiste em SQLite.
- `GET  /parental/onboarding/status` — retomada de sessão.
- `POST /parental/onboarding/complete` — valida ≥1 criança, escreve YAML em `fixturesDir`, registra evento `persona_ready_for_pilot` em `debug_actions`.
- `POST /parental/mc1/preview` — stub V0 que personaliza por nome + telos + idioma.
- `parental-onboarding-store.ts` — tabela `parental_onboarding` (acquirer_id PK, step/status/state_json/timestamps).
- Mini-YAML serializer inline (não há dep `yaml` no projeto).

## Testes

- BFF: 11 testes em `parental-onboarding.unit.test.ts` (MC10 fetch, draft idempotente, status not_started/in_progress/complete, complete + YAML write, MC1 preview validation).
- UI: 8 testes em `parental-wizard.test.ts` (render, gating step 1, navegação 1→2, unit logic de `isStep8Complete` / `isStep10Complete` / `emptyWizardState`).

## Resultados

- `npm run build --workspace=@ascendimacy/ebrota-console-bff` ✓
- `npm run build --workspace=@ascendimacy/ebrota-console-ui` ✓ (warnings a11y pré-existentes em JourneyPanel não relacionados)
- `npm run test --workspace=@ascendimacy/ebrota-console-bff` ✓ **161/161**
- `npm run test --workspace=@ascendimacy/ebrota-console-ui` ✓ **149/149**

## Não inclui

- Integração com orchestrator daemon para realmente notificar Jun via evento (V0 só loga em `debug_actions`).
- LLM real em `/parental/mc1/preview` (stub determinístico V0).
- Conexão com `shared/parental-profile.ts` schema completo (YAML gerado mirrora subset do WizardState; mapping completo fica para PR de polish).
- A11y deeper review (foco trap, keyboard nav entre steps) — visual baseline funciona, polish iterativo.

Refs:
- Spec: `docs/specs/2026-05-26-console-ebrota-user-stories-v0.md` US-PO-01..11
- MC10: `docs/specs/2026-05-19-mc10-onboarding-yuji.md`
- Schema: `shared/src/parental-profile.ts` (não modificado neste PR)