### PR TITLE
[ui] Console — Redesign Fase 1: 7 subsystem panels + landing grid + USE_SUBSYSTEM_LAYOUT flag

### DIFF
--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -13,14 +13,24 @@
   import MapsPanel from "./components/MapsPanel.svelte";
   import DiscoveriesPanel from "./components/DiscoveriesPanel.svelte";
   import LlmXrayPanel from "./components/LlmXrayPanel.svelte";
+  import SubsystemGrid from "./components/SubsystemGrid.svelte";
+  import S1AprendizPanel from "./components/subsystem-panels/S1AprendizPanel.svelte";
+  import S2DoutrinaPanel from "./components/subsystem-panels/S2DoutrinaPanel.svelte";
+  import S3DecisaoTurnPanel from "./components/subsystem-panels/S3DecisaoTurnPanel.svelte";
+  import S4ExpressaoTurnPanel from "./components/subsystem-panels/S4ExpressaoTurnPanel.svelte";
+  import S5AvaliacaoPanel from "./components/subsystem-panels/S5AvaliacaoPanel.svelte";
+  import B1SocialPanel from "./components/subsystem-panels/B1SocialPanel.svelte";
+  import B2DrillingPanel from "./components/subsystem-panels/B2DrillingPanel.svelte";
   import { createApiClient } from "./lib/api.js";
   import {
     bffStatus,
     consoleMode,
     currentSessionId,
+    expandedSubsystem,
     globalError,
     libraryOpen,
     replaySessionId,
+    subsystemLayoutEnabled,
   } from "./lib/stores.js";
   import {
     startTurnStateStream,
@@ -119,10 +129,45 @@
 
   <ApprovalGate {api} />
 
-  <main class="main-grid">
-    <ChatFeed />
-    <MotorView {api} />
-  </main>
+  {#if $subsystemLayoutEnabled}
+    <main
+      class="main-subsystem"
+      class:expanded={$expandedSubsystem !== null}
+      data-testid="main-subsystem"
+    >
+      <div class="left">
+        {#if $expandedSubsystem === null}
+          <SubsystemGrid />
+        {:else if $expandedSubsystem === "S1"}
+          <S1AprendizPanel />
+        {:else if $expandedSubsystem === "S2"}
+          <S2DoutrinaPanel />
+        {:else if $expandedSubsystem === "S3"}
+          <S3DecisaoTurnPanel />
+        {:else if $expandedSubsystem === "S4"}
+          <S4ExpressaoTurnPanel />
+        {:else if $expandedSubsystem === "S5"}
+          <S5AvaliacaoPanel />
+        {:else if $expandedSubsystem === "B1"}
+          <B1SocialPanel />
+        {:else if $expandedSubsystem === "B2"}
+          <B2DrillingPanel />
+        {/if}
+      </div>
+      <aside class="right">
+        <ChatFeed />
+      </aside>
+    </main>
+    <details class="motor-view-fold">
+      <summary>MotorView (debug — trace v2 expandido)</summary>
+      <MotorView {api} />
+    </details>
+  {:else}
+    <main class="main-grid" data-testid="main-grid-legacy">
+      <ChatFeed />
+      <MotorView {api} />
+    </main>
+  {/if}
 
   <SessionStart {api} />
 
@@ -176,6 +221,36 @@
       grid-template-columns: 1fr;
       grid-template-rows: 1fr 1fr;
     }
+  }
+
+  .main-subsystem {
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    gap: 1px;
+    background: rgba(127, 127, 127, 0.2);
+    flex: 1;
+    min-height: 0;
+  }
+  .main-subsystem > .left,
+  .main-subsystem > .right {
+    background: var(--color-bg, transparent);
+    overflow: auto;
+    min-height: 0;
+  }
+  @media (max-width: 768px) {
+    .main-subsystem {
+      grid-template-columns: 1fr;
+      grid-template-rows: 1fr auto;
+    }
+  }
+  .motor-view-fold {
+    border-top: 1px solid rgba(127, 127, 127, 0.3);
+    padding: 0.3rem 0.6rem;
+    font-size: 0.85rem;
+  }
+  .motor-view-fold > summary {
+    cursor: pointer;
+    opacity: 0.75;
   }
 
   .muted {

--- a/packages/ebrota-console-ui/src/components/SubsystemCard.svelte
+++ b/packages/ebrota-console-ui/src/components/SubsystemCard.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  /**
+   * SubsystemCard — card visual de um subsistema (S1/S2/S3/S4/S5/B1/B2).
+   * Usado no SubsystemGrid landing. Click → emite event "expand" com id.
+   *
+   * Spec: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-7-subsistemas-redesign-v0.md
+   */
+  import { createEventDispatcher } from "svelte";
+
+  export let id: string;
+  export let title: string;
+  export let subtitle: string = "";
+  export let vitalSign: string = "";
+  export let status: "impl" | "partial" | "placeholder" = "impl";
+  export let color: string = "#7f7f7f";
+
+  const dispatch = createEventDispatcher<{ expand: { id: string } }>();
+
+  function statusIcon(s: typeof status): string {
+    switch (s) {
+      case "impl":
+        return "✅";
+      case "partial":
+        return "◑";
+      case "placeholder":
+        return "📋";
+    }
+  }
+
+  function handleClick(): void {
+    dispatch("expand", { id });
+  }
+
+  function handleKey(e: KeyboardEvent): void {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleClick();
+    }
+  }
+</script>
+
+<button
+  type="button"
+  class="subsystem-card"
+  data-testid={`subsystem-card-${id}`}
+  data-subsystem-id={id}
+  on:click={handleClick}
+  on:keydown={handleKey}
+  style:--accent={color}
+>
+  <header class="card-header">
+    <span class="badge" aria-hidden="true">{id}</span>
+    <span class="status" title={`status: ${status}`}>{statusIcon(status)}</span>
+  </header>
+  <h3 class="title">{title}</h3>
+  {#if subtitle.length > 0}
+    <p class="subtitle">{subtitle}</p>
+  {/if}
+  {#if vitalSign.length > 0}
+    <div class="vital">{vitalSign}</div>
+  {/if}
+</button>
+
+<style>
+  .subsystem-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-left: 4px solid var(--accent);
+    border-radius: 6px;
+    background: var(--color-bg, transparent);
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+    min-height: 7.5rem;
+    transition: transform 80ms ease, box-shadow 80ms ease;
+  }
+  .subsystem-card:hover,
+  .subsystem-card:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.75rem;
+    opacity: 0.85;
+  }
+  .badge {
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: var(--accent);
+  }
+  .title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+  .subtitle {
+    margin: 0;
+    font-size: 0.8rem;
+    opacity: 0.75;
+  }
+  .vital {
+    margin-top: auto;
+    font-size: 0.8rem;
+    opacity: 0.9;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/SubsystemGrid.svelte
+++ b/packages/ebrota-console-ui/src/components/SubsystemGrid.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  /**
+   * SubsystemGrid — landing grid 4x2 dos 7 subsistemas (S1-S5 + B1-B2).
+   * Click num card → seta `expandedSubsystem` store.
+   *
+   * Layout: 4x2 desktop, 1x7 stacked mobile (media query).
+   *
+   * Spec: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-7-subsistemas-redesign-v0.md
+   */
+  import SubsystemCard from "./SubsystemCard.svelte";
+  import { expandedSubsystem } from "../lib/stores.js";
+
+  type SubsystemDef = {
+    id: string;
+    title: string;
+    subtitle: string;
+    vitalSign: string;
+    status: "impl" | "partial" | "placeholder";
+    color: string;
+  };
+
+  // Cores semânticas per spec (S1 azul ... B2 cinza).
+  const SUBSYSTEMS: SubsystemDef[] = [
+    {
+      id: "S1",
+      title: "Aprendiz",
+      subtitle: "modelo do aprendiz",
+      vitalSign: "CASEL × Dreyfus · mood · ledger",
+      status: "partial",
+      color: "#3b82f6",
+    },
+    {
+      id: "S2",
+      title: "Doutrina",
+      subtitle: "modelo pedagógico",
+      vitalSign: "charter · 5 jogadas · journey",
+      status: "partial",
+      color: "#10b981",
+    },
+    {
+      id: "S3",
+      title: "Decisão",
+      subtitle: "motor de decisão (per turn)",
+      vitalSign: "assessor · pool · selector",
+      status: "impl",
+      color: "#eab308",
+    },
+    {
+      id: "S4",
+      title: "Expressão",
+      subtitle: "motor de expressão (per turn)",
+      vitalSign: "materializer · sanitize · gate",
+      status: "impl",
+      color: "#f97316",
+    },
+    {
+      id: "S5",
+      title: "Avaliação",
+      subtitle: "guardrail · STS · longitudinal",
+      vitalSign: "3 sub-tabs",
+      status: "partial",
+      color: "#ef4444",
+    },
+    {
+      id: "B1",
+      title: "Social",
+      subtitle: "atrai/retém",
+      vitalSign: "cards · budget · dyad · hooks",
+      status: "placeholder",
+      color: "#8b5cf6",
+    },
+    {
+      id: "B2",
+      title: "Drilling",
+      subtitle: "automaticidade (SR)",
+      vitalSign: "ausente — ver spec",
+      status: "placeholder",
+      color: "#6b7280",
+    },
+  ];
+
+  function handleExpand(ev: CustomEvent<{ id: string }>): void {
+    expandedSubsystem.set(ev.detail.id);
+  }
+</script>
+
+<section
+  class="subsystem-grid"
+  data-testid="subsystem-grid"
+  aria-label="grid 7 subsistemas"
+>
+  {#each SUBSYSTEMS as sys (sys.id)}
+    <SubsystemCard
+      id={sys.id}
+      title={sys.title}
+      subtitle={sys.subtitle}
+      vitalSign={sys.vitalSign}
+      status={sys.status}
+      color={sys.color}
+      on:expand={handleExpand}
+    />
+  {/each}
+</section>
+
+<style>
+  .subsystem-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: minmax(7.5rem, auto);
+    gap: 0.75rem;
+    padding: 1rem;
+  }
+  @media (max-width: 900px) {
+    .subsystem-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  @media (max-width: 540px) {
+    .subsystem-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/B1SocialPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/B1SocialPanel.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  /**
+   * B1 — Camada Social (panel).
+   * Pergunta: "Como o motor está atraindo/retendo [persona]?"
+   *
+   * v0: placeholders em todos os blocos. Cards-repo / sacrifice budget /
+   * dyad / janelas temporais / Pulso — tudo ainda não wired.
+   */
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+
+  const COLOR = "#8b5cf6";
+</script>
+
+<SubsystemPanelShell id="B1" title="Camada Social" color={COLOR}>
+  <section class="block">
+    <h3>Cards emitidos</h3>
+    <div class="grid-placeholder" aria-hidden="true">
+      {#each Array(4) as _, i (i)}
+        <div class="card-slot">slot {i + 1}</div>
+      {/each}
+    </div>
+    <PlaceholderBanner
+      label="grid de cards (rarity · QR · cheat-code) — TODO link com cards-repo"
+      specPath="packages/ebrota-console-ui (TODO)"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>Sacrifice budget</h3>
+    <div class="gauge-placeholder">
+      <div class="gauge-fill" style="width:60%"></div>
+    </div>
+    <PlaceholderBanner
+      label="gauge sacrifice budget + breakdown — TODO"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>Dyad</h3>
+    <PlaceholderBanner
+      label="duplas ativas (Ryo+Kei) + playbook kids.group — TODO"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>Janelas temporais</h3>
+    <PlaceholderBanner
+      label="spec hooks temporais em rascunho/PR #243"
+      specPath="docs/specs/2026-05-26-b1-hooks-temporais-v0.md"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>Pulso</h3>
+    <PlaceholderBanner
+      label="último ritual de retorno (omikuji / mini-história) — TODO"
+      color={COLOR}
+    />
+  </section>
+</SubsystemPanelShell>
+
+<style>
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+  }
+  .grid-placeholder {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.4rem;
+  }
+  .card-slot {
+    border: 1px dashed rgba(139, 92, 246, 0.5);
+    border-radius: 4px;
+    padding: 0.8rem 0.4rem;
+    text-align: center;
+    font-size: 0.75rem;
+    opacity: 0.6;
+    min-height: 3.5rem;
+  }
+  .gauge-placeholder {
+    height: 12px;
+    background: rgba(127, 127, 127, 0.18);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .gauge-fill {
+    height: 100%;
+    background: linear-gradient(to right, #8b5cf6, #a78bfa);
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/B2DrillingPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/B2DrillingPanel.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  /**
+   * B2 — Drilling (panel).
+   * Pergunta: "O motor está treinando automaticidades em [persona]?"
+   *
+   * v0: B2 ausente como sistema. Banner principal + placeholders pra
+   * banks/due/SR stats.
+   */
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+
+  const COLOR = "#6b7280";
+</script>
+
+<SubsystemPanelShell id="B2" title="Drilling (automaticidade)" color={COLOR}>
+  <div class="absent-banner" data-testid="b2-absent-banner">
+    <strong>❌ B2 ausente como sistema</strong>
+    <p>
+      Drilling (SR / banks / mastery) ainda não é parte do motor canônico.
+      Especificação em rascunho:
+    </p>
+    <code>docs/specs/2026-05-26-b2-drilling-primer-v0.md</code> (PR #244)
+  </div>
+
+  <section class="block">
+    <h3>Banks ativos</h3>
+    <PlaceholderBanner
+      label="ja-pt-vocab-n5 (50 items) — TODO quando B2 wired"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>Items due agora</h3>
+    <PlaceholderBanner
+      label="DrillState com next_due_at < now — TODO"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>SR statistics</h3>
+    <PlaceholderBanner
+      label="avg easiness · retention curve — TODO"
+      color={COLOR}
+    />
+  </section>
+</SubsystemPanelShell>
+
+<style>
+  .absent-banner {
+    border: 1px solid rgba(239, 68, 68, 0.5);
+    border-left: 4px solid #ef4444;
+    border-radius: 4px;
+    padding: 0.8rem 1rem;
+    background: rgba(239, 68, 68, 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .absent-banner strong {
+    font-size: 0.95rem;
+  }
+  .absent-banner p {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.9;
+  }
+  .absent-banner code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+    align-self: flex-start;
+  }
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/PlaceholderBanner.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/PlaceholderBanner.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  /**
+   * PlaceholderBanner — bloco visual padronizado pra features ainda não
+   * wired. Mostra label + link clicável pra spec (clipboard fallback).
+   */
+  export let label: string;
+  export let specPath: string = "";
+  export let color: string = "#7f7f7f";
+</script>
+
+<div class="placeholder" style:--accent={color} data-testid="placeholder-banner">
+  <strong class="label">📋 {label}</strong>
+  {#if specPath.length > 0}
+    <code class="spec">{specPath}</code>
+  {/if}
+  <slot />
+</div>
+
+<style>
+  .placeholder {
+    border: 1px dashed rgba(127, 127, 127, 0.5);
+    border-left: 4px solid var(--accent);
+    padding: 0.7rem 0.9rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    opacity: 0.95;
+  }
+  .label {
+    font-weight: 600;
+  }
+  .spec {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+    align-self: flex-start;
+    word-break: break-all;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S1AprendizPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S1AprendizPanel.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  /**
+   * S1 — Modelo do Aprendiz (panel).
+   * Pergunta: "O que o motor crê sobre [persona] agora?"
+   *
+   * v0: identity card hardcoded + envelopa MapsPanel/DiscoveriesPanel
+   * abrindo os toggles existentes + placeholders pra Objetivos / Threads
+   * (specs em rascunho).
+   */
+  import { mapsPanelOpen, discoveriesPanelOpen, tracerSubjectId } from "../../lib/stores.js";
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+
+  const COLOR = "#3b82f6";
+
+  function openMaps(): void {
+    mapsPanelOpen.set(true);
+  }
+  function openDiscoveries(): void {
+    discoveriesPanelOpen.set(true);
+  }
+</script>
+
+<SubsystemPanelShell id="S1" title="Modelo do Aprendiz" color={COLOR}>
+  <section class="block">
+    <h3>Identity</h3>
+    <dl class="identity">
+      <dt>persona_id</dt><dd>{$tracerSubjectId}</dd>
+      <dt>age</dt><dd>— <span class="muted">(v0 hardcoded)</span></dd>
+      <dt>language</dt><dd>pt-BR · ja</dd>
+      <dt>household</dt><dd>— <span class="muted">(v0 hardcoded)</span></dd>
+      <dt>parental_telos</dt><dd>— <span class="muted">(v0 hardcoded)</span></dd>
+    </dl>
+  </section>
+
+  <section class="block">
+    <h3>Competências (CASEL × Dreyfus + Tree + Helix)</h3>
+    <p class="hint">
+      Visualização ao vivo via <code>MapsPanel</code> (Status bar → 🗺️).
+    </p>
+    <button type="button" class="action" on:click={openMaps}>
+      Abrir MapsPanel
+    </button>
+  </section>
+
+  <section class="block">
+    <h3>Subject Knowledge</h3>
+    <p class="hint">
+      Ledger de conceitos via <code>DiscoveriesPanel</code> (Status bar →
+      🔍).
+    </p>
+    <button type="button" class="action" on:click={openDiscoveries}>
+      Abrir DiscoveriesPanel
+    </button>
+  </section>
+
+  <section class="block">
+    <h3>Mood</h3>
+    <div class="sparkline-placeholder" aria-hidden="true">
+      <span class="bar" style="height:30%"></span>
+      <span class="bar" style="height:55%"></span>
+      <span class="bar" style="height:70%"></span>
+      <span class="bar" style="height:60%"></span>
+      <span class="bar" style="height:75%"></span>
+    </div>
+    <p class="muted small">
+      sparkline placeholder — TODO link com trace v2 (US-S1-04)
+    </p>
+  </section>
+
+  <section class="block">
+    <h3>Objetivos declarados</h3>
+    <PlaceholderBanner
+      label="spec em rascunho — feature ainda não wired"
+      specPath="docs/specs/2026-05-26-s1-objetivos-declarados-v0.md"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>Narrative Threads</h3>
+    <PlaceholderBanner
+      label="spec B1 hooks em rascunho — feature ainda não wired"
+      specPath="docs/specs/2026-05-26-b1-hooks-temporais-v0.md"
+      color={COLOR}
+    />
+  </section>
+</SubsystemPanelShell>
+
+<style>
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+  }
+  .identity {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 0.8rem;
+    row-gap: 0.2rem;
+    margin: 0;
+    font-size: 0.85rem;
+  }
+  .identity dt {
+    font-weight: 600;
+    opacity: 0.8;
+  }
+  .identity dd {
+    margin: 0;
+  }
+  .hint {
+    font-size: 0.85rem;
+    opacity: 0.85;
+    margin: 0;
+  }
+  .muted {
+    opacity: 0.55;
+    font-size: 0.78rem;
+  }
+  .small {
+    font-size: 0.75rem;
+    margin: 0;
+  }
+  .action {
+    align-self: flex-start;
+    padding: 0.3rem 0.7rem;
+    background: transparent;
+    border: 1px solid rgba(59, 130, 246, 0.6);
+    border-radius: 4px;
+    font: inherit;
+    font-size: 0.8rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .action:hover {
+    background: rgba(59, 130, 246, 0.12);
+  }
+  .sparkline-placeholder {
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+    height: 40px;
+    padding: 0.2rem 0;
+  }
+  .bar {
+    width: 8px;
+    background: linear-gradient(to top, rgba(59, 130, 246, 0.35), rgba(59, 130, 246, 0.9));
+    border-radius: 2px;
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S2DoutrinaPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S2DoutrinaPanel.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  /**
+   * S2 — Modelo Pedagógico (panel).
+   * Pergunta: "Como o motor crê que deve ensinar [persona] agora?"
+   *
+   * v0: charter resumo + jogadas catalog (5 + Recovery hardcoded) +
+   * envelopa JourneyPanel via toggle + placeholders pra
+   * transitions/phases.
+   */
+  import { journeyPanelOpen } from "../../lib/stores.js";
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+
+  const COLOR = "#10b981";
+
+  type Jogada = {
+    id: string;
+    name: string;
+    short: string;
+  };
+
+  // Hardcoded v0 — descrição curta canônica.
+  const JOGADAS: Jogada[] = [
+    { id: "bridge", name: "Bridge", short: "abrir ponte do mundo externo pro tema" },
+    { id: "espelho", name: "Espelho", short: "refletir afeto/intenção do aprendiz" },
+    { id: "canal", name: "Canal", short: "guiar fluxo de atenção em direção alvo" },
+    { id: "diamante", name: "Diamante", short: "consolidar insight em fact memorável" },
+    { id: "arena", name: "Arena", short: "convidar prática direta e risco produtivo" },
+    { id: "recovery", name: "Recovery", short: "voltar ao seguro quando tensão cresce" },
+  ];
+
+  function openJourney(): void {
+    journeyPanelOpen.set(true);
+  }
+</script>
+
+<SubsystemPanelShell id="S2" title="Modelo Pedagógico" color={COLOR}>
+  <section class="block">
+    <h3>Charter ativo</h3>
+    <p class="charter">
+      <strong>Brota Mestre Core</strong> + overlay <code>kids</code>
+    </p>
+    <a
+      class="spec-link"
+      href="https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/playbooks/brota-mestre.md"
+      target="_blank"
+      rel="noopener"
+    >
+      ler charter completo →
+    </a>
+  </section>
+
+  <section class="block">
+    <h3>Jogadas catalog (5 + Recovery)</h3>
+    <div class="jogadas-grid">
+      {#each JOGADAS as j (j.id)}
+        <article class="jogada-card" data-jogada-id={j.id}>
+          <h4>{j.name}</h4>
+          <p>{j.short}</p>
+        </article>
+      {/each}
+    </div>
+  </section>
+
+  <section class="block">
+    <h3>Journey (stage atual + transições)</h3>
+    <p class="hint">
+      Stage + override parental via <code>JourneyPanel</code>.
+    </p>
+    <button type="button" class="action" on:click={openJourney}>
+      Abrir JourneyPanel
+    </button>
+  </section>
+
+  <section class="block">
+    <h3>Transitions (4)</h3>
+    <PlaceholderBanner
+      label="lista de transitions ao vivo — feature ainda não wired no painel"
+      specPath="content/profiles/kids.transitions.yaml"
+      color={COLOR}
+    />
+  </section>
+
+  <section class="block">
+    <h3>Session phases</h3>
+    <PlaceholderBanner
+      label="icebreaker → helix → fechamento — feature ainda não wired"
+      specPath="content/profiles/kids.session-phases.yaml"
+      color={COLOR}
+    />
+  </section>
+</SubsystemPanelShell>
+
+<style>
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+  }
+  .charter {
+    margin: 0;
+    font-size: 0.9rem;
+  }
+  .spec-link {
+    align-self: flex-start;
+    font-size: 0.8rem;
+    color: #10b981;
+    text-decoration: none;
+  }
+  .spec-link:hover {
+    text-decoration: underline;
+  }
+  .jogadas-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 0.5rem;
+  }
+  .jogada-card {
+    border: 1px solid rgba(16, 185, 129, 0.4);
+    border-left: 3px solid #10b981;
+    border-radius: 4px;
+    padding: 0.5rem 0.6rem;
+  }
+  .jogada-card h4 {
+    margin: 0 0 0.2rem 0;
+    font-size: 0.85rem;
+    color: #10b981;
+  }
+  .jogada-card p {
+    margin: 0;
+    font-size: 0.75rem;
+    opacity: 0.85;
+  }
+  .hint {
+    font-size: 0.85rem;
+    opacity: 0.85;
+    margin: 0;
+  }
+  .action {
+    align-self: flex-start;
+    padding: 0.3rem 0.7rem;
+    background: transparent;
+    border: 1px solid rgba(16, 185, 129, 0.6);
+    border-radius: 4px;
+    font: inherit;
+    font-size: 0.8rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .action:hover {
+    background: rgba(16, 185, 129, 0.12);
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S3DecisaoTurnPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S3DecisaoTurnPanel.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  /**
+   * S3 — Motor de Decisão (panel, per turn).
+   * Pergunta: "Por que o motor escolheu esse movimento no turno N?"
+   *
+   * v0: lê `currentTurnSnapshot` store (live SSE); X-ray button abre
+   * LlmXrayPanel (calls vêm do Replay turn detail — vazio quando live).
+   *
+   * Placeholders pra Strategist/Tactician (specs em rascunho).
+   */
+  import {
+    currentTurnSnapshot,
+    llmXrayPanelOpen,
+    llmXrayCalls,
+  } from "../../lib/stores.js";
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+  import type { TurnSnapshot } from "../../lib/types.js";
+
+  export let turn: TurnSnapshot | null = null;
+  const COLOR = "#eab308";
+
+  $: snap = turn ?? $currentTurnSnapshot;
+
+  function openXray(): void {
+    // S3 → role=planejador + motor-drota (unified-assessor). v0 sem
+    // filtro porque calls são populados via Replay turn detail.
+    llmXrayCalls.set([]);
+    llmXrayPanelOpen.set(true);
+  }
+
+  function moodLabel(): string {
+    if (snap === null || snap.contextHints === undefined) return "—";
+    const m = snap.contextHints["mood"];
+    return typeof m === "string" || typeof m === "number" ? String(m) : "—";
+  }
+</script>
+
+<SubsystemPanelShell id="S3" title="Motor de Decisão (per turn)" color={COLOR}>
+  {#if snap === null}
+    <p class="empty">Sem turno ativo. Inicie uma sessão ou abra um Replay.</p>
+  {:else}
+    <div class="turn-header">
+      <span class="turn-badge">turn {snap.turn}</span>
+      <span class="phase">phase: <code>{snap.lastPhase}</code></span>
+    </div>
+
+    <section class="block">
+      <h3>Unified Assessor</h3>
+      <div class="kv">
+        <span class="k">mood</span><span class="v">{moodLabel()}</span>
+      </div>
+      <p class="hint">signals chips — visível no MotorView quando trace v2 expandido.</p>
+    </section>
+
+    <section class="block">
+      <h3>Planejador</h3>
+      <div class="kv">
+        <span class="k">contentPool</span>
+        <span class="v">{snap.contentPoolSize ?? 0} items</span>
+      </div>
+      <div class="kv">
+        <span class="k">strategicRationale</span>
+        <span class="v rationale">{snap.strategicRationale ?? "—"}</span>
+      </div>
+      <div class="kv">
+        <span class="k">transitionEvaluations</span>
+        <span class="v">{snap.transitionEvaluationsCount ?? 0}</span>
+      </div>
+    </section>
+
+    <section class="block">
+      <h3>Pragmatic Selector</h3>
+      <div class="kv">
+        <span class="k">selected</span>
+        <span class="v"><code>{snap.selectedContentId ?? "—"}</code></span>
+      </div>
+      <div class="kv">
+        <span class="k">score</span>
+        <span class="v">{snap.selectedContentScore?.toFixed(3) ?? "—"}</span>
+      </div>
+      <div class="kv">
+        <span class="k">rationale</span>
+        <span class="v rationale">{snap.selectionRationale ?? "—"}</span>
+      </div>
+    </section>
+
+    <section class="block">
+      <h3>Critical</h3>
+      <p class="hint">
+        Badge <code>is_critical</code> aparece via MotorView quando trace v2
+        expandido (TV2-7).
+      </p>
+    </section>
+
+    <section class="block">
+      <h3>Strategist (applied_double_helix)</h3>
+      <PlaceholderBanner
+        label="StrategyPlan card — só renderiza quando journey=applied_double_helix"
+        specPath="docs/specs/2026-05-24-strategist-applied-double-helix.md"
+        color={COLOR}
+      />
+    </section>
+
+    <section class="block">
+      <h3>Tactician (USE_SPLIT_DROTA)</h3>
+      <PlaceholderBanner
+        label="TacticDecision card — só renderiza quando USE_SPLIT_DROTA=true"
+        specPath="docs/specs/2026-05-26-s4-split-tactician-speaker-v0.md"
+        color={COLOR}
+      />
+    </section>
+  {/if}
+
+  <div class="actions">
+    <button
+      type="button"
+      class="xray"
+      on:click={openXray}
+      data-testid="s3-xray-btn"
+    >
+      🔬 X-ray (planejador)
+    </button>
+  </div>
+</SubsystemPanelShell>
+
+<style>
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+  }
+  .empty {
+    opacity: 0.6;
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 2rem 0;
+  }
+  .turn-header {
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+    font-size: 0.85rem;
+  }
+  .turn-badge {
+    background: rgba(234, 179, 8, 0.2);
+    color: #eab308;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+  .phase {
+    opacity: 0.8;
+  }
+  .kv {
+    display: grid;
+    grid-template-columns: 11rem 1fr;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+  }
+  .k {
+    opacity: 0.7;
+    font-weight: 500;
+  }
+  .v {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+  }
+  .rationale {
+    font-family: inherit;
+    font-size: 0.85rem;
+  }
+  .hint {
+    font-size: 0.82rem;
+    opacity: 0.75;
+    margin: 0;
+  }
+  .actions {
+    margin-top: auto;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .xray {
+    background: transparent;
+    border: 1px solid rgba(234, 179, 8, 0.6);
+    border-radius: 4px;
+    padding: 0.4rem 0.8rem;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .xray:hover {
+    background: rgba(234, 179, 8, 0.12);
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S4ExpressaoTurnPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S4ExpressaoTurnPanel.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+  /**
+   * S4 — Motor de Expressão (panel, per turn).
+   * Pergunta: "Como o motor falou esse turno e por quê?"
+   *
+   * v0: proposed text vs final (diff visual simples) + materializer
+   * prompt collapsible + cache/fallback badges + link ApprovalGate
+   * (gate aparece como overlay separado).
+   */
+  import {
+    currentTurnSnapshot,
+    llmXrayPanelOpen,
+    llmXrayCalls,
+  } from "../../lib/stores.js";
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import type { TurnSnapshot } from "../../lib/types.js";
+
+  export let turn: TurnSnapshot | null = null;
+  const COLOR = "#f97316";
+
+  $: snap = turn ?? $currentTurnSnapshot;
+
+  let promptOpen = false;
+
+  function openXray(): void {
+    // S4 → role=motor-drota (constrained-materializer).
+    llmXrayCalls.set([]);
+    llmXrayPanelOpen.set(true);
+  }
+</script>
+
+<SubsystemPanelShell id="S4" title="Motor de Expressão (per turn)" color={COLOR}>
+  {#if snap === null}
+    <p class="empty">Sem turno ativo. Inicie uma sessão ou abra um Replay.</p>
+  {:else}
+    <div class="turn-header">
+      <span class="turn-badge">turn {snap.turn}</span>
+      <span class="phase">phase: <code>{snap.lastPhase}</code></span>
+    </div>
+
+    <section class="block">
+      <h3>Proposed vs Final</h3>
+      <div class="diff">
+        <div class="diff-side proposed">
+          <header>proposed (raw LLM)</header>
+          <p>{snap.proposedText ?? "—"}</p>
+        </div>
+        <div class="diff-side final">
+          <header>final (post-sanitize)</header>
+          <p class="muted">
+            sanitização aplicada em S5.a guardrail — diff visível no MotorView
+            quando trace v2 expandido.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="block">
+      <h3>Materializer prompt</h3>
+      <button
+        type="button"
+        class="collapse-btn"
+        on:click={() => (promptOpen = !promptOpen)}
+      >
+        {promptOpen ? "▼" : "▶"} ver prompt completo
+      </button>
+      {#if promptOpen}
+        <pre class="prompt">
+prompt completo — disponível via X-ray (call role=motor-drota,
+operation=constrained-materializer) quando turno é replay.
+        </pre>
+      {/if}
+    </section>
+
+    <section class="block badges-block">
+      <h3>Badges</h3>
+      <div class="badges">
+        <span class="badge cache" title="STABLE_MATERIALIZER_PREFIX cache">
+          cache: <code>hit?/miss?</code> · ver X-ray
+        </span>
+        <span
+          class="badge instruction"
+          class:on={snap.instructionAdditionApplied === true}
+        >
+          instruction_addition: {snap.instructionAdditionApplied === true ? "✓" : "—"}
+        </span>
+        <span class="badge fallback" title="Speaker fallback (parse error → contentPool[0])">
+          speaker fallback: <code>—</code> · ver X-ray
+        </span>
+      </div>
+    </section>
+
+    <section class="block">
+      <h3>ApprovalGate</h3>
+      <p class="hint">
+        Gate semi-auto aparece como overlay separado (no-op aqui). Aprovar /
+        editar / rejeitar ocorre no <code>ApprovalGate</code> modal global.
+      </p>
+    </section>
+  {/if}
+
+  <div class="actions">
+    <button
+      type="button"
+      class="xray"
+      on:click={openXray}
+      data-testid="s4-xray-btn"
+    >
+      🔬 X-ray (motor-drota)
+    </button>
+  </div>
+</SubsystemPanelShell>
+
+<style>
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+  }
+  .empty {
+    opacity: 0.6;
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 2rem 0;
+  }
+  .turn-header {
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+    font-size: 0.85rem;
+  }
+  .turn-badge {
+    background: rgba(249, 115, 22, 0.2);
+    color: #f97316;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+  .phase {
+    opacity: 0.8;
+  }
+  .diff {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+  .diff-side {
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 4px;
+    padding: 0.5rem 0.6rem;
+  }
+  .diff-side header {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.7;
+    margin-bottom: 0.3rem;
+  }
+  .diff-side p {
+    margin: 0;
+    font-size: 0.85rem;
+  }
+  .diff-side.proposed {
+    border-left: 3px solid #f97316;
+  }
+  .diff-side.final {
+    border-left: 3px solid #10b981;
+  }
+  .collapse-btn {
+    align-self: flex-start;
+    background: transparent;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 4px;
+    padding: 0.25rem 0.6rem;
+    font: inherit;
+    font-size: 0.8rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .prompt {
+    margin: 0;
+    padding: 0.6rem;
+    background: rgba(127, 127, 127, 0.12);
+    border-radius: 4px;
+    font-size: 0.78rem;
+    white-space: pre-wrap;
+  }
+  .badges-block .badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .badge {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 3px;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+  }
+  .badge.instruction.on {
+    border-color: rgba(16, 185, 129, 0.7);
+    color: #10b981;
+  }
+  .hint {
+    font-size: 0.85rem;
+    opacity: 0.85;
+    margin: 0;
+  }
+  .muted {
+    opacity: 0.6;
+    margin: 0;
+    font-size: 0.85rem;
+  }
+  .actions {
+    margin-top: auto;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .xray {
+    background: transparent;
+    border: 1px solid rgba(249, 115, 22, 0.6);
+    border-radius: 4px;
+    padding: 0.4rem 0.8rem;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .xray:hover {
+    background: rgba(249, 115, 22, 0.12);
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S5AvaliacaoPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S5AvaliacaoPanel.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+  /**
+   * S5 — Motor de Avaliação (panel).
+   * Pergunta: "O motor está funcionando? Como sabemos?"
+   *
+   * Estrutura em 3 sub-tabs: Guardrail (S5.a) · STS (S5.b) · Longitudinal
+   * (S5.c). Envelopa Analytics + DebugPanel via toggles.
+   */
+  import {
+    analyticsOpen,
+    debugPanelOpen,
+    llmXrayPanelOpen,
+    llmXrayCalls,
+  } from "../../lib/stores.js";
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+
+  const COLOR = "#ef4444";
+
+  type Tab = "guardrail" | "sts" | "longitudinal";
+  let activeTab: Tab = "guardrail";
+
+  function setTab(t: Tab): void {
+    activeTab = t;
+  }
+
+  function openAnalytics(): void {
+    analyticsOpen.set(true);
+  }
+  function openDebug(): void {
+    debugPanelOpen.set(true);
+  }
+  function openXray(): void {
+    // S5 → role=motor-execucao (evaluators).
+    llmXrayCalls.set([]);
+    llmXrayPanelOpen.set(true);
+  }
+
+  type GuardrailCheck = { id: string; label: string; passed: boolean };
+  // v0 hardcoded — TODO: ligar com trace v2.
+  const guardrailChecks: GuardrailCheck[] = [
+    { id: "sanitize", label: "sanitize: items removidos", passed: true },
+    { id: "bullying", label: "bullying check (PT+JA): 0/5 patterns", passed: true },
+    { id: "scaffold", label: "scaffold guard: ok", passed: true },
+    { id: "parental", label: "parental authorization: 3 camadas ✓", passed: true },
+  ];
+</script>
+
+<SubsystemPanelShell id="S5" title="Motor de Avaliação" color={COLOR}>
+  <div class="tabs" role="tablist" aria-label="S5 sub-tabs">
+    <button
+      type="button"
+      role="tab"
+      aria-selected={activeTab === "guardrail"}
+      class:active={activeTab === "guardrail"}
+      on:click={() => setTab("guardrail")}
+      data-testid="s5-tab-guardrail"
+    >
+      Guardrail
+    </button>
+    <button
+      type="button"
+      role="tab"
+      aria-selected={activeTab === "sts"}
+      class:active={activeTab === "sts"}
+      on:click={() => setTab("sts")}
+      data-testid="s5-tab-sts"
+    >
+      STS
+    </button>
+    <button
+      type="button"
+      role="tab"
+      aria-selected={activeTab === "longitudinal"}
+      class:active={activeTab === "longitudinal"}
+      on:click={() => setTab("longitudinal")}
+      data-testid="s5-tab-longitudinal"
+    >
+      Longitudinal
+    </button>
+  </div>
+
+  {#if activeTab === "guardrail"}
+    <section class="tab-panel" data-testid="s5-pane-guardrail">
+      <h3>S5.a — Guardrail (per turn)</h3>
+      <ul class="checks">
+        {#each guardrailChecks as c (c.id)}
+          <li>
+            <span class="check-badge" class:passed={c.passed} class:failed={!c.passed}>
+              {c.passed ? "✓" : "✗"}
+            </span>
+            <span>{c.label}</span>
+          </li>
+        {/each}
+      </ul>
+      <p class="hint">
+        v0: status hardcoded — TODO ligar com trace v2 guardrail events.
+      </p>
+    </section>
+  {:else if activeTab === "sts"}
+    <section class="tab-panel" data-testid="s5-pane-sts">
+      <h3>S5.b — STS (cross-session)</h3>
+      <p class="hint">
+        STS run history + rubric G1-G5 — envelopado por
+        <code>Analytics</code> quando aberto (Status bar → 📊).
+      </p>
+      <button type="button" class="action" on:click={openAnalytics}>
+        Abrir Analytics
+      </button>
+    </section>
+  {:else}
+    <section class="tab-panel" data-testid="s5-pane-longitudinal">
+      <h3>S5.c — Longitudinal</h3>
+      <PlaceholderBanner
+        label="S5.c em rascunho — KPI dashboard + RecallCheck + Trigger Evaluator"
+        specPath="docs/specs/2026-05-26-s5c-longitudinal-v0.md"
+        color={COLOR}
+      />
+      <p class="hint">
+        Eventos verbose via <code>DebugPanel</code> (Status bar → 🔬 Debug).
+      </p>
+      <button type="button" class="action" on:click={openDebug}>
+        Abrir DebugPanel
+      </button>
+    </section>
+  {/if}
+
+  <div class="actions">
+    <button
+      type="button"
+      class="xray"
+      on:click={openXray}
+      data-testid="s5-xray-btn"
+    >
+      🔬 X-ray (motor-execucao)
+    </button>
+  </div>
+</SubsystemPanelShell>
+
+<style>
+  .tabs {
+    display: flex;
+    gap: 0.4rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+    padding-bottom: 0.4rem;
+  }
+  .tabs button {
+    background: transparent;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 4px 4px 0 0;
+    padding: 0.3rem 0.8rem;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .tabs button.active {
+    background: rgba(239, 68, 68, 0.15);
+    border-color: rgba(239, 68, 68, 0.6);
+    color: #ef4444;
+    font-weight: 600;
+  }
+  .tab-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  h3 {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+  .checks {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .checks li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+  }
+  .check-badge {
+    display: inline-block;
+    min-width: 1.3rem;
+    text-align: center;
+    border-radius: 3px;
+    padding: 0.1rem 0.3rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+  .check-badge.passed {
+    background: rgba(16, 185, 129, 0.2);
+    color: #10b981;
+  }
+  .check-badge.failed {
+    background: rgba(239, 68, 68, 0.2);
+    color: #ef4444;
+  }
+  .hint {
+    font-size: 0.82rem;
+    opacity: 0.78;
+    margin: 0;
+  }
+  .action {
+    align-self: flex-start;
+    padding: 0.3rem 0.7rem;
+    background: transparent;
+    border: 1px solid rgba(239, 68, 68, 0.6);
+    border-radius: 4px;
+    font: inherit;
+    font-size: 0.8rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .action:hover {
+    background: rgba(239, 68, 68, 0.12);
+  }
+  .actions {
+    margin-top: auto;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .xray {
+    background: transparent;
+    border: 1px solid rgba(239, 68, 68, 0.6);
+    border-radius: 4px;
+    padding: 0.4rem 0.8rem;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .xray:hover {
+    background: rgba(239, 68, 68, 0.12);
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/SubsystemPanelShell.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/SubsystemPanelShell.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  /**
+   * SubsystemPanelShell — chrome compartilhado dos 7 painéis (S1-B2).
+   * Header com badge + title + close, slot pra conteúdo.
+   * Click fora ou ESC fecha (seta expandedSubsystem=null).
+   */
+  import { expandedSubsystem } from "../../lib/stores.js";
+  import { onMount, onDestroy } from "svelte";
+
+  export let id: string;
+  export let title: string;
+  export let color: string = "#7f7f7f";
+
+  function close(): void {
+    expandedSubsystem.set(null);
+  }
+
+  function onKey(e: KeyboardEvent): void {
+    if (e.key === "Escape") close();
+  }
+
+  onMount(() => {
+    window.addEventListener("keydown", onKey);
+  });
+  onDestroy(() => {
+    window.removeEventListener("keydown", onKey);
+  });
+</script>
+
+<section
+  class="panel-shell"
+  data-testid={`subsystem-panel-${id}`}
+  data-subsystem-id={id}
+  style:--accent={color}
+  aria-label={`painel ${id} — ${title}`}
+>
+  <header class="panel-header">
+    <div class="title-block">
+      <span class="badge">{id}</span>
+      <h2>{title}</h2>
+    </div>
+    <button
+      type="button"
+      class="close-btn"
+      on:click={close}
+      data-testid={`subsystem-panel-${id}-close`}
+      aria-label="voltar ao grid"
+      title="voltar ao grid (Esc)"
+    >
+      ← voltar
+    </button>
+  </header>
+  <div class="panel-body">
+    <slot />
+  </div>
+</section>
+
+<style>
+  .panel-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    border-left: 4px solid var(--accent);
+    background: var(--color-bg, transparent);
+  }
+  .panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+  }
+  .title-block {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+  }
+  .badge {
+    font-weight: 700;
+    color: var(--accent);
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+  }
+  h2 {
+    margin: 0;
+    font-size: 1.05rem;
+  }
+  .close-btn {
+    background: transparent;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 4px;
+    padding: 0.25rem 0.6rem;
+    font: inherit;
+    font-size: 0.8rem;
+    color: inherit;
+    cursor: pointer;
+  }
+  .close-btn:hover {
+    border-color: var(--accent);
+  }
+  .panel-body {
+    flex: 1;
+    overflow: auto;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -79,3 +79,12 @@ export const llmXrayPanelOpen = writable<boolean>(false);
 /** Calls passados pelo parent (turno selecionado em engineTrace.llm_calls).
  *  Vazio = mostrar empty state. */
 export const llmXrayCalls = writable<LlmCallLike[]>([]);
+
+/** Console redesign Fase 1 (spec 2026-05-26-console-ebrota-7-subsistemas-redesign-v0):
+ *  feature flag para habilitar landing em grid 4×2 de cards por subsistema.
+ *  Default true; quando false, layout legacy (MotorView + ChatFeed grid). */
+export const subsystemLayoutEnabled = writable<boolean>(true);
+
+/** Subsistema atualmente expandido a partir do grid landing. Null = grid
+ *  visível. Valores: "S1" | "S2" | "S3" | "S4" | "S5" | "B1" | "B2". */
+export const expandedSubsystem = writable<string | null>(null);

--- a/packages/ebrota-console-ui/tests/subsystem-grid.test.ts
+++ b/packages/ebrota-console-ui/tests/subsystem-grid.test.ts
@@ -1,0 +1,80 @@
+/**
+ * SubsystemGrid + SubsystemCard tests — verifica que landing renderiza
+ * os 7 cards, click expande, e que SubsystemCard emite events.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-7-subsistemas-redesign-v0.md
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import SubsystemGrid from "../src/components/SubsystemGrid.svelte";
+import SubsystemCard from "../src/components/SubsystemCard.svelte";
+import { expandedSubsystem } from "../src/lib/stores.js";
+
+afterEach(() => cleanup());
+
+beforeEach(() => {
+  expandedSubsystem.set(null);
+});
+
+describe("SubsystemGrid", () => {
+  it("renderiza os 7 cards de subsistema", () => {
+    render(SubsystemGrid);
+    const grid = screen.getByTestId("subsystem-grid");
+    expect(grid).toBeDefined();
+    for (const id of ["S1", "S2", "S3", "S4", "S5", "B1", "B2"]) {
+      expect(screen.getByTestId(`subsystem-card-${id}`)).toBeDefined();
+    }
+  });
+
+  it("click no card S1 seta expandedSubsystem === 'S1'", async () => {
+    render(SubsystemGrid);
+    await fireEvent.click(screen.getByTestId("subsystem-card-S1"));
+    expect(get(expandedSubsystem)).toBe("S1");
+  });
+
+  it("click no card B2 seta expandedSubsystem === 'B2'", async () => {
+    render(SubsystemGrid);
+    await fireEvent.click(screen.getByTestId("subsystem-card-B2"));
+    expect(get(expandedSubsystem)).toBe("B2");
+  });
+});
+
+describe("SubsystemCard", () => {
+  it("emite event 'expand' com id correto quando clicado", async () => {
+    let captured: string | null = null;
+    const { component } = render(SubsystemCard, {
+      props: { id: "S3", title: "Decisão", color: "#eab308" },
+    });
+    component.$on("expand", (ev: CustomEvent<{ id: string }>) => {
+      captured = ev.detail.id;
+    });
+    await fireEvent.click(screen.getByTestId("subsystem-card-S3"));
+    expect(captured).toBe("S3");
+  });
+
+  it("mostra status icon impl/partial/placeholder", () => {
+    render(SubsystemCard, {
+      props: {
+        id: "S1",
+        title: "Aprendiz",
+        status: "partial",
+      },
+    });
+    // ◑ é o icon de partial
+    expect(screen.getByText("◑")).toBeDefined();
+  });
+
+  it("Enter ou Espaço dispara expand (acessibilidade)", async () => {
+    let captured: string | null = null;
+    const { component } = render(SubsystemCard, {
+      props: { id: "S5", title: "Avaliação" },
+    });
+    component.$on("expand", (ev: CustomEvent<{ id: string }>) => {
+      captured = ev.detail.id;
+    });
+    const btn = screen.getByTestId("subsystem-card-S5");
+    await fireEvent.keyDown(btn, { key: "Enter" });
+    expect(captured).toBe("S5");
+  });
+});

--- a/packages/ebrota-console-ui/tests/subsystem-panels-render.test.ts
+++ b/packages/ebrota-console-ui/tests/subsystem-panels-render.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Smoke tests para os 7 painéis de subsistema (S1-S5 + B1-B2).
+ * Verifica que cada um renderiza sem erro, expõe a shell com ID
+ * correto, e que placeholders mostram link pra spec quando aplicável.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-7-subsistemas-redesign-v0.md
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import S1AprendizPanel from "../src/components/subsystem-panels/S1AprendizPanel.svelte";
+import S2DoutrinaPanel from "../src/components/subsystem-panels/S2DoutrinaPanel.svelte";
+import S3DecisaoTurnPanel from "../src/components/subsystem-panels/S3DecisaoTurnPanel.svelte";
+import S4ExpressaoTurnPanel from "../src/components/subsystem-panels/S4ExpressaoTurnPanel.svelte";
+import S5AvaliacaoPanel from "../src/components/subsystem-panels/S5AvaliacaoPanel.svelte";
+import B1SocialPanel from "../src/components/subsystem-panels/B1SocialPanel.svelte";
+import B2DrillingPanel from "../src/components/subsystem-panels/B2DrillingPanel.svelte";
+import {
+  expandedSubsystem,
+  currentTurnSnapshot,
+  llmXrayPanelOpen,
+} from "../src/lib/stores.js";
+
+beforeEach(() => {
+  expandedSubsystem.set("S1");
+  currentTurnSnapshot.set(null);
+  llmXrayPanelOpen.set(false);
+  // Silence console errors from missing window APIs in jsdom edge cases.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("subsystem panels — smoke render", () => {
+  it("S1AprendizPanel renderiza shell com id correto + placeholder pra objetivos", () => {
+    render(S1AprendizPanel);
+    expect(screen.getByTestId("subsystem-panel-S1")).toBeDefined();
+    // placeholder banner aponta pra spec de objetivos declarados
+    const placeholders = screen.getAllByTestId("placeholder-banner");
+    expect(placeholders.length).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.getByText(/2026-05-26-s1-objetivos-declarados-v0\.md/),
+    ).toBeDefined();
+  });
+
+  it("S2DoutrinaPanel renderiza shell + 6 jogadas (5 + Recovery)", () => {
+    render(S2DoutrinaPanel);
+    expect(screen.getByTestId("subsystem-panel-S2")).toBeDefined();
+    expect(screen.getByText("Bridge")).toBeDefined();
+    expect(screen.getByText("Espelho")).toBeDefined();
+    expect(screen.getByText("Canal")).toBeDefined();
+    expect(screen.getByText("Diamante")).toBeDefined();
+    expect(screen.getByText("Arena")).toBeDefined();
+    expect(screen.getByText("Recovery")).toBeDefined();
+  });
+
+  it("S3DecisaoTurnPanel mostra empty state sem snapshot + botão X-ray", async () => {
+    render(S3DecisaoTurnPanel);
+    expect(screen.getByTestId("subsystem-panel-S3")).toBeDefined();
+    expect(screen.getByText(/Sem turno ativo/)).toBeDefined();
+    const xray = screen.getByTestId("s3-xray-btn");
+    await fireEvent.click(xray);
+    expect(get(llmXrayPanelOpen)).toBe(true);
+  });
+
+  it("S3DecisaoTurnPanel renderiza dados do turno quando snapshot existe", () => {
+    currentTurnSnapshot.set({
+      sessionId: "sess-x",
+      turn: 7,
+      lastPhase: "selection_made",
+      lastTimestamp: "2026-05-27T10:00:00Z",
+      strategicRationale: "explorar curiosidade sobre joaninhas",
+      contentPoolSize: 8,
+      selectedContentId: "ladybug.life-cycle.001",
+      selectedContentScore: 0.823,
+    });
+    render(S3DecisaoTurnPanel);
+    expect(screen.getByText(/turn 7/)).toBeDefined();
+    expect(screen.getByText(/explorar curiosidade sobre joaninhas/)).toBeDefined();
+    expect(screen.getByText("ladybug.life-cycle.001")).toBeDefined();
+  });
+
+  it("S4ExpressaoTurnPanel mostra empty state + botão X-ray funcional", async () => {
+    render(S4ExpressaoTurnPanel);
+    expect(screen.getByTestId("subsystem-panel-S4")).toBeDefined();
+    expect(screen.getByText(/Sem turno ativo/)).toBeDefined();
+    await fireEvent.click(screen.getByTestId("s4-xray-btn"));
+    expect(get(llmXrayPanelOpen)).toBe(true);
+  });
+
+  it("S5AvaliacaoPanel renderiza 3 sub-tabs (Guardrail / STS / Longitudinal)", async () => {
+    render(S5AvaliacaoPanel);
+    expect(screen.getByTestId("subsystem-panel-S5")).toBeDefined();
+    expect(screen.getByTestId("s5-tab-guardrail")).toBeDefined();
+    expect(screen.getByTestId("s5-tab-sts")).toBeDefined();
+    expect(screen.getByTestId("s5-tab-longitudinal")).toBeDefined();
+    // tab inicial = guardrail
+    expect(screen.getByTestId("s5-pane-guardrail")).toBeDefined();
+    // troca pra STS
+    await fireEvent.click(screen.getByTestId("s5-tab-sts"));
+    expect(screen.getByTestId("s5-pane-sts")).toBeDefined();
+    // troca pra Longitudinal — mostra placeholder com link spec
+    await fireEvent.click(screen.getByTestId("s5-tab-longitudinal"));
+    expect(screen.getByTestId("s5-pane-longitudinal")).toBeDefined();
+    expect(screen.getByText(/2026-05-26-s5c-longitudinal-v0\.md/)).toBeDefined();
+  });
+
+  it("B1SocialPanel renderiza shell + placeholder com link spec hooks", () => {
+    render(B1SocialPanel);
+    expect(screen.getByTestId("subsystem-panel-B1")).toBeDefined();
+    expect(screen.getByText(/2026-05-26-b1-hooks-temporais-v0\.md/)).toBeDefined();
+  });
+
+  it("B2DrillingPanel renderiza banner 'ausente como sistema'", () => {
+    render(B2DrillingPanel);
+    expect(screen.getByTestId("subsystem-panel-B2")).toBeDefined();
+    expect(screen.getByTestId("b2-absent-banner")).toBeDefined();
+    expect(screen.getByText(/B2 ausente como sistema/)).toBeDefined();
+    expect(screen.getByText(/2026-05-26-b2-drilling-primer-v0\.md/)).toBeDefined();
+  });
+
+  it("close button volta ao grid (seta expandedSubsystem=null)", async () => {
+    render(S1AprendizPanel);
+    await fireEvent.click(screen.getByTestId("subsystem-panel-S1-close"));
+    expect(get(expandedSubsystem)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Fase 1 do Console redesign per spec [2026-05-26-console-ebrota-7-subsistemas-redesign-v0](https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/specs/2026-05-26-console-ebrota-7-subsistemas-redesign-v0.md)

Reposiciona o landing pela lente dos **7 subsistemas pedagógicos** (S1-S5 + B1-B2). Componentes existentes ficam intactos — apenas re-envelopados atrás de uma fachada nova.

## Defaults da spec — aplicados

- **Landing layout**: grid 4×2 desktop, 2-col tablet, 1-col mobile (≤540px).
- **Click no card**: seta store `expandedSubsystem` (sem route — modal-like in-page substituição do grid; deep-linkable fica como follow-up).
- **Per turn vs cross-session**: status badges no card (✅ impl, ◑ partial, 📋 placeholder).
- **B1/B2 placeholders**: incluídos com banner apontando a spec correspondente (torna gap visível).
- **LLM X-ray drill**: botões X-ray em S3/S4/S5 abrem `LlmXrayPanel` (calls preenchidos pelo Replay turn detail — empty state quando live, conforme arquitetura TV2-7).

## Feature flag

\`subsystemLayoutEnabled\` (default \`true\`) controla landing:
- \`true\`: grid 7 cards à esquerda + ChatFeed à direita. MotorView acessível atrás de \`<details>\` fold pra preservar trace v2 debug.
- \`false\`: layout legacy (ChatFeed + MotorView side-by-side) — fallback intacto.

## Arquivos novos

| Arquivo | Função |
|---|---|
| \`src/components/SubsystemCard.svelte\` | Card visual reusável (props id/title/subtitle/vitalSign/status/color/onclick) |
| \`src/components/SubsystemGrid.svelte\` | Landing grid 4×2 hardcoded dos 7 subsistemas |
| \`src/components/subsystem-panels/SubsystemPanelShell.svelte\` | Chrome compartilhado (header + close + ESC) |
| \`src/components/subsystem-panels/PlaceholderBanner.svelte\` | Banner padronizado pra features ainda não wired |
| \`src/components/subsystem-panels/S1AprendizPanel.svelte\` | Identity + competências (link MapsPanel) + Subject Knowledge (link DiscoveriesPanel) + mood sparkline + placeholders Objetivos/Threads |
| \`src/components/subsystem-panels/S2DoutrinaPanel.svelte\` | Charter + 6 jogadas (5+Recovery) + Journey (link JourneyPanel) + placeholders transitions/phases |
| \`src/components/subsystem-panels/S3DecisaoTurnPanel.svelte\` | Per-turn: Unified Assessor + Planejador + Pragmatic Selector + Critical + placeholders Strategist/Tactician + X-ray button |
| \`src/components/subsystem-panels/S4ExpressaoTurnPanel.svelte\` | Per-turn: proposed/final diff + materializer prompt collapsible + cache/instruction/fallback badges + X-ray button |
| \`src/components/subsystem-panels/S5AvaliacaoPanel.svelte\` | 3 sub-tabs: Guardrail (checks list) · STS (link Analytics) · Longitudinal (placeholder + link DebugPanel) + X-ray button |
| \`src/components/subsystem-panels/B1SocialPanel.svelte\` | Placeholders cards/budget/dyad/janelas/Pulso |
| \`src/components/subsystem-panels/B2DrillingPanel.svelte\` | Banner 'ausente como sistema' + link PR #244 |
| \`tests/subsystem-grid.test.ts\` | 6 testes: render 7 cards, click expande, keyboard a11y, event dispatch |
| \`tests/subsystem-panels-render.test.ts\` | 9 testes: smoke render dos 7 painéis + verifica placeholders + X-ray + close button |

## Arquivos modificados

- \`src/lib/stores.ts\` — adiciona \`subsystemLayoutEnabled\` (default true) + \`expandedSubsystem\` (null | 'S1'..'B2').
- \`src/App.svelte\` — switch entre subsystem layout e legacy via flag. Preserva ApprovalGate, Status, SessionStart, SessionLibrary, Replay, DebugPanel, Analytics, JourneyPanel, MapsPanel, DiscoveriesPanel, LlmXrayPanel acessíveis via Status bar / overlays. MotorView reposicionado atrás de \`<details>\` fold quando subsystem layout ativo.

## Visual

- 7 cores semânticas: S1 azul (#3b82f6) · S2 verde (#10b981) · S3 amarelo (#eab308) · S4 laranja (#f97316) · S5 vermelho (#ef4444) · B1 roxo (#8b5cf6) · B2 cinza (#6b7280).
- Card: border-left 4px na cor + hover translateY + focus outline.
- Painel: header com badge + close (\"← voltar\") + ESC keyboard handler.
- Placeholder banner: border dashed + spec path em \`<code>\`.

## Critérios de aceitação

- ✅ \`npm run build\` (\`packages/ebrota-console-ui\`) passa (88 modules, 0 errors, 0 a11y warnings em código novo)
- ✅ \`npx tsc --noEmit\` passa
- ✅ Vitest: **156/156 tests pass** (141 pre-existentes + 15 novos)
- ✅ Navegação: grid → click card → painel → close/Esc → grid
- ✅ Componentes legacy intactos (MapsPanel, Analytics, JourneyPanel, etc.) — só re-envelopados via toggles

## Não toquei (conforme escopo)

- \`motor-drota/\`, \`planejador/\`, \`motor-execucao/\`, \`orchestrator/\`, \`shared/\`, \`motor-channels/\`
- \`LlmXrayPanel.svelte\`, \`ApprovalGate.svelte\`, \`ChatFeed.svelte\`, \`Status.svelte\`, \`SessionStart.svelte\`, \`SessionLibrary.svelte\`, \`Replay.svelte\`, \`MapsPanel.svelte\`, \`DiscoveriesPanel.svelte\`, \`JourneyPanel.svelte\`, \`Analytics.svelte\`, \`DebugPanel.svelte\`, \`MotorView.svelte\`
- \`ReplayTurnDetail.svelte\` (já modificado por PR #241)

## Notas

- Rota \`?onboarding=true\` (Parental Wizard PR #246) **não está em \`origin/main\` no momento do branch**. Quando PR #246 mergear primeiro, esse PR vai precisar de rebase trivial pra preservar o handler em \`applyUrlParams\`. Se este PR mergear antes, PR #246 só adiciona o caso \`onboarding\` no early-return de \`applyUrlParams\` (não toca subsystem layout).
- X-ray buttons abrem o painel com calls vazios em modo live (esperado — calls são populados pelo \`ReplayTurnDetail\` via store \`llmXrayCalls\`). Drill funcional via Replay já existe.
- MotorView fold (\`<details>\`) é solução conservadora pra Fase 2 (refator de ReplayTurnDetail em 7 sub-seções) — preserva acesso a trace v2 expandido sem quebrar testes de smoke existentes.

🌳 Spec: \`docs/specs/2026-05-26-console-ebrota-7-subsistemas-redesign-v0.md\`