### PR TITLE
[feat ops#1126] Mini-UI: + 🎯 Strategist + 🧬 Helix panels (rebased)

### DIFF
--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -12,6 +12,8 @@
   import JourneyPanel from "./components/JourneyPanel.svelte";
   import MapsPanel from "./components/MapsPanel.svelte";
   import DiscoveriesPanel from "./components/DiscoveriesPanel.svelte";
+  import StrategistPanel from "./components/StrategistPanel.svelte";
+  import HelixPanel from "./components/HelixPanel.svelte";
   import LlmXrayPanel from "./components/LlmXrayPanel.svelte";
   import { createApiClient } from "./lib/api.js";
   import {
@@ -133,6 +135,8 @@
   <JourneyPanel {api} />
   <MapsPanel {api} />
   <DiscoveriesPanel {api} />
+  <StrategistPanel {api} />
+  <HelixPanel {api} />
   <LlmXrayPanel />
 
   <footer>

--- a/packages/ebrota-console-ui/src/components/HelixPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/HelixPanel.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import type {
+    ApiClient,
+    JourneyStateLike,
+    SubjectKnowledgeEntryLike,
+  } from "../lib/api.js";
+  import { helixPanelOpen, tracerSubjectId } from "../lib/stores.js";
+
+  export let api: ApiClient;
+
+  let journey: JourneyStateLike | null = null;
+  let entries: SubjectKnowledgeEntryLike[] = [];
+  let loading = false;
+  let err: string | null = null;
+
+  const AXIS_LABELS: Record<number, string> = {
+    1: "Coragem",
+    2: "Honra",
+    3: "Resiliência",
+    4: "Autoconhecimento",
+    5: "Disciplina",
+    6: "Curiosidade",
+    7: "Generosidade",
+    8: "Honestidade",
+    9: "Pensamento crítico",
+    10: "Criatividade",
+    11: "Reflexão",
+    12: "Comunicação",
+  };
+
+  type KnowledgeRow = {
+    axis_id: number;
+    label: string;
+    presented_count: number;
+    recall_positive_count: number;
+    last_seen?: string;
+  };
+
+  type ValueRow = {
+    axis_id: number | null;
+    label: string;
+    proposed: boolean;
+    discovered: boolean;
+    last_seen?: string;
+  };
+
+  let knowledgeThread: KnowledgeRow[] = [];
+  let valuesThread: ValueRow[] = [];
+
+  async function load(): Promise<void> {
+    loading = true;
+    err = null;
+    try {
+      const [jRes, dRes] = await Promise.all([
+        api.getJourneyState($tracerSubjectId),
+        api.listSubjectDiscoveries($tracerSubjectId, { limit: 500 }),
+      ]);
+      journey = jRes.state;
+      entries = dRes.discoveries;
+      derive();
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    }
+    loading = false;
+  }
+
+  function payloadAxisId(e: SubjectKnowledgeEntryLike): number | null {
+    const ax = e.payload["axis_id"];
+    return typeof ax === "number" ? ax : null;
+  }
+
+  function derive(): void {
+    // Knowledge thread: presented_concept + recall_check_positive agrupados por axis_id.
+    const kByAxis = new Map<number, KnowledgeRow>();
+    for (const e of entries) {
+      if (e.type !== "presented_concept" && e.type !== "recall_check_attempt") continue;
+      const ax = payloadAxisId(e);
+      if (ax === null) continue;
+      const row = kByAxis.get(ax) ?? {
+        axis_id: ax,
+        label: AXIS_LABELS[ax] ?? `axis_${ax}`,
+        presented_count: 0,
+        recall_positive_count: 0,
+      };
+      if (e.type === "presented_concept") row.presented_count++;
+      if (
+        e.type === "recall_check_attempt" &&
+        e.payload["result"] === "positive"
+      ) {
+        row.recall_positive_count++;
+      }
+      if (!row.last_seen || e.created_at > row.last_seen) row.last_seen = e.created_at;
+      kByAxis.set(ax, row);
+    }
+    knowledgeThread = Array.from(kByAxis.values()).sort(
+      (a, b) => a.axis_id - b.axis_id,
+    );
+
+    // Values thread: discoveries de type=value + axes_active do journey
+    // (proposto pelos pais). Mostra "proposto" + "descoberto" lado a lado.
+    const vByAxis = new Map<number, ValueRow>();
+    const vWithoutAxis: ValueRow[] = [];
+    for (const e of entries) {
+      if (e.type !== "value") continue;
+      const ax = payloadAxisId(e);
+      const label =
+        typeof e.payload["label"] === "string"
+          ? e.payload["label"]
+          : typeof e.payload["concept_id"] === "string"
+            ? e.payload["concept_id"]
+            : "valor";
+      if (ax !== null) {
+        const row = vByAxis.get(ax) ?? {
+          axis_id: ax,
+          label: AXIS_LABELS[ax] ?? `axis_${ax}`,
+          proposed: false,
+          discovered: false,
+        };
+        row.discovered = true;
+        if (!row.last_seen || e.created_at > row.last_seen) row.last_seen = e.created_at;
+        vByAxis.set(ax, row);
+      } else {
+        vWithoutAxis.push({
+          axis_id: null,
+          label,
+          proposed: false,
+          discovered: true,
+          last_seen: e.created_at,
+        });
+      }
+    }
+    // Não temos axes_active do journey state (não exposto no DTO atual);
+    // se aparecer no futuro, marcamos proposed=true. Por ora só descoberta.
+    valuesThread = [
+      ...Array.from(vByAxis.values()).sort((a, b) =>
+        (a.axis_id ?? 0) - (b.axis_id ?? 0),
+      ),
+      ...vWithoutAxis,
+    ];
+  }
+
+  $: if ($helixPanelOpen) void load();
+</script>
+
+{#if $helixPanelOpen}
+  <div
+    class="modal-backdrop"
+    on:click={() => helixPanelOpen.set(false)}
+    on:keydown={(e) => e.key === "Escape" && helixPanelOpen.set(false)}
+    role="presentation"
+  >
+    <div
+      class="modal"
+      on:click|stopPropagation
+      role="dialog"
+      aria-label="Double helix"
+    >
+      <header>
+        <h2>🧬 Helix — {$tracerSubjectId}</h2>
+        <button on:click={() => helixPanelOpen.set(false)} aria-label="Fechar">×</button>
+      </header>
+
+      <div class="subject-picker">
+        <label for="helix-subject">subject_id:</label>
+        <input id="helix-subject" type="text" bind:value={$tracerSubjectId} on:blur={load} />
+        <button on:click={load} disabled={loading}>{loading ? "..." : "Reload"}</button>
+      </div>
+
+      {#if err}<p class="err">{err}</p>{/if}
+
+      {#if journey}
+        <div class="stage-banner" data-stage={journey.stage}>
+          Jornada: <strong>{journey.stage}</strong>
+          <span class="meta">
+            · {journey.discoveries_count} descobertas · famílias [{journey.families_covered.join(", ") || "—"}]
+          </span>
+        </div>
+      {/if}
+
+      <p class="muted">
+        Duas tradições entrelaçadas: <strong>conhecimento</strong> (o que foi
+        apresentado e checado) × <strong>valores</strong> (o que foi descoberto
+        no sujeito). Ambos pivotam no mesmo eixo (1..12) — daí a métafora helix.
+      </p>
+
+      <div class="helix-grid">
+        <section class="thread knowledge">
+          <h3>🧠 Knowledge thread</h3>
+          {#if knowledgeThread.length === 0}
+            <p class="empty">Nenhum conceito apresentado ainda.</p>
+          {:else}
+            <ul>
+              {#each knowledgeThread as k}
+                <li>
+                  <span class="axis-id">#{k.axis_id}</span>
+                  <span class="axis-label">{k.label}</span>
+                  <span class="counts">
+                    pres={k.presented_count}
+                    {#if k.recall_positive_count > 0}
+                      <span class="recall">· recall+={k.recall_positive_count}</span>
+                    {/if}
+                  </span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </section>
+
+        <section class="thread values">
+          <h3>⚖️ Values thread</h3>
+          {#if valuesThread.length === 0}
+            <p class="empty">Nenhum valor descoberto ainda.</p>
+          {:else}
+            <ul>
+              {#each valuesThread as v}
+                <li>
+                  {#if v.axis_id !== null}
+                    <span class="axis-id">#{v.axis_id}</span>
+                  {:else}
+                    <span class="axis-id no-axis">—</span>
+                  {/if}
+                  <span class="axis-label">{v.label}</span>
+                  <span class="flags">
+                    {#if v.discovered}<span class="flag discovered">descoberto</span>{/if}
+                    {#if v.proposed}<span class="flag proposed">proposto</span>{/if}
+                  </span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </section>
+      </div>
+
+      <div class="overlap">
+        <h4>Eixos com presença nos dois threads</h4>
+        {#each knowledgeThread.filter((k) => valuesThread.some((v) => v.axis_id === k.axis_id)) as o}
+          <span class="overlap-chip">#{o.axis_id} {o.label}</span>
+        {:else}
+          <span class="muted">Nenhum eixo com knowledge + value simultâneos ainda.</span>
+        {/each}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100; display: flex; align-items: center; justify-content: center; }
+  .modal { background: #fff; padding: 1.5rem; border-radius: 8px; width: min(900px, 92vw); max-height: 90vh; overflow-y: auto; }
+  header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+  header h2 { margin: 0; font-size: 1.1rem; }
+  header button { background: transparent; border: none; font-size: 1.5rem; cursor: pointer; }
+  .subject-picker { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
+  .subject-picker input { flex: 1; padding: 0.3rem; }
+  .err { color: #b00020; }
+  .stage-banner { padding: 0.5rem 0.75rem; border-radius: 4px; background: #f7f7f7; margin-bottom: 0.5rem; font-size: 0.9rem; }
+  .stage-banner[data-stage="applied_double_helix"] { background: #e8f5e9; border-left: 3px solid #388e3c; }
+  .stage-banner[data-stage="mapping_ready"] { background: #fff3e0; border-left: 3px solid #f57c00; }
+  .stage-banner[data-stage="discovery_only"] { background: #e3f2fd; border-left: 3px solid #1976d2; }
+  .stage-banner .meta { color: #555; font-size: 0.8rem; }
+  .muted { color: #888; font-size: 0.85rem; margin-bottom: 1rem; }
+  .helix-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+  .thread { border: 1px solid #e0e0e0; border-radius: 6px; padding: 0.85rem; }
+  .thread h3 { font-size: 0.95rem; margin: 0 0 0.5rem 0; }
+  .knowledge { background: linear-gradient(180deg, #f0f7ff 0%, #ffffff 100%); }
+  .values { background: linear-gradient(180deg, #fff5f0 0%, #ffffff 100%); }
+  .empty { color: #999; font-style: italic; }
+  .thread ul { list-style: none; padding: 0; }
+  .thread li { display: grid; grid-template-columns: auto 1fr auto; gap: 0.5rem; align-items: center; padding: 0.3rem 0; border-bottom: 1px solid #f7f7f7; font-size: 0.85rem; }
+  .axis-id { font-family: monospace; font-weight: 600; color: #1976d2; }
+  .axis-id.no-axis { color: #aaa; }
+  .axis-label { color: #333; }
+  .counts { color: #555; font-size: 0.8rem; }
+  .recall { color: #388e3c; font-weight: 600; }
+  .flags { display: flex; gap: 0.25rem; }
+  .flag { padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; }
+  .flag.discovered { background: #ffecb3; color: #8a6d00; }
+  .flag.proposed { background: #c8e6c9; color: #1b5e20; }
+  .overlap { background: #f3e5f5; padding: 0.75rem; border-radius: 4px; border-left: 3px solid #7b1fa2; }
+  .overlap h4 { margin: 0 0 0.4rem 0; font-size: 0.85rem; }
+  .overlap-chip { display: inline-block; padding: 0.2rem 0.5rem; margin: 0.15rem 0.25rem 0 0; background: white; border-radius: 3px; font-size: 0.8rem; }
+  @media (max-width: 700px) {
+    .helix-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/Status.svelte
+++ b/packages/ebrota-console-ui/src/components/Status.svelte
@@ -5,10 +5,12 @@
     consoleMode,
     debugPanelOpen,
     discoveriesPanelOpen,
+    helixPanelOpen,
     journeyPanelOpen,
     libraryOpen,
     llmXrayPanelOpen,
     mapsPanelOpen,
+    strategistPanelOpen,
   } from "../lib/stores.js";
   import type { ApiClient } from "../lib/api.js";
   import type { ConsoleMode } from "../lib/types.js";
@@ -126,6 +128,28 @@
     title="Descobertas + boundaries"
   >
     🔍 Descobertas
+  </button>
+
+  <button
+    type="button"
+    class="tracer-toggle"
+    class:active={$strategistPanelOpen}
+    on:click={() => strategistPanelOpen.update((o) => !o)}
+    data-testid="strategist-toggle"
+    title="Strategist — plans compostos pelas sessões"
+  >
+    🎯 Strategist
+  </button>
+
+  <button
+    type="button"
+    class="tracer-toggle"
+    class:active={$helixPanelOpen}
+    on:click={() => helixPanelOpen.update((o) => !o)}
+    data-testid="helix-toggle"
+    title="Double helix — knowledge × values entrelaçados"
+  >
+    🧬 Helix
   </button>
 
   <button

--- a/packages/ebrota-console-ui/src/components/StrategistPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/StrategistPanel.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import type {
+    ApiClient,
+    JourneyStateLike,
+    StrategyPlanLike,
+  } from "../lib/api.js";
+  import { strategistPanelOpen, tracerSubjectId } from "../lib/stores.js";
+
+  export let api: ApiClient;
+
+  let plans: StrategyPlanLike[] = [];
+  let journey: JourneyStateLike | null = null;
+  let loading = false;
+  let err: string | null = null;
+
+  async function load(): Promise<void> {
+    loading = true;
+    err = null;
+    try {
+      const [pRes, jRes] = await Promise.all([
+        api.listSubjectStrategyPlans($tracerSubjectId, { limit: 20 }),
+        api.getJourneyState($tracerSubjectId),
+      ]);
+      plans = pRes.plans;
+      journey = jRes.state;
+    } catch (e) {
+      err = e instanceof Error ? e.message : String(e);
+    }
+    loading = false;
+  }
+
+  $: if ($strategistPanelOpen) void load();
+
+  function goalColor(goal: string): string {
+    if (goal === "expose") return "#f57c00";
+    if (goal === "explore") return "#1976d2";
+    if (goal === "challenge") return "#b00020";
+    if (goal === "consolidate") return "#388e3c";
+    return "#666";
+  }
+
+  function phaseColor(phase: string): string {
+    if (phase === "ice_breaker") return "#90a4ae";
+    if (phase === "challenge_explain") return "#1976d2";
+    if (phase === "challenge_execute") return "#d32f2f";
+    if (phase === "follow_up") return "#388e3c";
+    return "#666";
+  }
+</script>
+
+{#if $strategistPanelOpen}
+  <div
+    class="modal-backdrop"
+    on:click={() => strategistPanelOpen.set(false)}
+    on:keydown={(e) => e.key === "Escape" && strategistPanelOpen.set(false)}
+    role="presentation"
+  >
+    <div
+      class="modal"
+      on:click|stopPropagation
+      role="dialog"
+      aria-label="Strategist plans"
+    >
+      <header>
+        <h2>🎯 Strategist — {$tracerSubjectId}</h2>
+        <button on:click={() => strategistPanelOpen.set(false)} aria-label="Fechar">×</button>
+      </header>
+
+      <div class="subject-picker">
+        <label for="strat-subject">subject_id:</label>
+        <input id="strat-subject" type="text" bind:value={$tracerSubjectId} on:blur={load} />
+        <button on:click={load} disabled={loading}>{loading ? "..." : "Reload"}</button>
+      </div>
+
+      {#if err}<p class="err">{err}</p>{/if}
+
+      {#if journey}
+        <div class="stage-banner" data-stage={journey.stage}>
+          Stage atual: <strong>{journey.stage}</strong>
+          {#if journey.stage !== "applied_double_helix"}
+            <span class="hint">
+              Strategist só compõe planos em <code>applied_double_helix</code>. Em
+              <code>{journey.stage}</code> o pipeline usa ice-breaker / mapeamento.
+            </span>
+          {/if}
+        </div>
+      {/if}
+
+      {#if plans.length === 0}
+        <div class="empty">
+          <p>Nenhum StrategyPlan armazenado pra este sujeito ainda.</p>
+          <p class="muted">
+            Plans são compostos quando uma sessão entra em
+            <code>applied_double_helix</code> e o planejador chama
+            <code>composeStrategyPlan()</code>. Vide spec
+            <code>2026-05-25-session-phases-journey-stages-strategist.md §5</code>.
+          </p>
+        </div>
+      {:else}
+        <section class="plans">
+          <h3>{plans.length} plano(s) recente(s)</h3>
+          {#each plans as plan}
+            <article class="plan">
+              <header class="plan-header">
+                <code class="session">{plan.session_id}</code>
+                <span class="when">{new Date(plan.composed_at).toLocaleString()}</span>
+              </header>
+
+              <div class="block">
+                <h4>Target demonstrations</h4>
+                <ul>
+                  {#each plan.target_demonstrations as td}
+                    <li>
+                      <span
+                        class="goal-badge"
+                        style="background: {goalColor(td.goal)}">{td.goal}</span
+                      >
+                      <span class="dim">
+                        <code>{td.framework}</code>/<code>{td.dimension}</code>
+                      </span>
+                      <p class="rationale">{td.rationale}</p>
+                    </li>
+                  {/each}
+                </ul>
+              </div>
+
+              <div class="block">
+                <h4>
+                  Playbook composition · {plan.playbook_composition.reduce(
+                    (s, p) => s + p.estimated_minutes,
+                    0,
+                  )}min
+                </h4>
+                <ol>
+                  {#each plan.playbook_composition as step}
+                    <li>
+                      <span
+                        class="phase-badge"
+                        style="background: {phaseColor(step.phase)}">{step.phase}</span
+                      >
+                      <code class="move">{step.move_id}</code>
+                      <span class="minutes">~{step.estimated_minutes}min</span>
+                      <span class="signal">→ {step.success_signal}</span>
+                    </li>
+                  {/each}
+                </ol>
+              </div>
+
+              <div class="block">
+                <h4>Critério geral</h4>
+                <p>{plan.overall_success_criteria}</p>
+              </div>
+
+              {#if plan.fallback_strategy}
+                <div class="block fallback">
+                  <h4>Fallback</h4>
+                  <p>{plan.fallback_strategy}</p>
+                </div>
+              {/if}
+
+              {#if plan.demonstrations_observed && plan.demonstrations_observed.length > 0}
+                <div class="block observed">
+                  <h4>Observado (follow_up)</h4>
+                  <ul>
+                    {#each plan.demonstrations_observed as obs}
+                      <li>
+                        <span
+                          class="goal-badge"
+                          style="background: {goalColor(obs.goal)}">{obs.goal}</span
+                        >
+                        <code>{obs.dimension}</code> — {obs.rationale}
+                      </li>
+                    {/each}
+                  </ul>
+                </div>
+              {/if}
+            </article>
+          {/each}
+        </section>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100; display: flex; align-items: center; justify-content: center; }
+  .modal { background: #fff; padding: 1.5rem; border-radius: 8px; width: min(820px, 92vw); max-height: 90vh; overflow-y: auto; }
+  header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+  header h2 { margin: 0; font-size: 1.1rem; }
+  header button { background: transparent; border: none; font-size: 1.5rem; cursor: pointer; }
+  .subject-picker { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
+  .subject-picker input { flex: 1; padding: 0.3rem; }
+  .err { color: #b00020; }
+  .stage-banner { padding: 0.5rem 0.75rem; border-radius: 4px; background: #f7f7f7; margin-bottom: 1rem; font-size: 0.9rem; }
+  .stage-banner[data-stage="applied_double_helix"] { background: #e8f5e9; border-left: 3px solid #388e3c; }
+  .stage-banner[data-stage="mapping_ready"] { background: #fff3e0; border-left: 3px solid #f57c00; }
+  .stage-banner[data-stage="discovery_only"] { background: #e3f2fd; border-left: 3px solid #1976d2; }
+  .hint { display: block; margin-top: 0.3rem; opacity: 0.75; font-size: 0.8rem; }
+  .empty { background: #f7f7f7; padding: 1rem; border-radius: 4px; text-align: center; }
+  .empty p:first-child { font-weight: 600; }
+  .empty .muted { color: #888; font-size: 0.85rem; margin-top: 0.5rem; }
+  .plans h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+  .plan { border: 1px solid #e0e0e0; border-radius: 6px; padding: 0.85rem; margin-bottom: 1rem; }
+  .plan-header { margin-bottom: 0.5rem; }
+  .plan-header .session { font-family: monospace; font-size: 0.8rem; color: #555; }
+  .plan-header .when { float: right; color: #999; font-size: 0.8rem; }
+  .block { margin-top: 0.75rem; }
+  .block h4 { font-size: 0.85rem; margin: 0 0 0.4rem 0; color: #333; }
+  .block ul, .block ol { list-style: none; padding: 0; margin: 0; }
+  .block ol li { display: flex; gap: 0.5rem; align-items: center; padding: 0.3rem 0; border-bottom: 1px solid #f7f7f7; font-size: 0.85rem; }
+  .block ul li { padding: 0.3rem 0; font-size: 0.85rem; border-bottom: 1px solid #f7f7f7; }
+  .goal-badge, .phase-badge { color: white; padding: 0.15rem 0.5rem; border-radius: 3px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; }
+  .dim, .move { font-family: monospace; }
+  .rationale { margin: 0.25rem 0 0 0; color: #555; font-size: 0.8rem; }
+  .minutes { color: #888; font-size: 0.75rem; }
+  .signal { color: #555; font-style: italic; font-size: 0.8rem; }
+  .fallback { background: #fff3e0; padding: 0.5rem 0.75rem; border-radius: 4px; }
+  .observed { background: #e8f5e9; padding: 0.5rem 0.75rem; border-radius: 4px; }
+</style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -406,6 +406,17 @@ export interface ApiClient {
     subjectId: string,
     frameworkIds?: string[],
   ): Promise<{ maps: SubjectMapLike }>;
+
+  // ─── Strategist (Fase 8 PR 3) ───────────────────────────────────
+  /** Plan composto pra uma sessão. 404 quando não existe. */
+  getSessionStrategyPlan(
+    sessionId: string,
+  ): Promise<{ plan: StrategyPlanLike } | { error: string }>;
+  /** Histórico recente de StrategyPlans do sujeito. */
+  listSubjectStrategyPlans(
+    subjectId: string,
+    opts?: { limit?: number },
+  ): Promise<{ plans: StrategyPlanLike[] }>;
 }
 
 export interface SubjectKnowledgeEntryLike {
@@ -447,6 +458,32 @@ export interface SubjectMapLike {
   subject_id: string;
   computed_at: string;
   positions: Record<string, Record<string, unknown>>;
+}
+
+export interface TargetDemonstrationLike {
+  framework: string;
+  dimension: string;
+  goal: "expose" | "explore" | "challenge" | "consolidate";
+  rationale: string;
+}
+
+export interface PlaybookCompositionStepLike {
+  move_id: string;
+  phase: string;
+  estimated_minutes: number;
+  content_inputs?: string[];
+  success_signal: string;
+}
+
+export interface StrategyPlanLike {
+  session_id: string;
+  subject_id: string;
+  composed_at: string;
+  target_demonstrations: TargetDemonstrationLike[];
+  playbook_composition: PlaybookCompositionStepLike[];
+  overall_success_criteria: string;
+  fallback_strategy?: string;
+  demonstrations_observed?: TargetDemonstrationLike[];
 }
 
 /**
@@ -633,6 +670,28 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
       const q = params.toString();
       return get<{ maps: SubjectMapLike }>(
         `/subjects/${encodeURIComponent(subjectId)}/maps${q ? `?${q}` : ""}`,
+      );
+    },
+    getSessionStrategyPlan: async (sessionId) => {
+      const res = await f(
+        `${baseUrl}/sessions/${encodeURIComponent(sessionId)}/strategy-plan`,
+      );
+      if (res.status === 404) {
+        return { error: "strategy_plan não encontrado" };
+      }
+      if (!res.ok) {
+        throw new Error(
+          `BFF GET strategy-plan failed: ${res.status} ${res.statusText}`,
+        );
+      }
+      return (await res.json()) as { plan: StrategyPlanLike };
+    },
+    listSubjectStrategyPlans: (subjectId, opts) => {
+      const params = new URLSearchParams();
+      if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+      const q = params.toString();
+      return get<{ plans: StrategyPlanLike[] }>(
+        `/subjects/${encodeURIComponent(subjectId)}/strategy-plans${q ? `?${q}` : ""}`,
       );
     },
   };

--- a/packages/ebrota-console-ui/src/lib/stores.ts
+++ b/packages/ebrota-console-ui/src/lib/stores.ts
@@ -69,6 +69,8 @@ export const debugLlmEvents = writable<DebugLlmCallEvent[]>([]);
 export const journeyPanelOpen = writable<boolean>(false);
 export const mapsPanelOpen = writable<boolean>(false);
 export const discoveriesPanelOpen = writable<boolean>(false);
+export const strategistPanelOpen = writable<boolean>(false);
+export const helixPanelOpen = writable<boolean>(false);
 
 /** Subject ID corrente nos painéis tracer. Default ryo-ochiai. */
 export const tracerSubjectId = writable<string>("ryo-ochiai");


### PR DESCRIPTION
Rebase do PR #224 sobre o `main` atual.

## O que adiciona
- `StrategistPanel.svelte` — lista StrategyPlans por sujeito/sessão, jogadas compostas, stage banner
- `HelixPanel.svelte` — double helix two-thread view (knowledge × values por axis_id)
- `Status.svelte` — botões 🎯 Strategist + 🧬 Helix
- `stores.ts` — `strategistPanelOpen` + `helixPanelOpen`
- `api.ts` — `getSessionStrategyPlan` + `listSubjectStrategyPlans` + interfaces `StrategyPlanLike`

## Por que novo PR
PR #224 tinha conflito de merge em 30+ arquivos (main avançou com PRs #240-#247). Rebase aplicou as mudanças cirurgicamente sobre o main atual.

## Testes
- `tsc --noEmit` — clean
- Mesmos 3 suites passam (api.test.ts, types.test.ts, url-params.test.ts) — sem regressões
- `vite build` — clean (175 KB JS / 51 KB CSS)

Fecha: #224