### PR TITLE
[motor] S1 — Declared objectives + drift triggers (rebased)

### DIFF
--- a/motor-drota/src/intent-extractor.ts
+++ b/motor-drota/src/intent-extractor.ts
@@ -1,0 +1,286 @@
+/**
+ * intent-extractor — detector de intenção temporal declarada pelo aprendiz.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-s1-objetivos-declarados-v0.md
+ *
+ * Pipeline:
+ *  1. Regex rule-based (PT + JP) — fast path, alta precisão
+ *  2. Fallback LLM (Haiku 1-shot) — só se regex não confiar e caller injetou
+ *
+ * Returns DeclaredObjective | null. Sem id (caller atribui via repo).
+ *
+ * Confidence:
+ *  - 1.0 quando target_date veio literal (data ISO ou "DD/MM")
+ *  - 0.7 quando inferido (e.g., "fim do mês", "em 2 semanas")
+ *  - confidence < 0.5 → null (não confia)
+ */
+
+import { randomUUID } from "node:crypto";
+import type { DeclaredObjective } from "@ascendimacy/shared";
+
+export interface IntentExtractorInput {
+  message: string;
+  personaId: string;
+  sessionId: string;
+  /** ISO8601 string. Default: Date.now(). */
+  now?: string;
+  /** Callback LLM 1-shot. Recebe message, retorna parcial sem id/status. */
+  llmFallback?: (input: { message: string; nowIso: string }) => Promise<
+    | (Pick<DeclaredObjective, "statement" | "target_date"> &
+        Partial<Pick<DeclaredObjective, "axis">>)
+    | null
+  >;
+}
+
+interface RegexCandidate {
+  statement: string;
+  target_date: string;
+  confidence: number;
+  axis?: string;
+}
+
+const MIN_CONFIDENCE = 0.5;
+
+function endOfMonthIso(now: Date): string {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  const lastDay = new Date(Date.UTC(y, m + 1, 0));
+  return new Date(
+    Date.UTC(
+      lastDay.getUTCFullYear(),
+      lastDay.getUTCMonth(),
+      lastDay.getUTCDate(),
+      23,
+      59,
+      59,
+    ),
+  ).toISOString();
+}
+
+function addDaysIso(now: Date, days: number): string {
+  const next = new Date(now);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next.toISOString();
+}
+
+function tryParseExplicitDate(token: string, now: Date): string | null {
+  // ISO 8601 — full datetime ou só date
+  if (/^\d{4}-\d{2}-\d{2}(T|$)/.test(token)) {
+    const ms = Date.parse(token);
+    if (!Number.isNaN(ms)) {
+      // Se for só date sem hora, normalizar pra fim do dia UTC.
+      if (token.length === 10) {
+        return `${token}T23:59:59.000Z`;
+      }
+      return new Date(ms).toISOString();
+    }
+  }
+  // DD/MM ou DD/MM/YYYY
+  const ddmm = /^(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?$/.exec(token);
+  if (ddmm) {
+    const day = Number(ddmm[1]);
+    const month = Number(ddmm[2]) - 1;
+    const yearRaw = ddmm[3];
+    let year = now.getUTCFullYear();
+    if (yearRaw !== undefined) {
+      year = yearRaw.length === 2 ? 2000 + Number(yearRaw) : Number(yearRaw);
+    }
+    const date = new Date(Date.UTC(year, month, day, 23, 59, 59));
+    if (!Number.isNaN(date.getTime())) {
+      // Se data já passou no ano corrente sem ano explícito, próximo ano.
+      if (yearRaw === undefined && date.getTime() < now.getTime()) {
+        date.setUTCFullYear(year + 1);
+      }
+      return date.toISOString();
+    }
+  }
+  return null;
+}
+
+const WEEKDAYS_PT: Record<string, number> = {
+  domingo: 0,
+  "segunda": 1,
+  "segunda-feira": 1,
+  terca: 2,
+  terça: 2,
+  "terca-feira": 2,
+  "terça-feira": 2,
+  quarta: 3,
+  "quarta-feira": 3,
+  quinta: 4,
+  "quinta-feira": 4,
+  sexta: 5,
+  "sexta-feira": 5,
+  sabado: 6,
+  sábado: 6,
+};
+
+function nextWeekday(now: Date, targetDow: number): string {
+  const cur = now.getUTCDay();
+  let delta = targetDow - cur;
+  if (delta <= 0) delta += 7;
+  return addDaysIso(now, delta);
+}
+
+function inferTargetDate(
+  phrase: string,
+  now: Date,
+): { iso: string; inferred: boolean } | null {
+  const norm = phrase.trim().toLowerCase();
+
+  // Literal date attempt
+  const literal = tryParseExplicitDate(norm, now);
+  if (literal !== null) return { iso: literal, inferred: false };
+
+  // PT: "fim do mês" / "fim deste mês"
+  if (/\bfim (?:do|deste|de\s+esse)\s*m[eê]s\b/.test(norm)) {
+    return { iso: endOfMonthIso(now), inferred: true };
+  }
+  // JP: "今月末" / "今月の末"
+  if (/今月(?:の)?末/.test(phrase)) {
+    return { iso: endOfMonthIso(now), inferred: true };
+  }
+
+  // PT: "N semanas" / "N dias" / "N meses" (sem prefixo "em" — quando o
+  // regex outer já consumiu o "em" ou "até")
+  const nUnit = /(\d{1,3})\s*(dias?|semanas?|meses?)/.exec(norm);
+  if (nUnit) {
+    const n = Number(nUnit[1]);
+    const unit = nUnit[2] ?? "";
+    const days = unit.startsWith("semana")
+      ? n * 7
+      : unit.startsWith("mes")
+        ? n * 30
+        : n;
+    return { iso: addDaysIso(now, days), inferred: true };
+  }
+
+  // PT: weekday standalone ("sexta", "segunda-feira", etc.)
+  const dowToken = norm.trim();
+  if (dowToken in WEEKDAYS_PT) {
+    return {
+      iso: nextWeekday(now, WEEKDAYS_PT[dowToken]!),
+      inferred: true,
+    };
+  }
+
+  // JP: "N週間" / "N日"
+  const jpN = /(\d{1,3})\s*(週間|日|か月|ヶ月)/.exec(phrase);
+  if (jpN) {
+    const n = Number(jpN[1]);
+    const unit = jpN[2];
+    const days = unit === "週間" ? n * 7 : unit === "日" ? n : n * 30;
+    return { iso: addDaysIso(now, days), inferred: true };
+  }
+
+  return null;
+}
+
+const PT_PATTERNS: RegExp[] = [
+  /quero\s+(?<what>.+?)\s+(?:at[ée]|em)\s+(?<when>.+?)(?:[.!?]|$)/i,
+  /vou\s+(?<what>.+?)\s+(?:at[ée]|em)\s+(?<when>.+?)(?:[.!?]|$)/i,
+  /pretendo\s+(?<what>.+?)\s+(?:at[ée]|em)\s+(?<when>.+?)(?:[.!?]|$)/i,
+  /meta[:\s]+(?<what>.+?)\s+(?:at[ée]|em)\s+(?<when>.+?)(?:[.!?]|$)/i,
+];
+
+const JP_PATTERNS: RegExp[] = [
+  // 〜まで〜したい / 〜までに〜する
+  /(?<when>.+?)(?:まで(?:に)?)(?<what>.+?)(?:したい|する|やる)(?:[.!?。！？]|$)/,
+  // N週間で〜したい / N日で〜する
+  /(?<when>\d+\s*(?:週間|日|か月|ヶ月|時間))で(?<what>.+?)(?:したい|する|やる|覚えたい|マスターしたい)(?:[.!?。！？]|$)/,
+];
+
+function tryRegex(message: string, now: Date): RegexCandidate | null {
+  for (const re of PT_PATTERNS) {
+    const m = re.exec(message);
+    if (m?.groups?.["what"] && m.groups["when"]) {
+      const what = m.groups["what"].trim();
+      const when = m.groups["when"].trim();
+      const date = inferTargetDate(when, now);
+      if (date === null) continue;
+      const statement = what.slice(0, 200);
+      return {
+        statement,
+        target_date: date.iso,
+        confidence: date.inferred ? 0.7 : 1.0,
+      };
+    }
+  }
+  for (const re of JP_PATTERNS) {
+    const m = re.exec(message);
+    if (m?.groups?.["what"] && m.groups["when"]) {
+      const what = m.groups["what"].trim();
+      const when = m.groups["when"].trim();
+      const date = inferTargetDate(when, now);
+      if (date === null) continue;
+      return {
+        statement: what.slice(0, 200),
+        target_date: date.iso,
+        confidence: date.inferred ? 0.7 : 1.0,
+      };
+    }
+  }
+  return null;
+}
+
+export async function extractIntent(
+  input: IntentExtractorInput,
+): Promise<DeclaredObjective | null> {
+  const nowIso = input.now ?? new Date().toISOString();
+  const now = new Date(nowIso);
+  if (Number.isNaN(now.getTime())) return null;
+
+  const regex = tryRegex(input.message, now);
+  if (regex !== null && regex.confidence >= MIN_CONFIDENCE) {
+    return buildObjective({
+      personaId: input.personaId,
+      sessionId: input.sessionId,
+      nowIso,
+      statement: regex.statement,
+      targetDate: regex.target_date,
+      ...(regex.axis !== undefined ? { axis: regex.axis } : {}),
+    });
+  }
+
+  if (input.llmFallback !== undefined) {
+    try {
+      const llm = await input.llmFallback({
+        message: input.message,
+        nowIso,
+      });
+      if (llm !== null) {
+        return buildObjective({
+          personaId: input.personaId,
+          sessionId: input.sessionId,
+          nowIso,
+          statement: llm.statement.slice(0, 200),
+          targetDate: llm.target_date,
+          ...(llm.axis !== undefined ? { axis: llm.axis } : {}),
+        });
+      }
+    } catch {
+      // fail-soft — LLM erro vira "sem extração"
+    }
+  }
+  return null;
+}
+
+function buildObjective(args: {
+  personaId: string;
+  sessionId: string;
+  nowIso: string;
+  statement: string;
+  targetDate: string;
+  axis?: string;
+}): DeclaredObjective {
+  return {
+    id: randomUUID(),
+    persona_id: args.personaId,
+    declared_at: args.nowIso,
+    declared_in_session: args.sessionId,
+    target_date: args.targetDate,
+    statement: args.statement,
+    ...(args.axis !== undefined ? { axis: args.axis } : {}),
+    status: "active",
+  };
+}

--- a/motor-drota/tests/intent-extractor.unit.test.ts
+++ b/motor-drota/tests/intent-extractor.unit.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import { extractIntent } from "../src/intent-extractor.js";
+
+const NOW = "2026-05-26T10:00:00.000Z"; // terça-feira
+
+function baseInput(message: string): {
+  message: string;
+  personaId: string;
+  sessionId: string;
+  now: string;
+} {
+  return {
+    message,
+    personaId: "ryo",
+    sessionId: "sess-1",
+    now: NOW,
+  };
+}
+
+describe("extractIntent — positive cases", () => {
+  it("PT: 'quero ... até fim do mês'", async () => {
+    const obj = await extractIntent(
+      baseInput("Quero aprender frações até fim do mês"),
+    );
+    expect(obj).not.toBeNull();
+    expect(obj!.statement).toContain("aprender frações");
+    // fim de maio 2026 — 23:59:59 UTC
+    expect(obj!.target_date.startsWith("2026-05-31T23:59:59")).toBe(true);
+    expect(obj!.status).toBe("active");
+    expect(obj!.persona_id).toBe("ryo");
+  });
+
+  it("PT: 'quero ... em 2 semanas' (inferido)", async () => {
+    const obj = await extractIntent(
+      baseInput("Quero treinar tabuada em 2 semanas"),
+    );
+    expect(obj).not.toBeNull();
+    // 2026-05-26 + 14d = 2026-06-09
+    expect(obj!.target_date.startsWith("2026-06-09")).toBe(true);
+  });
+
+  it("PT: 'vou ... em 7 dias'", async () => {
+    const obj = await extractIntent(baseInput("Vou ler 3 livros em 7 dias"));
+    expect(obj).not.toBeNull();
+    expect(obj!.target_date.startsWith("2026-06-02")).toBe(true);
+  });
+
+  it("PT: 'pretendo ... até 2026-06-15' (literal ISO)", async () => {
+    const obj = await extractIntent(
+      baseInput("Pretendo terminar o projeto até 2026-06-15"),
+    );
+    expect(obj).not.toBeNull();
+    expect(obj!.target_date.startsWith("2026-06-15")).toBe(true);
+  });
+
+  it("PT: 'meta: ... até sexta'", async () => {
+    const obj = await extractIntent(
+      baseInput("Meta: aprender hiragana até sexta"),
+    );
+    expect(obj).not.toBeNull();
+    // 2026-05-26 = terça, próxima sexta = 2026-05-29
+    expect(obj!.target_date.startsWith("2026-05-29")).toBe(true);
+  });
+
+  it("PT: 'quero ... até 30/06' (DD/MM no ano corrente)", async () => {
+    const obj = await extractIntent(
+      baseInput("Quero correr 5km até 30/06"),
+    );
+    expect(obj).not.toBeNull();
+    expect(obj!.target_date.startsWith("2026-06-30")).toBe(true);
+  });
+
+  it("PT: caso com pontuação final", async () => {
+    const obj = await extractIntent(
+      baseInput("Quero aprender violão em 30 dias."),
+    );
+    expect(obj).not.toBeNull();
+    expect(obj!.statement.endsWith(".")).toBe(false);
+  });
+
+  it("JP: '今月末までに〜したい'", async () => {
+    const obj = await extractIntent(
+      baseInput("今月末までに掛け算をマスターしたい"),
+    );
+    expect(obj).not.toBeNull();
+    expect(obj!.target_date.startsWith("2026-05-31T23:59:59")).toBe(true);
+  });
+
+  it("JP: '2週間で〜したい'", async () => {
+    const obj = await extractIntent(
+      baseInput("2週間でひらがなを覚えたい"),
+    );
+    expect(obj).not.toBeNull();
+    expect(obj!.target_date.startsWith("2026-06-09")).toBe(true);
+  });
+
+  it("PT: statement trunca em 200 chars", async () => {
+    const longWhat = "a".repeat(250);
+    const obj = await extractIntent(
+      baseInput(`Quero ${longWhat} até fim do mês`),
+    );
+    expect(obj).not.toBeNull();
+    expect(obj!.statement.length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe("extractIntent — negative cases", () => {
+  it("retorna null se sem verbo intent", async () => {
+    const obj = await extractIntent(baseInput("Hoje fez frio na escola"));
+    expect(obj).toBeNull();
+  });
+
+  it("retorna null se sem expressão temporal", async () => {
+    const obj = await extractIntent(baseInput("Quero aprender violão"));
+    expect(obj).toBeNull();
+  });
+
+  it("retorna null se expressão temporal não-resolvível", async () => {
+    const obj = await extractIntent(
+      baseInput("Quero aprender alguma coisa até qualquer dia"),
+    );
+    expect(obj).toBeNull();
+  });
+
+  it("retorna null se message vazia", async () => {
+    const obj = await extractIntent(baseInput(""));
+    expect(obj).toBeNull();
+  });
+
+  it("retorna null se now invalido", async () => {
+    const obj = await extractIntent({
+      ...baseInput("Quero X até fim do mês"),
+      now: "not-a-date",
+    });
+    expect(obj).toBeNull();
+  });
+});
+
+describe("extractIntent — LLM fallback", () => {
+  it("chama llmFallback quando regex falha", async () => {
+    let called = false;
+    const obj = await extractIntent({
+      ...baseInput("alguma frase sem padrão regex"),
+      llmFallback: async () => {
+        called = true;
+        return {
+          statement: "objetivo via LLM",
+          target_date: "2026-07-01T23:59:59.000Z",
+          axis: "virtue:wisdom",
+        };
+      },
+    });
+    expect(called).toBe(true);
+    expect(obj).not.toBeNull();
+    expect(obj!.statement).toBe("objetivo via LLM");
+    expect(obj!.axis).toBe("virtue:wisdom");
+  });
+
+  it("NÃO chama llmFallback quando regex já matchou", async () => {
+    let called = false;
+    const obj = await extractIntent({
+      ...baseInput("Quero aprender frações até fim do mês"),
+      llmFallback: async () => {
+        called = true;
+        return null;
+      },
+    });
+    expect(called).toBe(false);
+    expect(obj).not.toBeNull();
+  });
+
+  it("llmFallback retornando null → extract retorna null", async () => {
+    const obj = await extractIntent({
+      ...baseInput("frase sem padrão"),
+      llmFallback: async () => null,
+    });
+    expect(obj).toBeNull();
+  });
+
+  it("llmFallback erro é absorvido fail-soft", async () => {
+    const obj = await extractIntent({
+      ...baseInput("frase sem padrão"),
+      llmFallback: async () => {
+        throw new Error("LLM down");
+      },
+    });
+    expect(obj).toBeNull();
+  });
+});

--- a/motor-execucao/src/declared-objective-repo.ts
+++ b/motor-execucao/src/declared-objective-repo.ts
@@ -1,0 +1,245 @@
+/**
+ * kids_declared_objectives — repo append-only de objetivos declarados.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-s1-objetivos-declarados-v0.md
+ *
+ * Convenção: nenhuma row é alterada após inserida. Mudanças de status criam
+ * nova versão linkada via `parent_objective_id`. "Latest version" de uma
+ * cadeia é a row cujo id não é referenciado por nenhum parent_objective_id.
+ */
+
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import {
+  DeclaredObjectiveSchema,
+  type DeclaredObjective,
+  type DeclaredObjectiveDraft,
+  type DeclaredObjectiveStatus,
+} from "@ascendimacy/shared";
+
+export const DECLARED_OBJECTIVES_DDL = `
+CREATE TABLE IF NOT EXISTS kids_declared_objectives (
+  id TEXT PRIMARY KEY,
+  persona_id TEXT NOT NULL,
+  declared_at TEXT NOT NULL,
+  declared_in_session TEXT NOT NULL,
+  target_date TEXT NOT NULL,
+  statement TEXT NOT NULL,
+  axis TEXT,
+  status TEXT NOT NULL,
+  parent_objective_id TEXT,
+  evidence_event_ids TEXT,
+  drift_check_due_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_declared_objectives_by_persona
+  ON kids_declared_objectives(persona_id);
+CREATE INDEX IF NOT EXISTS idx_declared_objectives_by_status
+  ON kids_declared_objectives(status);
+CREATE INDEX IF NOT EXISTS idx_declared_objectives_by_parent
+  ON kids_declared_objectives(parent_objective_id);
+CREATE INDEX IF NOT EXISTS idx_declared_objectives_by_drift_due
+  ON kids_declared_objectives(drift_check_due_at);
+`;
+
+interface ObjectiveRow {
+  id: string;
+  persona_id: string;
+  declared_at: string;
+  declared_in_session: string;
+  target_date: string;
+  statement: string;
+  axis: string | null;
+  status: string;
+  parent_objective_id: string | null;
+  evidence_event_ids: string | null;
+  drift_check_due_at: string | null;
+}
+
+function rowToObjective(row: ObjectiveRow): DeclaredObjective {
+  const evidence = row.evidence_event_ids
+    ? (JSON.parse(row.evidence_event_ids) as string[])
+    : undefined;
+  return DeclaredObjectiveSchema.parse({
+    id: row.id,
+    persona_id: row.persona_id,
+    declared_at: row.declared_at,
+    declared_in_session: row.declared_in_session,
+    target_date: row.target_date,
+    statement: row.statement,
+    ...(row.axis !== null ? { axis: row.axis } : {}),
+    status: row.status,
+    ...(row.parent_objective_id !== null
+      ? { parent_objective_id: row.parent_objective_id }
+      : {}),
+    ...(evidence !== undefined ? { evidence_event_ids: evidence } : {}),
+    ...(row.drift_check_due_at !== null
+      ? { drift_check_due_at: row.drift_check_due_at }
+      : {}),
+  });
+}
+
+function insert(db: Database.Database, obj: DeclaredObjective): void {
+  db.prepare(
+    `INSERT INTO kids_declared_objectives
+      (id, persona_id, declared_at, declared_in_session, target_date,
+       statement, axis, status, parent_objective_id, evidence_event_ids,
+       drift_check_due_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    obj.id,
+    obj.persona_id,
+    obj.declared_at,
+    obj.declared_in_session,
+    obj.target_date,
+    obj.statement,
+    obj.axis ?? null,
+    obj.status,
+    obj.parent_objective_id ?? null,
+    obj.evidence_event_ids !== undefined
+      ? JSON.stringify(obj.evidence_event_ids)
+      : null,
+    obj.drift_check_due_at ?? null,
+  );
+}
+
+function getById(db: Database.Database, id: string): DeclaredObjective | null {
+  const row = db
+    .prepare("SELECT * FROM kids_declared_objectives WHERE id = ?")
+    .get(id) as ObjectiveRow | undefined;
+  return row ? rowToObjective(row) : null;
+}
+
+export function createObjective(
+  db: Database.Database,
+  input: DeclaredObjectiveDraft,
+): DeclaredObjective {
+  const objective: DeclaredObjective = {
+    id: randomUUID(),
+    persona_id: input.persona_id,
+    declared_at: input.declared_at,
+    declared_in_session: input.declared_in_session,
+    target_date: input.target_date,
+    statement: input.statement,
+    ...(input.axis !== undefined ? { axis: input.axis } : {}),
+    status: "active",
+    ...(input.evidence_event_ids !== undefined
+      ? { evidence_event_ids: input.evidence_event_ids }
+      : {}),
+    ...(input.drift_check_due_at !== undefined
+      ? { drift_check_due_at: input.drift_check_due_at }
+      : {}),
+  };
+  insert(db, objective);
+  return objective;
+}
+
+/**
+ * Marca objective antigo como "revised" criando nova row no chain.
+ *
+ * `newId` é o id da nova row "revised" (deve ser único). Tipicamente
+ * gerado pelo caller que separadamente também cria o objetivo de
+ * substituição via createObjective.
+ */
+export function markRevised(
+  db: Database.Database,
+  oldId: string,
+  newId: string,
+): DeclaredObjective {
+  const old = getById(db, oldId);
+  if (old === null) {
+    throw new Error(`markRevised: objective ${oldId} not found`);
+  }
+  const revised: DeclaredObjective = {
+    ...old,
+    id: newId,
+    status: "revised",
+    parent_objective_id: oldId,
+  };
+  insert(db, revised);
+  return revised;
+}
+
+/**
+ * Atualiza status criando nova row linkada via parent_objective_id.
+ * Mantém append-only: row antiga continua existindo.
+ */
+export function updateStatus(
+  db: Database.Database,
+  id: string,
+  status: DeclaredObjectiveStatus,
+  evidenceEventIds?: string[],
+): DeclaredObjective {
+  const current = getById(db, id);
+  if (current === null) {
+    throw new Error(`updateStatus: objective ${id} not found`);
+  }
+  const mergedEvidence =
+    evidenceEventIds !== undefined
+      ? [...(current.evidence_event_ids ?? []), ...evidenceEventIds]
+      : current.evidence_event_ids;
+  const next: DeclaredObjective = {
+    ...current,
+    id: randomUUID(),
+    status,
+    parent_objective_id: id,
+    ...(mergedEvidence !== undefined
+      ? { evidence_event_ids: mergedEvidence }
+      : {}),
+  };
+  insert(db, next);
+  return next;
+}
+
+/**
+ * Active = rows com status='active' que não foram superseded por outra
+ * versão na cadeia (id não referenciado por nenhum parent_objective_id).
+ */
+export function listActive(
+  db: Database.Database,
+  personaId: string,
+): DeclaredObjective[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM kids_declared_objectives
+       WHERE persona_id = ?
+         AND status = 'active'
+         AND id NOT IN (
+           SELECT parent_objective_id FROM kids_declared_objectives
+           WHERE parent_objective_id IS NOT NULL
+         )
+       ORDER BY declared_at`,
+    )
+    .all(personaId) as ObjectiveRow[];
+  return rows.map(rowToObjective);
+}
+
+/**
+ * Drift check due: rows active com drift_check_due_at < now,
+ * que não foram superseded.
+ */
+export function findDueForDriftCheck(
+  db: Database.Database,
+  now: string,
+): DeclaredObjective[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM kids_declared_objectives
+       WHERE status = 'active'
+         AND drift_check_due_at IS NOT NULL
+         AND drift_check_due_at < ?
+         AND id NOT IN (
+           SELECT parent_objective_id FROM kids_declared_objectives
+           WHERE parent_objective_id IS NOT NULL
+         )
+       ORDER BY drift_check_due_at`,
+    )
+    .all(now) as ObjectiveRow[];
+  return rows.map(rowToObjective);
+}
+
+export function getDeclaredObjective(
+  db: Database.Database,
+  id: string,
+): DeclaredObjective | null {
+  return getById(db, id);
+}

--- a/motor-execucao/tests/declared-objective-repo.unit.test.ts
+++ b/motor-execucao/tests/declared-objective-repo.unit.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  DECLARED_OBJECTIVES_DDL,
+  createObjective,
+  markRevised,
+  updateStatus,
+  listActive,
+  findDueForDriftCheck,
+  getDeclaredObjective,
+} from "../src/declared-objective-repo.js";
+import type { DeclaredObjectiveDraft } from "@ascendimacy/shared";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(DECLARED_OBJECTIVES_DDL);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function draft(overrides: Partial<DeclaredObjectiveDraft> = {}): DeclaredObjectiveDraft {
+  return {
+    persona_id: "ryo",
+    declared_at: "2026-05-26T10:00:00.000Z",
+    declared_in_session: "sess-1",
+    target_date: "2026-06-30T23:59:59.000Z",
+    statement: "Aprender frações até fim do mês",
+    axis: "math:fractions",
+    ...overrides,
+  };
+}
+
+describe("declared-objective-repo CRUD", () => {
+  it("createObjective insere com status='active' e id auto-gerado", () => {
+    const obj = createObjective(db, draft());
+    expect(obj.id).toBeTruthy();
+    expect(obj.status).toBe("active");
+    expect(obj.persona_id).toBe("ryo");
+    expect(obj.statement).toBe("Aprender frações até fim do mês");
+    expect(obj.target_date).toBe("2026-06-30T23:59:59.000Z");
+    expect(obj.axis).toBe("math:fractions");
+  });
+
+  it("createObjective persiste axis opcional", () => {
+    const a = createObjective(db, draft({ axis: undefined }));
+    const b = createObjective(db, draft({ axis: "virtue:wisdom" }));
+    const ra = getDeclaredObjective(db, a.id);
+    const rb = getDeclaredObjective(db, b.id);
+    expect(ra?.axis).toBeUndefined();
+    expect(rb?.axis).toBe("virtue:wisdom");
+  });
+
+  it("createObjective persiste drift_check_due_at", () => {
+    const obj = createObjective(
+      db,
+      draft({ drift_check_due_at: "2026-06-09T00:00:00.000Z" }),
+    );
+    const fetched = getDeclaredObjective(db, obj.id);
+    expect(fetched?.drift_check_due_at).toBe("2026-06-09T00:00:00.000Z");
+  });
+
+  it("createObjective persiste evidence_event_ids array", () => {
+    const obj = createObjective(
+      db,
+      draft({ evidence_event_ids: ["evt-1", "evt-2"] }),
+    );
+    const fetched = getDeclaredObjective(db, obj.id);
+    expect(fetched?.evidence_event_ids).toEqual(["evt-1", "evt-2"]);
+  });
+});
+
+describe("declared-objective-repo status transitions", () => {
+  it("updateStatus cria nova versão linkada via parent_objective_id", () => {
+    const orig = createObjective(db, draft());
+    const flagged = updateStatus(db, orig.id, "drift_flagged");
+    expect(flagged.id).not.toBe(orig.id);
+    expect(flagged.status).toBe("drift_flagged");
+    expect(flagged.parent_objective_id).toBe(orig.id);
+    // Original ainda existe (append-only)
+    expect(getDeclaredObjective(db, orig.id)?.status).toBe("active");
+  });
+
+  it("updateStatus merge evidence_event_ids existentes + novos", () => {
+    const orig = createObjective(
+      db,
+      draft({ evidence_event_ids: ["evt-1"] }),
+    );
+    const achieved = updateStatus(db, orig.id, "achieved", ["evt-2", "evt-3"]);
+    expect(achieved.evidence_event_ids).toEqual(["evt-1", "evt-2", "evt-3"]);
+  });
+
+  it("updateStatus throw em id inexistente", () => {
+    expect(() => updateStatus(db, "nonexistent", "achieved")).toThrow();
+  });
+
+  it("markRevised cria row com newId, status='revised', parent=oldId", () => {
+    const orig = createObjective(db, draft());
+    const newId = "manually-assigned-new-id";
+    const rev = markRevised(db, orig.id, newId);
+    expect(rev.id).toBe(newId);
+    expect(rev.status).toBe("revised");
+    expect(rev.parent_objective_id).toBe(orig.id);
+    expect(rev.statement).toBe(orig.statement);
+  });
+
+  it("markRevised throw em oldId inexistente", () => {
+    expect(() => markRevised(db, "nonexistent", "x")).toThrow();
+  });
+});
+
+describe("declared-objective-repo listActive", () => {
+  it("retorna apenas rows active sem descendentes", () => {
+    const a = createObjective(db, draft({ statement: "obj A" }));
+    const b = createObjective(db, draft({ statement: "obj B" }));
+    const _c = createObjective(db, draft({ statement: "obj C" }));
+    // B fica superseded por achievement
+    updateStatus(db, b.id, "achieved");
+    // A fica superseded por drift_flagged
+    updateStatus(db, a.id, "drift_flagged");
+
+    const active = listActive(db, "ryo");
+    expect(active.map((o) => o.statement)).toEqual(["obj C"]);
+  });
+
+  it("isola por persona", () => {
+    createObjective(db, draft({ persona_id: "ryo", statement: "R1" }));
+    createObjective(db, draft({ persona_id: "kei", statement: "K1" }));
+    expect(listActive(db, "ryo").map((o) => o.statement)).toEqual(["R1"]);
+    expect(listActive(db, "kei").map((o) => o.statement)).toEqual(["K1"]);
+  });
+
+  it("retorna lista vazia pra persona desconhecido", () => {
+    expect(listActive(db, "unknown")).toEqual([]);
+  });
+});
+
+describe("declared-objective-repo findDueForDriftCheck", () => {
+  it("retorna apenas active com drift_check_due_at < now", () => {
+    createObjective(
+      db,
+      draft({
+        statement: "due",
+        drift_check_due_at: "2026-05-20T00:00:00.000Z",
+      }),
+    );
+    createObjective(
+      db,
+      draft({
+        statement: "future",
+        drift_check_due_at: "2026-12-31T00:00:00.000Z",
+      }),
+    );
+    createObjective(db, draft({ statement: "no-due" })); // sem drift_check_due_at
+
+    const due = findDueForDriftCheck(db, "2026-05-26T10:00:00.000Z");
+    expect(due.map((o) => o.statement)).toEqual(["due"]);
+  });
+
+  it("ignora objectives superseded mesmo se due", () => {
+    const obj = createObjective(
+      db,
+      draft({
+        statement: "due-but-revised",
+        drift_check_due_at: "2026-05-20T00:00:00.000Z",
+      }),
+    );
+    updateStatus(db, obj.id, "drift_flagged");
+    const due = findDueForDriftCheck(db, "2026-05-26T10:00:00.000Z");
+    expect(due).toEqual([]);
+  });
+});

--- a/orchestrator/src/drift-checker.ts
+++ b/orchestrator/src/drift-checker.ts
@@ -1,0 +1,131 @@
+/**
+ * drift-checker — emite eventos de drift sobre DeclaredObjectives.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-s1-objetivos-declarados-v0.md
+ *
+ * Triggers (por evento, NÃO cron):
+ *  - anniversary: target_date < now e status="active"
+ *  - stagnation: 14d (kids) / 30d (adultos) sem evento que toque `axis`
+ *  - conflict: novo objetivo declarado no mesmo `axis` enquanto outro ativo
+ *
+ * Não escreve no event_log nem muta status — emite events que o caller
+ * (orchestrator + motor-execucao.log_event) dispatcha. Mantém drift-checker
+ * puro e fácil de testar.
+ */
+
+import type { DeclaredObjective } from "@ascendimacy/shared";
+
+export type DriftCheckEventType =
+  | "objective_drift_check_anniversary"
+  | "objective_drift_check_stagnation"
+  | "objective_drift_check_conflict";
+
+export interface DriftCheckEvent {
+  type: DriftCheckEventType;
+  objective_id: string;
+  persona_id: string;
+  axis?: string;
+  detected_at: string;
+  evidence_summary: string;
+}
+
+export interface DriftCheckerConfig {
+  /** Dias sem evento no axis pra disparar stagnation. Default: 14 (crianças). */
+  stagnationThresholdDays: number;
+}
+
+export const DEFAULT_KIDS_DRIFT_CONFIG: DriftCheckerConfig = {
+  stagnationThresholdDays: 14,
+};
+
+export const DEFAULT_ADULTS_DRIFT_CONFIG: DriftCheckerConfig = {
+  stagnationThresholdDays: 30,
+};
+
+export interface DriftCheckerSources {
+  /** Lista objetivos ativos do persona. */
+  listActiveObjectives: (personaId: string) => Promise<DeclaredObjective[]>;
+  /** Último ISO timestamp de event que tocou `axis` pro persona. Null = nunca. */
+  lastEventOnAxis: (
+    personaId: string,
+    axis: string,
+  ) => Promise<string | null>;
+}
+
+export interface RunDriftChecksInput {
+  personaId: string;
+  now: string;
+  sources: DriftCheckerSources;
+  config?: DriftCheckerConfig;
+  /** Se fornecido, dispara conflict check pro axis do novo objetivo. */
+  newlyDeclaredObjective?: DeclaredObjective;
+}
+
+function daysBetween(fromIso: string, toIso: string): number {
+  const a = Date.parse(fromIso);
+  const b = Date.parse(toIso);
+  if (Number.isNaN(a) || Number.isNaN(b)) return 0;
+  return Math.floor((b - a) / (24 * 60 * 60 * 1000));
+}
+
+export async function runDriftChecks(
+  input: RunDriftChecksInput,
+): Promise<DriftCheckEvent[]> {
+  const config = input.config ?? DEFAULT_KIDS_DRIFT_CONFIG;
+  const active = await input.sources.listActiveObjectives(input.personaId);
+  const events: DriftCheckEvent[] = [];
+
+  for (const obj of active) {
+    // Anniversary: target_date passou
+    if (Date.parse(obj.target_date) < Date.parse(input.now)) {
+      events.push({
+        type: "objective_drift_check_anniversary",
+        objective_id: obj.id,
+        persona_id: obj.persona_id,
+        ...(obj.axis !== undefined ? { axis: obj.axis } : {}),
+        detected_at: input.now,
+        evidence_summary: `target_date ${obj.target_date} passou (now=${input.now}); statement="${obj.statement}"`,
+      });
+    }
+
+    // Stagnation: sem evento no axis nos últimos N dias
+    if (obj.axis !== undefined) {
+      const last = await input.sources.lastEventOnAxis(
+        obj.persona_id,
+        obj.axis,
+      );
+      const reference = last ?? obj.declared_at;
+      const idleDays = daysBetween(reference, input.now);
+      if (idleDays >= config.stagnationThresholdDays) {
+        events.push({
+          type: "objective_drift_check_stagnation",
+          objective_id: obj.id,
+          persona_id: obj.persona_id,
+          axis: obj.axis,
+          detected_at: input.now,
+          evidence_summary: `${idleDays}d sem evento no axis="${obj.axis}" (limite=${config.stagnationThresholdDays}d); último=${reference}`,
+        });
+      }
+    }
+  }
+
+  // Conflict: novo objetivo no mesmo axis de outro ativo
+  if (input.newlyDeclaredObjective?.axis !== undefined) {
+    const newAxis = input.newlyDeclaredObjective.axis;
+    const conflicts = active.filter(
+      (o) => o.axis === newAxis && o.id !== input.newlyDeclaredObjective?.id,
+    );
+    for (const c of conflicts) {
+      events.push({
+        type: "objective_drift_check_conflict",
+        objective_id: c.id,
+        persona_id: c.persona_id,
+        axis: c.axis,
+        detected_at: input.now,
+        evidence_summary: `novo objetivo "${input.newlyDeclaredObjective.statement}" no axis="${newAxis}" conflita com existente "${c.statement}"`,
+      });
+    }
+  }
+
+  return events;
+}

--- a/orchestrator/tests/drift-checker.unit.test.ts
+++ b/orchestrator/tests/drift-checker.unit.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  runDriftChecks,
+  DEFAULT_KIDS_DRIFT_CONFIG,
+  DEFAULT_ADULTS_DRIFT_CONFIG,
+  type DriftCheckerSources,
+} from "../src/drift-checker.js";
+import type { DeclaredObjective } from "@ascendimacy/shared";
+
+function obj(overrides: Partial<DeclaredObjective> = {}): DeclaredObjective {
+  return {
+    id: "obj-1",
+    persona_id: "ryo",
+    declared_at: "2026-05-01T10:00:00.000Z",
+    declared_in_session: "sess-1",
+    target_date: "2026-06-15T23:59:59.000Z",
+    statement: "aprender X",
+    axis: "math:fractions",
+    status: "active",
+    ...overrides,
+  };
+}
+
+function sources(
+  active: DeclaredObjective[],
+  lastEvent: Record<string, string | null> = {},
+): DriftCheckerSources {
+  return {
+    listActiveObjectives: async () => active,
+    lastEventOnAxis: async (_, axis) => lastEvent[axis] ?? null,
+  };
+}
+
+describe("runDriftChecks — anniversary", () => {
+  it("emite event quando target_date passou", async () => {
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-06-20T00:00:00.000Z",
+      sources: sources([obj()], {
+        "math:fractions": "2026-06-19T00:00:00.000Z",
+      }),
+    });
+    const anniv = events.filter(
+      (e) => e.type === "objective_drift_check_anniversary",
+    );
+    expect(anniv).toHaveLength(1);
+    expect(anniv[0]!.objective_id).toBe("obj-1");
+  });
+
+  it("não emite quando target_date está no futuro", async () => {
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-06-01T00:00:00.000Z",
+      sources: sources([obj()], {
+        "math:fractions": "2026-05-31T00:00:00.000Z",
+      }),
+    });
+    expect(
+      events.filter((e) => e.type === "objective_drift_check_anniversary"),
+    ).toHaveLength(0);
+  });
+});
+
+describe("runDriftChecks — stagnation", () => {
+  it("emite stagnation kids quando 14d+ sem evento no axis", async () => {
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-05-20T00:00:00.000Z",
+      sources: sources([obj()], {
+        "math:fractions": "2026-05-01T00:00:00.000Z", // 19 dias atrás
+      }),
+      config: DEFAULT_KIDS_DRIFT_CONFIG,
+    });
+    expect(
+      events.filter((e) => e.type === "objective_drift_check_stagnation"),
+    ).toHaveLength(1);
+  });
+
+  it("threshold adultos 30d não dispara em 19d", async () => {
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-05-20T00:00:00.000Z",
+      sources: sources([obj()], {
+        "math:fractions": "2026-05-01T00:00:00.000Z",
+      }),
+      config: DEFAULT_ADULTS_DRIFT_CONFIG,
+    });
+    expect(
+      events.filter((e) => e.type === "objective_drift_check_stagnation"),
+    ).toHaveLength(0);
+  });
+
+  it("usa declared_at quando nunca houve evento no axis", async () => {
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-05-20T00:00:00.000Z",
+      sources: sources(
+        [obj({ declared_at: "2026-05-01T00:00:00.000Z" })],
+        {},
+      ),
+      config: DEFAULT_KIDS_DRIFT_CONFIG,
+    });
+    expect(
+      events.filter((e) => e.type === "objective_drift_check_stagnation"),
+    ).toHaveLength(1);
+  });
+
+  it("objetivos sem axis são ignorados em stagnation", async () => {
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-05-30T00:00:00.000Z",
+      sources: sources([obj({ axis: undefined })], {}),
+    });
+    expect(
+      events.filter((e) => e.type === "objective_drift_check_stagnation"),
+    ).toHaveLength(0);
+  });
+});
+
+describe("runDriftChecks — conflict", () => {
+  it("emite conflict quando novo objetivo no mesmo axis de ativo", async () => {
+    const existing = obj({ id: "old-1" });
+    const novo = obj({ id: "new-1", statement: "outro objetivo X" });
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-05-26T00:00:00.000Z",
+      sources: sources([existing]),
+      newlyDeclaredObjective: novo,
+    });
+    const conflicts = events.filter(
+      (e) => e.type === "objective_drift_check_conflict",
+    );
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]!.objective_id).toBe("old-1");
+  });
+
+  it("não emite conflict pra axis diferente", async () => {
+    const existing = obj({ id: "old-1", axis: "math:fractions" });
+    const novo = obj({ id: "new-1", axis: "language:jp" });
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-05-26T00:00:00.000Z",
+      sources: sources([existing]),
+      newlyDeclaredObjective: novo,
+    });
+    expect(
+      events.filter((e) => e.type === "objective_drift_check_conflict"),
+    ).toHaveLength(0);
+  });
+
+  it("não emite conflict consigo mesmo (mesmo id)", async () => {
+    const same = obj({ id: "x-1" });
+    const events = await runDriftChecks({
+      personaId: "ryo",
+      now: "2026-05-26T00:00:00.000Z",
+      sources: sources([same]),
+      newlyDeclaredObjective: same,
+    });
+    expect(
+      events.filter((e) => e.type === "objective_drift_check_conflict"),
+    ).toHaveLength(0);
+  });
+});

--- a/planejador/src/s1-read.ts
+++ b/planejador/src/s1-read.ts
@@ -9,7 +9,7 @@
  *  - D-P41-02: cache em memória (in-process Map)
  */
 
-import type { LearnerSummary } from "@ascendimacy/shared";
+import type { DeclaredObjective, LearnerSummary } from "@ascendimacy/shared";
 
 export const S1_CACHE_TTL_MS = 60_000;
 
@@ -29,6 +29,9 @@ export interface S1DataSources {
   getTreeZones(persona: string): Promise<string[]>;
   getHelixPosition(persona: string): Promise<string | null>;
   getLastSession(persona: string): Promise<string | null>;
+  // S1 declared objectives (ops spec 2026-05-26-s1-objetivos-declarados-v0).
+  // Opcional pra preservar compat com callers anteriores.
+  getDeclaredObjectives?(persona: string): Promise<DeclaredObjective[]>;
 }
 
 const defaultSources: S1DataSources = {
@@ -49,12 +52,15 @@ export const S1 = {
       return cached.data;
     }
 
-    const [casel_levels, tree_zones, helix_position, last_session] =
+    const [casel_levels, tree_zones, helix_position, last_session, declared_objectives] =
       await Promise.all([
         sources.getCaselLevels(persona),
         sources.getTreeZones(persona),
         sources.getHelixPosition(persona),
         sources.getLastSession(persona),
+        sources.getDeclaredObjectives !== undefined
+          ? sources.getDeclaredObjectives(persona)
+          : Promise.resolve(undefined),
       ]);
 
     const summary: LearnerSummary = {
@@ -64,6 +70,7 @@ export const S1 = {
       helix_position,
       last_session,
       cached_at: now,
+      ...(declared_objectives !== undefined ? { declared_objectives } : {}),
     };
 
     _cache.set(persona, { data: summary, cachedAt: now });

--- a/planejador/tests/s1-read.unit.test.ts
+++ b/planejador/tests/s1-read.unit.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { S1, S1_CACHE_TTL_MS, type S1DataSources } from "../src/s1-read.js";
+import type { DeclaredObjective } from "@ascendimacy/shared";
 
 const mockSources: S1DataSources = {
   getCaselLevels: async (persona) => (persona === "ryo" ? { SA: 3, SM: 2 } : { SA: 1 }),
   getTreeZones: async () => ["raiz", "tronco"],
   getHelixPosition: async () => "active",
   getLastSession: async () => "2026-05-26T10:00:00.000Z",
+};
+
+const sampleObjective: DeclaredObjective = {
+  id: "obj-1",
+  persona_id: "ryo",
+  declared_at: "2026-05-20T10:00:00.000Z",
+  declared_in_session: "sess-a",
+  target_date: "2026-05-31T23:59:59.000Z",
+  statement: "Aprender frações até fim do mês",
+  axis: "math:fractions",
+  status: "active",
 };
 
 describe("S1.read", () => {
@@ -120,5 +132,32 @@ describe("S1.read", () => {
     await S1.read({ persona: "kei" }, countingSources); // should still be cached
 
     expect(ryoFetches).toBe(2); // fetched twice (second after clearCache)
+  });
+
+  it("includes declared_objectives when source fornecido (S1 spec)", async () => {
+    const withObjectives: S1DataSources = {
+      ...mockSources,
+      getDeclaredObjectives: async (persona) =>
+        persona === "ryo" ? [sampleObjective] : [],
+    };
+    const result = await S1.read({ persona: "ryo" }, withObjectives);
+    expect(result.declared_objectives).toHaveLength(1);
+    expect(result.declared_objectives![0]!.statement).toBe(
+      "Aprender frações até fim do mês",
+    );
+  });
+
+  it("omite declared_objectives quando source não fornecido (back-compat)", async () => {
+    const result = await S1.read({ persona: "kei" }, mockSources);
+    expect(result.declared_objectives).toBeUndefined();
+  });
+
+  it("retorna array vazio quando persona sem objetivos", async () => {
+    const withObjectives: S1DataSources = {
+      ...mockSources,
+      getDeclaredObjectives: async () => [],
+    };
+    const result = await S1.read({ persona: "saki" }, withObjectives);
+    expect(result.declared_objectives).toEqual([]);
   });
 });

--- a/shared/src/contracts/declared-objective.ts
+++ b/shared/src/contracts/declared-objective.ts
@@ -1,0 +1,52 @@
+/**
+ * DeclaredObjective — promessa datada do aprendiz consigo mesmo.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-s1-objetivos-declarados-v0.md
+ *
+ * Conceito: o motor não dita objetivos; recebe-os via captura conversacional,
+ * lembra deles, e periodicamente verifica drift. Persistência é append-only —
+ * mudanças de status criam nova versão linkada via `parent_objective_id`.
+ *
+ * Sem `target_date` não é objetivo: é desejo.
+ */
+
+import { z } from "zod";
+import { Iso8601DateTime } from "./iso8601.js";
+
+export const DeclaredObjectiveStatusSchema = z.enum([
+  "active",
+  "achieved",
+  "abandoned",
+  "drift_flagged",
+  "revised",
+]);
+
+export const DECLARED_OBJECTIVE_STATUSES = DeclaredObjectiveStatusSchema.options;
+export type DeclaredObjectiveStatus = z.infer<typeof DeclaredObjectiveStatusSchema>;
+
+export const DeclaredObjectiveSchema = z.object({
+  id: z.string().min(1),
+  persona_id: z.string().min(1),
+  declared_at: Iso8601DateTime,
+  declared_in_session: z.string().min(1),
+  target_date: Iso8601DateTime,
+  statement: z.string().min(1).max(200),
+  axis: z.string().optional(),
+  status: DeclaredObjectiveStatusSchema,
+  parent_objective_id: z.string().optional(),
+  evidence_event_ids: z.array(z.string()).optional(),
+  drift_check_due_at: Iso8601DateTime.optional(),
+});
+
+export type DeclaredObjective = z.infer<typeof DeclaredObjectiveSchema>;
+
+export const DeclaredObjectiveDraftSchema = DeclaredObjectiveSchema.omit({
+  id: true,
+  status: true,
+}).extend({
+  axis: z.string().optional(),
+  evidence_event_ids: z.array(z.string()).optional(),
+  drift_check_due_at: Iso8601DateTime.optional(),
+});
+
+export type DeclaredObjectiveDraft = z.infer<typeof DeclaredObjectiveDraftSchema>;

--- a/shared/src/contracts/index.ts
+++ b/shared/src/contracts/index.ts
@@ -141,3 +141,14 @@ export {
   type NarrativeThread,
   type NarrativeThreadStatus,
 } from "./narrative-thread.js";
+
+// S1 declared objectives (ops spec 2026-05-26-s1-objetivos-declarados-v0)
+export {
+  DECLARED_OBJECTIVE_STATUSES,
+  DeclaredObjectiveSchema,
+  DeclaredObjectiveStatusSchema,
+  DeclaredObjectiveDraftSchema,
+  type DeclaredObjective,
+  type DeclaredObjectiveStatus,
+  type DeclaredObjectiveDraft,
+} from "./declared-objective.js";

--- a/shared/src/contracts/learner-summary.ts
+++ b/shared/src/contracts/learner-summary.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from "zod";
+import { DeclaredObjectiveSchema } from "./declared-objective.js";
 
 export const LearnerSummarySchema = z.object({
   persona: z.string().min(1),
@@ -18,6 +19,9 @@ export const LearnerSummarySchema = z.object({
   helix_position: z.string().nullable(),
   last_session: z.string().nullable(),
   cached_at: z.number(),
+  // S1 declared objectives (ops spec 2026-05-26-s1-objetivos-declarados-v0).
+  // Opcional pra preservar compat com S1.read sem source injetado.
+  declared_objectives: z.array(DeclaredObjectiveSchema).optional(),
 });
 
 export type LearnerSummary = z.infer<typeof LearnerSummarySchema>;


### PR DESCRIPTION
Rebase do PR #242 sobre o `main` atual.

## O que adiciona
- `shared/src/contracts/declared-objective.ts` — DeclaredObjective schema + Zod
- `shared/src/contracts/learner-summary.ts` — campo `declared_objectives` opcional (back-compat)
- `shared/src/contracts/index.ts` — exports declared-objective
- `planejador/src/s1-read.ts` — `getDeclaredObjectives?` source opcional
- `motor-drota/src/intent-extractor.ts` — PT+JP intent detection
- `motor-execucao/src/declared-objective-repo.ts` — SQLite append-only
- `orchestrator/src/drift-checker.ts` — 3 tipos de drift triggers
- 4 arquivos de teste (52 testes)

## Testes
- ✅ 52/52 passing (drift-checker, s1-read, intent-extractor, declared-objective-repo)
- `shared` build clean

Fecha: #242