### PR TITLE
[ui+bff] B1+B2 wiring — temporal windows + pulso + cards + budget + drilling state

### DIFF
--- a/motor-execucao/package.json
+++ b/motor-execucao/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "type": "module",
   "main": "./dist/server.js",
+  "exports": {
+    ".": "./dist/server.js",
+    "./cards-repo": "./dist/cards-repo.js",
+    "./drill-repo": "./dist/drill-repo.js",
+    "./narrative-thread-repo": "./dist/narrative-thread-repo.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",

--- a/packages/ebrota-console-bff/package.json
+++ b/packages/ebrota-console-bff/package.json
@@ -16,13 +16,17 @@
     "ebrota-console-bff": "./dist/cli.js"
   },
   "dependencies": {
+    "@ascendimacy/motor-execucao": "*",
+    "@ascendimacy/shared": "*",
     "@modelcontextprotocol/sdk": "^1.10.2",
     "better-sqlite3": "^11.0.0",
     "fastify": "^5.0.0",
+    "js-yaml": "^4.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "*",
+    "@types/js-yaml": "*",
     "@types/node": "*",
     "tsx": "^4.22.3",
     "typescript": "*",

--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -11,6 +11,9 @@
 
 import Database from "better-sqlite3";
 import type { Database as DatabaseType } from "better-sqlite3";
+import { EMITTED_CARDS_DDL } from "@ascendimacy/motor-execucao/cards-repo";
+import { DRILL_STATES_DDL } from "@ascendimacy/motor-execucao/drill-repo";
+import { NARRATIVE_THREADS_DDL } from "@ascendimacy/motor-execucao/narrative-thread-repo";
 
 const SCHEMA_SQL = `
 -- Session library (S-OC-30/31/32)
@@ -180,5 +183,10 @@ export function initDb(opts: InitDbOptions): DatabaseType {
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
   db.exec(SCHEMA_SQL);
+  // B1/B2 wiring — aplica DDLs do motor-execucao para que reads via BFF
+  // não falhem com "no such table" em personas sem dados ainda.
+  db.exec(EMITTED_CARDS_DDL);
+  db.exec(DRILL_STATES_DDL);
+  db.exec(NARRATIVE_THREADS_DDL);
   return db;
 }

--- a/packages/ebrota-console-bff/src/routes/b1-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/b1-routes.ts
@@ -1,0 +1,160 @@
+/**
+ * B1 routes — Camada Social (cards, sacrifice budget, dyad, janelas, pulso).
+ *
+ * Plugin Fastify registrado em server.ts via:
+ *   await fastify.register((await import("./routes/b1-routes.js")).default, opts)
+ *
+ * Endpoints:
+ *   GET /personas/:id/temporal-windows  → TemporalWindow ou 404
+ *   GET /personas/:id/pulso-events      → { events: PulsoEventLike[] }  (stub v0)
+ *   GET /personas/:id/sacrifice-budget  → { ..., source: "stub_v0" }    (stub v0)
+ *   GET /personas/:id/cards             → { cards: EmittedCard[] }
+ *   GET /personas/:id/dyad              → { dyad: null, source: "stub_v0" } (stub v0)
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, isAbsolute } from "node:path";
+import yaml from "js-yaml";
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import {
+  TemporalWindowSchema,
+  initBudget,
+  MOOD_HIGH_BONUS,
+  MOOD_HIGH_THRESHOLD,
+  MOOD_LOW_PENALTY,
+  MOOD_LOW_THRESHOLD,
+  TRUST_HIGH_BONUS,
+  TRUST_HIGH_THRESHOLD,
+  TRUST_LOW_PENALTY,
+  TRUST_LOW_THRESHOLD,
+} from "@ascendimacy/shared";
+import { getEmittedCardsByChild } from "@ascendimacy/motor-execucao/cards-repo";
+
+export interface B1RoutesOptions {
+  db: DatabaseType;
+  /** Diretório raiz onde estão fixtures/temporal-windows/<persona>.yaml.
+   *  Default: `fixtures` resolvido a partir de process.cwd(). */
+  fixturesDir?: string;
+}
+
+/** Baseline budget Kids per spec §3 (sacrifice-budget.ts). */
+const KIDS_BASELINE = 15;
+
+interface PulsoEventLike {
+  emitted_at: string;
+  trigger: string;
+  pulso_kind: string;
+  text: string;
+}
+
+function readTemporalWindow(
+  fixturesDir: string,
+  personaId: string,
+): unknown | null {
+  const path = resolve(fixturesDir, "temporal-windows", `${personaId}.yaml`);
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf-8");
+  return yaml.load(raw);
+}
+
+const b1RoutesPlugin: FastifyPluginAsync<B1RoutesOptions> = async (
+  fastify: FastifyInstance,
+  opts: B1RoutesOptions,
+) => {
+  const fixturesDir = opts.fixturesDir
+    ? isAbsolute(opts.fixturesDir)
+      ? opts.fixturesDir
+      : resolve(opts.fixturesDir)
+    : resolve(process.cwd(), "fixtures");
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/temporal-windows",
+    async (req, reply) => {
+      const parsed = readTemporalWindow(fixturesDir, req.params.id);
+      if (parsed === null) {
+        return reply.code(404).send({
+          error: `temporal-window não encontrada para persona ${req.params.id}`,
+        });
+      }
+      const result = TemporalWindowSchema.safeParse(parsed);
+      if (!result.success) {
+        return reply.code(500).send({
+          error: "YAML inválido para TemporalWindowSchema",
+          issues: result.error.issues,
+        });
+      }
+      return result.data;
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/pulso-events",
+    async () => {
+      const events: PulsoEventLike[] = [];
+      return { events };
+    },
+  );
+
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { mood?: string; trust?: string };
+  }>("/personas/:id/sacrifice-budget", async (req) => {
+    const mood = req.query.mood !== undefined ? Number(req.query.mood) : 5;
+    const trust =
+      req.query.trust !== undefined ? Number(req.query.trust) : 0.5;
+    const baseline = KIDS_BASELINE;
+    const current = initBudget({ baseline }, mood, trust);
+
+    const modifiers: Array<{
+      label: string;
+      delta: number;
+      active: boolean;
+    }> = [
+      {
+        label: `mood ≥ ${MOOD_HIGH_THRESHOLD} (+${MOOD_HIGH_BONUS})`,
+        delta: MOOD_HIGH_BONUS,
+        active: mood >= MOOD_HIGH_THRESHOLD,
+      },
+      {
+        label: `mood < ${MOOD_LOW_THRESHOLD} (${MOOD_LOW_PENALTY})`,
+        delta: MOOD_LOW_PENALTY,
+        active: mood < MOOD_LOW_THRESHOLD,
+      },
+      {
+        label: `trust ≥ ${TRUST_HIGH_THRESHOLD} (+${TRUST_HIGH_BONUS})`,
+        delta: TRUST_HIGH_BONUS,
+        active: trust >= TRUST_HIGH_THRESHOLD,
+      },
+      {
+        label: `trust < ${TRUST_LOW_THRESHOLD} (${TRUST_LOW_PENALTY})`,
+        delta: TRUST_LOW_PENALTY,
+        active: trust < TRUST_LOW_THRESHOLD,
+      },
+    ];
+
+    return {
+      persona_id: req.params.id,
+      baseline,
+      current,
+      mood,
+      trust,
+      modifiers,
+      source: "stub_v0",
+    };
+  });
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/cards",
+    async (req) => {
+      const cards = getEmittedCardsByChild(opts.db, req.params.id);
+      return { cards };
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>("/personas/:id/dyad", async () => {
+    return { dyad: null, source: "stub_v0" };
+  });
+};
+
+export default b1RoutesPlugin;

--- a/packages/ebrota-console-bff/src/routes/b2-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/b2-routes.ts
@@ -1,0 +1,142 @@
+/**
+ * B2 routes — Drilling (banks, drill state, due, mastered).
+ *
+ * Plugin Fastify registrado em server.ts via:
+ *   await fastify.register((await import("./routes/b2-routes.js")).default, opts)
+ *
+ * Endpoints:
+ *   GET /banks                          → { banks: [{ bank_id, title, item_count }] }
+ *   GET /banks/:bankId                  → DrillBank (full content)
+ *   GET /personas/:id/drill-state       → { states: DrillState[] }
+ *   GET /personas/:id/drill-due         → { states: DrillState[] }
+ *   GET /personas/:id/drill-mastered    → { states: DrillState[] }
+ */
+
+import { readdirSync, existsSync } from "node:fs";
+import { resolve, isAbsolute } from "node:path";
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import type { DrillResponse, DrillState } from "@ascendimacy/shared";
+import {
+  loadBank,
+  listDue,
+  listMastered,
+} from "@ascendimacy/motor-execucao/drill-repo";
+
+export interface B2RoutesOptions {
+  db: DatabaseType;
+  /** Diretório raiz onde estão fixtures/banks/*.yaml.
+   *  Default: `fixtures` resolvido a partir de process.cwd(). */
+  fixturesDir?: string;
+}
+
+interface DrillStateRow {
+  persona_id: string;
+  item_id: string;
+  presented_count: number;
+  correct_count: number;
+  last_seen_at: string;
+  next_due_at: string;
+  current_interval_days: number;
+  current_easiness: number;
+  mastery_reached_at: string | null;
+  last_5_attempts_json: string;
+}
+
+function rowToState(row: DrillStateRow): DrillState {
+  return {
+    persona_id: row.persona_id,
+    item_id: row.item_id,
+    presented_count: row.presented_count,
+    correct_count: row.correct_count,
+    last_seen_at: row.last_seen_at,
+    next_due_at: row.next_due_at,
+    current_interval_days: row.current_interval_days,
+    current_easiness: row.current_easiness,
+    mastery_reached_at: row.mastery_reached_at,
+    last_5_attempts: JSON.parse(row.last_5_attempts_json) as DrillResponse[],
+  };
+}
+
+const b2RoutesPlugin: FastifyPluginAsync<B2RoutesOptions> = async (
+  fastify: FastifyInstance,
+  opts: B2RoutesOptions,
+) => {
+  const fixturesDir = opts.fixturesDir
+    ? isAbsolute(opts.fixturesDir)
+      ? opts.fixturesDir
+      : resolve(opts.fixturesDir)
+    : resolve(process.cwd(), "fixtures");
+
+  const banksRoot = resolve(fixturesDir, "banks");
+
+  fastify.get("/banks", async () => {
+    if (!existsSync(banksRoot)) return { banks: [] };
+    const files = readdirSync(banksRoot).filter((f) => f.endsWith(".yaml"));
+    const banks = files.map((file) => {
+      const bankId = file.replace(/\.yaml$/, "");
+      try {
+        const { bank } = loadBank(bankId, { root: banksRoot });
+        return {
+          bank_id: bank.bank_id,
+          title: bank.title,
+          curator: bank.curator,
+          item_count: bank.items.length,
+          target_personas: bank.target_personas ?? [],
+        };
+      } catch {
+        return {
+          bank_id: bankId,
+          title: "(falha ao carregar)",
+          curator: "?",
+          item_count: 0,
+          target_personas: [],
+        };
+      }
+    });
+    return { banks };
+  });
+
+  fastify.get<{ Params: { bankId: string } }>(
+    "/banks/:bankId",
+    async (req, reply) => {
+      try {
+        const { bank, items } = loadBank(req.params.bankId, {
+          root: banksRoot,
+        });
+        return { bank, items };
+      } catch (err) {
+        return reply.code(404).send({
+          error: `bank não encontrado: ${req.params.bankId}`,
+          cause: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/drill-state",
+    async (req) => {
+      const rows = opts.db
+        .prepare("SELECT * FROM drill_states WHERE persona_id = ?")
+        .all(req.params.id) as DrillStateRow[];
+      return { states: rows.map(rowToState) };
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/drill-due",
+    async (req) => {
+      return { states: listDue(opts.db, req.params.id) };
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/drill-mastered",
+    async (req) => {
+      return { states: listMastered(opts.db, req.params.id) };
+    },
+  );
+};
+
+export default b2RoutesPlugin;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -80,6 +80,8 @@ import {
 } from "./parental-onboarding-store.js";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import b1RoutesPlugin from "./routes/b1-routes.js";
+import b2RoutesPlugin from "./routes/b2-routes.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -133,6 +135,17 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   let mode: ConsoleMode = opts.initialMode ?? "auto";
 
   initParentalOnboardingSchema(opts.db);
+
+  // B1/B2 wiring — Camada Social + Drilling. Fastify enfileira o register
+  // até .listen()/.ready() resolverem; ok chamar síncrono dentro do factory.
+  const sharedRouteOpts = {
+    db: opts.db,
+    ...(opts.fixturesDir !== undefined
+      ? { fixturesDir: opts.fixturesDir }
+      : {}),
+  };
+  void fastify.register(b1RoutesPlugin, sharedRouteOpts);
+  void fastify.register(b2RoutesPlugin, sharedRouteOpts);
 
   // In-memory set de sessionIds ativos (iniciados via /sessions/start-card,
   // removidos via /sessions/:id/end). Permite que App.svelte faça polling

--- a/packages/ebrota-console-bff/tests/b1-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/b1-routes.unit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests para B1 routes (Camada Social wiring).
+ *
+ * Setup: cria BFF server in-memory + fixturesDir aponta pra
+ * <repo-root>/fixtures (4 personas têm YAML).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolve } from "node:path";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+const FIXTURES_DIR = resolve(__dirname, "../../../fixtures");
+
+let server: BffServer;
+
+beforeEach(() => {
+  const db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  server = createBffServer({
+    daemon,
+    db,
+    logger: false,
+    fixturesDir: FIXTURES_DIR,
+  });
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+const inject = async (url: string) => {
+  const res = await server.fastify.inject({ method: "GET", url });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+describe("GET /personas/:id/temporal-windows", () => {
+  it("retorna janela parseada para persona com fixture", async () => {
+    const res = await inject("/personas/ryo-ochiai/temporal-windows");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      persona_id: string;
+      timezone: string;
+      windows: Array<{ name: string }>;
+    };
+    expect(body.persona_id).toBe("ryo-ochiai");
+    expect(body.timezone).toBe("Asia/Tokyo");
+    expect(body.windows.length).toBeGreaterThan(0);
+  });
+
+  it("retorna 404 quando persona não tem fixture", async () => {
+    const res = await inject("/personas/inexistente/temporal-windows");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /personas/:id/pulso-events", () => {
+  it("retorna events vazio (stub v0)", async () => {
+    const res = await inject("/personas/ryo-ochiai/pulso-events");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ events: [] });
+  });
+});
+
+describe("GET /personas/:id/sacrifice-budget", () => {
+  it("retorna baseline + current + modifiers", async () => {
+    const res = await inject("/personas/ryo-ochiai/sacrifice-budget");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      baseline: number;
+      current: number;
+      mood: number;
+      trust: number;
+      modifiers: Array<{ label: string; active: boolean; delta: number }>;
+      source: string;
+    };
+    expect(body.baseline).toBe(15);
+    expect(body.current).toBe(15); // default mood=5, trust=0.5 → sem modifiers
+    expect(body.modifiers.length).toBe(4);
+    expect(body.modifiers.every((m) => m.active === false)).toBe(true);
+    expect(body.source).toBe("stub_v0");
+  });
+
+  it("aplica modifier de mood alto via query", async () => {
+    const res = await inject(
+      "/personas/ryo-ochiai/sacrifice-budget?mood=8&trust=0.5",
+    );
+    const body = res.body as {
+      current: number;
+      modifiers: Array<{ active: boolean; delta: number }>;
+    };
+    expect(body.current).toBe(20); // 15 + 5
+    expect(body.modifiers.find((m) => m.delta === 5)?.active).toBe(true);
+  });
+
+  it("aplica modifier de trust baixo via query", async () => {
+    const res = await inject(
+      "/personas/ryo-ochiai/sacrifice-budget?mood=5&trust=0.2",
+    );
+    const body = res.body as { current: number };
+    expect(body.current).toBe(10); // 15 - 5
+  });
+});
+
+describe("GET /personas/:id/cards", () => {
+  it("retorna cards vazio para persona sem emissões", async () => {
+    const res = await inject("/personas/ryo-ochiai/cards");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ cards: [] });
+  });
+});
+
+describe("GET /personas/:id/dyad", () => {
+  it("retorna dyad null (stub v0)", async () => {
+    const res = await inject("/personas/ryo-ochiai/dyad");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ dyad: null, source: "stub_v0" });
+  });
+});

--- a/packages/ebrota-console-bff/tests/b2-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/b2-routes.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests para B2 routes (Drilling wiring).
+ *
+ * Setup: cria BFF server in-memory + fixturesDir aponta pra
+ * <repo-root>/fixtures (ja-pt-vocab-n5 bank disponível).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolve } from "node:path";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+import { recordAttempt } from "@ascendimacy/motor-execucao/drill-repo";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+const FIXTURES_DIR = resolve(__dirname, "../../../fixtures");
+
+let server: BffServer;
+let db: DatabaseType;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  server = createBffServer({
+    daemon,
+    db,
+    logger: false,
+    fixturesDir: FIXTURES_DIR,
+  });
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+const inject = async (url: string) => {
+  const res = await server.fastify.inject({ method: "GET", url });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+describe("GET /banks", () => {
+  it("lista banks disponíveis na fixturesDir", async () => {
+    const res = await inject("/banks");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      banks: Array<{ bank_id: string; item_count: number }>;
+    };
+    expect(body.banks.length).toBeGreaterThan(0);
+    const n5 = body.banks.find((b) => b.bank_id === "ja-pt-vocab-n5");
+    expect(n5).toBeDefined();
+    expect(n5!.item_count).toBe(50);
+  });
+});
+
+describe("GET /banks/:bankId", () => {
+  it("retorna conteúdo completo do bank existente", async () => {
+    const res = await inject("/banks/ja-pt-vocab-n5");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      bank: { bank_id: string; curator: string };
+      items: Array<{ id: string; bank_id: string; payload: { prompt: string } }>;
+    };
+    expect(body.bank.bank_id).toBe("ja-pt-vocab-n5");
+    expect(body.bank.curator).toBe("jun");
+    expect(body.items.length).toBe(50);
+    expect(body.items[0]!.bank_id).toBe("ja-pt-vocab-n5");
+    expect(body.items[0]!.payload.prompt).toBeDefined();
+  });
+
+  it("retorna 404 para bank inexistente", async () => {
+    const res = await inject("/banks/inexistente");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /personas/:id/drill-state", () => {
+  it("retorna states vazio para persona nunca drilada", async () => {
+    const res = await inject("/personas/ryo-ochiai/drill-state");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ states: [] });
+  });
+
+  it("retorna states populados após recordAttempt", async () => {
+    recordAttempt(db, {
+      personaId: "ryo-ochiai",
+      itemId: "jpv-001",
+      response: "correct",
+      nowIso: "2026-05-27T10:00:00.000Z",
+    });
+    const res = await inject("/personas/ryo-ochiai/drill-state");
+    const body = res.body as {
+      states: Array<{ item_id: string; presented_count: number }>;
+    };
+    expect(body.states.length).toBe(1);
+    expect(body.states[0]!.item_id).toBe("jpv-001");
+    expect(body.states[0]!.presented_count).toBe(1);
+  });
+});
+
+describe("GET /personas/:id/drill-due", () => {
+  it("retorna due states após recordAttempt (next_due_at futuro)", async () => {
+    recordAttempt(db, {
+      personaId: "ryo-ochiai",
+      itemId: "jpv-002",
+      response: "correct",
+      nowIso: "2026-05-27T10:00:00.000Z",
+    });
+    // No momento da query (default Date.now), o item está due ou ainda não?
+    // Como SR move o due pra frente, em ~now ele NÃO está due. Sem
+    // assert de length específico — apenas shape.
+    const res = await inject("/personas/ryo-ochiai/drill-due");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("states");
+  });
+});
+
+describe("GET /personas/:id/drill-mastered", () => {
+  it("retorna mastered vazio quando não há mastery alcançado", async () => {
+    const res = await inject("/personas/ryo-ochiai/drill-mastered");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ states: [] });
+  });
+});

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/B1SocialPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/B1SocialPanel.svelte
@@ -3,68 +3,252 @@
    * B1 — Camada Social (panel).
    * Pergunta: "Como o motor está atraindo/retendo [persona]?"
    *
-   * v0: placeholders em todos os blocos. Cards-repo / sacrifice budget /
-   * dyad / janelas temporais / Pulso — tudo ainda não wired.
+   * Wiring (PR #243): consome BFF /personas/:id/{temporal-windows,
+   * pulso-events, sacrifice-budget, cards, dyad}. Mantém placeholders
+   * em stubs ainda não persistidos (dyad, pulso) com badge `(stub v0)`.
    */
+  import { onMount } from "svelte";
+  import { tracerSubjectId } from "../../lib/stores.js";
+  import { createApiClient } from "../../lib/api.js";
+  import type {
+    ApiClient,
+    EmittedCardLike,
+    SacrificeBudgetSnapshotLike,
+    TemporalWindowLike,
+    PulsoEventLike,
+    DyadConfigLike,
+  } from "../../lib/api.js";
   import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
-  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+
+  /** Cliente injetável pra testes. Default = createApiClient(). */
+  export let api: ApiClient = createApiClient();
 
   const COLOR = "#8b5cf6";
+
+  let loading = true;
+  let error: string | null = null;
+  let cards: EmittedCardLike[] = [];
+  let budget: SacrificeBudgetSnapshotLike | null = null;
+  let dyad: DyadConfigLike | null = null;
+  let windows: TemporalWindowLike | null = null;
+  let pulso: PulsoEventLike[] = [];
+
+  $: personaId = $tracerSubjectId;
+
+  async function loadAll(persona: string): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const [cardsRes, budgetRes, dyadRes, windowsRes, pulsoRes] =
+        await Promise.all([
+          api.listEmittedCards(persona),
+          api.getSacrificeBudget(persona),
+          api.getDyad(persona),
+          api.getTemporalWindows(persona),
+          api.listPulsoEvents(persona),
+        ]);
+      cards = cardsRes.cards;
+      budget = budgetRes;
+      dyad = dyadRes;
+      windows = windowsRes;
+      pulso = pulsoRes.events;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    void loadAll(personaId);
+  });
+
+  $: if (personaId) void loadAll(personaId);
+
+  function budgetPercent(b: SacrificeBudgetSnapshotLike): number {
+    if (b.baseline === 0) return 0;
+    return Math.max(0, Math.min(100, (b.current / b.baseline) * 100));
+  }
+
+  function formatCardTitle(c: EmittedCardLike): string {
+    const t = c.front?.title;
+    if (typeof t === "string" && t.length > 0) return t;
+    return c.archetype_id;
+  }
 </script>
 
 <SubsystemPanelShell id="B1" title="Camada Social" color={COLOR}>
-  <section class="block">
-    <h3>Cards emitidos</h3>
-    <div class="grid-placeholder" aria-hidden="true">
-      {#each Array(4) as _, i (i)}
-        <div class="card-slot">slot {i + 1}</div>
-      {/each}
-    </div>
-    <PlaceholderBanner
-      label="grid de cards (rarity · QR · cheat-code) — TODO link com cards-repo"
-      specPath="packages/ebrota-console-ui (TODO)"
-      color={COLOR}
-    />
-  </section>
+  {#if loading}
+    <p class="status" data-testid="b1-loading">Carregando dados de {personaId}…</p>
+  {:else if error}
+    <p class="status error" data-testid="b1-error">
+      Erro ao carregar B1: {error}
+    </p>
+  {:else}
+    <section class="block" data-testid="b1-cards-block">
+      <h3>Cards emitidos <span class="count">({cards.length})</span></h3>
+      {#if cards.length === 0}
+        <p class="empty">Nenhum card emitido ainda pra {personaId}.</p>
+      {:else}
+        <div class="cards-grid">
+          {#each cards as card (card.card_id)}
+            <article class="card" data-testid="b1-card">
+              <header class="card-header">
+                <span class="rarity" title="rarity"
+                  >{card.front?.rarity ?? "—"}</span
+                >
+                <span class="archetype">{card.archetype_id}</span>
+              </header>
+              <h4 class="card-title">{formatCardTitle(card)}</h4>
+              <div class="card-meta">
+                <code class="serial"
+                  >{card.back?.serial_number ?? card.card_id}</code
+                >
+                {#if card.back?.cheat_code}
+                  <code class="cheat" title="cheat-code"
+                    >{card.back.cheat_code}</code
+                  >
+                {/if}
+              </div>
+              <div class="qr" aria-hidden="true">QR</div>
+            </article>
+          {/each}
+        </div>
+      {/if}
+    </section>
 
-  <section class="block">
-    <h3>Sacrifice budget</h3>
-    <div class="gauge-placeholder">
-      <div class="gauge-fill" style="width:60%"></div>
-    </div>
-    <PlaceholderBanner
-      label="gauge sacrifice budget + breakdown — TODO"
-      color={COLOR}
-    />
-  </section>
+    <section class="block" data-testid="b1-budget-block">
+      <h3>
+        Sacrifice budget
+        {#if budget?.source === "stub_v0"}
+          <span class="badge-stub">stub v0</span>
+        {/if}
+      </h3>
+      {#if budget}
+        <div class="budget-row">
+          <div class="gauge">
+            <div
+              class="gauge-fill"
+              style:width={budgetPercent(budget) + "%"}
+            ></div>
+          </div>
+          <span class="budget-numeric"
+            >{budget.current} / {budget.baseline}</span
+          >
+        </div>
+        <ul class="modifiers">
+          {#each budget.modifiers as m, i (i)}
+            <li class:active={m.active}>
+              <span class="dot" class:on={m.active}></span>
+              {m.label}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
 
-  <section class="block">
-    <h3>Dyad</h3>
-    <PlaceholderBanner
-      label="duplas ativas (Ryo+Kei) + playbook kids.group — TODO"
-      color={COLOR}
-    />
-  </section>
+    <section class="block" data-testid="b1-dyad-block">
+      <h3>
+        Dyad
+        {#if dyad?.source === "stub_v0"}
+          <span class="badge-stub">stub v0</span>
+        {/if}
+      </h3>
+      {#if dyad?.dyad === null}
+        <p class="empty">Sem dyad ativo no momento.</p>
+      {:else if dyad?.dyad}
+        <pre class="json">{JSON.stringify(dyad.dyad, null, 2)}</pre>
+      {/if}
+    </section>
 
-  <section class="block">
-    <h3>Janelas temporais</h3>
-    <PlaceholderBanner
-      label="spec hooks temporais em rascunho/PR #243"
-      specPath="docs/specs/2026-05-26-b1-hooks-temporais-v0.md"
-      color={COLOR}
-    />
-  </section>
+    <section class="block" data-testid="b1-windows-block">
+      <h3>Janelas temporais</h3>
+      {#if windows === null}
+        <p class="empty">
+          Sem fixture <code>fixtures/temporal-windows/{personaId}.yaml</code>.
+        </p>
+      {:else}
+        <p class="muted small">
+          timezone: <code>{windows.timezone}</code>
+        </p>
+        <table class="windows">
+          <thead>
+            <tr>
+              <th>nome</th>
+              <th>dias</th>
+              <th>início</th>
+              <th>fim</th>
+              <th>cap/dia</th>
+              <th>parental?</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each windows.windows as w (w.name)}
+              <tr>
+                <td>{w.name}</td>
+                <td>{w.weekday.join(", ")}</td>
+                <td><code>{w.start_local}</code></td>
+                <td><code>{w.end_local}</code></td>
+                <td>{w.max_hooks_per_day}</td>
+                <td>{w.requires_parental_ok ? "sim" : "não"}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+        {#if windows.school_window || windows.sleep_window}
+          <p class="muted small">
+            exclusões —
+            {#if windows.school_window}
+              escola <code
+                >{windows.school_window.start_local}–{windows.school_window
+                  .end_local}</code
+              >
+            {/if}
+            {#if windows.school_window && windows.sleep_window} · {/if}
+            {#if windows.sleep_window}
+              sono <code
+                >{windows.sleep_window.start_local}–{windows.sleep_window
+                  .end_local}</code
+              >
+            {/if}
+          </p>
+        {/if}
+      {/if}
+    </section>
 
-  <section class="block">
-    <h3>Pulso</h3>
-    <PlaceholderBanner
-      label="último ritual de retorno (omikuji / mini-história) — TODO"
-      color={COLOR}
-    />
-  </section>
+    <section class="block" data-testid="b1-pulso-block">
+      <h3>
+        Pulso events
+        <span class="badge-stub">stub v0</span>
+      </h3>
+      {#if pulso.length === 0}
+        <p class="empty">
+          Sem eventos pulso ainda (persistência pendente — scheduler
+          ainda não loga emissões).
+        </p>
+      {:else}
+        <ul class="pulso-list">
+          {#each pulso as ev, i (i)}
+            <li>
+              <time>{ev.emitted_at}</time>
+              <span class="trigger">{ev.trigger}</span>
+              <span class="text">{ev.text}</span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  {/if}
 </SubsystemPanelShell>
 
 <style>
+  .status {
+    font-size: 0.9rem;
+    opacity: 0.8;
+  }
+  .status.error {
+    color: #ef4444;
+  }
   .block {
     display: flex;
     flex-direction: column;
@@ -75,22 +259,99 @@
     font-size: 0.95rem;
     border-bottom: 1px solid rgba(127, 127, 127, 0.25);
     padding-bottom: 0.2rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
   }
-  .grid-placeholder {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 0.4rem;
-  }
-  .card-slot {
-    border: 1px dashed rgba(139, 92, 246, 0.5);
-    border-radius: 4px;
-    padding: 0.8rem 0.4rem;
-    text-align: center;
+  .count {
     font-size: 0.75rem;
     opacity: 0.6;
-    min-height: 3.5rem;
+    font-weight: 400;
   }
-  .gauge-placeholder {
+  .badge-stub {
+    font-size: 0.65rem;
+    background: rgba(139, 92, 246, 0.18);
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #a78bfa;
+    font-weight: 600;
+  }
+  .empty {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.65;
+    font-style: italic;
+  }
+  .cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 0.6rem;
+  }
+  .card {
+    border: 1px solid rgba(139, 92, 246, 0.4);
+    border-left: 3px solid #8b5cf6;
+    border-radius: 5px;
+    padding: 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    background: rgba(139, 92, 246, 0.04);
+  }
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.7rem;
+    opacity: 0.75;
+  }
+  .rarity {
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #a78bfa;
+  }
+  .card-title {
+    margin: 0;
+    font-size: 0.88rem;
+    font-weight: 600;
+  }
+  .card-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .serial {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.7rem;
+    opacity: 0.75;
+  }
+  .cheat {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    align-self: flex-start;
+  }
+  .qr {
+    align-self: flex-start;
+    width: 28px;
+    height: 28px;
+    border: 1px dashed rgba(139, 92, 246, 0.5);
+    border-radius: 3px;
+    font-size: 0.6rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.6;
+  }
+  .budget-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .gauge {
+    flex: 1;
     height: 12px;
     background: rgba(127, 127, 127, 0.18);
     border-radius: 6px;
@@ -99,5 +360,100 @@
   .gauge-fill {
     height: 100%;
     background: linear-gradient(to right, #8b5cf6, #a78bfa);
+    transition: width 0.2s;
+  }
+  .budget-numeric {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+  .modifiers {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .modifiers li {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    opacity: 0.55;
+  }
+  .modifiers li.active {
+    opacity: 1;
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(127, 127, 127, 0.3);
+  }
+  .dot.on {
+    background: #8b5cf6;
+  }
+  .json {
+    margin: 0;
+    font-size: 0.78rem;
+    background: rgba(127, 127, 127, 0.12);
+    padding: 0.4rem;
+    border-radius: 3px;
+    overflow: auto;
+  }
+  .windows {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+  }
+  .windows th,
+  .windows td {
+    border-bottom: 1px solid rgba(127, 127, 127, 0.18);
+    padding: 0.25rem 0.4rem;
+    text-align: left;
+  }
+  .windows th {
+    font-weight: 600;
+    opacity: 0.75;
+  }
+  .muted {
+    opacity: 0.65;
+  }
+  .small {
+    font-size: 0.75rem;
+    margin: 0;
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.78em;
+    background: rgba(127, 127, 127, 0.15);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+  .pulso-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .pulso-list li {
+    display: grid;
+    grid-template-columns: max-content max-content 1fr;
+    gap: 0.5rem;
+    align-items: baseline;
+    font-size: 0.82rem;
+  }
+  .pulso-list time {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.7rem;
+    opacity: 0.7;
+  }
+  .trigger {
+    font-size: 0.7rem;
+    opacity: 0.75;
+    text-transform: uppercase;
   }
 </style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/B2DrillingPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/B2DrillingPanel.svelte
@@ -3,86 +3,325 @@
    * B2 — Drilling (panel).
    * Pergunta: "O motor está treinando automaticidades em [persona]?"
    *
-   * v0: B2 ausente como sistema. Banner principal + placeholders pra
-   * banks/due/SR stats.
+   * Wiring (PR #244): consome BFF /banks, /banks/:id, /personas/:id/
+   * drill-{state,due,mastered}. Mostra empty state quando persona não
+   * tem drill ainda (primeiro turn dispara).
    */
+  import { onMount } from "svelte";
+  import { tracerSubjectId } from "../../lib/stores.js";
+  import { createApiClient } from "../../lib/api.js";
+  import type {
+    ApiClient,
+    DrillBankSummaryLike,
+    DrillStateLike,
+  } from "../../lib/api.js";
   import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
-  import PlaceholderBanner from "./PlaceholderBanner.svelte";
+
+  /** Cliente injetável pra testes. Default = createApiClient(). */
+  export let api: ApiClient = createApiClient();
 
   const COLOR = "#6b7280";
+
+  let loading = true;
+  let error: string | null = null;
+  let banks: DrillBankSummaryLike[] = [];
+  let states: DrillStateLike[] = [];
+  let due: DrillStateLike[] = [];
+  let mastered: DrillStateLike[] = [];
+
+  $: personaId = $tracerSubjectId;
+
+  async function loadAll(persona: string): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const [banksRes, statesRes, dueRes, masteredRes] = await Promise.all([
+        api.listBanks(),
+        api.listDrillStates(persona),
+        api.listDrillDue(persona),
+        api.listDrillMastered(persona),
+      ]);
+      banks = banksRes.banks;
+      states = statesRes.states;
+      due = dueRes.states;
+      mastered = masteredRes.states;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    void loadAll(personaId);
+  });
+
+  $: if (personaId) void loadAll(personaId);
+
+  $: avgEasiness = (() => {
+    if (states.length === 0) return null;
+    const sum = states.reduce((a, s) => a + s.current_easiness, 0);
+    return sum / states.length;
+  })();
+
+  $: retentionPct = (() => {
+    if (states.length === 0) return null;
+    const totalAttempts = states.reduce((a, s) => a + s.presented_count, 0);
+    const totalCorrect = states.reduce((a, s) => a + s.correct_count, 0);
+    if (totalAttempts === 0) return null;
+    return (totalCorrect / totalAttempts) * 100;
+  })();
+
+  function attemptGlyph(r: string): string {
+    if (r === "correct") return "✓";
+    if (r === "slow_correct") return "~";
+    if (r === "incorrect") return "✗";
+    if (r === "timeout") return "⊘";
+    return "?";
+  }
 </script>
 
 <SubsystemPanelShell id="B2" title="Drilling (automaticidade)" color={COLOR}>
-  <div class="absent-banner" data-testid="b2-absent-banner">
-    <strong>❌ B2 ausente como sistema</strong>
-    <p>
-      Drilling (SR / banks / mastery) ainda não é parte do motor canônico.
-      Especificação em rascunho:
+  {#if loading}
+    <p class="status" data-testid="b2-loading">Carregando B2 para {personaId}…</p>
+  {:else if error}
+    <p class="status error" data-testid="b2-error">
+      Erro ao carregar B2: {error}
     </p>
-    <code>docs/specs/2026-05-26-b2-drilling-primer-v0.md</code> (PR #244)
-  </div>
+  {:else}
+    <section class="block" data-testid="b2-banks-block">
+      <h3>Banks ativos <span class="count">({banks.length})</span></h3>
+      {#if banks.length === 0}
+        <p class="empty">Nenhum bank registrado em fixtures/banks/.</p>
+      {:else}
+        <ul class="banks-list">
+          {#each banks as bank (bank.bank_id)}
+            <li>
+              <strong>{bank.title}</strong>
+              <code>{bank.bank_id}</code>
+              <span class="muted small"
+                >{bank.item_count} items · curator: {bank.curator}</span
+              >
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
 
-  <section class="block">
-    <h3>Banks ativos</h3>
-    <PlaceholderBanner
-      label="ja-pt-vocab-n5 (50 items) — TODO quando B2 wired"
-      color={COLOR}
-    />
-  </section>
+    <section class="block" data-testid="b2-due-block">
+      <h3>
+        Due now <span class="count">({due.length})</span>
+      </h3>
+      {#if states.length === 0}
+        <p class="empty" data-testid="b2-empty-state">
+          Ainda sem drill pra {personaId} — primeiro turn dispara.
+        </p>
+      {:else if due.length === 0}
+        <p class="empty">Nenhum item due no momento.</p>
+      {:else}
+        <table class="drill-table">
+          <thead>
+            <tr>
+              <th>item</th>
+              <th>next_due_at</th>
+              <th>easiness</th>
+              <th>últimas 5</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each due as s (s.item_id)}
+              <tr>
+                <td><code>{s.item_id}</code></td>
+                <td><time>{s.next_due_at}</time></td>
+                <td>{s.current_easiness.toFixed(2)}</td>
+                <td class="attempts">
+                  {#each s.last_5_attempts as r, i (i)}
+                    <span class="attempt {r}">{attemptGlyph(r)}</span>
+                  {/each}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+    </section>
 
-  <section class="block">
-    <h3>Items due agora</h3>
-    <PlaceholderBanner
-      label="DrillState com next_due_at < now — TODO"
-      color={COLOR}
-    />
-  </section>
+    <section class="block" data-testid="b2-mastered-block">
+      <h3>
+        Mastered <span class="count">({mastered.length})</span>
+      </h3>
+      {#if mastered.length === 0}
+        <p class="empty">Nenhum item mastered ainda.</p>
+      {:else}
+        <ul class="mastered-list">
+          {#each mastered as s (s.item_id)}
+            <li>
+              <code>{s.item_id}</code>
+              <span class="muted small"
+                >mastered em {s.mastery_reached_at}</span
+              >
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
 
-  <section class="block">
-    <h3>SR statistics</h3>
-    <PlaceholderBanner
-      label="avg easiness · retention curve — TODO"
-      color={COLOR}
-    />
-  </section>
+    <section class="block" data-testid="b2-stats-block">
+      <h3>SR statistics</h3>
+      {#if states.length === 0}
+        <p class="empty">Stats indisponíveis — sem drill states.</p>
+      {:else}
+        <dl class="stats">
+          <dt>items rastreados</dt>
+          <dd>{states.length}</dd>
+          <dt>avg easiness</dt>
+          <dd>
+            {avgEasiness !== null ? avgEasiness.toFixed(2) : "—"}
+          </dd>
+          <dt>retention rate</dt>
+          <dd>
+            {retentionPct !== null ? retentionPct.toFixed(1) + "%" : "—"}
+          </dd>
+        </dl>
+      {/if}
+    </section>
+  {/if}
 </SubsystemPanelShell>
 
 <style>
-  .absent-banner {
-    border: 1px solid rgba(239, 68, 68, 0.5);
-    border-left: 4px solid #ef4444;
-    border-radius: 4px;
-    padding: 0.8rem 1rem;
-    background: rgba(239, 68, 68, 0.06);
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
+  .status {
+    font-size: 0.9rem;
+    opacity: 0.8;
   }
-  .absent-banner strong {
-    font-size: 0.95rem;
-  }
-  .absent-banner p {
-    margin: 0;
-    font-size: 0.85rem;
-    opacity: 0.9;
-  }
-  .absent-banner code {
-    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
-    font-size: 0.78rem;
-    background: rgba(127, 127, 127, 0.18);
-    padding: 0.15rem 0.4rem;
-    border-radius: 3px;
-    align-self: flex-start;
+  .status.error {
+    color: #ef4444;
   }
   .block {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    gap: 0.4rem;
   }
   h3 {
     margin: 0 0 0.3rem 0;
     font-size: 0.95rem;
     border-bottom: 1px solid rgba(127, 127, 127, 0.25);
     padding-bottom: 0.2rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+  .count {
+    font-size: 0.75rem;
+    opacity: 0.6;
+    font-weight: 400;
+  }
+  .empty {
+    margin: 0;
+    font-size: 0.85rem;
+    opacity: 0.65;
+    font-style: italic;
+  }
+  .banks-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .banks-list li {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.4rem;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.12);
+  }
+  .drill-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+  }
+  .drill-table th,
+  .drill-table td {
+    border-bottom: 1px solid rgba(127, 127, 127, 0.18);
+    padding: 0.25rem 0.4rem;
+    text-align: left;
+  }
+  .drill-table th {
+    font-weight: 600;
+    opacity: 0.75;
+  }
+  .attempts {
+    display: flex;
+    gap: 0.2rem;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  }
+  .attempt {
+    width: 1rem;
+    text-align: center;
+    border-radius: 2px;
+    background: rgba(127, 127, 127, 0.15);
+  }
+  .attempt.correct {
+    background: rgba(34, 197, 94, 0.25);
+    color: #22c55e;
+  }
+  .attempt.slow_correct {
+    background: rgba(234, 179, 8, 0.22);
+    color: #ca8a04;
+  }
+  .attempt.incorrect {
+    background: rgba(239, 68, 68, 0.22);
+    color: #ef4444;
+  }
+  .attempt.timeout {
+    background: rgba(107, 114, 128, 0.25);
+  }
+  .mastered-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .mastered-list li {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+  }
+  .stats {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 0.8rem;
+    row-gap: 0.2rem;
+    margin: 0;
+    font-size: 0.85rem;
+  }
+  .stats dt {
+    opacity: 0.75;
+  }
+  .stats dd {
+    margin: 0;
+    font-weight: 600;
+  }
+  .muted {
+    opacity: 0.7;
+  }
+  .small {
+    font-size: 0.75rem;
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.78em;
+    background: rgba(127, 127, 127, 0.15);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+  time {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.74rem;
+    opacity: 0.85;
   }
 </style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -340,6 +340,111 @@ export interface DebugLlmCallEvent {
   turn?: number;
 }
 
+// ─── B1/B2 wiring (Camada Social + Drilling) ─────────────────────
+
+export interface TemporalWindowEntryLike {
+  name: string;
+  weekday: string[];
+  start_local: string;
+  end_local: string;
+  max_hooks_per_day: number;
+  requires_parental_ok: boolean;
+}
+
+export interface TemporalWindowLike {
+  persona_id: string;
+  timezone: string;
+  windows: TemporalWindowEntryLike[];
+  sleep_window?: { start_local: string; end_local: string };
+  school_window?: { start_local: string; end_local: string };
+}
+
+export interface PulsoEventLike {
+  emitted_at: string;
+  trigger: string;
+  pulso_kind: string;
+  text: string;
+}
+
+export interface SacrificeBudgetSnapshotLike {
+  persona_id: string;
+  baseline: number;
+  current: number;
+  mood: number;
+  trust: number;
+  modifiers: Array<{ label: string; delta: number; active: boolean }>;
+  source: string;
+}
+
+export interface EmittedCardLike {
+  card_id: string;
+  child_id: string;
+  session_id: string;
+  archetype_id: string;
+  signature: string;
+  emitted_at: string;
+  front: {
+    title?: string;
+    rarity?: string;
+    [k: string]: unknown;
+  };
+  back: {
+    serial_number?: string;
+    cheat_code?: string;
+    qr_payload?: string;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+
+export interface DyadConfigLike {
+  dyad: {
+    members?: string[];
+    playbook?: string;
+    [k: string]: unknown;
+  } | null;
+  source: string;
+}
+
+export interface DrillBankSummaryLike {
+  bank_id: string;
+  title: string;
+  curator: string;
+  item_count: number;
+  target_personas: string[];
+}
+
+export interface DrillBankDetailLike {
+  bank: {
+    bank_id: string;
+    title: string;
+    curator: string;
+    license?: string;
+    target_personas?: string[];
+  };
+  items: Array<{
+    id: string;
+    bank_id: string;
+    type: string;
+    axis: string;
+    difficulty: number;
+    payload: { prompt: string; answer: string; hint?: string };
+  }>;
+}
+
+export interface DrillStateLike {
+  persona_id: string;
+  item_id: string;
+  presented_count: number;
+  correct_count: number;
+  last_seen_at: string;
+  next_due_at: string;
+  current_interval_days: number;
+  current_easiness: number;
+  mastery_reached_at: string | null;
+  last_5_attempts: string[];
+}
+
 export interface ApiClient {
   getStatus(): Promise<BffStatus>;
   getMode(): Promise<{ mode: ConsoleMode }>;
@@ -417,6 +522,41 @@ export interface ApiClient {
     subjectId: string,
     opts?: { limit?: number },
   ): Promise<{ plans: StrategyPlanLike[] }>;
+
+  // ─── B1 Camada Social ───────────────────────────────────────────
+  /** TemporalWindow YAML parseada. Pode retornar null se 404. */
+  getTemporalWindows(personaId: string): Promise<TemporalWindowLike | null>;
+  /** Pulso events recentes da persona (V0: stub vazio). */
+  listPulsoEvents(personaId: string): Promise<{ events: PulsoEventLike[] }>;
+  /** Sacrifice budget snapshot (V0: derivado de defaults, source=stub_v0). */
+  getSacrificeBudget(
+    personaId: string,
+    opts?: { mood?: number; trust?: number },
+  ): Promise<SacrificeBudgetSnapshotLike>;
+  /** Cards emitidos para a persona. */
+  listEmittedCards(
+    personaId: string,
+  ): Promise<{ cards: EmittedCardLike[] }>;
+  /** Configuração de dyad ativo (V0: stub null). */
+  getDyad(personaId: string): Promise<DyadConfigLike>;
+
+  // ─── B2 Drilling ────────────────────────────────────────────────
+  /** Lista banks disponíveis em fixtures/banks/. */
+  listBanks(): Promise<{ banks: DrillBankSummaryLike[] }>;
+  /** Conteúdo completo de um bank por id. */
+  getBank(bankId: string): Promise<DrillBankDetailLike>;
+  /** Todos os DrillStates da persona. */
+  listDrillStates(
+    personaId: string,
+  ): Promise<{ states: DrillStateLike[] }>;
+  /** DrillStates due agora. */
+  listDrillDue(
+    personaId: string,
+  ): Promise<{ states: DrillStateLike[] }>;
+  /** DrillStates que atingiram mastery. */
+  listDrillMastered(
+    personaId: string,
+  ): Promise<{ states: DrillStateLike[] }>;
 }
 
 export interface SubjectKnowledgeEntryLike {
@@ -694,6 +834,58 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
         `/subjects/${encodeURIComponent(subjectId)}/strategy-plans${q ? `?${q}` : ""}`,
       );
     },
+
+    // ─── B1 ─────────────────────────────────────────────────────────
+    getTemporalWindows: async (personaId) => {
+      const res = await f(
+        `${baseUrl}/personas/${encodeURIComponent(personaId)}/temporal-windows`,
+      );
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        throw new Error(
+          `BFF GET temporal-windows failed: ${res.status} ${res.statusText}`,
+        );
+      }
+      return (await res.json()) as TemporalWindowLike;
+    },
+    listPulsoEvents: (personaId) =>
+      get<{ events: PulsoEventLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/pulso-events`,
+      ),
+    getSacrificeBudget: (personaId, opts) => {
+      const params = new URLSearchParams();
+      if (opts?.mood !== undefined) params.set("mood", String(opts.mood));
+      if (opts?.trust !== undefined) params.set("trust", String(opts.trust));
+      const q = params.toString();
+      return get<SacrificeBudgetSnapshotLike>(
+        `/personas/${encodeURIComponent(personaId)}/sacrifice-budget${q ? `?${q}` : ""}`,
+      );
+    },
+    listEmittedCards: (personaId) =>
+      get<{ cards: EmittedCardLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/cards`,
+      ),
+    getDyad: (personaId) =>
+      get<DyadConfigLike>(
+        `/personas/${encodeURIComponent(personaId)}/dyad`,
+      ),
+
+    // ─── B2 ─────────────────────────────────────────────────────────
+    listBanks: () => get<{ banks: DrillBankSummaryLike[] }>("/banks"),
+    getBank: (bankId) =>
+      get<DrillBankDetailLike>(`/banks/${encodeURIComponent(bankId)}`),
+    listDrillStates: (personaId) =>
+      get<{ states: DrillStateLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/drill-state`,
+      ),
+    listDrillDue: (personaId) =>
+      get<{ states: DrillStateLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/drill-due`,
+      ),
+    listDrillMastered: (personaId) =>
+      get<{ states: DrillStateLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/drill-mastered`,
+      ),
   };
 }
 

--- a/packages/ebrota-console-ui/tests/b1-social-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/b1-social-panel.test.ts
@@ -1,0 +1,165 @@
+/**
+ * B1SocialPanel — render com mock ApiClient.
+ *
+ * Cobre:
+ *  - loading state inicial
+ *  - render com dados completos (cards + budget + dyad + windows)
+ *  - empty states (sem cards, sem dyad, sem fixture de window)
+ *  - error state
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/svelte";
+import B1SocialPanel from "../src/components/subsystem-panels/B1SocialPanel.svelte";
+import { expandedSubsystem, tracerSubjectId } from "../src/lib/stores.js";
+import type { ApiClient } from "../src/lib/api.js";
+
+function buildApi(over: Partial<ApiClient> = {}): ApiClient {
+  const base: Partial<ApiClient> = {
+    listEmittedCards: vi.fn().mockResolvedValue({ cards: [] }),
+    getSacrificeBudget: vi.fn().mockResolvedValue({
+      persona_id: "ryo-ochiai",
+      baseline: 15,
+      current: 15,
+      mood: 5,
+      trust: 0.5,
+      modifiers: [
+        { label: "mood ≥ 7 (+5)", delta: 5, active: false },
+        { label: "mood < 5 (-5)", delta: -5, active: false },
+        { label: "trust ≥ 0.8 (+3)", delta: 3, active: false },
+        { label: "trust < 0.5 (-5)", delta: -5, active: false },
+      ],
+      source: "stub_v0",
+    }),
+    getDyad: vi.fn().mockResolvedValue({ dyad: null, source: "stub_v0" }),
+    getTemporalWindows: vi.fn().mockResolvedValue(null),
+    listPulsoEvents: vi.fn().mockResolvedValue({ events: [] }),
+  };
+  return { ...base, ...over } as ApiClient;
+}
+
+beforeEach(() => {
+  expandedSubsystem.set("B1");
+  tracerSubjectId.set("ryo-ochiai");
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("B1SocialPanel", () => {
+  it("mostra loading enquanto carrega", () => {
+    const api = buildApi();
+    render(B1SocialPanel, { props: { api } });
+    expect(screen.getByTestId("b1-loading")).toBeDefined();
+  });
+
+  it("renderiza blocos básicos após carregar (sem cards, sem windows)", async () => {
+    const api = buildApi();
+    render(B1SocialPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("b1-loading")).toBeNull();
+    });
+    expect(screen.getByTestId("b1-cards-block")).toBeDefined();
+    expect(screen.getByTestId("b1-budget-block")).toBeDefined();
+    expect(screen.getByTestId("b1-dyad-block")).toBeDefined();
+    expect(screen.getByTestId("b1-windows-block")).toBeDefined();
+    expect(screen.getByTestId("b1-pulso-block")).toBeDefined();
+    // empty state pra cards
+    expect(screen.getByText(/Nenhum card emitido/)).toBeDefined();
+    // dyad stub null
+    expect(screen.getByText(/Sem dyad ativo/)).toBeDefined();
+  });
+
+  it("renderiza cards quando há dados", async () => {
+    const api = buildApi({
+      listEmittedCards: vi.fn().mockResolvedValue({
+        cards: [
+          {
+            card_id: "c-001",
+            child_id: "ryo-ochiai",
+            session_id: "s-1",
+            archetype_id: "naturalist:butterfly",
+            signature: "sig-1",
+            emitted_at: "2026-05-27T10:00:00Z",
+            front: { title: "Borboleta laranja", rarity: "rare" },
+            back: { serial_number: "0001", cheat_code: "PAPILIO-7X" },
+          },
+        ],
+      }),
+    });
+    render(B1SocialPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("b1-loading")).toBeNull();
+    });
+    const cards = screen.getAllByTestId("b1-card");
+    expect(cards.length).toBe(1);
+    expect(screen.getByText("Borboleta laranja")).toBeDefined();
+    expect(screen.getByText("PAPILIO-7X")).toBeDefined();
+  });
+
+  it("renderiza budget gauge com baseline/current", async () => {
+    const api = buildApi({
+      getSacrificeBudget: vi.fn().mockResolvedValue({
+        persona_id: "ryo-ochiai",
+        baseline: 15,
+        current: 20,
+        mood: 8,
+        trust: 0.5,
+        modifiers: [
+          { label: "mood ≥ 7 (+5)", delta: 5, active: true },
+          { label: "mood < 5 (-5)", delta: -5, active: false },
+          { label: "trust ≥ 0.8 (+3)", delta: 3, active: false },
+          { label: "trust < 0.5 (-5)", delta: -5, active: false },
+        ],
+        source: "stub_v0",
+      }),
+    });
+    render(B1SocialPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("b1-loading")).toBeNull();
+    });
+    expect(screen.getByText("20 / 15")).toBeDefined();
+    expect(screen.getByText(/mood ≥ 7/)).toBeDefined();
+  });
+
+  it("renderiza tabela de janelas quando há fixture", async () => {
+    const api = buildApi({
+      getTemporalWindows: vi.fn().mockResolvedValue({
+        persona_id: "ryo-ochiai",
+        timezone: "Asia/Tokyo",
+        windows: [
+          {
+            name: "post-school-jp",
+            weekday: ["mon", "tue", "wed", "thu", "fri"],
+            start_local: "16:30",
+            end_local: "17:30",
+            max_hooks_per_day: 1,
+            requires_parental_ok: true,
+          },
+        ],
+        school_window: { start_local: "08:00", end_local: "15:30" },
+        sleep_window: { start_local: "21:00", end_local: "06:30" },
+      }),
+    });
+    render(B1SocialPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("b1-loading")).toBeNull();
+    });
+    expect(screen.getByText("Asia/Tokyo")).toBeDefined();
+    expect(screen.getByText("post-school-jp")).toBeDefined();
+    expect(screen.getByText("16:30")).toBeDefined();
+  });
+
+  it("renderiza error state quando API falha", async () => {
+    const api = buildApi({
+      listEmittedCards: vi.fn().mockRejectedValue(new Error("BFF down")),
+    });
+    render(B1SocialPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.getByTestId("b1-error")).toBeDefined();
+    });
+    expect(screen.getByText(/BFF down/)).toBeDefined();
+  });
+});

--- a/packages/ebrota-console-ui/tests/b2-drilling-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/b2-drilling-panel.test.ts
@@ -1,0 +1,136 @@
+/**
+ * B2DrillingPanel — render com mock ApiClient.
+ *
+ * Cobre:
+ *  - loading state
+ *  - empty state quando persona não tem drill (states=0)
+ *  - blocos populados com banks/due/mastered/stats
+ *  - error state
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/svelte";
+import B2DrillingPanel from "../src/components/subsystem-panels/B2DrillingPanel.svelte";
+import { expandedSubsystem, tracerSubjectId } from "../src/lib/stores.js";
+import type { ApiClient, DrillStateLike } from "../src/lib/api.js";
+
+function buildApi(over: Partial<ApiClient> = {}): ApiClient {
+  const base: Partial<ApiClient> = {
+    listBanks: vi.fn().mockResolvedValue({ banks: [] }),
+    listDrillStates: vi.fn().mockResolvedValue({ states: [] }),
+    listDrillDue: vi.fn().mockResolvedValue({ states: [] }),
+    listDrillMastered: vi.fn().mockResolvedValue({ states: [] }),
+  };
+  return { ...base, ...over } as ApiClient;
+}
+
+function makeState(over: Partial<DrillStateLike> = {}): DrillStateLike {
+  return {
+    persona_id: "ryo-ochiai",
+    item_id: "jpv-001",
+    presented_count: 3,
+    correct_count: 2,
+    last_seen_at: "2026-05-27T10:00:00.000Z",
+    next_due_at: "2026-05-30T10:00:00.000Z",
+    current_interval_days: 3,
+    current_easiness: 2.5,
+    mastery_reached_at: null,
+    last_5_attempts: ["correct", "incorrect", "correct"],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  expandedSubsystem.set("B2");
+  tracerSubjectId.set("ryo-ochiai");
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("B2DrillingPanel", () => {
+  it("mostra loading enquanto carrega", () => {
+    const api = buildApi();
+    render(B2DrillingPanel, { props: { api } });
+    expect(screen.getByTestId("b2-loading")).toBeDefined();
+  });
+
+  it("mostra empty state quando persona nunca drilou", async () => {
+    const api = buildApi({
+      listBanks: vi.fn().mockResolvedValue({
+        banks: [
+          {
+            bank_id: "ja-pt-vocab-n5",
+            title: "JP-PT N5",
+            curator: "jun",
+            item_count: 50,
+            target_personas: ["ryo-ochiai"],
+          },
+        ],
+      }),
+    });
+    render(B2DrillingPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("b2-loading")).toBeNull();
+    });
+    expect(screen.getByTestId("b2-empty-state")).toBeDefined();
+    expect(screen.getByText(/primeiro turn dispara/)).toBeDefined();
+    // banks bloco sempre renderiza
+    expect(screen.getByText("JP-PT N5")).toBeDefined();
+  });
+
+  it("renderiza due + mastered + stats com dados completos", async () => {
+    const dueState = makeState({ item_id: "jpv-001", current_easiness: 2.3 });
+    const masteredState = makeState({
+      item_id: "jpv-099",
+      mastery_reached_at: "2026-05-20T12:00:00.000Z",
+      presented_count: 5,
+      correct_count: 5,
+    });
+    const allStates = [dueState, masteredState];
+    const api = buildApi({
+      listBanks: vi.fn().mockResolvedValue({
+        banks: [
+          {
+            bank_id: "ja-pt-vocab-n5",
+            title: "JP-PT N5",
+            curator: "jun",
+            item_count: 50,
+            target_personas: [],
+          },
+        ],
+      }),
+      listDrillStates: vi.fn().mockResolvedValue({ states: allStates }),
+      listDrillDue: vi.fn().mockResolvedValue({ states: [dueState] }),
+      listDrillMastered: vi
+        .fn()
+        .mockResolvedValue({ states: [masteredState] }),
+    });
+    render(B2DrillingPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("b2-loading")).toBeNull();
+    });
+    expect(screen.getByTestId("b2-due-block")).toBeDefined();
+    expect(screen.getByTestId("b2-mastered-block")).toBeDefined();
+    expect(screen.getByTestId("b2-stats-block")).toBeDefined();
+    expect(screen.getByText("jpv-001")).toBeDefined();
+    expect(screen.getByText("jpv-099")).toBeDefined();
+    // avg easiness = (2.3 + 2.5)/2 = 2.4
+    expect(screen.getByText("2.40")).toBeDefined();
+    // retention = (2 + 5)/(3 + 5) * 100 = 87.5%
+    expect(screen.getByText("87.5%")).toBeDefined();
+  });
+
+  it("renderiza error state quando API falha", async () => {
+    const api = buildApi({
+      listBanks: vi.fn().mockRejectedValue(new Error("BFF unreachable")),
+    });
+    render(B2DrillingPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.getByTestId("b2-error")).toBeDefined();
+    });
+    expect(screen.getByText(/BFF unreachable/)).toBeDefined();
+  });
+});

--- a/packages/ebrota-console-ui/tests/subsystem-panels-render.test.ts
+++ b/packages/ebrota-console-ui/tests/subsystem-panels-render.test.ts
@@ -108,18 +108,18 @@ describe("subsystem panels — smoke render", () => {
     expect(screen.getByText(/2026-05-26-s5c-longitudinal-v0\.md/)).toBeDefined();
   });
 
-  it("B1SocialPanel renderiza shell + placeholder com link spec hooks", () => {
+  it("B1SocialPanel renderiza shell + loading inicial (B1/B2 wiring PR #243)", () => {
+    // Render sem api injetado → usa default client; b1-loading aparece antes
+    // do Promise resolver, garantindo que a shell montou.
     render(B1SocialPanel);
     expect(screen.getByTestId("subsystem-panel-B1")).toBeDefined();
-    expect(screen.getByText(/2026-05-26-b1-hooks-temporais-v0\.md/)).toBeDefined();
+    expect(screen.getByTestId("b1-loading")).toBeDefined();
   });
 
-  it("B2DrillingPanel renderiza banner 'ausente como sistema'", () => {
+  it("B2DrillingPanel renderiza shell + loading inicial (B1/B2 wiring PR #244)", () => {
     render(B2DrillingPanel);
     expect(screen.getByTestId("subsystem-panel-B2")).toBeDefined();
-    expect(screen.getByTestId("b2-absent-banner")).toBeDefined();
-    expect(screen.getByText(/B2 ausente como sistema/)).toBeDefined();
-    expect(screen.getByText(/2026-05-26-b2-drilling-primer-v0\.md/)).toBeDefined();
+    expect(screen.getByTestId("b2-loading")).toBeDefined();
   });
 
   it("close button volta ao grid (seta expandedSubsystem=null)", async () => {


### PR DESCRIPTION
## Resumo

Conecta as features B1 (Temporal Windows + Pulso) e B2 (Drilling) mergeadas em main (PRs #243 e #244) aos panels existentes via BFF, substituindo placeholders por dados reais.

## Backend (BFF — `packages/ebrota-console-bff`)

### Novos endpoints

**B1 (`src/routes/b1-routes.ts`):**
- `GET /personas/:id/temporal-windows` — parser YAML de `fixtures/temporal-windows/<persona>.yaml` + valida via `TemporalWindowSchema`. 404 quando fixture ausente.
- `GET /personas/:id/pulso-events` — **stub v0** retornando `{ events: [] }` (sem persistência ainda; scheduler não loga emissões).
- `GET /personas/:id/sacrifice-budget` — **stub v0** derivado de `initBudget` com baseline Kids=15 e modifiers (mood/trust) calculados em runtime. Query opcional `?mood=N&trust=N`.
- `GET /personas/:id/cards` — `cards-repo.getEmittedCardsByChild`.
- `GET /personas/:id/dyad` — **stub v0** retornando `{ dyad: null }`.

**B2 (`src/routes/b2-routes.ts`):**
- `GET /banks` — lista todos os `.yaml` em `fixtures/banks/` com summary (bank_id, title, curator, item_count, target_personas).
- `GET /banks/:bankId` — `loadBank` completo (DrillBank + items denormalizados).
- `GET /personas/:id/drill-state` — query direta em `drill_states` (todos os states da persona).
- `GET /personas/:id/drill-due` — `listDue` (filtro `next_due_at <= now`).
- `GET /personas/:id/drill-mastered` — `listMastered` (filtro `mastery_reached_at IS NOT NULL`).

### Suporte de infra
- `db.ts` agora aplica `EMITTED_CARDS_DDL` + `DRILL_STATES_DDL` + `NARRATIVE_THREADS_DDL` no `initDb` pra reads via BFF retornarem empty arrays em vez de "no such table".
- `server.ts` registra ambos plugins (2 linhas `fastify.register` + shared opts).
- BFF `package.json` ganha deps `@ascendimacy/motor-execucao`, `@ascendimacy/shared`, `js-yaml`.
- `motor-execucao/package.json` ganha `exports` field expondo subpaths (`cards-repo`, `drill-repo`, `narrative-thread-repo`).

### Testes
- `tests/b1-routes.unit.test.ts` (8 testes) — temporal-windows existente + 404, pulso vazio, budget defaults + modifiers via query, cards vazio, dyad stub.
- `tests/b2-routes.unit.test.ts` (7 testes) — banks list, bank full content + 404, drill-state vazio + populado após `recordAttempt`, drill-due/mastered shapes.

## Frontend (UI — `packages/ebrota-console-ui`)

### `lib/api.ts`
- 10 métodos novos no `ApiClient`: `getTemporalWindows`, `listPulsoEvents`, `getSacrificeBudget`, `listEmittedCards`, `getDyad`, `listBanks`, `getBank`, `listDrillStates`, `listDrillDue`, `listDrillMastered`.
- Duck-types `TemporalWindowLike`, `PulsoEventLike`, `SacrificeBudgetSnapshotLike`, `EmittedCardLike`, `DyadConfigLike`, `DrillBankSummaryLike`, `DrillBankDetailLike`, `DrillStateLike`.

### `B1SocialPanel.svelte`
Substitui 5 placeholders por dados reais:
- **Cards emitidos** — grid com rarity badge, archetype_id, title, serial_number, cheat-code, QR slot.
- **Sacrifice budget** — gauge proporcional (current/baseline) + lista 4 modifiers com indicador ativo/inativo. Badge `stub v0`.
- **Dyad** — placeholder "Sem dyad ativo" quando null. Badge `stub v0`.
- **Janelas temporais** — tabela (nome, dias, início, fim, cap/dia, parental) + linha de exclusões (sleep/school).
- **Pulso events** — lista cronológica ou empty state. Badge `stub v0`.

Loading + error states. `api` prop injetável pra testes (default = `createApiClient()`).

### `B2DrillingPanel.svelte`
Remove banner "❌ B2 ausente como sistema". Adiciona:
- **Banks ativos** — lista com item_count + curator.
- **Due now** — tabela (item, next_due_at, easiness, últimas 5 tentativas como ícones coloridos ✓/~/✗/⊘).
- **Mastered** — lista com mastery_reached_at.
- **SR statistics** — avg easiness + retention rate (agregação client-side).
- **Empty state** — "Ainda sem drill pra <persona> — primeiro turn dispara" quando `states.length === 0`.

### Testes
- `tests/b1-social-panel.test.ts` (6 testes) — loading, empty states, cards populados, budget gauge, tabela janelas, error.
- `tests/b2-drilling-panel.test.ts` (4 testes) — loading, empty state, populated (avg+retention), error.
- `tests/subsystem-panels-render.test.ts` — assertions B1/B2 legadas trocadas pra checar `b1-loading`/`b2-loading` testIds (S1-S5 intactos).

## Critério de aceitação

- [x] Build BFF passa (`npm run build -w @ascendimacy/ebrota-console-bff`)
- [x] Build UI passa (`npm run build -w @ascendimacy/ebrota-console-ui`)
- [x] Tests novos passam (BFF: 176 testes incluindo 15 novos; UI: 180 testes incluindo 10 novos)
- [x] B1 panel mostra cards, budget, dyad, windows, pulso reais
- [x] B2 panel mostra banks + items + due + mastered reais com empty state

## V0 limitations (honesty)

- **Pulso events**: persistência não existe ainda. Endpoint devolve array vazio até scheduler ganhar log de emissões.
- **Sacrifice budget**: stub v0 derivado de defaults (`initBudget` + modifiers calculados em runtime). Quando integrar com session state real, basta substituir o cálculo no route.
- **Dyad**: não há config persistida; retorna `null` com `source: stub_v0`.

Badges `stub v0` aparecem inline nos 3 blocos pra evitar confusão sobre data freshness.

## Não-mergeável ainda
Aguardando review humano (Jun). Não mergeie.