### PR TITLE
[ui+bff] Parental Engaged Dashboard — daily/weekly view + escalation flows

### DIFF
--- a/packages/ebrota-console-bff/src/routes/parental-dashboard-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/parental-dashboard-routes.ts
@@ -1,0 +1,559 @@
+/**
+ * Parental Engaged Dashboard — view "dia dos meus filhos" (US-PE-01..09).
+ *
+ * Plugin Fastify registrado em server.ts. V0 retorna stubs determinísticos
+ * estruturados conforme a forma final, com a flag `developmentStub: true`
+ * sinalizando ao UI que aquele bloco ainda não vem do motor real. Conforme
+ * subsistemas amadurecerem (S1/S2/S5/B1), cada handler troca o stub por
+ * leitura de repos sem mudar shape de resposta.
+ *
+ * Spec: docs/specs/2026-05-26-console-ebrota-user-stories-v0.md §"Parental
+ * Journey — Navigation Flows".
+ */
+
+import type { FastifyPluginAsync } from "fastify";
+
+export interface KidSummary {
+  childId: string;
+  name: string;
+  age: number;
+  primaryLanguage: string;
+  avatarColor: string;
+  engagedToday: boolean;
+  lastSeenAt: string | null;
+  moodToday: number | null;
+  durationMinutesToday: number;
+  oneLineSummary: string;
+  developmentStub?: boolean;
+}
+
+export interface DashboardResponse {
+  acquirerId: string;
+  acquirerName: string;
+  generatedAt: string;
+  pendingQuestionsCount: number;
+  unreadAlertsCount: number;
+  children: KidSummary[];
+}
+
+export interface TodaySummary {
+  childId: string;
+  date: string;
+  engaged: boolean;
+  moodAverage: number | null;
+  durationMinutes: number;
+  topicsDiscussed: string[];
+  lastMessagePreview: string | null;
+  lastSeenAt: string | null;
+  cardsEmittedToday: number;
+  developmentStub?: boolean;
+}
+
+export interface WeekProgress {
+  childId: string;
+  weekStartIso: string;
+  weekEndIso: string;
+  moodTimeline: Array<{ date: string; mood: number | null }>;
+  moodAverage: number | null;
+  cardsCount: number;
+  cardThumbnails: Array<{ cardId: string; title: string; rarity: string }>;
+  sacrificeBudgetTotal: number;
+  sacrificeBudgetUsed: number;
+  offScreenRatio: number;
+  topThemes: string[];
+  qualitativeSummary: string;
+  developmentStub?: boolean;
+}
+
+export interface PhysicalCard {
+  cardId: string;
+  title: string;
+  rarity: "common" | "rare" | "epic" | "legendary";
+  emittedAt: string;
+  thumbnailUrl: string;
+  qrCodePayload: string;
+  cheatCode: string;
+  pdfUrl: string;
+  used: boolean;
+}
+
+export interface ConversationSession {
+  sessionId: string;
+  startedAt: string;
+  endedAt: string | null;
+  turnCount: number;
+  durationMinutes: number;
+  topicSummary: string;
+  preview: Array<{ from: "kid" | "brota"; text: string; at: string }>;
+  developmentStub?: boolean;
+}
+
+export interface ParentalAlert {
+  alertId: string;
+  type: "distress" | "drift" | "negative_sequence" | "other";
+  severity: "info" | "warn" | "critical";
+  raisedAt: string;
+  context: string;
+  excerpt: string;
+  sessionRefs: string[];
+  proposedAction: "pause_brota" | "contact_jun" | "wait" | "review";
+  status: "open" | "ack" | "resolved";
+  developmentStub?: boolean;
+}
+
+export interface PulsoEvent {
+  eventId: string;
+  type: "omikuji" | "mini_historia" | "lembrete_cultural" | "outro";
+  firedAt: string;
+  windowLabel: string;
+  culturalContext: string;
+  payloadPreview: string;
+  kidReaction: "engaged" | "ignored" | "positive" | "negative" | "unknown";
+  developmentStub?: boolean;
+}
+
+export interface PendingQuestion {
+  questionId: string;
+  childId: string;
+  raisedAt: string;
+  brotaContextTurns: Array<{ from: "kid" | "brota"; text: string }>;
+  rawQuestion: string;
+  escalationReason: string;
+  status: "open" | "answered";
+  developmentStub?: boolean;
+}
+
+export interface ParentalDashboardOptions {
+  /**
+   * Resolver de família/crianças. V0 default retorna a família Yuji
+   * (Ryo/Kei/Saki) — em prod, virá de parental-onboarding-store ou
+   * subject-knowledge-repo.
+   */
+  resolveFamily?: (acquirerId: string) => {
+    acquirerName: string;
+    children: Array<{
+      childId: string;
+      name: string;
+      age: number;
+      primaryLanguage: string;
+      avatarColor: string;
+    }>;
+  };
+}
+
+const DEFAULT_FAMILY = {
+  acquirerName: "Yuji",
+  children: [
+    {
+      childId: "ryo-ochiai",
+      name: "Ryo",
+      age: 8,
+      primaryLanguage: "pt",
+      avatarColor: "#5B8DEF",
+    },
+    {
+      childId: "kei-ochiai",
+      name: "Kei",
+      age: 6,
+      primaryLanguage: "pt",
+      avatarColor: "#F2A65A",
+    },
+    {
+      childId: "saki-ochiai",
+      name: "Saki",
+      age: 4,
+      primaryLanguage: "pt",
+      avatarColor: "#E36588",
+    },
+  ],
+};
+
+function hashSeed(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = (h * 16777619) >>> 0;
+  }
+  return h;
+}
+
+function pseudoRandom(seed: number): () => number {
+  let s = seed || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+function isoDaysAgo(days: number, hoursOffset = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  d.setHours(d.getHours() - hoursOffset);
+  return d.toISOString();
+}
+
+function isoHoursAgo(hours: number): string {
+  const d = new Date(Date.now() - hours * 3600_000);
+  return d.toISOString();
+}
+
+const parentalDashboardRoutes: FastifyPluginAsync<
+  ParentalDashboardOptions
+> = async (fastify, opts) => {
+  const resolveFamily =
+    opts.resolveFamily ?? ((_id: string) => DEFAULT_FAMILY);
+
+  // GET /parental/dashboard/:acquirerId → US-PE-01 agregado.
+  fastify.get<{ Params: { acquirerId: string } }>(
+    "/parental/dashboard/:acquirerId",
+    async (req) => {
+      const fam = resolveFamily(req.params.acquirerId);
+      const rng = pseudoRandom(hashSeed(req.params.acquirerId));
+      const children: KidSummary[] = fam.children.map((c) => {
+        const engaged = rng() > 0.25;
+        const mood = engaged ? Math.round(5 + rng() * 4 * 10) / 10 : null;
+        const minutes = engaged ? Math.round(3 + rng() * 12) : 0;
+        const topic = ["joaninhas", "estrelas", "dinossauros", "Pokémon", "música"][
+          Math.floor(rng() * 5)
+        ];
+        const hoursAgo = engaged ? Math.round(rng() * 8 + 1) : 36;
+        return {
+          childId: c.childId,
+          name: c.name,
+          age: c.age,
+          primaryLanguage: c.primaryLanguage,
+          avatarColor: c.avatarColor,
+          engagedToday: engaged,
+          lastSeenAt: engaged ? isoHoursAgo(hoursAgo) : isoHoursAgo(36),
+          moodToday: mood,
+          durationMinutesToday: minutes,
+          oneLineSummary: engaged
+            ? `${c.name} conversou ${minutes}min, falou sobre ${topic}`
+            : `${c.name} não interagiu hoje`,
+          developmentStub: true,
+        };
+      });
+      const response: DashboardResponse = {
+        acquirerId: req.params.acquirerId,
+        acquirerName: fam.acquirerName,
+        generatedAt: new Date().toISOString(),
+        pendingQuestionsCount: 1,
+        unreadAlertsCount: 0,
+        children,
+      };
+      return response;
+    },
+  );
+
+  // GET /parental/children/:childId/today → US-PE-01 drill-in.
+  fastify.get<{ Params: { childId: string } }>(
+    "/parental/children/:childId/today",
+    async (req) => {
+      const rng = pseudoRandom(hashSeed(req.params.childId + "today"));
+      const engaged = rng() > 0.25;
+      const minutes = engaged ? Math.round(3 + rng() * 12) : 0;
+      const moodAvg = engaged ? Math.round(5 + rng() * 4) : null;
+      const today = new Date().toISOString().slice(0, 10);
+      const result: TodaySummary = {
+        childId: req.params.childId,
+        date: today,
+        engaged,
+        moodAverage: moodAvg,
+        durationMinutes: minutes,
+        topicsDiscussed: engaged ? ["joaninhas", "cores do céu"] : [],
+        lastMessagePreview: engaged
+          ? "Brota: que cor de joaninha você mais gosta?"
+          : null,
+        lastSeenAt: engaged ? isoHoursAgo(2) : null,
+        cardsEmittedToday: engaged ? 1 : 0,
+        developmentStub: true,
+      };
+      return result;
+    },
+  );
+
+  // GET /parental/children/:childId/week → US-PE-02.
+  fastify.get<{ Params: { childId: string } }>(
+    "/parental/children/:childId/week",
+    async (req) => {
+      const rng = pseudoRandom(hashSeed(req.params.childId + "week"));
+      const timeline: Array<{ date: string; mood: number | null }> = [];
+      let moodSum = 0;
+      let moodCount = 0;
+      for (let i = 6; i >= 0; i--) {
+        const d = new Date();
+        d.setDate(d.getDate() - i);
+        const has = rng() > 0.2;
+        const mood = has ? Math.round((5 + rng() * 4) * 10) / 10 : null;
+        if (mood !== null) {
+          moodSum += mood;
+          moodCount++;
+        }
+        timeline.push({ date: d.toISOString().slice(0, 10), mood });
+      }
+      const result: WeekProgress = {
+        childId: req.params.childId,
+        weekStartIso: timeline[0]!.date,
+        weekEndIso: timeline[timeline.length - 1]!.date,
+        moodTimeline: timeline,
+        moodAverage:
+          moodCount > 0 ? Math.round((moodSum / moodCount) * 10) / 10 : null,
+        cardsCount: Math.floor(rng() * 4) + 1,
+        cardThumbnails: [
+          { cardId: "card-joaninhas", title: "Joaninhas", rarity: "common" },
+          { cardId: "card-estrelas", title: "Estrelas", rarity: "rare" },
+        ],
+        sacrificeBudgetTotal: 100,
+        sacrificeBudgetUsed: Math.floor(rng() * 40) + 20,
+        offScreenRatio: Math.round((1.5 + rng() * 1.5) * 10) / 10,
+        topThemes: ["joaninhas", "estrelas", "dinossauros"],
+        qualitativeSummary:
+          "Semana com mood estável (~7), forte interesse em natureza " +
+          "(joaninhas e estrelas). Sem sinais de drift; engajamento " +
+          "consistente nas janelas configuradas.",
+        developmentStub: true,
+      };
+      return result;
+    },
+  );
+
+  // GET /parental/children/:childId/cards → US-PE-03.
+  fastify.get<{ Params: { childId: string } }>(
+    "/parental/children/:childId/cards",
+    async (req) => {
+      const cid = req.params.childId;
+      const cards: PhysicalCard[] = [
+        {
+          cardId: `${cid}-card-joaninhas-001`,
+          title: "Joaninhas amarelas",
+          rarity: "common",
+          emittedAt: isoDaysAgo(2),
+          thumbnailUrl: "/placeholder-card-joaninhas.png",
+          qrCodePayload: `ebrota://card/${cid}/joaninhas-001`,
+          cheatCode: "BR-JOA-001",
+          pdfUrl: `/api/parental/children/${cid}/cards/joaninhas-001.pdf`,
+          used: false,
+        },
+        {
+          cardId: `${cid}-card-estrelas-002`,
+          title: "Estrelas e constelações",
+          rarity: "rare",
+          emittedAt: isoDaysAgo(5),
+          thumbnailUrl: "/placeholder-card-estrelas.png",
+          qrCodePayload: `ebrota://card/${cid}/estrelas-002`,
+          cheatCode: "BR-EST-002",
+          pdfUrl: `/api/parental/children/${cid}/cards/estrelas-002.pdf`,
+          used: true,
+        },
+      ];
+      return { childId: cid, cards, developmentStub: true };
+    },
+  );
+
+  // GET /parental/children/:childId/conversations → US-PE-05.
+  fastify.get<{ Params: { childId: string }; Querystring: { limit?: string } }>(
+    "/parental/children/:childId/conversations",
+    async (req) => {
+      const cid = req.params.childId;
+      const limit = req.query.limit ? Number(req.query.limit) : 5;
+      const sessions: ConversationSession[] = [];
+      for (let i = 0; i < Math.min(limit, 5); i++) {
+        sessions.push({
+          sessionId: `${cid}-sess-${i}`,
+          startedAt: isoDaysAgo(i),
+          endedAt: isoDaysAgo(i, -1),
+          turnCount: 8 + i,
+          durationMinutes: 5 + i,
+          topicSummary:
+            i === 0 ? "joaninhas e cores do céu" : `tema do dia ${i}`,
+          preview: [
+            {
+              from: "brota",
+              text: "Oi! O que te chamou atenção hoje?",
+              at: isoDaysAgo(i),
+            },
+            {
+              from: "kid",
+              text: "vi uma joaninha amarela!",
+              at: isoDaysAgo(i),
+            },
+            {
+              from: "brota",
+              text: "Que sorte! Joaninha amarela é menos comum.",
+              at: isoDaysAgo(i),
+            },
+          ],
+          developmentStub: true,
+        });
+      }
+      return { childId: cid, sessions };
+    },
+  );
+
+  // GET /parental/children/:childId/alerts → US-PE-06.
+  fastify.get<{ Params: { childId: string } }>(
+    "/parental/children/:childId/alerts",
+    async (req) => {
+      const cid = req.params.childId;
+      const alerts: ParentalAlert[] = [];
+      return { childId: cid, alerts, developmentStub: true };
+    },
+  );
+
+  // GET /parental/children/:childId/pulso-events → US-PE-08.
+  fastify.get<{
+    Params: { childId: string };
+    Querystring: { type?: string; limit?: string };
+  }>(
+    "/parental/children/:childId/pulso-events",
+    async (req) => {
+      const cid = req.params.childId;
+      const all: PulsoEvent[] = [
+        {
+          eventId: `${cid}-pulso-1`,
+          type: "omikuji",
+          firedAt: isoDaysAgo(1),
+          windowLabel: "manhã (07:30)",
+          culturalContext:
+            "Omikuji — sorte do dia no estilo dos santuários japoneses. " +
+            "Ryo conhece o costume via avô.",
+          payloadPreview: "Hoje: 中吉 (chuu-kichi — sorte média). Tema: paciência.",
+          kidReaction: "engaged",
+          developmentStub: true,
+        },
+        {
+          eventId: `${cid}-pulso-2`,
+          type: "mini_historia",
+          firedAt: isoDaysAgo(2),
+          windowLabel: "tarde (17:00)",
+          culturalContext:
+            "Mini-história curta de 3 frases — uso reduzido pra não competir com janela do jantar.",
+          payloadPreview:
+            "A formiga carregava uma folha grande. O vento veio forte. Ela soltou — e a folha virou barco.",
+          kidReaction: "positive",
+          developmentStub: true,
+        },
+      ];
+      const filtered =
+        req.query.type !== undefined
+          ? all.filter((e) => e.type === req.query.type)
+          : all;
+      const limit = req.query.limit ? Number(req.query.limit) : 20;
+      return { childId: cid, events: filtered.slice(0, limit) };
+    },
+  );
+
+  // GET /parental/escalation/pending-questions → todas perguntas pendentes
+  //   (não está no spec explicitamente, mas necessário pra badge + modal).
+  fastify.get("/parental/escalation/pending-questions", async () => {
+    const questions: PendingQuestion[] = [
+      {
+        questionId: "pq-001",
+        childId: "saki-ochiai",
+        raisedAt: isoHoursAgo(6),
+        brotaContextTurns: [
+          { from: "kid", text: "por que o céu fica vermelho?" },
+          {
+            from: "brota",
+            text: "Boa pergunta — vou conferir com seu pai pra te explicar direitinho.",
+          },
+        ],
+        rawQuestion: "por que o céu fica vermelho?",
+        escalationReason:
+          "tema científico fora do baseline garantido — pais decidem profundidade.",
+        status: "open",
+        developmentStub: true,
+      },
+    ];
+    return { questions };
+  });
+
+  // POST /parental/escalation/pending-questions/:questionId/answer → US-PE-04.
+  fastify.post<{
+    Params: { questionId: string };
+    Body: {
+      answerText?: string;
+      instructionToBrota?: string;
+      tone?: string;
+    };
+  }>(
+    "/parental/escalation/pending-questions/:questionId/answer",
+    async (req, reply) => {
+      const body = req.body ?? {};
+      if (
+        (typeof body.answerText !== "string" || body.answerText.length === 0) &&
+        (typeof body.instructionToBrota !== "string" ||
+          body.instructionToBrota.length === 0)
+      ) {
+        return reply.code(400).send({
+          error: "answerText ou instructionToBrota obrigatório",
+        });
+      }
+      return {
+        questionId: req.params.questionId,
+        status: "answered",
+        scheduledForNextSession: true,
+        recordedAt: new Date().toISOString(),
+      };
+    },
+  );
+
+  // POST /parental/escalation/report → US-PE-07.
+  fastify.post<{
+    Body: {
+      childId?: string;
+      type?: "tom" | "repeticao" | "off-topic" | "outro";
+      text?: string;
+      sessionRef?: string;
+    };
+  }>("/parental/escalation/report", async (req, reply) => {
+    const body = req.body ?? {};
+    if (typeof body.childId !== "string" || body.childId.length === 0) {
+      return reply.code(400).send({ error: "childId obrigatório" });
+    }
+    if (typeof body.type !== "string") {
+      return reply.code(400).send({ error: "type obrigatório" });
+    }
+    if (
+      typeof body.text !== "string" ||
+      body.text.length === 0 ||
+      body.text.length > 500
+    ) {
+      return reply
+        .code(400)
+        .send({ error: "text obrigatório, 1..500 chars" });
+    }
+    return {
+      reportId: `rep-${Date.now()}`,
+      childId: body.childId,
+      type: body.type,
+      status: "open",
+      notifiedJun: true,
+      createdAt: new Date().toISOString(),
+    };
+  });
+
+  // POST /parental/children/:childId/pause → US-PE-09.
+  fastify.post<{
+    Params: { childId: string };
+    Body: { reason?: string; pauseUntilIso?: string; immediate?: boolean };
+  }>("/parental/children/:childId/pause", async (req, reply) => {
+    const body = req.body ?? {};
+    if (typeof body.reason !== "string" || body.reason.length === 0) {
+      return reply.code(400).send({ error: "reason obrigatório" });
+    }
+    const immediate = body.immediate !== false;
+    return {
+      childId: req.params.childId,
+      paused: true,
+      immediate,
+      pauseUntilIso: body.pauseUntilIso ?? null,
+      notifiedJun:
+        typeof body.pauseUntilIso === "string" &&
+        Date.parse(body.pauseUntilIso) - Date.now() > 24 * 3600_000,
+      pausedAt: new Date().toISOString(),
+    };
+  });
+};
+
+export default parentalDashboardRoutes;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -78,6 +78,7 @@ import {
   saveDraft as saveOnboardingDraft,
   markComplete as markOnboardingComplete,
 } from "./parental-onboarding-store.js";
+import parentalDashboardRoutes from "./routes/parental-dashboard-routes.js";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import b1RoutesPlugin from "./routes/b1-routes.js";
@@ -147,6 +148,9 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   };
   void fastify.register(b1RoutesPlugin, sharedRouteOpts);
   void fastify.register(b2RoutesPlugin, sharedRouteOpts);
+
+  // Parental Engaged Dashboard (US-PE-01..09) — plugin Fastify isolado.
+  void fastify.register(parentalDashboardRoutes, {});
 
   // In-memory set de sessionIds ativos (iniciados via /sessions/start-card,
   // removidos via /sessions/:id/end). Permite que App.svelte faça polling

--- a/packages/ebrota-console-bff/tests/parental-dashboard-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/parental-dashboard-routes.unit.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests pro plugin parental-dashboard-routes (US-PE-01..09).
+ *
+ * Cobrem shape de resposta + validação de input. V0 endpoints retornam
+ * stubs determinísticos com `developmentStub: true` — testes verificam
+ * que campos esperados existem e que erros chegam com 400.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+let server: BffServer;
+
+const inject = async (
+  method: "GET" | "POST",
+  url: string,
+  payload?: unknown,
+) => {
+  const res = await server.fastify.inject({
+    method,
+    url,
+    ...(payload !== undefined ? { payload } : {}),
+  });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as Record<string, unknown>) : null,
+  };
+};
+
+beforeEach(() => {
+  const db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+describe("GET /parental/dashboard/:acquirerId", () => {
+  it("retorna agregado com children + counts", async () => {
+    const res = await inject("GET", "/parental/dashboard/yuji-ochiai");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      acquirerId: string;
+      acquirerName: string;
+      generatedAt: string;
+      pendingQuestionsCount: number;
+      unreadAlertsCount: number;
+      children: Array<{
+        childId: string;
+        name: string;
+        engagedToday: boolean;
+        oneLineSummary: string;
+      }>;
+    };
+    expect(body.acquirerId).toBe("yuji-ochiai");
+    expect(body.acquirerName).toBe("Yuji");
+    expect(body.children.length).toBe(3);
+    expect(body.children.map((c) => c.name).sort()).toEqual(
+      ["Kei", "Ryo", "Saki"],
+    );
+    for (const c of body.children) {
+      expect(typeof c.oneLineSummary).toBe("string");
+      expect(c.oneLineSummary.length).toBeGreaterThan(0);
+    }
+    expect(typeof body.pendingQuestionsCount).toBe("number");
+  });
+});
+
+describe("GET /parental/children/:childId/today", () => {
+  it("retorna TodaySummary com data ISO + campos requeridos", async () => {
+    const res = await inject("GET", "/parental/children/ryo-ochiai/today");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      childId: string;
+      date: string;
+      engaged: boolean;
+      durationMinutes: number;
+      topicsDiscussed: string[];
+    };
+    expect(body.childId).toBe("ryo-ochiai");
+    expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(Array.isArray(body.topicsDiscussed)).toBe(true);
+  });
+});
+
+describe("GET /parental/children/:childId/week", () => {
+  it("retorna WeekProgress com 7 dias na timeline", async () => {
+    const res = await inject("GET", "/parental/children/kei-ochiai/week");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      moodTimeline: Array<{ date: string; mood: number | null }>;
+      topThemes: string[];
+      qualitativeSummary: string;
+      sacrificeBudgetTotal: number;
+    };
+    expect(body.moodTimeline.length).toBe(7);
+    expect(body.topThemes.length).toBeGreaterThan(0);
+    expect(typeof body.qualitativeSummary).toBe("string");
+    expect(body.sacrificeBudgetTotal).toBe(100);
+  });
+});
+
+describe("GET /parental/children/:childId/cards", () => {
+  it("retorna lista de cards físicos com QR + cheat-code", async () => {
+    const res = await inject("GET", "/parental/children/saki-ochiai/cards");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      cards: Array<{
+        cardId: string;
+        qrCodePayload: string;
+        cheatCode: string;
+        pdfUrl: string;
+      }>;
+    };
+    expect(body.cards.length).toBeGreaterThan(0);
+    for (const c of body.cards) {
+      expect(c.qrCodePayload).toContain("ebrota://card/");
+      expect(c.cheatCode.length).toBeGreaterThan(0);
+      expect(c.pdfUrl.endsWith(".pdf")).toBe(true);
+    }
+  });
+});
+
+describe("GET /parental/children/:childId/conversations", () => {
+  it("retorna lista de sessões com preview", async () => {
+    const res = await inject(
+      "GET",
+      "/parental/children/ryo-ochiai/conversations?limit=3",
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      sessions: Array<{
+        sessionId: string;
+        preview: Array<{ from: string; text: string }>;
+      }>;
+    };
+    expect(body.sessions.length).toBe(3);
+    for (const s of body.sessions) {
+      expect(s.preview.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("GET /parental/children/:childId/alerts", () => {
+  it("retorna array (possivelmente vazio) de alertas", async () => {
+    const res = await inject("GET", "/parental/children/kei-ochiai/alerts");
+    expect(res.status).toBe(200);
+    const body = res.body as { alerts: unknown[] };
+    expect(Array.isArray(body.alerts)).toBe(true);
+  });
+});
+
+describe("GET /parental/children/:childId/pulso-events", () => {
+  it("retorna eventos com cultural context", async () => {
+    const res = await inject(
+      "GET",
+      "/parental/children/ryo-ochiai/pulso-events",
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      events: Array<{ type: string; culturalContext: string }>;
+    };
+    expect(body.events.length).toBeGreaterThan(0);
+    expect(body.events[0]!.culturalContext.length).toBeGreaterThan(0);
+  });
+
+  it("filtra por type", async () => {
+    const res = await inject(
+      "GET",
+      "/parental/children/ryo-ochiai/pulso-events?type=omikuji",
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { events: Array<{ type: string }> };
+    for (const e of body.events) {
+      expect(e.type).toBe("omikuji");
+    }
+  });
+});
+
+describe("GET /parental/escalation/pending-questions", () => {
+  it("retorna lista de perguntas pendentes", async () => {
+    const res = await inject("GET", "/parental/escalation/pending-questions");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      questions: Array<{ questionId: string; rawQuestion: string }>;
+    };
+    expect(body.questions.length).toBeGreaterThan(0);
+  });
+});
+
+describe("POST /parental/escalation/pending-questions/:id/answer", () => {
+  it("aceita answerText e marca answered", async () => {
+    const res = await inject(
+      "POST",
+      "/parental/escalation/pending-questions/pq-001/answer",
+      { answerText: "O céu fica vermelho por causa da luz do pôr-do-sol." },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { status: string; scheduledForNextSession: boolean };
+    expect(body.status).toBe("answered");
+    expect(body.scheduledForNextSession).toBe(true);
+  });
+
+  it("rejeita body vazio com 400", async () => {
+    const res = await inject(
+      "POST",
+      "/parental/escalation/pending-questions/pq-001/answer",
+      {},
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /parental/escalation/report", () => {
+  it("cria report e notifica Jun", async () => {
+    const res = await inject("POST", "/parental/escalation/report", {
+      childId: "ryo-ochiai",
+      type: "tom",
+      text: "Brota falou de um jeito que o Ryo achou meio chato.",
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      reportId: string;
+      status: string;
+      notifiedJun: boolean;
+    };
+    expect(body.reportId.startsWith("rep-")).toBe(true);
+    expect(body.status).toBe("open");
+    expect(body.notifiedJun).toBe(true);
+  });
+
+  it("rejeita texto >500 chars", async () => {
+    const res = await inject("POST", "/parental/escalation/report", {
+      childId: "ryo-ochiai",
+      type: "tom",
+      text: "x".repeat(501),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejeita sem childId", async () => {
+    const res = await inject("POST", "/parental/escalation/report", {
+      type: "tom",
+      text: "abc",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /parental/children/:childId/pause", () => {
+  it("pausa imediato com razão", async () => {
+    const res = await inject("POST", "/parental/children/saki-ochiai/pause", {
+      reason: "criança cansada",
+      immediate: true,
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { paused: boolean; immediate: boolean };
+    expect(body.paused).toBe(true);
+    expect(body.immediate).toBe(true);
+  });
+
+  it("notifica Jun quando pausa >24h", async () => {
+    const futureIso = new Date(
+      Date.now() + 48 * 3600_000,
+    ).toISOString();
+    const res = await inject("POST", "/parental/children/saki-ochiai/pause", {
+      reason: "viagem",
+      pauseUntilIso: futureIso,
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { notifiedJun: boolean };
+    expect(body.notifiedJun).toBe(true);
+  });
+
+  it("rejeita sem reason", async () => {
+    const res = await inject("POST", "/parental/children/saki-ochiai/pause", {});
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -24,6 +24,7 @@
   import B1SocialPanel from "./components/subsystem-panels/B1SocialPanel.svelte";
   import B2DrillingPanel from "./components/subsystem-panels/B2DrillingPanel.svelte";
   import ParentalOnboardingWizard from "./components/ParentalOnboardingWizard.svelte";
+  import ParentalEngagedDashboard from "./components/parental/ParentalEngagedDashboard.svelte";
   import { createApiClient } from "./lib/api.js";
   import {
     bffStatus,
@@ -50,6 +51,9 @@
   // US-PO-01..11 — quando ?onboarding=true na URL, mostra o wizard parental
   // em vez do console operador. Default false.
   let onboardingMode = false;
+  // US-PE-01..09 — quando ?parental=engaged na URL, mostra o engaged dashboard
+  // ("dia dos meus filhos"). Convive com onboarding mode mas exclusivo.
+  let parentalRole: "engaged" | null = null;
 
   async function refreshStatus(): Promise<void> {
     try {
@@ -100,6 +104,10 @@
       onboardingMode = true;
       return;
     }
+    if (params.get("parental") === "engaged") {
+      parentalRole = "engaged";
+      return;
+    }
     if (r !== null) {
       replaySessionId.set(r);
       libraryOpen.set(false);
@@ -110,7 +118,7 @@
 
   onMount(() => {
     applyUrlParams();
-    if (onboardingMode) return;
+    if (onboardingMode || parentalRole !== null) return;
     void refreshStatus();
     void checkActiveSessions();
     pollTimer = setInterval(() => {
@@ -137,6 +145,13 @@
     </header>
     <main class="onboarding-main">
       <ParentalOnboardingWizard />
+    </main>
+  {:else if parentalRole === "engaged"}
+    <header class="status-bar simple">
+      <h1>eBrota Console — Parental Engaged</h1>
+    </header>
+    <main class="onboarding-main" data-testid="parental-engaged-main">
+      <ParentalEngagedDashboard />
     </main>
   {:else}
     <Status {api} />

--- a/packages/ebrota-console-ui/src/components/parental/AlertBanner.svelte
+++ b/packages/ebrota-console-ui/src/components/parental/AlertBanner.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import type { ParentalAlert } from "./parental-types.js";
+
+  export let alert: ParentalAlert;
+  export let onPause: () => void;
+  export let onContactJun: () => void;
+  export let onDismiss: () => void;
+
+  function severityLabel(s: ParentalAlert["severity"]): string {
+    if (s === "critical") return "CRÍTICO";
+    if (s === "warn") return "ATENÇÃO";
+    return "INFO";
+  }
+
+  function typeLabel(t: ParentalAlert["type"]): string {
+    if (t === "distress") return "Distress detectado";
+    if (t === "drift") return "Drift de objetivo";
+    if (t === "negative_sequence") return "Sequência negativa";
+    return "Outro";
+  }
+</script>
+
+<div
+  class="banner severity-{alert.severity}"
+  data-testid="alert-banner"
+  data-alert-id={alert.alertId}
+  role="alert"
+>
+  <div class="head">
+    <span class="badge">{severityLabel(alert.severity)}</span>
+    <strong>{typeLabel(alert.type)}</strong>
+  </div>
+  <p class="context">{alert.context}</p>
+  <blockquote class="excerpt">"{alert.excerpt}"</blockquote>
+  {#if alert.sessionRefs.length > 0}
+    <p class="refs">
+      <span class="muted small">Sessões:</span>
+      {alert.sessionRefs.join(", ")}
+    </p>
+  {/if}
+  <div class="actions">
+    {#if alert.proposedAction === "pause_brota"}
+      <button class="primary" on:click={onPause}>Pausar Brota agora</button>
+    {/if}
+    <button class="ghost" on:click={onContactJun}>Contatar Jun</button>
+    <button class="ghost" on:click={onDismiss}>Dispensar</button>
+  </div>
+</div>
+
+<style>
+  .banner {
+    border-radius: 10px;
+    padding: 1rem 1.1rem;
+    margin: 0.5rem 0;
+    border-left: 4px solid currentColor;
+    background: rgba(255, 255, 255, 0.04);
+  }
+  .banner.severity-critical {
+    color: #e57373;
+    background: rgba(229, 115, 115, 0.08);
+  }
+  .banner.severity-warn {
+    color: #ffb74d;
+    background: rgba(255, 183, 77, 0.08);
+  }
+  .banner.severity-info {
+    color: #64b5f6;
+    background: rgba(100, 181, 246, 0.08);
+  }
+  .head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.3rem;
+  }
+  .badge {
+    font-size: 0.7rem;
+    background: currentColor;
+    color: var(--color-bg, #1f1f1f);
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .context {
+    color: inherit;
+    margin: 0.2rem 0;
+    font-size: 0.9rem;
+  }
+  .excerpt {
+    margin: 0.4rem 0;
+    padding: 0.4rem 0.7rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-left: 2px solid rgba(127, 127, 127, 0.4);
+    font-size: 0.85rem;
+    font-style: italic;
+    color: var(--color-fg, inherit);
+  }
+  .refs {
+    margin: 0.3rem 0;
+    font-size: 0.85rem;
+    color: var(--color-fg, inherit);
+  }
+  .muted {
+    opacity: 0.7;
+  }
+  .small {
+    font-size: 0.8rem;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+  }
+  button {
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-family: inherit;
+  }
+  .primary {
+    background: currentColor;
+    color: var(--color-bg, #1f1f1f);
+    border-color: currentColor;
+    font-weight: 600;
+  }
+  .ghost {
+    background: transparent;
+    color: var(--color-fg, inherit);
+    border-color: rgba(127, 127, 127, 0.4);
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/parental/KidSummaryCard.svelte
+++ b/packages/ebrota-console-ui/src/components/parental/KidSummaryCard.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import type { KidSummary } from "./parental-types.js";
+
+  export let kid: KidSummary;
+  export let active: boolean = false;
+  export let onClick: (() => void) | undefined = undefined;
+
+  function initials(name: string): string {
+    return name.slice(0, 1).toUpperCase();
+  }
+
+  function formatLastSeen(iso: string | null): string {
+    if (!iso) return "—";
+    const ms = Date.now() - Date.parse(iso);
+    const h = Math.floor(ms / 3600_000);
+    if (h < 1) return "agora há pouco";
+    if (h < 24) return `há ${h}h`;
+    const d = Math.floor(h / 24);
+    return `há ${d}d`;
+  }
+
+  function moodColor(mood: number | null): string {
+    if (mood === null) return "rgba(127,127,127,0.4)";
+    if (mood >= 7) return "#4caf50";
+    if (mood >= 5) return "#ffb74d";
+    return "#e57373";
+  }
+</script>
+
+<button
+  class="card"
+  class:active
+  data-testid="kid-summary-card"
+  data-child-id={kid.childId}
+  on:click={onClick}
+>
+  <div class="avatar" style="background: {kid.avatarColor};">
+    {initials(kid.name)}
+  </div>
+  <div class="body">
+    <div class="row top">
+      <span class="name">{kid.name}</span>
+      <span class="age">{kid.age} anos</span>
+    </div>
+    <div class="row status">
+      {#if kid.engagedToday}
+        <span class="dot" style="background:{moodColor(kid.moodToday)}"></span>
+        <span class="status-text"
+          >engajou hoje{kid.moodToday !== null ? ` (mood ${kid.moodToday})` : ""}</span
+        >
+      {:else}
+        <span class="dot off"></span>
+        <span class="status-text muted">não interagiu</span>
+      {/if}
+    </div>
+    <p class="summary">{kid.oneLineSummary}</p>
+    <div class="row last">
+      <span class="muted small">Last seen: {formatLastSeen(kid.lastSeenAt)}</span>
+    </div>
+  </div>
+</button>
+
+<style>
+  .card {
+    display: flex;
+    gap: 0.85rem;
+    width: 100%;
+    align-items: stretch;
+    padding: 0.9rem 1rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-radius: 10px;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  .card:hover {
+    background: rgba(255, 255, 255, 0.07);
+    border-color: rgba(127, 127, 127, 0.5);
+  }
+  .card.active {
+    border-color: var(--accent, #5b8def);
+    background: rgba(91, 141, 239, 0.08);
+  }
+  .avatar {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    font-size: 1.4rem;
+    flex-shrink: 0;
+  }
+  .body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .top {
+    justify-content: space-between;
+  }
+  .name {
+    font-weight: 600;
+    font-size: 1.05rem;
+  }
+  .age {
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+  .dot.off {
+    background: rgba(127, 127, 127, 0.4);
+  }
+  .status-text {
+    font-size: 0.85rem;
+  }
+  .summary {
+    margin: 0.2rem 0 0;
+    font-size: 0.85rem;
+    opacity: 0.85;
+    line-height: 1.35;
+  }
+  .muted {
+    opacity: 0.7;
+  }
+  .small {
+    font-size: 0.75rem;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/parental/ParentalEngagedDashboard.svelte
+++ b/packages/ebrota-console-ui/src/components/parental/ParentalEngagedDashboard.svelte
@@ -1,0 +1,982 @@
+<script lang="ts">
+  import KidSummaryCard from "./KidSummaryCard.svelte";
+  import PendingQuestionModal from "./PendingQuestionModal.svelte";
+  import AlertBanner from "./AlertBanner.svelte";
+  import ProblemReportForm from "./ProblemReportForm.svelte";
+  import type {
+    DashboardResponse,
+    KidSummary,
+    TodaySummary,
+    WeekProgress,
+    PhysicalCard,
+    ConversationSession,
+    ParentalAlert,
+    PulsoEvent,
+    PendingQuestion,
+  } from "./parental-types.js";
+
+  export let baseUrl: string = "/api";
+  export let acquirerId: string = "yuji-ochiai";
+  /** Fetch impl injetável pra testes — default globalThis.fetch. */
+  export let fetchImpl: typeof globalThis.fetch | undefined = undefined;
+
+  type Tab = "hoje" | "semana" | "cards" | "conversas" | "alertas" | "pulso";
+
+  function getFetch(): typeof globalThis.fetch {
+    if (fetchImpl) return fetchImpl;
+    return globalThis.fetch.bind(globalThis);
+  }
+
+  let dashboard: DashboardResponse | null = null;
+  let loadingDashboard = true;
+  let dashboardError: string | null = null;
+
+  let selectedChildId: string | null = null;
+  let activeTab: Tab = "hoje";
+
+  let today: TodaySummary | null = null;
+  let week: WeekProgress | null = null;
+  let cards: PhysicalCard[] = [];
+  let conversations: ConversationSession[] = [];
+  let alerts: ParentalAlert[] = [];
+  let pulsoEvents: PulsoEvent[] = [];
+  let tabLoading = false;
+  let tabError: string | null = null;
+
+  let pendingQuestions: PendingQuestion[] = [];
+  let activeQuestion: PendingQuestion | null = null;
+  let showReportForm = false;
+  let showPauseConfirm = false;
+  let pauseReason = "";
+  let pauseSubmitting = false;
+  let pauseFeedback: string | null = null;
+
+  async function loadDashboard(): Promise<void> {
+    loadingDashboard = true;
+    dashboardError = null;
+    try {
+      const f = getFetch();
+      const res = await f(
+        `${baseUrl}/parental/dashboard/${encodeURIComponent(acquirerId)}`,
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      dashboard = (await res.json()) as DashboardResponse;
+      if (selectedChildId === null && dashboard.children.length > 0) {
+        selectedChildId = dashboard.children[0]!.childId;
+        void loadTab(activeTab);
+      }
+      void loadPendingQuestions();
+    } catch (err) {
+      dashboardError = err instanceof Error ? err.message : String(err);
+    } finally {
+      loadingDashboard = false;
+    }
+  }
+
+  async function loadPendingQuestions(): Promise<void> {
+    try {
+      const f = getFetch();
+      const res = await f(`${baseUrl}/parental/escalation/pending-questions`);
+      if (!res.ok) return;
+      const data = (await res.json()) as { questions: PendingQuestion[] };
+      pendingQuestions = data.questions;
+    } catch {
+      // best-effort
+    }
+  }
+
+  async function loadTab(tab: Tab): Promise<void> {
+    if (selectedChildId === null) return;
+    tabLoading = true;
+    tabError = null;
+    try {
+      const f = getFetch();
+      const cid = encodeURIComponent(selectedChildId);
+      if (tab === "hoje") {
+        const res = await f(`${baseUrl}/parental/children/${cid}/today`);
+        today = (await res.json()) as TodaySummary;
+      } else if (tab === "semana") {
+        const res = await f(`${baseUrl}/parental/children/${cid}/week`);
+        week = (await res.json()) as WeekProgress;
+      } else if (tab === "cards") {
+        const res = await f(`${baseUrl}/parental/children/${cid}/cards`);
+        const data = (await res.json()) as { cards: PhysicalCard[] };
+        cards = data.cards;
+      } else if (tab === "conversas") {
+        const res = await f(
+          `${baseUrl}/parental/children/${cid}/conversations`,
+        );
+        const data = (await res.json()) as { sessions: ConversationSession[] };
+        conversations = data.sessions;
+      } else if (tab === "alertas") {
+        const res = await f(`${baseUrl}/parental/children/${cid}/alerts`);
+        const data = (await res.json()) as { alerts: ParentalAlert[] };
+        alerts = data.alerts;
+      } else if (tab === "pulso") {
+        const res = await f(
+          `${baseUrl}/parental/children/${cid}/pulso-events`,
+        );
+        const data = (await res.json()) as { events: PulsoEvent[] };
+        pulsoEvents = data.events;
+      }
+    } catch (err) {
+      tabError = err instanceof Error ? err.message : String(err);
+    } finally {
+      tabLoading = false;
+    }
+  }
+
+  function selectKid(childId: string): void {
+    selectedChildId = childId;
+    void loadTab(activeTab);
+  }
+
+  function switchTab(tab: Tab): void {
+    activeTab = tab;
+    void loadTab(tab);
+  }
+
+  function openQuestion(q: PendingQuestion): void {
+    activeQuestion = q;
+  }
+
+  async function submitAnswer(payload: {
+    answerText?: string;
+    instructionToBrota?: string;
+  }): Promise<void> {
+    if (activeQuestion === null) return;
+    const f = getFetch();
+    const res = await f(
+      `${baseUrl}/parental/escalation/pending-questions/${encodeURIComponent(
+        activeQuestion.questionId,
+      )}/answer`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      },
+    );
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    pendingQuestions = pendingQuestions.filter(
+      (q) => q.questionId !== activeQuestion?.questionId,
+    );
+  }
+
+  async function submitReport(payload: {
+    childId: string;
+    type: "tom" | "repeticao" | "off-topic" | "outro";
+    text: string;
+    sessionRef?: string;
+  }): Promise<void> {
+    const f = getFetch();
+    const res = await f(`${baseUrl}/parental/escalation/report`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  }
+
+  async function confirmPause(): Promise<void> {
+    if (selectedChildId === null || pauseReason.trim().length === 0) return;
+    pauseSubmitting = true;
+    pauseFeedback = null;
+    try {
+      const f = getFetch();
+      const res = await f(
+        `${baseUrl}/parental/children/${encodeURIComponent(
+          selectedChildId,
+        )}/pause`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            reason: pauseReason.trim(),
+            immediate: true,
+          }),
+        },
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      pauseFeedback = "Brota pausado.";
+      pauseReason = "";
+      setTimeout(() => {
+        showPauseConfirm = false;
+        pauseFeedback = null;
+      }, 1500);
+    } catch (err) {
+      pauseFeedback = err instanceof Error ? err.message : String(err);
+    } finally {
+      pauseSubmitting = false;
+    }
+  }
+
+  $: selectedKid =
+    dashboard?.children.find((c: KidSummary) => c.childId === selectedChildId) ??
+    null;
+
+  // Trigger inicial — usa reactive guard em vez de onMount pra
+  // funcionar tanto em prod (browser) quanto em jsdom/test runner. O
+  // guard `bootstrapped` evita refetch quando acquirerId não muda.
+  let bootstrapped = false;
+  $: if (!bootstrapped && acquirerId) {
+    bootstrapped = true;
+    void loadDashboard();
+  }
+</script>
+
+<div class="dashboard" data-testid="parental-engaged-dashboard">
+  <header class="topbar">
+    <div class="greeting">
+      <h1>Olá, {dashboard?.acquirerName ?? "..."}</h1>
+      <span class="role-badge" title="Parental Engaged">PE</span>
+    </div>
+    <div class="topbar-actions">
+      {#if pendingQuestions.length > 0}
+        <button
+          class="action with-badge"
+          on:click={() => openQuestion(pendingQuestions[0])}
+          data-testid="open-pending-questions"
+        >
+          Pergunta pendente
+          <span class="badge">{pendingQuestions.length}</span>
+        </button>
+      {/if}
+      {#if selectedKid !== null}
+        <button
+          class="action"
+          on:click={() => (showReportForm = true)}
+          data-testid="open-report"
+        >
+          Reportar problema
+        </button>
+        <button
+          class="action danger"
+          on:click={() => (showPauseConfirm = true)}
+          data-testid="open-pause"
+        >
+          Pausar Brota
+        </button>
+      {/if}
+    </div>
+  </header>
+
+  {#if dashboardError !== null}
+    <p class="error-banner">Erro ao carregar: {dashboardError}</p>
+  {/if}
+
+  {#if loadingDashboard}
+    <p class="muted center">Carregando "dia dos meus filhos"...</p>
+  {:else if dashboard !== null}
+    <section class="kid-grid" data-testid="kid-grid">
+      {#each dashboard.children as kid (kid.childId)}
+        <KidSummaryCard
+          {kid}
+          active={kid.childId === selectedChildId}
+          onClick={() => selectKid(kid.childId)}
+        />
+      {/each}
+    </section>
+
+    {#if selectedKid !== null}
+      <section class="detail" data-testid="kid-detail">
+        <nav class="tabs" data-testid="kid-tabs">
+          <button
+            class:active={activeTab === "hoje"}
+            on:click={() => switchTab("hoje")}
+            data-testid="tab-hoje">Hoje</button
+          >
+          <button
+            class:active={activeTab === "semana"}
+            on:click={() => switchTab("semana")}
+            data-testid="tab-semana">Semana</button
+          >
+          <button
+            class:active={activeTab === "cards"}
+            on:click={() => switchTab("cards")}
+            data-testid="tab-cards">Cards</button
+          >
+          <button
+            class:active={activeTab === "conversas"}
+            on:click={() => switchTab("conversas")}
+            data-testid="tab-conversas">Conversas</button
+          >
+          <button
+            class:active={activeTab === "alertas"}
+            on:click={() => switchTab("alertas")}
+            data-testid="tab-alertas">Alertas</button
+          >
+          <button
+            class:active={activeTab === "pulso"}
+            on:click={() => switchTab("pulso")}
+            data-testid="tab-pulso">Pulso</button
+          >
+        </nav>
+
+        <div class="tab-content">
+          {#if tabError !== null}
+            <p class="error">Erro: {tabError}</p>
+          {/if}
+          {#if tabLoading}
+            <p class="muted">Carregando...</p>
+          {:else if activeTab === "hoje" && today !== null}
+            <div class="block">
+              <h3>Hoje — {selectedKid.name}</h3>
+              {#if today.engaged}
+                <ul class="kv">
+                  <li><span>Mood médio:</span> {today.moodAverage ?? "—"}</li>
+                  <li>
+                    <span>Duração:</span>
+                    {today.durationMinutes} min
+                  </li>
+                  <li>
+                    <span>Cards emitidos:</span>
+                    {today.cardsEmittedToday}
+                  </li>
+                  <li>
+                    <span>Temas:</span>
+                    {today.topicsDiscussed.join(", ") || "—"}
+                  </li>
+                </ul>
+                {#if today.lastMessagePreview !== null}
+                  <p class="preview">
+                    <strong>Última mensagem:</strong>
+                    {today.lastMessagePreview}
+                  </p>
+                {/if}
+              {:else}
+                <p class="muted">
+                  {selectedKid.name} ainda não interagiu hoje. Não tem problema —
+                  Brota envia mensagem nas janelas configuradas.
+                </p>
+              {/if}
+              {#if today.developmentStub}
+                <p class="dev-stub-note">
+                  Dados de demonstração — view será preenchida quando S5 expor agregado real.
+                </p>
+              {/if}
+            </div>
+          {:else if activeTab === "semana" && week !== null}
+            <div class="block">
+              <h3>Semana — {selectedKid.name}</h3>
+              <div class="mood-line">
+                {#each week.moodTimeline as day}
+                  <div
+                    class="mood-cell"
+                    title={`${day.date}: ${day.mood ?? "sem dado"}`}
+                  >
+                    <div
+                      class="bar"
+                      style={day.mood !== null
+                        ? `height:${day.mood * 10}%;`
+                        : "height:0;"}
+                    ></div>
+                    <span class="mood-date">{day.date.slice(8)}</span>
+                  </div>
+                {/each}
+              </div>
+              <ul class="kv">
+                <li><span>Mood médio:</span> {week.moodAverage ?? "—"}</li>
+                <li>
+                  <span>Cards emitidos:</span>
+                  {week.cardsCount}
+                </li>
+                <li>
+                  <span>Budget usado:</span>
+                  {week.sacrificeBudgetUsed}/{week.sacrificeBudgetTotal}
+                </li>
+                <li>
+                  <span>Ratio off-screen:</span>
+                  {week.offScreenRatio}
+                </li>
+                <li>
+                  <span>Top temas:</span>
+                  {week.topThemes.join(", ")}
+                </li>
+              </ul>
+              <p class="qualitative">{week.qualitativeSummary}</p>
+              {#if week.developmentStub}
+                <p class="dev-stub-note">
+                  Dados de demonstração — view será preenchida quando S5 expor agregado real.
+                </p>
+              {/if}
+            </div>
+          {:else if activeTab === "cards"}
+            <div class="block">
+              <h3>Cards físicos — {selectedKid.name}</h3>
+              {#if cards.length === 0}
+                <p class="muted">Sem cards emitidos.</p>
+              {:else}
+                <ul class="card-grid">
+                  {#each cards as c (c.cardId)}
+                    <li class="phys-card rarity-{c.rarity}">
+                      <div class="card-head">
+                        <strong>{c.title}</strong>
+                        <span class="rarity">{c.rarity}</span>
+                      </div>
+                      <div class="card-body">
+                        <p class="cheat">
+                          Cheat code: <code>{c.cheatCode}</code>
+                        </p>
+                        <p class="qr muted small">QR: {c.qrCodePayload}</p>
+                      </div>
+                      <div class="card-actions">
+                        <a href={c.pdfUrl} target="_blank" rel="noopener"
+                          >Imprimir PDF</a
+                        >
+                        {#if c.used}
+                          <span class="used-badge">usado</span>
+                        {/if}
+                      </div>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </div>
+          {:else if activeTab === "conversas"}
+            <div class="block">
+              <h3>Conversas recentes — {selectedKid.name}</h3>
+              <p class="muted small">
+                View parental — somente leitura, sem painéis técnicos.
+              </p>
+              {#if conversations.length === 0}
+                <p class="muted">Sem sessões.</p>
+              {:else}
+                <ul class="sessions">
+                  {#each conversations as s (s.sessionId)}
+                    <li class="session">
+                      <div class="session-head">
+                        <strong>{s.topicSummary}</strong>
+                        <span class="muted small"
+                          >{s.durationMinutes} min · {s.turnCount} turnos</span
+                        >
+                      </div>
+                      <ol class="msgs">
+                        {#each s.preview as m}
+                          <li class="msg from-{m.from}">
+                            <span class="who"
+                              >{m.from === "kid" ? selectedKid.name : "Brota"}:</span
+                            >
+                            <span>{m.text}</span>
+                          </li>
+                        {/each}
+                      </ol>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </div>
+          {:else if activeTab === "alertas"}
+            <div class="block">
+              <h3>Alertas — {selectedKid.name}</h3>
+              {#if alerts.length === 0}
+                <p class="muted">
+                  Sem alertas ativos. Brota monitora distress/drift continuamente.
+                </p>
+              {:else}
+                {#each alerts as a (a.alertId)}
+                  <AlertBanner
+                    alert={a}
+                    onPause={() => (showPauseConfirm = true)}
+                    onContactJun={() => alert("Contato Jun: stub V0")}
+                    onDismiss={() =>
+                      (alerts = alerts.filter((x) => x.alertId !== a.alertId))}
+                  />
+                {/each}
+              {/if}
+            </div>
+          {:else if activeTab === "pulso"}
+            <div class="block">
+              <h3>Pulso events — {selectedKid.name}</h3>
+              {#if pulsoEvents.length === 0}
+                <p class="muted">Sem eventos no período.</p>
+              {:else}
+                <ul class="pulso-list">
+                  {#each pulsoEvents as e (e.eventId)}
+                    <li class="pulso-item">
+                      <div class="pulso-head">
+                        <strong>{e.type.replace("_", " ")}</strong>
+                        <span class="muted small">{e.windowLabel}</span>
+                      </div>
+                      <p class="preview">{e.payloadPreview}</p>
+                      <p class="ctx muted small">{e.culturalContext}</p>
+                      <p class="reaction small">
+                        Reação da criança: <em>{e.kidReaction}</em>
+                      </p>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      </section>
+    {/if}
+  {/if}
+
+  {#if activeQuestion !== null}
+    <PendingQuestionModal
+      question={activeQuestion}
+      onClose={() => (activeQuestion = null)}
+      onSubmit={submitAnswer}
+    />
+  {/if}
+
+  {#if showReportForm && selectedKid !== null}
+    <ProblemReportForm
+      childId={selectedKid.childId}
+      childName={selectedKid.name}
+      onClose={() => (showReportForm = false)}
+      onSubmit={submitReport}
+    />
+  {/if}
+
+  {#if showPauseConfirm && selectedKid !== null}
+    <div
+      class="backdrop"
+      data-testid="pause-confirm"
+      on:click={() => (showPauseConfirm = false)}
+      on:keydown={(e) => e.key === "Escape" && (showPauseConfirm = false)}
+      role="presentation"
+    >
+      <div
+        class="modal small"
+        on:click|stopPropagation
+        on:keydown|stopPropagation
+        role="dialog"
+        aria-modal="true"
+      >
+        <h3>Pausar Brota — {selectedKid.name}?</h3>
+        <p class="muted small">
+          Brota não envia mensagens espontâneas até você liberar de novo. Conta
+          rapidinho o motivo (Jun é notificado).
+        </p>
+        <textarea
+          bind:value={pauseReason}
+          rows="3"
+          placeholder="Ex: viagem, criança cansada, querendo testar 1 semana sem..."
+          data-testid="pause-reason"
+        ></textarea>
+        {#if pauseFeedback !== null}
+          <p class="success">{pauseFeedback}</p>
+        {/if}
+        <footer>
+          <button
+            class="ghost"
+            on:click={() => (showPauseConfirm = false)}
+            disabled={pauseSubmitting}>Cancelar</button
+          >
+          <button
+            class="danger"
+            on:click={confirmPause}
+            disabled={pauseSubmitting || pauseReason.trim().length === 0}
+            data-testid="confirm-pause"
+          >
+            {pauseSubmitting ? "Pausando..." : "Pausar agora"}
+          </button>
+        </footer>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+    padding: 1rem 1.2rem 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+  .greeting {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .greeting h1 {
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 500;
+  }
+  .role-badge {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    padding: 0.2rem 0.5rem;
+    border-radius: 3px;
+    background: rgba(127, 127, 127, 0.2);
+    opacity: 0.85;
+  }
+  .topbar-actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .action {
+    padding: 0.45rem 0.8rem;
+    border-radius: 6px;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-family: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .action:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+  .action.danger {
+    border-color: rgba(229, 115, 115, 0.6);
+    color: #e57373;
+  }
+  .with-badge .badge {
+    background: var(--accent, #5b8def);
+    color: white;
+    border-radius: 10px;
+    padding: 0.05rem 0.4rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+  .error-banner {
+    color: #e57373;
+    background: rgba(229, 115, 115, 0.1);
+    padding: 0.4rem 0.7rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+  }
+  .center {
+    text-align: center;
+  }
+  .muted {
+    opacity: 0.7;
+  }
+  .small {
+    font-size: 0.8rem;
+  }
+  .kid-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 0.7rem;
+  }
+  .detail {
+    border-top: 1px solid rgba(127, 127, 127, 0.25);
+    padding-top: 1rem;
+  }
+  .tabs {
+    display: flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.9rem;
+  }
+  .tabs button {
+    padding: 0.4rem 0.85rem;
+    border-radius: 6px 6px 0 0;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-bottom: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-family: inherit;
+  }
+  .tabs button.active {
+    background: rgba(91, 141, 239, 0.12);
+    border-color: var(--accent, #5b8def);
+    font-weight: 600;
+  }
+  .tab-content {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-radius: 0 6px 6px 6px;
+    padding: 1rem;
+  }
+  .block h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+  }
+  .kv {
+    list-style: none;
+    padding: 0;
+    margin: 0.5rem 0;
+  }
+  .kv li {
+    padding: 0.2rem 0;
+    font-size: 0.9rem;
+  }
+  .kv li span {
+    display: inline-block;
+    min-width: 140px;
+    opacity: 0.7;
+  }
+  .preview {
+    font-style: italic;
+    padding: 0.4rem 0.6rem;
+    background: rgba(127, 127, 127, 0.08);
+    border-left: 2px solid rgba(91, 141, 239, 0.6);
+    border-radius: 0 4px 4px 0;
+    margin: 0.5rem 0;
+  }
+  .qualitative {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    padding: 0.6rem;
+    background: rgba(91, 141, 239, 0.06);
+    border-radius: 6px;
+    margin-top: 0.6rem;
+  }
+  .dev-stub-note {
+    margin-top: 0.6rem;
+    font-size: 0.75rem;
+    opacity: 0.55;
+    font-style: italic;
+  }
+  .mood-line {
+    display: flex;
+    gap: 4px;
+    height: 80px;
+    align-items: end;
+    margin: 0.5rem 0 1rem;
+  }
+  .mood-cell {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+    justify-content: end;
+  }
+  .mood-cell .bar {
+    width: 100%;
+    background: linear-gradient(180deg, #5b8def, #4caf50);
+    border-radius: 3px 3px 0 0;
+    min-height: 3px;
+  }
+  .mood-cell .mood-date {
+    font-size: 0.65rem;
+    opacity: 0.6;
+    margin-top: 3px;
+  }
+  .card-grid {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.6rem;
+  }
+  .phys-card {
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-radius: 8px;
+    padding: 0.7rem;
+    background: rgba(255, 255, 255, 0.04);
+  }
+  .phys-card.rarity-rare {
+    border-color: #5b8def;
+  }
+  .phys-card.rarity-epic {
+    border-color: #a87ddf;
+  }
+  .phys-card.rarity-legendary {
+    border-color: #f2a65a;
+  }
+  .card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.3rem;
+  }
+  .rarity {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    opacity: 0.7;
+    letter-spacing: 0.06em;
+  }
+  .card-body {
+    font-size: 0.85rem;
+  }
+  .cheat code {
+    background: rgba(127, 127, 127, 0.15);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-family: ui-monospace, monospace;
+  }
+  .qr {
+    word-break: break-all;
+  }
+  .card-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 0.4rem;
+    font-size: 0.85rem;
+  }
+  .used-badge {
+    font-size: 0.7rem;
+    background: rgba(127, 127, 127, 0.2);
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+  }
+  .sessions {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .session {
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-radius: 8px;
+    padding: 0.6rem 0.8rem;
+    background: rgba(255, 255, 255, 0.03);
+  }
+  .session-head {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.3rem;
+    align-items: baseline;
+  }
+  .msgs {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .msg {
+    font-size: 0.88rem;
+    padding: 0.2rem 0;
+  }
+  .msg .who {
+    font-weight: 600;
+    margin-right: 0.3rem;
+    opacity: 0.85;
+  }
+  .pulso-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .pulso-item {
+    border-left: 3px solid #a87ddf;
+    padding: 0.4rem 0.7rem;
+    background: rgba(168, 125, 223, 0.06);
+    border-radius: 0 6px 6px 0;
+  }
+  .pulso-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    text-transform: capitalize;
+  }
+  .pulso-item .preview {
+    margin: 0.3rem 0;
+    background: transparent;
+    border-left: none;
+    padding: 0;
+    font-style: normal;
+    font-size: 0.9rem;
+  }
+  .ctx {
+    margin: 0.3rem 0;
+  }
+  .reaction em {
+    color: var(--accent, #5b8def);
+    font-style: normal;
+  }
+  .error {
+    color: #e57373;
+    font-size: 0.85rem;
+  }
+  .success {
+    color: #81c784;
+    font-size: 0.85rem;
+    margin: 0.4rem 0 0;
+  }
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+  }
+  .modal {
+    background: var(--color-bg, #1f1f1f);
+    border-radius: 12px;
+    width: 100%;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    padding: 1.5rem;
+  }
+  .modal.small {
+    max-width: 420px;
+  }
+  .modal textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.6rem;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.04);
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.95rem;
+    resize: vertical;
+    margin-top: 0.5rem;
+  }
+  footer {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+  footer button {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-family: inherit;
+  }
+  footer button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  footer .ghost {
+    background: transparent;
+    border-color: rgba(127, 127, 127, 0.4);
+    color: inherit;
+  }
+  footer .danger {
+    background: #e57373;
+    color: white;
+  }
+  @media (max-width: 640px) {
+    .greeting h1 {
+      font-size: 1.2rem;
+    }
+    .topbar {
+      align-items: flex-start;
+    }
+    .kid-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/parental/PendingQuestionModal.svelte
+++ b/packages/ebrota-console-ui/src/components/parental/PendingQuestionModal.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+  import type { PendingQuestion } from "./parental-types.js";
+
+  export let question: PendingQuestion | null;
+  export let onClose: () => void;
+  export let onSubmit: (payload: {
+    answerText?: string;
+    instructionToBrota?: string;
+  }) => Promise<void>;
+
+  let mode: "answer" | "instruct" = "answer";
+  let answerText = "";
+  let instructionToBrota = "";
+  let submitting = false;
+  let errorMsg: string | null = null;
+
+  async function handleSubmit(): Promise<void> {
+    errorMsg = null;
+    const payload =
+      mode === "answer"
+        ? { answerText: answerText.trim() }
+        : { instructionToBrota: instructionToBrota.trim() };
+    const value =
+      mode === "answer" ? payload.answerText : payload.instructionToBrota;
+    if (!value || value.length === 0) {
+      errorMsg = "Texto obrigatório";
+      return;
+    }
+    submitting = true;
+    try {
+      await onSubmit(payload);
+      onClose();
+    } catch (err) {
+      errorMsg = err instanceof Error ? err.message : String(err);
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+{#if question !== null}
+  <div
+    class="backdrop"
+    data-testid="pending-question-modal"
+    on:click={onClose}
+    on:keydown={(e) => e.key === "Escape" && onClose()}
+    role="presentation"
+  >
+    <div
+      class="modal"
+      on:click|stopPropagation
+      on:keydown|stopPropagation
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pending-q-title"
+    >
+      <h3 id="pending-q-title">Pergunta encaminhada</h3>
+      <p class="muted small">
+        Brota redirecionou pra você responder. Razão: {question.escalationReason}
+      </p>
+
+      <section class="context">
+        <h4>Contexto da conversa</h4>
+        <ul class="turns">
+          {#each question.brotaContextTurns as turn}
+            <li class="turn {turn.from}">
+              <span class="who">{turn.from === "kid" ? "criança" : "Brota"}:</span>
+              <span class="text">{turn.text}</span>
+            </li>
+          {/each}
+        </ul>
+        <p class="raw">
+          <strong>Pergunta:</strong>
+          <em>"{question.rawQuestion}"</em>
+        </p>
+      </section>
+
+      <div class="mode-toggle">
+        <label>
+          <input
+            type="radio"
+            bind:group={mode}
+            value="answer"
+            data-testid="mode-answer"
+          />
+          Responder direto (Brota repete pra criança)
+        </label>
+        <label>
+          <input
+            type="radio"
+            bind:group={mode}
+            value="instruct"
+            data-testid="mode-instruct"
+          />
+          Instruir Brota (texto + tom desejado)
+        </label>
+      </div>
+
+      {#if mode === "answer"}
+        <textarea
+          bind:value={answerText}
+          rows="4"
+          placeholder="Sua resposta direta..."
+          data-testid="answer-text"
+        ></textarea>
+      {:else}
+        <textarea
+          bind:value={instructionToBrota}
+          rows="4"
+          placeholder="Ex: explica simples, com analogia de tinta diluída, tom curioso..."
+          data-testid="instruction-text"
+        ></textarea>
+      {/if}
+
+      {#if errorMsg !== null}
+        <p class="error">{errorMsg}</p>
+      {/if}
+
+      <footer>
+        <button class="ghost" on:click={onClose} disabled={submitting}>
+          Cancelar
+        </button>
+        <button
+          class="primary"
+          on:click={handleSubmit}
+          disabled={submitting}
+          data-testid="submit-answer"
+        >
+          {submitting ? "Enviando..." : "Enviar"}
+        </button>
+      </footer>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+  }
+  .modal {
+    background: var(--color-bg, #1f1f1f);
+    color: inherit;
+    border-radius: 12px;
+    max-width: 540px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: 1.5rem;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+  }
+  h3 {
+    margin: 0 0 0.3rem;
+  }
+  .muted {
+    opacity: 0.7;
+  }
+  .small {
+    font-size: 0.85rem;
+  }
+  .context {
+    margin: 1rem 0;
+    padding: 0.8rem;
+    background: rgba(127, 127, 127, 0.08);
+    border-radius: 8px;
+  }
+  .context h4 {
+    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.75;
+  }
+  .turns {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.6rem;
+  }
+  .turn {
+    padding: 0.25rem 0;
+    font-size: 0.9rem;
+  }
+  .turn .who {
+    font-weight: 600;
+    margin-right: 0.3rem;
+    opacity: 0.85;
+  }
+  .raw {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+  .mode-toggle {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    margin: 1rem 0 0.5rem;
+    font-size: 0.9rem;
+  }
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.6rem;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.04);
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.95rem;
+    resize: vertical;
+  }
+  .error {
+    color: #e57373;
+    font-size: 0.85rem;
+    margin: 0.4rem 0 0;
+  }
+  footer {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+  button {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-family: inherit;
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .primary {
+    background: var(--accent, #5b8def);
+    color: white;
+  }
+  .ghost {
+    background: transparent;
+    border-color: rgba(127, 127, 127, 0.4);
+    color: inherit;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/parental/ProblemReportForm.svelte
+++ b/packages/ebrota-console-ui/src/components/parental/ProblemReportForm.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  export let childId: string;
+  export let childName: string;
+  export let onClose: () => void;
+  export let onSubmit: (payload: {
+    childId: string;
+    type: "tom" | "repeticao" | "off-topic" | "outro";
+    text: string;
+    sessionRef?: string;
+  }) => Promise<void>;
+
+  let type: "tom" | "repeticao" | "off-topic" | "outro" = "tom";
+  let text = "";
+  let sessionRef = "";
+  let submitting = false;
+  let errorMsg: string | null = null;
+  let successMsg: string | null = null;
+
+  $: charCount = text.length;
+  $: charsOverLimit = charCount > 500;
+
+  async function handleSubmit(): Promise<void> {
+    errorMsg = null;
+    successMsg = null;
+    if (text.trim().length === 0) {
+      errorMsg = "Descreva o problema brevemente";
+      return;
+    }
+    if (charsOverLimit) {
+      errorMsg = "Texto excede 500 caracteres";
+      return;
+    }
+    submitting = true;
+    try {
+      await onSubmit({
+        childId,
+        type,
+        text: text.trim(),
+        ...(sessionRef.trim().length > 0
+          ? { sessionRef: sessionRef.trim() }
+          : {}),
+      });
+      successMsg = "Reportado. Jun foi notificado.";
+      text = "";
+      setTimeout(onClose, 1200);
+    } catch (err) {
+      errorMsg = err instanceof Error ? err.message : String(err);
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div
+  class="backdrop"
+  data-testid="problem-report-form"
+  on:click={onClose}
+  on:keydown={(e) => e.key === "Escape" && onClose()}
+  role="presentation"
+>
+  <div
+    class="modal"
+    on:click|stopPropagation
+    on:keydown|stopPropagation
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="report-title"
+  >
+    <h3 id="report-title">Reportar problema — {childName}</h3>
+    <p class="muted small">
+      Algo no Brota não está legal pra essa criança? Conta brevemente. Jun
+      é notificado e pode ajustar.
+    </p>
+
+    <label>
+      Tipo
+      <select bind:value={type} data-testid="report-type">
+        <option value="tom">Tom (jeito de falar)</option>
+        <option value="repeticao">Repetição (assunto repetido demais)</option>
+        <option value="off-topic">Off-topic (Brota fugiu do assunto)</option>
+        <option value="outro">Outro</option>
+      </select>
+    </label>
+
+    <label>
+      Descrição (até 500 caracteres)
+      <textarea
+        bind:value={text}
+        rows="4"
+        maxlength="600"
+        placeholder="Ex: o Ryo disse que o Brota fala muito formal e ele não gosta."
+        data-testid="report-text"
+      ></textarea>
+      <small class="char-count" class:over={charsOverLimit}>
+        {charCount}/500
+      </small>
+    </label>
+
+    <label>
+      Sessão referência (opcional)
+      <input
+        type="text"
+        bind:value={sessionRef}
+        placeholder="Ex: ryo-ochiai-sess-3"
+        data-testid="report-session"
+      />
+    </label>
+
+    {#if errorMsg !== null}
+      <p class="error">{errorMsg}</p>
+    {/if}
+    {#if successMsg !== null}
+      <p class="success">{successMsg}</p>
+    {/if}
+
+    <footer>
+      <button class="ghost" on:click={onClose} disabled={submitting}>
+        Cancelar
+      </button>
+      <button
+        class="primary"
+        on:click={handleSubmit}
+        disabled={submitting || charsOverLimit}
+        data-testid="submit-report"
+      >
+        {submitting ? "Enviando..." : "Enviar"}
+      </button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+  }
+  .modal {
+    background: var(--color-bg, #1f1f1f);
+    color: inherit;
+    border-radius: 12px;
+    max-width: 480px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: 1.5rem;
+    border: 1px solid rgba(127, 127, 127, 0.3);
+  }
+  h3 {
+    margin: 0 0 0.3rem;
+  }
+  .muted {
+    opacity: 0.7;
+  }
+  .small {
+    font-size: 0.85rem;
+  }
+  label {
+    display: block;
+    margin: 0.8rem 0;
+    font-size: 0.9rem;
+  }
+  select,
+  textarea,
+  input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.5rem;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.04);
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.95rem;
+    margin-top: 0.3rem;
+  }
+  textarea {
+    resize: vertical;
+  }
+  .char-count {
+    display: block;
+    text-align: right;
+    font-size: 0.75rem;
+    opacity: 0.7;
+    margin-top: 0.2rem;
+  }
+  .char-count.over {
+    color: #e57373;
+    opacity: 1;
+  }
+  .error {
+    color: #e57373;
+    font-size: 0.85rem;
+    margin: 0.4rem 0 0;
+  }
+  .success {
+    color: #81c784;
+    font-size: 0.9rem;
+    margin: 0.4rem 0 0;
+  }
+  footer {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+  button {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-family: inherit;
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .primary {
+    background: var(--accent, #5b8def);
+    color: white;
+  }
+  .ghost {
+    background: transparent;
+    border-color: rgba(127, 127, 127, 0.4);
+    color: inherit;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/parental/parental-types.ts
+++ b/packages/ebrota-console-ui/src/components/parental/parental-types.ts
@@ -1,0 +1,116 @@
+/**
+ * Types compartilhados pelos componentes parental engaged.
+ *
+ * Duck-typed contra os shapes do BFF (routes/parental-dashboard-routes.ts).
+ * Mantidos UI-side pra evitar dependência cross-package.
+ */
+
+export interface KidSummary {
+  childId: string;
+  name: string;
+  age: number;
+  primaryLanguage: string;
+  avatarColor: string;
+  engagedToday: boolean;
+  lastSeenAt: string | null;
+  moodToday: number | null;
+  durationMinutesToday: number;
+  oneLineSummary: string;
+  developmentStub?: boolean;
+}
+
+export interface DashboardResponse {
+  acquirerId: string;
+  acquirerName: string;
+  generatedAt: string;
+  pendingQuestionsCount: number;
+  unreadAlertsCount: number;
+  children: KidSummary[];
+}
+
+export interface TodaySummary {
+  childId: string;
+  date: string;
+  engaged: boolean;
+  moodAverage: number | null;
+  durationMinutes: number;
+  topicsDiscussed: string[];
+  lastMessagePreview: string | null;
+  lastSeenAt: string | null;
+  cardsEmittedToday: number;
+  developmentStub?: boolean;
+}
+
+export interface WeekProgress {
+  childId: string;
+  weekStartIso: string;
+  weekEndIso: string;
+  moodTimeline: Array<{ date: string; mood: number | null }>;
+  moodAverage: number | null;
+  cardsCount: number;
+  cardThumbnails: Array<{ cardId: string; title: string; rarity: string }>;
+  sacrificeBudgetTotal: number;
+  sacrificeBudgetUsed: number;
+  offScreenRatio: number;
+  topThemes: string[];
+  qualitativeSummary: string;
+  developmentStub?: boolean;
+}
+
+export interface PhysicalCard {
+  cardId: string;
+  title: string;
+  rarity: "common" | "rare" | "epic" | "legendary";
+  emittedAt: string;
+  thumbnailUrl: string;
+  qrCodePayload: string;
+  cheatCode: string;
+  pdfUrl: string;
+  used: boolean;
+}
+
+export interface ConversationSession {
+  sessionId: string;
+  startedAt: string;
+  endedAt: string | null;
+  turnCount: number;
+  durationMinutes: number;
+  topicSummary: string;
+  preview: Array<{ from: "kid" | "brota"; text: string; at: string }>;
+  developmentStub?: boolean;
+}
+
+export interface ParentalAlert {
+  alertId: string;
+  type: "distress" | "drift" | "negative_sequence" | "other";
+  severity: "info" | "warn" | "critical";
+  raisedAt: string;
+  context: string;
+  excerpt: string;
+  sessionRefs: string[];
+  proposedAction: "pause_brota" | "contact_jun" | "wait" | "review";
+  status: "open" | "ack" | "resolved";
+  developmentStub?: boolean;
+}
+
+export interface PulsoEvent {
+  eventId: string;
+  type: "omikuji" | "mini_historia" | "lembrete_cultural" | "outro";
+  firedAt: string;
+  windowLabel: string;
+  culturalContext: string;
+  payloadPreview: string;
+  kidReaction: "engaged" | "ignored" | "positive" | "negative" | "unknown";
+  developmentStub?: boolean;
+}
+
+export interface PendingQuestion {
+  questionId: string;
+  childId: string;
+  raisedAt: string;
+  brotaContextTurns: Array<{ from: "kid" | "brota"; text: string }>;
+  rawQuestion: string;
+  escalationReason: string;
+  status: "open" | "answered";
+  developmentStub?: boolean;
+}

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -658,6 +658,46 @@ export interface ApiClient {
   listDrillMastered(
     personaId: string,
   ): Promise<{ states: DrillStateLike[] }>;
+
+  // ─── Parental Engaged Dashboard (US-PE-01..09) ──────────────────
+  getParentalDashboard(
+    acquirerId: string,
+  ): Promise<ParentalDashboardLike>;
+  getParentalToday(
+    childId: string,
+  ): Promise<ParentalTodayLike>;
+  getParentalWeek(
+    childId: string,
+  ): Promise<ParentalWeekLike>;
+  getParentalCards(
+    childId: string,
+  ): Promise<{ childId: string; cards: ParentalPhysCardLike[] }>;
+  getParentalConversations(
+    childId: string,
+    limit?: number,
+  ): Promise<{ childId: string; sessions: ParentalConversationLike[] }>;
+  getParentalAlerts(
+    childId: string,
+  ): Promise<{ childId: string; alerts: ParentalAlertLike[] }>;
+  getParentalPulsoEvents(
+    childId: string,
+    opts?: { type?: string; limit?: number },
+  ): Promise<{ childId: string; events: ParentalPulsoEventLike[] }>;
+  listPendingQuestions(): Promise<{ questions: ParentalPendingQuestionLike[] }>;
+  answerPendingQuestion(
+    questionId: string,
+    payload: { answerText?: string; instructionToBrota?: string },
+  ): Promise<{ status: string; scheduledForNextSession: boolean }>;
+  reportProblem(payload: {
+    childId: string;
+    type: "tom" | "repeticao" | "off-topic" | "outro";
+    text: string;
+    sessionRef?: string;
+  }): Promise<{ reportId: string; status: string; notifiedJun: boolean }>;
+  pauseChild(
+    childId: string,
+    payload: { reason: string; pauseUntilIso?: string; immediate?: boolean },
+  ): Promise<{ paused: boolean; immediate: boolean; notifiedJun: boolean }>;
 }
 
 // ─── S1 wiring — Declared Objectives + Narrative Threads + SK summary ──
@@ -701,6 +741,106 @@ export interface SubjectKnowledgeSummary {
   recallPositiveRate: number | null;
   recallTotal: number;
   topConcepts: TopConceptEntry[];
+}
+
+// ─── Parental dashboard duck-types ────────────────────────────────
+export interface ParentalKidSummaryLike {
+  childId: string;
+  name: string;
+  age: number;
+  primaryLanguage: string;
+  avatarColor: string;
+  engagedToday: boolean;
+  lastSeenAt: string | null;
+  moodToday: number | null;
+  durationMinutesToday: number;
+  oneLineSummary: string;
+  developmentStub?: boolean;
+}
+export interface ParentalDashboardLike {
+  acquirerId: string;
+  acquirerName: string;
+  generatedAt: string;
+  pendingQuestionsCount: number;
+  unreadAlertsCount: number;
+  children: ParentalKidSummaryLike[];
+}
+export interface ParentalTodayLike {
+  childId: string;
+  date: string;
+  engaged: boolean;
+  moodAverage: number | null;
+  durationMinutes: number;
+  topicsDiscussed: string[];
+  lastMessagePreview: string | null;
+  lastSeenAt: string | null;
+  cardsEmittedToday: number;
+  developmentStub?: boolean;
+}
+export interface ParentalWeekLike {
+  childId: string;
+  weekStartIso: string;
+  weekEndIso: string;
+  moodTimeline: Array<{ date: string; mood: number | null }>;
+  moodAverage: number | null;
+  cardsCount: number;
+  cardThumbnails: Array<{ cardId: string; title: string; rarity: string }>;
+  sacrificeBudgetTotal: number;
+  sacrificeBudgetUsed: number;
+  offScreenRatio: number;
+  topThemes: string[];
+  qualitativeSummary: string;
+  developmentStub?: boolean;
+}
+export interface ParentalPhysCardLike {
+  cardId: string;
+  title: string;
+  rarity: "common" | "rare" | "epic" | "legendary";
+  emittedAt: string;
+  thumbnailUrl: string;
+  qrCodePayload: string;
+  cheatCode: string;
+  pdfUrl: string;
+  used: boolean;
+}
+export interface ParentalConversationLike {
+  sessionId: string;
+  startedAt: string;
+  endedAt: string | null;
+  turnCount: number;
+  durationMinutes: number;
+  topicSummary: string;
+  preview: Array<{ from: "kid" | "brota"; text: string; at: string }>;
+  developmentStub?: boolean;
+}
+export interface ParentalAlertLike {
+  alertId: string;
+  type: "distress" | "drift" | "negative_sequence" | "other";
+  severity: "info" | "warn" | "critical";
+  raisedAt: string;
+  context: string;
+  excerpt: string;
+  sessionRefs: string[];
+  proposedAction: "pause_brota" | "contact_jun" | "wait" | "review";
+  status: "open" | "ack" | "resolved";
+}
+export interface ParentalPulsoEventLike {
+  eventId: string;
+  type: "omikuji" | "mini_historia" | "lembrete_cultural" | "outro";
+  firedAt: string;
+  windowLabel: string;
+  culturalContext: string;
+  payloadPreview: string;
+  kidReaction: "engaged" | "ignored" | "positive" | "negative" | "unknown";
+}
+export interface ParentalPendingQuestionLike {
+  questionId: string;
+  childId: string;
+  raisedAt: string;
+  brotaContextTurns: Array<{ from: "kid" | "brota"; text: string }>;
+  rawQuestion: string;
+  escalationReason: string;
+  status: "open" | "answered";
 }
 
 export interface SubjectKnowledgeEntryLike {
@@ -1045,6 +1185,62 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     listDrillMastered: (personaId) =>
       get<{ states: DrillStateLike[] }>(
         `/personas/${encodeURIComponent(personaId)}/drill-mastered`,
+      ),
+
+    // ── Parental Engaged Dashboard (US-PE-01..09) ──────────────────
+    getParentalDashboard: (acquirerId) =>
+      get<ParentalDashboardLike>(
+        `/parental/dashboard/${encodeURIComponent(acquirerId)}`,
+      ),
+    getParentalToday: (childId) =>
+      get<ParentalTodayLike>(
+        `/parental/children/${encodeURIComponent(childId)}/today`,
+      ),
+    getParentalWeek: (childId) =>
+      get<ParentalWeekLike>(
+        `/parental/children/${encodeURIComponent(childId)}/week`,
+      ),
+    getParentalCards: (childId) =>
+      get<{ childId: string; cards: ParentalPhysCardLike[] }>(
+        `/parental/children/${encodeURIComponent(childId)}/cards`,
+      ),
+    getParentalConversations: (childId, limit) =>
+      get<{ childId: string; sessions: ParentalConversationLike[] }>(
+        `/parental/children/${encodeURIComponent(childId)}/conversations${
+          limit !== undefined ? `?limit=${limit}` : ""
+        }`,
+      ),
+    getParentalAlerts: (childId) =>
+      get<{ childId: string; alerts: ParentalAlertLike[] }>(
+        `/parental/children/${encodeURIComponent(childId)}/alerts`,
+      ),
+    getParentalPulsoEvents: (childId, opts) => {
+      const params = new URLSearchParams();
+      if (opts?.type !== undefined) params.set("type", opts.type);
+      if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+      const q = params.toString();
+      return get<{ childId: string; events: ParentalPulsoEventLike[] }>(
+        `/parental/children/${encodeURIComponent(childId)}/pulso-events${q ? `?${q}` : ""}`,
+      );
+    },
+    listPendingQuestions: () =>
+      get<{ questions: ParentalPendingQuestionLike[] }>(
+        "/parental/escalation/pending-questions",
+      ),
+    answerPendingQuestion: (questionId, payload) =>
+      post<{ status: string; scheduledForNextSession: boolean }>(
+        `/parental/escalation/pending-questions/${encodeURIComponent(questionId)}/answer`,
+        payload,
+      ),
+    reportProblem: (payload) =>
+      post<{ reportId: string; status: string; notifiedJun: boolean }>(
+        "/parental/escalation/report",
+        payload,
+      ),
+    pauseChild: (childId, payload) =>
+      post<{ paused: boolean; immediate: boolean; notifiedJun: boolean }>(
+        `/parental/children/${encodeURIComponent(childId)}/pause`,
+        payload,
       ),
   };
 }

--- a/packages/ebrota-console-ui/tests/parental-engaged-dashboard.test.ts
+++ b/packages/ebrota-console-ui/tests/parental-engaged-dashboard.test.ts
@@ -1,0 +1,282 @@
+/**
+ * UI tests pro ParentalEngagedDashboard (US-PE-01..09).
+ *
+ * Cobre: render inicial + dashboard load + click no kid card + tab navigation.
+ * Mocka fetch pra evitar BFF real; verifica que chamadas certas são feitas.
+ */
+
+import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import ParentalEngagedDashboard from "../src/components/parental/ParentalEngagedDashboard.svelte";
+
+interface FetchCall {
+  url: string;
+  method: string;
+}
+
+const DASHBOARD_RESPONSE = {
+  acquirerId: "yuji-ochiai",
+  acquirerName: "Yuji",
+  generatedAt: "2026-05-27T10:00:00Z",
+  pendingQuestionsCount: 1,
+  unreadAlertsCount: 0,
+  children: [
+    {
+      childId: "ryo-ochiai",
+      name: "Ryo",
+      age: 8,
+      primaryLanguage: "pt",
+      avatarColor: "#5B8DEF",
+      engagedToday: true,
+      lastSeenAt: "2026-05-27T08:00:00Z",
+      moodToday: 7.5,
+      durationMinutesToday: 8,
+      oneLineSummary: "Ryo conversou 8min, falou sobre joaninhas",
+    },
+    {
+      childId: "kei-ochiai",
+      name: "Kei",
+      age: 6,
+      primaryLanguage: "pt",
+      avatarColor: "#F2A65A",
+      engagedToday: false,
+      lastSeenAt: null,
+      moodToday: null,
+      durationMinutesToday: 0,
+      oneLineSummary: "Kei não interagiu hoje",
+    },
+    {
+      childId: "saki-ochiai",
+      name: "Saki",
+      age: 4,
+      primaryLanguage: "pt",
+      avatarColor: "#E36588",
+      engagedToday: true,
+      lastSeenAt: "2026-05-27T07:00:00Z",
+      moodToday: 6,
+      durationMinutesToday: 5,
+      oneLineSummary: "Saki conversou 5min, falou sobre estrelas",
+    },
+  ],
+};
+
+const TODAY_RESPONSE = {
+  childId: "ryo-ochiai",
+  date: "2026-05-27",
+  engaged: true,
+  moodAverage: 7.5,
+  durationMinutes: 8,
+  topicsDiscussed: ["joaninhas", "cores"],
+  lastMessagePreview: "Brota: que cor de joaninha?",
+  lastSeenAt: "2026-05-27T08:00:00Z",
+  cardsEmittedToday: 1,
+};
+
+const WEEK_RESPONSE = {
+  childId: "ryo-ochiai",
+  weekStartIso: "2026-05-21",
+  weekEndIso: "2026-05-27",
+  moodTimeline: Array.from({ length: 7 }, (_, i) => ({
+    date: `2026-05-${21 + i}`,
+    mood: 7,
+  })),
+  moodAverage: 7,
+  cardsCount: 2,
+  cardThumbnails: [],
+  sacrificeBudgetTotal: 100,
+  sacrificeBudgetUsed: 30,
+  offScreenRatio: 2.5,
+  topThemes: ["joaninhas", "estrelas"],
+  qualitativeSummary: "Semana estável.",
+};
+
+const PENDING_QUESTIONS = {
+  questions: [
+    {
+      questionId: "pq-001",
+      childId: "saki-ochiai",
+      raisedAt: "2026-05-27T05:00:00Z",
+      brotaContextTurns: [{ from: "kid", text: "por que o céu fica vermelho?" }],
+      rawQuestion: "por que o céu fica vermelho?",
+      escalationReason: "tema científico",
+      status: "open",
+    },
+  ],
+};
+
+function buildFetchMock(): {
+  fn: typeof globalThis.fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fn = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    calls.push({ url, method });
+
+    if (url.endsWith("/parental/dashboard/yuji-ochiai")) {
+      return jsonResponse(DASHBOARD_RESPONSE);
+    }
+    if (url.endsWith("/parental/escalation/pending-questions")) {
+      return jsonResponse(PENDING_QUESTIONS);
+    }
+    if (url.endsWith("/today")) {
+      return jsonResponse(TODAY_RESPONSE);
+    }
+    if (url.endsWith("/week")) {
+      return jsonResponse(WEEK_RESPONSE);
+    }
+    if (url.endsWith("/cards")) {
+      return jsonResponse({ childId: "ryo-ochiai", cards: [] });
+    }
+    if (url.includes("/conversations")) {
+      return jsonResponse({ childId: "ryo-ochiai", sessions: [] });
+    }
+    if (url.endsWith("/alerts")) {
+      return jsonResponse({ childId: "ryo-ochiai", alerts: [] });
+    }
+    if (url.includes("/pulso-events")) {
+      return jsonResponse({ childId: "ryo-ochiai", events: [] });
+    }
+    return jsonResponse({});
+  };
+  return { fn: fn as typeof globalThis.fetch, calls };
+}
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+describe("ParentalEngagedDashboard", () => {
+  it("renderiza saudação + 3 kid cards após load", async () => {
+    const { fn, calls } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Olá, Yuji/)).toBeTruthy();
+    });
+
+    const cards = await screen.findAllByTestId("kid-summary-card");
+    expect(cards.length).toBe(3);
+
+    expect(screen.getByText("Ryo")).toBeTruthy();
+    expect(screen.getByText("Kei")).toBeTruthy();
+    expect(screen.getByText("Saki")).toBeTruthy();
+
+    expect(
+      calls.some((c) => c.url.endsWith("/parental/dashboard/yuji-ochiai")),
+    ).toBe(true);
+  });
+
+  it("seleciona primeira criança por default e carrega tab Hoje", async () => {
+    const { fn, calls } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    await waitFor(() => {
+      expect(
+        calls.some((c) => c.url.endsWith("/parental/children/ryo-ochiai/today")),
+      ).toBe(true);
+    });
+
+    expect(await screen.findByText(/Hoje — Ryo/)).toBeTruthy();
+  });
+
+  it("muda criança selecionada ao clicar em outro card", async () => {
+    const { fn, calls } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    const cards = await screen.findAllByTestId("kid-summary-card");
+    const sakiCard = cards.find(
+      (c) => c.getAttribute("data-child-id") === "saki-ochiai",
+    );
+    expect(sakiCard).toBeTruthy();
+    await fireEvent.click(sakiCard!);
+
+    await waitFor(() => {
+      expect(
+        calls.some((c) =>
+          c.url.endsWith("/parental/children/saki-ochiai/today"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("navega entre sub-tabs", async () => {
+    const { fn, calls } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    await screen.findByTestId("kid-tabs");
+    await fireEvent.click(screen.getByTestId("tab-semana"));
+    await waitFor(() => {
+      expect(
+        calls.some((c) => c.url.endsWith("/parental/children/ryo-ochiai/week")),
+      ).toBe(true);
+    });
+    expect(await screen.findByText(/Semana — Ryo/)).toBeTruthy();
+
+    await fireEvent.click(screen.getByTestId("tab-cards"));
+    await waitFor(() => {
+      expect(
+        calls.some((c) => c.url.endsWith("/parental/children/ryo-ochiai/cards")),
+      ).toBe(true);
+    });
+
+    await fireEvent.click(screen.getByTestId("tab-pulso"));
+    await waitFor(() => {
+      expect(
+        calls.some((c) =>
+          c.url.endsWith("/parental/children/ryo-ochiai/pulso-events"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("mostra badge de perguntas pendentes e abre modal", async () => {
+    const { fn } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    const trigger = await screen.findByTestId("open-pending-questions");
+    expect(trigger.textContent).toMatch(/Pergunta pendente/);
+    await fireEvent.click(trigger);
+    await screen.findByTestId("pending-question-modal");
+  });
+
+  it("abre form de Reportar problema", async () => {
+    const { fn } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    const trigger = await screen.findByTestId("open-report");
+    await fireEvent.click(trigger);
+    await screen.findByTestId("problem-report-form");
+  });
+
+  it("abre modal de Pausar Brota", async () => {
+    const { fn } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    const trigger = await screen.findByTestId("open-pause");
+    await fireEvent.click(trigger);
+    await screen.findByTestId("pause-confirm");
+  });
+});


### PR DESCRIPTION
## Resumo

Implementa o **Parental Engaged Dashboard** (US-PE-01 a US-PE-09) — view "dia dos meus filhos" para Yuji/Yuko usarem dia-a-dia depois do onboarding parental (PR #250). Spec: \`docs/specs/2026-05-26-console-ebrota-user-stories-v0.md\`.

## Como abrir

\`\`\`
http://localhost:5173/?parental=engaged
\`\`\`

Convive com:
- \`?onboarding=true\` (PR #250 — wizard parental)
- default (subsystem grid do operador)

## US cobertas

| US | Componente | Endpoint(s) |
|---|---|---|
| US-PE-01 dashboard "dia dos meus filhos" | \`ParentalEngagedDashboard\` + \`KidSummaryCard\` | \`GET /parental/dashboard/:acquirerId\` + \`GET /parental/children/:childId/today\` |
| US-PE-02 progresso semanal | tab "Semana" | \`GET /parental/children/:childId/week\` |
| US-PE-03 cards físicos | tab "Cards" | \`GET /parental/children/:childId/cards\` |
| US-PE-04 responder pergunta encaminhada | \`PendingQuestionModal\` | \`GET /parental/escalation/pending-questions\` + \`POST /parental/escalation/pending-questions/:id/answer\` |
| US-PE-05 últimas N mensagens | tab "Conversas" (read-only, sem painel técnico) | \`GET /parental/children/:childId/conversations\` |
| US-PE-06 alerta distress/drift | \`AlertBanner\` em tab "Alertas" | \`GET /parental/children/:childId/alerts\` |
| US-PE-07 feedback negativo escalation | \`ProblemReportForm\` | \`POST /parental/escalation/report\` |
| US-PE-08 Pulso events | tab "Pulso" com cultural context | \`GET /parental/children/:childId/pulso-events\` |
| US-PE-09 pausar conversa | modal de confirmação no dashboard | \`POST /parental/children/:childId/pause\` |

## V0 stubs

Endpoints retornam stubs determinísticos (seeded por childId) com flag \`developmentStub: true\` indicando ao UI que aquele bloco vem do motor quando S5/B1 amadurecerem. UI renderiza uma nota discreta "Dados de demonstração — view será preenchida quando S5 expor agregado real" nos blocos Hoje/Semana, sem crashes.

Quando o motor estiver pronto, cada handler troca o stub por leitura de repo (subject-knowledge / journey-state / etc.) sem mudar shape de resposta.

## Arquivos

### Novos
**BFF**
- \`packages/ebrota-console-bff/src/routes/parental-dashboard-routes.ts\` — plugin Fastify, 10 endpoints
- \`packages/ebrota-console-bff/tests/parental-dashboard-routes.unit.test.ts\` — 17 testes

**UI**
- \`packages/ebrota-console-ui/src/components/parental/ParentalEngagedDashboard.svelte\` — componente principal
- \`packages/ebrota-console-ui/src/components/parental/KidSummaryCard.svelte\` — card individual
- \`packages/ebrota-console-ui/src/components/parental/PendingQuestionModal.svelte\` — modal US-PE-04
- \`packages/ebrota-console-ui/src/components/parental/AlertBanner.svelte\` — banner US-PE-06
- \`packages/ebrota-console-ui/src/components/parental/ProblemReportForm.svelte\` — form US-PE-07
- \`packages/ebrota-console-ui/src/components/parental/parental-types.ts\` — duck-types
- \`packages/ebrota-console-ui/tests/parental-engaged-dashboard.test.ts\` — 7 testes

### Modificados
- \`packages/ebrota-console-bff/src/server.ts\` — \`fastify.register(parentalDashboardRoutes)\`
- \`packages/ebrota-console-ui/src/App.svelte\` — detect \`?parental=engaged\` e render dashboard
- \`packages/ebrota-console-ui/src/lib/api.ts\` — 10 novos métodos + duck-types

## Tests

\`\`\`
ebrota-console-bff: 178/178 ✓ (17 novos no PR)
ebrota-console-ui:  177/177 ✓ (7 novos no PR)
\`\`\`

## Visual

- Tom acolhedor (não "interface técnica") — tipografia normal, sem emojis técnicos
- Avatares: initials em círculo colorido (Ryo azul, Kei laranja, Saki rosa)
- Cards coloridos por raridade (common/rare/epic/legendary)
- Mood indicator: verde ≥7, âmbar 5-7, vermelho <5
- Mobile responsive (kid-grid colapsa em 1 coluna ≤640px)

## Notas de implementação

- Trigger inicial do load usa reactive guard (\`\$: if (!bootstrapped && acquirerId)\`) em vez de \`onMount\`, porque \`@testing-library/svelte\` v5 com Svelte 4 não dispara \`onMount\` no jsdom. Em produção (browser), o reactive bootstrapa idêntico a \`onMount\`.
- A11y warnings (mouse listener em backdrop) são intencionais para permitir click-outside fechar modal — o conteúdo do modal mantém role="dialog" + aria-modal correto.

## Anti-collision

Em worktree isolada \`/tmp/oc/agent-pe-dashboard\` durante todo o desenvolvimento (3 outros agentes em paralelo).

NÃO modificou:
- \`subsystem-panels/*\`, \`ReplayTurnDetail\`, \`Status\`, \`ChatFeed\`
- \`ParentalOnboardingWizard\` + \`wizard-steps/*\` (PR #250)
- arquivos em \`motor-drota/\`, \`planejador/\`, etc.
- outros routes em \`server.ts\`