### PR TITLE
[ui+bff] S1 wiring — declared objectives + threads + subject knowledge in S1AprendizPanel

### DIFF
--- a/packages/ebrota-console-bff/src/routes/s1-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/s1-routes.ts
@@ -1,0 +1,313 @@
+/**
+ * S1 wiring — Modelo do Aprendiz endpoints (declared objectives,
+ * narrative threads, subject-knowledge aggregate).
+ *
+ * Spec parent: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ * Specs feature:
+ *   - 2026-05-26-s1-objetivos-declarados-v0.md (PR #249)
+ *   - 2026-05-26-b1-hooks-temporais-v0.md       (PR #243, threads compartilhadas)
+ *   - 2026-05-25-subject-knowledge-bridge.md    (ledger por sujeito)
+ *
+ * Plugin separado pra não inflar `server.ts` (outros agentes paralelos
+ * editando). DDL idempotente garante schema mesmo quando o motor-execucao
+ * ainda não escreveu na sessão corrente.
+ *
+ * Query SQL inline porque motor-execucao ainda não exporta um entrypoint
+ * de pacote — duplicação aceita: 1 SELECT por endpoint, projeção zod
+ * via shared schemas.
+ */
+
+import type { FastifyPluginAsync } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import {
+  DeclaredObjectiveSchema,
+  type DeclaredObjective,
+  type NarrativeThread,
+  type NarrativeThreadStatus,
+} from "@ascendimacy/shared";
+
+export interface S1RoutesOptions {
+  db: DatabaseType;
+}
+
+const DDL = `
+CREATE TABLE IF NOT EXISTS kids_declared_objectives (
+  id TEXT PRIMARY KEY,
+  persona_id TEXT NOT NULL,
+  declared_at TEXT NOT NULL,
+  declared_in_session TEXT NOT NULL,
+  target_date TEXT NOT NULL,
+  statement TEXT NOT NULL,
+  axis TEXT,
+  status TEXT NOT NULL,
+  parent_objective_id TEXT,
+  evidence_event_ids TEXT,
+  drift_check_due_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_declared_objectives_by_persona
+  ON kids_declared_objectives(persona_id);
+CREATE INDEX IF NOT EXISTS idx_declared_objectives_by_parent
+  ON kids_declared_objectives(parent_objective_id);
+
+CREATE TABLE IF NOT EXISTS kids_narrative_threads (
+  id TEXT PRIMARY KEY,
+  persona_id TEXT NOT NULL,
+  opened_in_session TEXT NOT NULL,
+  opened_at TEXT NOT NULL,
+  thread_text TEXT NOT NULL,
+  axis TEXT,
+  follow_up_triggered INTEGER NOT NULL DEFAULT 0,
+  closed_at TEXT,
+  status TEXT NOT NULL,
+  stale_after TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_threads_by_persona
+  ON kids_narrative_threads(persona_id);
+`;
+
+interface ObjectiveRow {
+  id: string;
+  persona_id: string;
+  declared_at: string;
+  declared_in_session: string;
+  target_date: string;
+  statement: string;
+  axis: string | null;
+  status: string;
+  parent_objective_id: string | null;
+  evidence_event_ids: string | null;
+  drift_check_due_at: string | null;
+}
+
+function rowToObjective(row: ObjectiveRow): DeclaredObjective {
+  const evidence = row.evidence_event_ids
+    ? (JSON.parse(row.evidence_event_ids) as string[])
+    : undefined;
+  return DeclaredObjectiveSchema.parse({
+    id: row.id,
+    persona_id: row.persona_id,
+    declared_at: row.declared_at,
+    declared_in_session: row.declared_in_session,
+    target_date: row.target_date,
+    statement: row.statement,
+    ...(row.axis !== null ? { axis: row.axis } : {}),
+    status: row.status,
+    ...(row.parent_objective_id !== null
+      ? { parent_objective_id: row.parent_objective_id }
+      : {}),
+    ...(evidence !== undefined ? { evidence_event_ids: evidence } : {}),
+    ...(row.drift_check_due_at !== null
+      ? { drift_check_due_at: row.drift_check_due_at }
+      : {}),
+  });
+}
+
+interface ThreadRow {
+  id: string;
+  persona_id: string;
+  opened_in_session: string;
+  opened_at: string;
+  thread_text: string;
+  axis: string | null;
+  follow_up_triggered: number;
+  closed_at: string | null;
+  status: string;
+  stale_after: string;
+}
+
+function rowToThread(row: ThreadRow): NarrativeThread {
+  const out: NarrativeThread = {
+    id: row.id,
+    persona_id: row.persona_id,
+    opened_in_session: row.opened_in_session,
+    opened_at: row.opened_at,
+    thread_text: row.thread_text,
+    follow_up_triggered: row.follow_up_triggered === 1,
+    status: row.status as NarrativeThreadStatus,
+    stale_after: row.stale_after,
+  };
+  if (row.axis !== null) out.axis = row.axis;
+  if (row.closed_at !== null) out.closed_at = row.closed_at;
+  return out;
+}
+
+/** "Latest in chain" = row cujo id não é parent_objective_id de nenhuma outra. */
+function listLatestByPersona(
+  db: DatabaseType,
+  personaId: string,
+): DeclaredObjective[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM kids_declared_objectives
+       WHERE persona_id = ?
+         AND id NOT IN (
+           SELECT parent_objective_id FROM kids_declared_objectives
+           WHERE parent_objective_id IS NOT NULL
+         )
+       ORDER BY declared_at DESC`,
+    )
+    .all(personaId) as ObjectiveRow[];
+  return rows.map(rowToObjective);
+}
+
+/** Trail completo do objetivo: ancestrais + ele próprio + sucessores. */
+function getObjectiveTrail(
+  db: DatabaseType,
+  personaId: string,
+  objectiveId: string,
+): DeclaredObjective[] {
+  const all = db
+    .prepare(
+      `SELECT * FROM kids_declared_objectives WHERE persona_id = ?`,
+    )
+    .all(personaId) as ObjectiveRow[];
+  if (all.length === 0) return [];
+  const byId = new Map(all.map((r) => [r.id, r]));
+  const byParent = new Map<string, ObjectiveRow>();
+  for (const r of all) {
+    if (r.parent_objective_id !== null) byParent.set(r.parent_objective_id, r);
+  }
+  const seed = byId.get(objectiveId);
+  if (!seed) return [];
+  const chain: ObjectiveRow[] = [];
+  let cur: ObjectiveRow | undefined = seed;
+  while (cur && cur.parent_objective_id !== null) {
+    const parent = byId.get(cur.parent_objective_id);
+    if (!parent) break;
+    chain.unshift(parent);
+    cur = parent;
+  }
+  chain.push(seed);
+  cur = byParent.get(seed.id);
+  while (cur) {
+    chain.push(cur);
+    cur = byParent.get(cur.id);
+  }
+  return chain.map(rowToObjective);
+}
+
+function listOpenThreadsByPersona(
+  db: DatabaseType,
+  personaId: string,
+): NarrativeThread[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM kids_narrative_threads
+       WHERE persona_id = ?
+       ORDER BY opened_at DESC
+       LIMIT 50`,
+    )
+    .all(personaId) as ThreadRow[];
+  return rows.map(rowToThread);
+}
+
+export interface SubjectKnowledgeSummary {
+  conceptsPresentedCount: number;
+  recallPositiveRate: number | null;
+  recallTotal: number;
+  topConcepts: TopConceptEntry[];
+}
+
+export interface TopConceptEntry {
+  concept_id: string;
+  lineage_anchor: string;
+  presentedCount: number;
+  lastSeenAt: string;
+}
+
+function summarizeSubjectKnowledge(
+  db: DatabaseType,
+  personaId: string,
+): SubjectKnowledgeSummary {
+  // subject_knowledge.subject_id == persona_id no contexto eBrota Kids.
+  const presented = db
+    .prepare(
+      `SELECT json_extract(payload_json, '$.concept_id') AS concept_id,
+              json_extract(payload_json, '$.lineage_anchor') AS lineage_anchor,
+              COUNT(*) AS presented_count,
+              MAX(created_at) AS last_seen_at
+       FROM subject_knowledge
+       WHERE subject_id = ? AND type = 'presented_concept'
+       GROUP BY concept_id, lineage_anchor
+       ORDER BY last_seen_at DESC
+       LIMIT 5`,
+    )
+    .all(personaId) as Array<{
+      concept_id: string | null;
+      lineage_anchor: string | null;
+      presented_count: number;
+      last_seen_at: string;
+    }>;
+
+  const totalPresented = db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM subject_knowledge
+       WHERE subject_id = ? AND type = 'presented_concept'`,
+    )
+    .get(personaId) as { n: number };
+
+  const recall = db
+    .prepare(
+      `SELECT
+         SUM(CASE WHEN json_extract(payload_json, '$.result') = 'positive' THEN 1 ELSE 0 END) AS positive,
+         COUNT(*) AS total
+       FROM subject_knowledge
+       WHERE subject_id = ? AND type = 'recall_check_attempt'`,
+    )
+    .get(personaId) as { positive: number | null; total: number };
+
+  const recallTotal = recall.total ?? 0;
+  const positiveCount = recall.positive ?? 0;
+  const recallPositiveRate = recallTotal > 0 ? positiveCount / recallTotal : null;
+
+  return {
+    conceptsPresentedCount: totalPresented.n,
+    recallPositiveRate,
+    recallTotal,
+    topConcepts: presented.map((r) => ({
+      concept_id: r.concept_id ?? "?",
+      lineage_anchor: r.lineage_anchor ?? "?",
+      presentedCount: r.presented_count,
+      lastSeenAt: r.last_seen_at,
+    })),
+  };
+}
+
+const s1Routes: FastifyPluginAsync<S1RoutesOptions> = async (fastify, opts) => {
+  const { db } = opts;
+  db.exec(DDL);
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/objectives",
+    async (req) => ({
+      objectives: listLatestByPersona(db, req.params.id),
+    }),
+  );
+
+  fastify.get<{ Params: { id: string; objId: string } }>(
+    "/personas/:id/objectives/:objId/history",
+    async (req, reply) => {
+      const trail = getObjectiveTrail(db, req.params.id, req.params.objId);
+      if (trail.length === 0) {
+        return reply
+          .code(404)
+          .send({ error: `objective ${req.params.objId} não encontrado` });
+      }
+      return { trail };
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/narrative-threads",
+    async (req) => ({
+      threads: listOpenThreadsByPersona(db, req.params.id),
+    }),
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/subject-knowledge",
+    async (req) => summarizeSubjectKnowledge(db, req.params.id),
+  );
+};
+
+export default s1Routes;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -133,6 +133,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   let mode: ConsoleMode = opts.initialMode ?? "auto";
 
   initParentalOnboardingSchema(opts.db);
+  void fastify.register(async (instance) => (await import("./routes/s1-routes.js")).default(instance, { db: opts.db }));
 
   // In-memory set de sessionIds ativos (iniciados via /sessions/start-card,
   // removidos via /sessions/:id/end). Permite que App.svelte faça polling

--- a/packages/ebrota-console-bff/tests/s1-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/s1-routes.unit.test.ts
@@ -1,0 +1,405 @@
+/**
+ * S1 routes — unit tests com SQLite :memory:.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-s1-objetivos-declarados-v0.md
+ *       ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md
+ *
+ * Cobre: 4 endpoints + empty state + history trail + agregação ledger.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import Database from "better-sqlite3";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import s1Routes from "../src/routes/s1-routes.js";
+import type {
+  DeclaredObjective,
+  NarrativeThread,
+} from "@ascendimacy/shared";
+
+let app: FastifyInstance;
+let db: DatabaseType;
+
+beforeEach(async () => {
+  db = initDb({ dbPath: ":memory:" });
+  app = Fastify({ logger: false });
+  await app.register(s1Routes, { db });
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  db.close();
+});
+
+const inject = async (url: string) => {
+  const res = await app.inject({ method: "GET", url });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+function insertObjective(row: {
+  id: string;
+  persona_id: string;
+  declared_at: string;
+  declared_in_session: string;
+  target_date: string;
+  statement: string;
+  axis?: string;
+  status: string;
+  parent_objective_id?: string;
+}): void {
+  db.prepare(
+    `INSERT INTO kids_declared_objectives
+       (id, persona_id, declared_at, declared_in_session, target_date,
+        statement, axis, status, parent_objective_id, evidence_event_ids,
+        drift_check_due_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
+  ).run(
+    row.id,
+    row.persona_id,
+    row.declared_at,
+    row.declared_in_session,
+    row.target_date,
+    row.statement,
+    row.axis ?? null,
+    row.status,
+    row.parent_objective_id ?? null,
+  );
+}
+
+function insertThread(row: {
+  id: string;
+  persona_id: string;
+  opened_in_session: string;
+  opened_at: string;
+  thread_text: string;
+  status: string;
+  stale_after: string;
+}): void {
+  db.prepare(
+    `INSERT INTO kids_narrative_threads
+       (id, persona_id, opened_in_session, opened_at, thread_text, axis,
+        follow_up_triggered, closed_at, status, stale_after)
+     VALUES (?, ?, ?, ?, ?, NULL, 0, NULL, ?, ?)`,
+  ).run(
+    row.id,
+    row.persona_id,
+    row.opened_in_session,
+    row.opened_at,
+    row.thread_text,
+    row.status,
+    row.stale_after,
+  );
+}
+
+function insertSubjectKnowledge(row: {
+  id: string;
+  subject_id: string;
+  type: string;
+  source: string;
+  confidence: number;
+  payload: Record<string, unknown>;
+  session_id?: string;
+  created_at?: string;
+}): void {
+  db.prepare(
+    `INSERT INTO subject_knowledge
+       (id, subject_id, type, source, confidence, alignment, payload_json,
+        turn_ref, session_id, created_at)
+     VALUES (?, ?, ?, ?, ?, 'unknown', ?, 't1', ?, ?)`,
+  ).run(
+    row.id,
+    row.subject_id,
+    row.type,
+    row.source,
+    row.confidence,
+    JSON.stringify(row.payload),
+    row.session_id ?? "sess-test",
+    row.created_at ?? new Date().toISOString(),
+  );
+}
+
+describe("GET /personas/:id/objectives", () => {
+  it("retorna lista vazia quando persona sem objetivos", async () => {
+    const res = await inject("/personas/ryo/objectives");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ objectives: [] });
+  });
+
+  it("retorna apenas latest-in-chain (revised não aparece)", async () => {
+    insertObjective({
+      id: "obj-1",
+      persona_id: "ryo",
+      declared_at: "2026-05-01T10:00:00Z",
+      declared_in_session: "sess-A",
+      target_date: "2026-06-01T10:00:00Z",
+      statement: "Ler 5 livros sobre dinossauros",
+      axis: "curiosidade",
+      status: "active",
+    });
+    insertObjective({
+      id: "obj-1-revised",
+      persona_id: "ryo",
+      declared_at: "2026-05-15T10:00:00Z",
+      declared_in_session: "sess-B",
+      target_date: "2026-07-01T10:00:00Z",
+      statement: "Ler 3 livros sobre dinossauros",
+      status: "active",
+      parent_objective_id: "obj-1",
+    });
+    insertObjective({
+      id: "obj-2",
+      persona_id: "ryo",
+      declared_at: "2026-05-20T10:00:00Z",
+      declared_in_session: "sess-C",
+      target_date: "2026-08-01T10:00:00Z",
+      statement: "Aprender 10 dobraduras de origami",
+      status: "active",
+    });
+
+    const res = await inject("/personas/ryo/objectives");
+    expect(res.status).toBe(200);
+    const objectives = (res.body as { objectives: DeclaredObjective[] }).objectives;
+    expect(objectives.map((o) => o.id).sort()).toEqual(["obj-1-revised", "obj-2"]);
+  });
+
+  it("filtra por persona_id (não vaza outros)", async () => {
+    insertObjective({
+      id: "obj-ryo",
+      persona_id: "ryo",
+      declared_at: "2026-05-01T10:00:00Z",
+      declared_in_session: "sess-A",
+      target_date: "2026-06-01T10:00:00Z",
+      statement: "Algo",
+      status: "active",
+    });
+    insertObjective({
+      id: "obj-saki",
+      persona_id: "saki",
+      declared_at: "2026-05-01T10:00:00Z",
+      declared_in_session: "sess-B",
+      target_date: "2026-06-01T10:00:00Z",
+      statement: "Outro",
+      status: "active",
+    });
+
+    const res = await inject("/personas/ryo/objectives");
+    const objectives = (res.body as { objectives: DeclaredObjective[] }).objectives;
+    expect(objectives).toHaveLength(1);
+    expect(objectives[0]!.persona_id).toBe("ryo");
+  });
+});
+
+describe("GET /personas/:id/objectives/:objId/history", () => {
+  it("404 quando objective não existe", async () => {
+    const res = await inject("/personas/ryo/objectives/missing/history");
+    expect(res.status).toBe(404);
+  });
+
+  it("retorna trail completo (ancestrais + node + sucessores)", async () => {
+    insertObjective({
+      id: "o-v1",
+      persona_id: "ryo",
+      declared_at: "2026-05-01T10:00:00Z",
+      declared_in_session: "sess-A",
+      target_date: "2026-06-01T10:00:00Z",
+      statement: "v1",
+      status: "revised",
+    });
+    insertObjective({
+      id: "o-v2",
+      persona_id: "ryo",
+      declared_at: "2026-05-10T10:00:00Z",
+      declared_in_session: "sess-B",
+      target_date: "2026-06-15T10:00:00Z",
+      statement: "v2",
+      status: "revised",
+      parent_objective_id: "o-v1",
+    });
+    insertObjective({
+      id: "o-v3",
+      persona_id: "ryo",
+      declared_at: "2026-05-20T10:00:00Z",
+      declared_in_session: "sess-C",
+      target_date: "2026-07-01T10:00:00Z",
+      statement: "v3",
+      status: "active",
+      parent_objective_id: "o-v2",
+    });
+
+    const res = await inject("/personas/ryo/objectives/o-v2/history");
+    expect(res.status).toBe(200);
+    const trail = (res.body as { trail: DeclaredObjective[] }).trail;
+    expect(trail.map((o) => o.id)).toEqual(["o-v1", "o-v2", "o-v3"]);
+  });
+});
+
+describe("GET /personas/:id/narrative-threads", () => {
+  it("retorna lista vazia para persona nova", async () => {
+    const res = await inject("/personas/ryo/narrative-threads");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ threads: [] });
+  });
+
+  it("retorna threads ordenados por opened_at desc", async () => {
+    insertThread({
+      id: "t-old",
+      persona_id: "ryo",
+      opened_in_session: "sess-A",
+      opened_at: "2026-05-01T10:00:00Z",
+      thread_text: "queria ver como joaninha come",
+      status: "open",
+      stale_after: "2026-05-08T10:00:00Z",
+    });
+    insertThread({
+      id: "t-new",
+      persona_id: "ryo",
+      opened_in_session: "sess-B",
+      opened_at: "2026-05-20T10:00:00Z",
+      thread_text: "vou tentar fazer origami de baleia",
+      status: "open",
+      stale_after: "2026-05-27T10:00:00Z",
+    });
+
+    const res = await inject("/personas/ryo/narrative-threads");
+    const threads = (res.body as { threads: NarrativeThread[] }).threads;
+    expect(threads.map((t) => t.id)).toEqual(["t-new", "t-old"]);
+  });
+
+  it("filtra por persona", async () => {
+    insertThread({
+      id: "t-saki",
+      persona_id: "saki",
+      opened_in_session: "sess-X",
+      opened_at: "2026-05-01T10:00:00Z",
+      thread_text: "qualquer",
+      status: "open",
+      stale_after: "2026-05-08T10:00:00Z",
+    });
+
+    const res = await inject("/personas/ryo/narrative-threads");
+    expect((res.body as { threads: NarrativeThread[] }).threads).toEqual([]);
+  });
+});
+
+describe("GET /personas/:id/subject-knowledge", () => {
+  it("retorna empty summary quando ledger vazio", async () => {
+    const res = await inject("/personas/ryo/subject-knowledge");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      conceptsPresentedCount: 0,
+      recallPositiveRate: null,
+      recallTotal: 0,
+      topConcepts: [],
+    });
+  });
+
+  it("agrega presented_concepts + calcula recall rate", async () => {
+    insertSubjectKnowledge({
+      id: "sk-1",
+      subject_id: "ryo",
+      type: "presented_concept",
+      source: "motor_inferred",
+      confidence: 1,
+      payload: {
+        kind: "presented_concept",
+        concept_id: "estoica/dicotomia_controle",
+        lineage_anchor: "estoica/dicotomia_controle",
+        axis_id: 3,
+        family: "carater",
+        keywords: ["controle"],
+        points: 1,
+      },
+      created_at: "2026-05-20T10:00:00Z",
+    });
+    insertSubjectKnowledge({
+      id: "sk-2",
+      subject_id: "ryo",
+      type: "presented_concept",
+      source: "motor_inferred",
+      confidence: 1,
+      payload: {
+        kind: "presented_concept",
+        concept_id: "estoica/dicotomia_controle",
+        lineage_anchor: "estoica/dicotomia_controle",
+        axis_id: 3,
+        family: "carater",
+        keywords: ["controle"],
+        points: 1,
+      },
+      created_at: "2026-05-22T10:00:00Z",
+    });
+    insertSubjectKnowledge({
+      id: "sk-3",
+      subject_id: "ryo",
+      type: "recall_check_attempt",
+      source: "motor_inferred",
+      confidence: 1,
+      payload: {
+        kind: "recall_check_attempt",
+        concept_id_referenced: "estoica/dicotomia_controle",
+        framing_used: "...",
+        result: "positive",
+        points_awarded: 5,
+      },
+    });
+    insertSubjectKnowledge({
+      id: "sk-4",
+      subject_id: "ryo",
+      type: "recall_check_attempt",
+      source: "motor_inferred",
+      confidence: 1,
+      payload: {
+        kind: "recall_check_attempt",
+        concept_id_referenced: "estoica/dicotomia_controle",
+        framing_used: "...",
+        result: "negative",
+        points_awarded: 0,
+      },
+    });
+
+    const res = await inject("/personas/ryo/subject-knowledge");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      conceptsPresentedCount: number;
+      recallPositiveRate: number | null;
+      recallTotal: number;
+      topConcepts: Array<{ concept_id: string; presentedCount: number }>;
+    };
+    expect(body.conceptsPresentedCount).toBe(2);
+    expect(body.recallTotal).toBe(2);
+    expect(body.recallPositiveRate).toBeCloseTo(0.5);
+    expect(body.topConcepts).toHaveLength(1);
+    expect(body.topConcepts[0]!.concept_id).toBe("estoica/dicotomia_controle");
+    expect(body.topConcepts[0]!.presentedCount).toBe(2);
+  });
+
+  it("limita topConcepts a 5", async () => {
+    for (let i = 0; i < 8; i++) {
+      insertSubjectKnowledge({
+        id: `sk-c${i}`,
+        subject_id: "ryo",
+        type: "presented_concept",
+        source: "motor_inferred",
+        confidence: 1,
+        payload: {
+          kind: "presented_concept",
+          concept_id: `concept-${i}`,
+          lineage_anchor: `lin-${i}`,
+          axis_id: i + 1,
+          family: "carater",
+          keywords: [],
+          points: 1,
+        },
+        created_at: new Date(2026, 4, i + 1).toISOString(),
+      });
+    }
+    const res = await inject("/personas/ryo/subject-knowledge");
+    const body = res.body as { topConcepts: unknown[] };
+    expect(body.topConcepts).toHaveLength(5);
+  });
+});

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S1AprendizPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S1AprendizPanel.svelte
@@ -3,13 +3,37 @@
    * S1 — Modelo do Aprendiz (panel).
    * Pergunta: "O que o motor crê sobre [persona] agora?"
    *
-   * v0: identity card hardcoded + envelopa MapsPanel/DiscoveriesPanel
-   * abrindo os toggles existentes + placeholders pra Objetivos / Threads
-   * (specs em rascunho).
+   * Consome BFF:
+   *   - GET /personas/:id/objectives          (declared objectives)
+   *   - GET /personas/:id/objectives/:id/history
+   *   - GET /personas/:id/narrative-threads   (B1)
+   *   - GET /personas/:id/subject-knowledge   (agregado ledger)
+   *
+   * Persona ativa derivada de `$currentSessionId` (formato
+   * `${persona_id}__${conversation_id}`). Quando vazio, mostra empty
+   * state. Fallback gracioso pra placeholders quando endpoint falha.
+   *
+   * Spec parent: docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
    */
-  import { mapsPanelOpen, discoveriesPanelOpen, tracerSubjectId } from "../../lib/stores.js";
+
+  import {
+    mapsPanelOpen,
+    discoveriesPanelOpen,
+    tracerSubjectId,
+    currentSessionId,
+  } from "../../lib/stores.js";
   import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
   import PlaceholderBanner from "./PlaceholderBanner.svelte";
+  import {
+    createApiClient,
+    type ApiClient,
+    type DeclaredObjectiveLike,
+    type NarrativeThreadLike,
+    type SubjectKnowledgeSummary,
+  } from "../../lib/api.js";
+
+  /** Permite injetar mock em testes; default = real BFF client. */
+  export let api: ApiClient = createApiClient();
 
   const COLOR = "#3b82f6";
 
@@ -19,13 +43,122 @@
   function openDiscoveries(): void {
     discoveriesPanelOpen.set(true);
   }
+
+  /** SessionId = `${personaId}__${conversationId}`. Quando null, cai
+   *  no tracerSubjectId (default ryo-ochiai) pra ainda mostrar algo. */
+  function derivePersonaId(sessionId: string | null, fallback: string): string {
+    if (sessionId === null || sessionId.length === 0) return fallback;
+    const idx = sessionId.indexOf("__");
+    return idx > 0 ? sessionId.slice(0, idx) : sessionId;
+  }
+
+  $: personaId = derivePersonaId($currentSessionId, $tracerSubjectId);
+
+  type LoadState = "idle" | "loading" | "loaded" | "error";
+
+  let objectivesState: LoadState = "idle";
+  let objectives: DeclaredObjectiveLike[] = [];
+  let objectivesError = "";
+
+  let threadsState: LoadState = "idle";
+  let threads: NarrativeThreadLike[] = [];
+  let threadsError = "";
+
+  let skState: LoadState = "idle";
+  let sk: SubjectKnowledgeSummary | null = null;
+  let skError = "";
+
+  let expandedObjectiveId: string | null = null;
+  let historyTrail: DeclaredObjectiveLike[] = [];
+  let historyLoading = false;
+  let historyError = "";
+
+  async function loadObjectives(pid: string): Promise<void> {
+    objectivesState = "loading";
+    try {
+      const res = await api.getDeclaredObjectives(pid);
+      objectives = res.objectives;
+      objectivesState = "loaded";
+    } catch (err) {
+      objectivesError = err instanceof Error ? err.message : String(err);
+      objectivesState = "error";
+    }
+  }
+
+  async function loadThreads(pid: string): Promise<void> {
+    threadsState = "loading";
+    try {
+      const res = await api.getNarrativeThreads(pid);
+      threads = res.threads;
+      threadsState = "loaded";
+    } catch (err) {
+      threadsError = err instanceof Error ? err.message : String(err);
+      threadsState = "error";
+    }
+  }
+
+  async function loadSubjectKnowledge(pid: string): Promise<void> {
+    skState = "loading";
+    try {
+      sk = await api.getSubjectKnowledge(pid);
+      skState = "loaded";
+    } catch (err) {
+      skError = err instanceof Error ? err.message : String(err);
+      skState = "error";
+    }
+  }
+
+  async function toggleHistory(objectiveId: string): Promise<void> {
+    if (expandedObjectiveId === objectiveId) {
+      expandedObjectiveId = null;
+      historyTrail = [];
+      return;
+    }
+    expandedObjectiveId = objectiveId;
+    historyLoading = true;
+    historyError = "";
+    historyTrail = [];
+    try {
+      const res = await api.getObjectiveHistory(personaId, objectiveId);
+      historyTrail = res.trail;
+    } catch (err) {
+      historyError = err instanceof Error ? err.message : String(err);
+    } finally {
+      historyLoading = false;
+    }
+  }
+
+  // Trigger inicial + re-fetch quando persona muda. Reactive `$:` dispara
+  // em init e em cada change; o tracking via `lastLoadedFor` impede loop.
+  let lastLoadedFor = "";
+  $: if (personaId !== "" && personaId !== lastLoadedFor) {
+    lastLoadedFor = personaId;
+    void loadObjectives(personaId);
+    void loadThreads(personaId);
+    void loadSubjectKnowledge(personaId);
+  }
+
+  function formatRelative(iso: string): string {
+    const t = Date.parse(iso);
+    if (Number.isNaN(t)) return iso;
+    const diffMs = t - Date.now();
+    const absDays = Math.round(Math.abs(diffMs) / 86_400_000);
+    if (absDays === 0) return "hoje";
+    if (diffMs > 0) return absDays === 1 ? "amanhã" : `em ${absDays}d`;
+    return absDays === 1 ? "ontem" : `há ${absDays}d`;
+  }
+
+  function formatRate(rate: number | null, total: number): string {
+    if (rate === null) return "—";
+    return `${Math.round(rate * 100)}% (${total} attempts)`;
+  }
 </script>
 
 <SubsystemPanelShell id="S1" title="Modelo do Aprendiz" color={COLOR}>
   <section class="block">
     <h3>Identity</h3>
     <dl class="identity">
-      <dt>persona_id</dt><dd>{$tracerSubjectId}</dd>
+      <dt>persona_id</dt><dd>{personaId}</dd>
       <dt>age</dt><dd>— <span class="muted">(v0 hardcoded)</span></dd>
       <dt>language</dt><dd>pt-BR · ja</dd>
       <dt>household</dt><dd>— <span class="muted">(v0 hardcoded)</span></dd>
@@ -43,11 +176,47 @@
     </button>
   </section>
 
-  <section class="block">
+  <section class="block" data-testid="s1-subject-knowledge">
     <h3>Subject Knowledge</h3>
+    {#if skState === "loading"}
+      <p class="muted small" data-testid="sk-loading">carregando ledger…</p>
+    {:else if skState === "error"}
+      <p class="error small" data-testid="sk-error">
+        falha ao carregar ledger: {skError}
+      </p>
+      <PlaceholderBanner
+        label="ledger indisponível — fallback"
+        specPath="docs/specs/2026-05-25-subject-knowledge-bridge.md"
+        color={COLOR}
+      />
+    {:else if sk !== null && (sk.conceptsPresentedCount > 0 || sk.recallTotal > 0)}
+      <ul class="sk-stats" data-testid="sk-stats">
+        <li>
+          <span class="sk-label">presented</span>
+          <span class="sk-value">{sk.conceptsPresentedCount}</span>
+        </li>
+        <li>
+          <span class="sk-label">recall+</span>
+          <span class="sk-value">{formatRate(sk.recallPositiveRate, sk.recallTotal)}</span>
+        </li>
+      </ul>
+      {#if sk.topConcepts.length > 0}
+        <ol class="top-concepts" data-testid="sk-top-concepts">
+          {#each sk.topConcepts as c (c.concept_id)}
+            <li>
+              <code>{c.concept_id}</code>
+              <span class="muted small">×{c.presentedCount} · {formatRelative(c.lastSeenAt)}</span>
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    {:else}
+      <p class="muted small" data-testid="sk-empty">
+        nenhum conceito apresentado ainda
+      </p>
+    {/if}
     <p class="hint">
-      Ledger de conceitos via <code>DiscoveriesPanel</code> (Status bar →
-      🔍).
+      Detalhes via <code>DiscoveriesPanel</code> (Status bar → 🔍).
     </p>
     <button type="button" class="action" on:click={openDiscoveries}>
       Abrir DiscoveriesPanel
@@ -68,22 +237,103 @@
     </p>
   </section>
 
-  <section class="block">
+  <section class="block" data-testid="s1-objectives">
     <h3>Objetivos declarados</h3>
-    <PlaceholderBanner
-      label="spec em rascunho — feature ainda não wired"
-      specPath="docs/specs/2026-05-26-s1-objetivos-declarados-v0.md"
-      color={COLOR}
-    />
+    {#if objectivesState === "loading"}
+      <p class="muted small" data-testid="objectives-loading">carregando…</p>
+    {:else if objectivesState === "error"}
+      <p class="error small" data-testid="objectives-error">
+        falha: {objectivesError}
+      </p>
+      <PlaceholderBanner
+        label="endpoint indisponível — fallback"
+        specPath="docs/specs/2026-05-26-s1-objetivos-declarados-v0.md"
+        color={COLOR}
+      />
+    {:else if objectives.length === 0}
+      <p class="muted small" data-testid="objectives-empty">
+        nenhum objetivo declarado ainda
+      </p>
+    {:else}
+      <ul class="objective-list" data-testid="objective-list">
+        {#each objectives as obj (obj.id)}
+          <li class="objective-card" data-testid="objective-card">
+            <button
+              type="button"
+              class="objective-toggle"
+              on:click={() => toggleHistory(obj.id)}
+              aria-expanded={expandedObjectiveId === obj.id}
+              data-testid={`objective-toggle-${obj.id}`}
+            >
+              <div class="objective-head">
+                <span class="objective-statement">{obj.statement}</span>
+                <span class={`status-badge status-${obj.status}`}>{obj.status}</span>
+              </div>
+              <div class="objective-meta">
+                <span>target {formatRelative(obj.target_date)}</span>
+                {#if obj.axis}<span class="axis-chip">{obj.axis}</span>{/if}
+              </div>
+            </button>
+            {#if expandedObjectiveId === obj.id}
+              <div class="history" data-testid={`objective-history-${obj.id}`}>
+                {#if historyLoading}
+                  <p class="muted small">carregando histórico…</p>
+                {:else if historyError}
+                  <p class="error small">{historyError}</p>
+                {:else if historyTrail.length === 0}
+                  <p class="muted small">sem histórico</p>
+                {:else}
+                  <ol class="history-trail">
+                    {#each historyTrail as h (h.id)}
+                      <li>
+                        <code class="history-status">{h.status}</code>
+                        <span>{h.statement}</span>
+                        <span class="muted small">{formatRelative(h.declared_at)}</span>
+                      </li>
+                    {/each}
+                  </ol>
+                {/if}
+              </div>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
   </section>
 
-  <section class="block">
+  <section class="block" data-testid="s1-threads">
     <h3>Narrative Threads</h3>
-    <PlaceholderBanner
-      label="spec B1 hooks em rascunho — feature ainda não wired"
-      specPath="docs/specs/2026-05-26-b1-hooks-temporais-v0.md"
-      color={COLOR}
-    />
+    {#if threadsState === "loading"}
+      <p class="muted small" data-testid="threads-loading">carregando…</p>
+    {:else if threadsState === "error"}
+      <p class="error small" data-testid="threads-error">
+        falha: {threadsError}
+      </p>
+      <PlaceholderBanner
+        label="endpoint indisponível — fallback"
+        specPath="docs/specs/2026-05-26-b1-hooks-temporais-v0.md"
+        color={COLOR}
+      />
+    {:else if threads.length === 0}
+      <p class="muted small" data-testid="threads-empty">
+        nenhum thread aberto
+      </p>
+    {:else}
+      <ul class="thread-list" data-testid="thread-list">
+        {#each threads as t (t.id)}
+          <li class="thread-card" data-testid="thread-card">
+            <div class="thread-head">
+              <span class="thread-text">{t.thread_text}</span>
+              <span class={`status-badge status-${t.status}`}>{t.status}</span>
+            </div>
+            <div class="thread-meta">
+              <span>aberto {formatRelative(t.opened_at)}</span>
+              {#if t.axis}<span class="axis-chip">{t.axis}</span>{/if}
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
   </section>
 </SubsystemPanelShell>
 
@@ -127,6 +377,11 @@
     font-size: 0.75rem;
     margin: 0;
   }
+  .error {
+    color: #d97706;
+    font-size: 0.78rem;
+    margin: 0;
+  }
   .action {
     align-self: flex-start;
     padding: 0.3rem 0.7rem;
@@ -159,5 +414,156 @@
     background: rgba(127, 127, 127, 0.18);
     padding: 0.05rem 0.3rem;
     border-radius: 3px;
+  }
+  .sk-stats {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 1.2rem;
+    font-size: 0.85rem;
+  }
+  .sk-stats li {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .sk-label {
+    opacity: 0.6;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .sk-value {
+    font-weight: 600;
+  }
+  .top-concepts {
+    list-style: decimal inside;
+    margin: 0;
+    padding: 0;
+    font-size: 0.82rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .top-concepts li {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+  }
+  .objective-list,
+  .thread-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+  .objective-card,
+  .thread-card {
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-left: 3px solid rgba(59, 130, 246, 0.7);
+    border-radius: 4px;
+    background: rgba(59, 130, 246, 0.05);
+  }
+  .objective-toggle {
+    width: 100%;
+    background: transparent;
+    border: none;
+    text-align: left;
+    padding: 0.5rem 0.65rem;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .objective-toggle:hover {
+    background: rgba(59, 130, 246, 0.08);
+  }
+  .thread-card {
+    padding: 0.5rem 0.65rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .objective-head,
+  .thread-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+  .objective-statement,
+  .thread-text {
+    font-weight: 500;
+    font-size: 0.88rem;
+  }
+  .status-badge {
+    font-size: 0.7rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    background: rgba(127, 127, 127, 0.2);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+  .status-active,
+  .status-open {
+    background: rgba(34, 197, 94, 0.22);
+  }
+  .status-achieved,
+  .status-closed_natural {
+    background: rgba(59, 130, 246, 0.22);
+  }
+  .status-abandoned,
+  .status-closed_abandoned {
+    background: rgba(127, 127, 127, 0.28);
+    opacity: 0.7;
+  }
+  .status-drift_flagged,
+  .status-stale {
+    background: rgba(245, 158, 11, 0.28);
+  }
+  .status-revised,
+  .status-resumed {
+    background: rgba(168, 85, 247, 0.22);
+  }
+  .objective-meta,
+  .thread-meta {
+    display: flex;
+    gap: 0.6rem;
+    font-size: 0.78rem;
+    opacity: 0.8;
+  }
+  .axis-chip {
+    background: rgba(59, 130, 246, 0.15);
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.72rem;
+  }
+  .history {
+    padding: 0.4rem 0.65rem 0.6rem;
+    border-top: 1px dashed rgba(127, 127, 127, 0.3);
+  }
+  .history-trail {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.8rem;
+  }
+  .history-trail li {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+  }
+  .history-status {
+    font-size: 0.68rem;
+    flex-shrink: 0;
   }
 </style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -407,6 +407,21 @@ export interface ApiClient {
     frameworkIds?: string[],
   ): Promise<{ maps: SubjectMapLike }>;
 
+  // ─── S1 wiring — Declared Objectives + Threads + SK summary ─────
+  getDeclaredObjectives(
+    personaId: string,
+  ): Promise<{ objectives: DeclaredObjectiveLike[] }>;
+  getObjectiveHistory(
+    personaId: string,
+    objectiveId: string,
+  ): Promise<{ trail: DeclaredObjectiveLike[] }>;
+  getNarrativeThreads(
+    personaId: string,
+  ): Promise<{ threads: NarrativeThreadLike[] }>;
+  getSubjectKnowledge(
+    personaId: string,
+  ): Promise<SubjectKnowledgeSummary>;
+
   // ─── Strategist (Fase 8 PR 3) ───────────────────────────────────
   /** Plan composto pra uma sessão. 404 quando não existe. */
   getSessionStrategyPlan(
@@ -417,6 +432,49 @@ export interface ApiClient {
     subjectId: string,
     opts?: { limit?: number },
   ): Promise<{ plans: StrategyPlanLike[] }>;
+}
+
+// ─── S1 wiring — Declared Objectives + Narrative Threads + SK summary ──
+
+export interface DeclaredObjectiveLike {
+  id: string;
+  persona_id: string;
+  declared_at: string;
+  declared_in_session: string;
+  target_date: string;
+  statement: string;
+  axis?: string;
+  status: "active" | "achieved" | "abandoned" | "drift_flagged" | "revised";
+  parent_objective_id?: string;
+  evidence_event_ids?: string[];
+  drift_check_due_at?: string;
+}
+
+export interface NarrativeThreadLike {
+  id: string;
+  persona_id: string;
+  opened_in_session: string;
+  opened_at: string;
+  thread_text: string;
+  axis?: string;
+  follow_up_triggered: boolean;
+  closed_at?: string;
+  status: "open" | "resumed" | "closed_natural" | "closed_abandoned" | "stale";
+  stale_after: string;
+}
+
+export interface TopConceptEntry {
+  concept_id: string;
+  lineage_anchor: string;
+  presentedCount: number;
+  lastSeenAt: string;
+}
+
+export interface SubjectKnowledgeSummary {
+  conceptsPresentedCount: number;
+  recallPositiveRate: number | null;
+  recallTotal: number;
+  topConcepts: TopConceptEntry[];
 }
 
 export interface SubjectKnowledgeEntryLike {
@@ -672,6 +730,22 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
         `/subjects/${encodeURIComponent(subjectId)}/maps${q ? `?${q}` : ""}`,
       );
     },
+    getDeclaredObjectives: (personaId) =>
+      get<{ objectives: DeclaredObjectiveLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/objectives`,
+      ),
+    getObjectiveHistory: (personaId, objectiveId) =>
+      get<{ trail: DeclaredObjectiveLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/objectives/${encodeURIComponent(objectiveId)}/history`,
+      ),
+    getNarrativeThreads: (personaId) =>
+      get<{ threads: NarrativeThreadLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/narrative-threads`,
+      ),
+    getSubjectKnowledge: (personaId) =>
+      get<SubjectKnowledgeSummary>(
+        `/personas/${encodeURIComponent(personaId)}/subject-knowledge`,
+      ),
     getSessionStrategyPlan: async (sessionId) => {
       const res = await f(
         `${baseUrl}/sessions/${encodeURIComponent(sessionId)}/strategy-plan`,

--- a/packages/ebrota-console-ui/tests/s1-aprendiz-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/s1-aprendiz-panel.test.ts
@@ -1,0 +1,289 @@
+/**
+ * S1AprendizPanel — wiring tests com mock ApiClient.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ *
+ * Cobre:
+ *  - Render com mock returning objectives + threads + SK summary
+ *  - Click no objetivo → fetch history e expande inline
+ *  - Loading state visível durante fetch
+ *  - Empty states graciosos
+ *  - Error fallback pra PlaceholderBanner
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/svelte";
+import S1AprendizPanel from "../src/components/subsystem-panels/S1AprendizPanel.svelte";
+import {
+  currentSessionId,
+  tracerSubjectId,
+  expandedSubsystem,
+} from "../src/lib/stores.js";
+import type {
+  ApiClient,
+  DeclaredObjectiveLike,
+  NarrativeThreadLike,
+  SubjectKnowledgeSummary,
+} from "../src/lib/api.js";
+
+type DeferredFetch<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): DeferredFetch<T> {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function mockApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  const stub = (): never => {
+    throw new Error("not stubbed");
+  };
+  // Cast pra ApiClient — preencho só os métodos usados pelo painel.
+  return {
+    getStatus: stub,
+    getMode: stub,
+    setMode: stub,
+    startCardSession: stub,
+    getActiveSessions: stub,
+    listOptions: stub,
+    overrideSelection: stub,
+    listDecisions: stub,
+    getPendingApproval: stub,
+    approveOrEdit: stub,
+    endSession: stub,
+    listSessionLibrary: stub,
+    getSessionReplay: stub,
+    listDebugLlmCalls: stub,
+    clearDebugLlmCalls: stub,
+    listAnalyticsPersonas: stub,
+    getPersonaEvolution: stub,
+    turnStateSseUrl: () => "/api/turn-state",
+    listSubjectDiscoveries: stub,
+    listSubjectBoundaries: stub,
+    getBoundariesSummary: stub,
+    getJourneyState: stub,
+    setJourneyOverride: stub,
+    clearJourneyOverride: stub,
+    listFrameworks: stub,
+    getSubjectMaps: stub,
+    getDeclaredObjectives: async () => ({ objectives: [] }),
+    getObjectiveHistory: async () => ({ trail: [] }),
+    getNarrativeThreads: async () => ({ threads: [] }),
+    getSubjectKnowledge: async () => ({
+      conceptsPresentedCount: 0,
+      recallPositiveRate: null,
+      recallTotal: 0,
+      topConcepts: [],
+    }),
+    getSessionStrategyPlan: stub,
+    listSubjectStrategyPlans: stub,
+    ...overrides,
+  } as ApiClient;
+}
+
+const sampleObjective: DeclaredObjectiveLike = {
+  id: "obj-1",
+  persona_id: "ryo",
+  declared_at: "2026-05-20T10:00:00Z",
+  declared_in_session: "sess-A",
+  target_date: "2026-06-20T10:00:00Z",
+  statement: "Ler 5 livros sobre dinossauros",
+  axis: "curiosidade",
+  status: "active",
+};
+
+const sampleThread: NarrativeThreadLike = {
+  id: "t-1",
+  persona_id: "ryo",
+  opened_in_session: "sess-A",
+  opened_at: "2026-05-22T10:00:00Z",
+  thread_text: "queria fazer origami de baleia",
+  axis: "criatividade",
+  follow_up_triggered: false,
+  status: "open",
+  stale_after: "2026-05-29T10:00:00Z",
+};
+
+const sampleSummary: SubjectKnowledgeSummary = {
+  conceptsPresentedCount: 7,
+  recallPositiveRate: 0.6,
+  recallTotal: 5,
+  topConcepts: [
+    {
+      concept_id: "estoica/dicotomia_controle",
+      lineage_anchor: "estoica/dicotomia_controle",
+      presentedCount: 3,
+      lastSeenAt: "2026-05-26T10:00:00Z",
+    },
+  ],
+};
+
+beforeEach(() => {
+  expandedSubsystem.set("S1");
+  currentSessionId.set("ryo__conv-1");
+  tracerSubjectId.set("ryo");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("S1AprendizPanel — wiring", () => {
+  it("renderiza dados reais (objectives + threads + SK) com mock api", async () => {
+    const api = mockApi({
+      getDeclaredObjectives: async () => ({ objectives: [sampleObjective] }),
+      getNarrativeThreads: async () => ({ threads: [sampleThread] }),
+      getSubjectKnowledge: async () => sampleSummary,
+    });
+
+    render(S1AprendizPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByText("Ler 5 livros sobre dinossauros")).toBeDefined();
+    });
+    expect(screen.getByText("queria fazer origami de baleia")).toBeDefined();
+    expect(screen.getByTestId("sk-stats")).toBeDefined();
+    expect(screen.getByText("estoica/dicotomia_controle")).toBeDefined();
+  });
+
+  it("loading state visível durante fetch", async () => {
+    const objectivesDef = deferred<{ objectives: DeclaredObjectiveLike[] }>();
+    const threadsDef = deferred<{ threads: NarrativeThreadLike[] }>();
+    const skDef = deferred<SubjectKnowledgeSummary>();
+    const api = mockApi({
+      getDeclaredObjectives: () => objectivesDef.promise,
+      getNarrativeThreads: () => threadsDef.promise,
+      getSubjectKnowledge: () => skDef.promise,
+    });
+
+    render(S1AprendizPanel, { api });
+
+    expect(screen.getByTestId("objectives-loading")).toBeDefined();
+    expect(screen.getByTestId("threads-loading")).toBeDefined();
+    expect(screen.getByTestId("sk-loading")).toBeDefined();
+
+    objectivesDef.resolve({ objectives: [sampleObjective] });
+    threadsDef.resolve({ threads: [] });
+    skDef.resolve({
+      conceptsPresentedCount: 0,
+      recallPositiveRate: null,
+      recallTotal: 0,
+      topConcepts: [],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Ler 5 livros sobre dinossauros")).toBeDefined();
+    });
+  });
+
+  it("click no objetivo expande inline com history trail", async () => {
+    const api = mockApi({
+      getDeclaredObjectives: async () => ({ objectives: [sampleObjective] }),
+      getObjectiveHistory: async () => ({
+        trail: [
+          { ...sampleObjective, id: "obj-1-v0", statement: "Ler 3 livros", status: "revised" },
+          sampleObjective,
+        ],
+      }),
+    });
+
+    render(S1AprendizPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("objective-toggle-obj-1")).toBeDefined();
+    });
+    await fireEvent.click(screen.getByTestId("objective-toggle-obj-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("objective-history-obj-1")).toBeDefined();
+    });
+    expect(screen.getByText("Ler 3 livros")).toBeDefined();
+  });
+
+  it("empty state quando persona sem dados", async () => {
+    const api = mockApi();
+    render(S1AprendizPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("objectives-empty")).toBeDefined();
+    });
+    expect(screen.getByTestId("threads-empty")).toBeDefined();
+    expect(screen.getByTestId("sk-empty")).toBeDefined();
+  });
+
+  it("error → fallback pra PlaceholderBanner", async () => {
+    const api = mockApi({
+      getDeclaredObjectives: async () => {
+        throw new Error("BFF offline");
+      },
+      getNarrativeThreads: async () => {
+        throw new Error("BFF offline");
+      },
+      getSubjectKnowledge: async () => {
+        throw new Error("BFF offline");
+      },
+    });
+
+    render(S1AprendizPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("objectives-error")).toBeDefined();
+    });
+    expect(screen.getByTestId("threads-error")).toBeDefined();
+    expect(screen.getByTestId("sk-error")).toBeDefined();
+    expect(screen.getByText(/2026-05-26-s1-objetivos-declarados-v0\.md/)).toBeDefined();
+    expect(screen.getByText(/2026-05-26-b1-hooks-temporais-v0\.md/)).toBeDefined();
+  });
+
+  it("deriva persona_id de $currentSessionId (split em __)", async () => {
+    currentSessionId.set("yuji__conv-42");
+    const captured: string[] = [];
+    const api = mockApi({
+      getDeclaredObjectives: async (pid) => {
+        captured.push(pid);
+        return { objectives: [] };
+      },
+      getNarrativeThreads: async (pid) => {
+        captured.push(pid);
+        return { threads: [] };
+      },
+      getSubjectKnowledge: async (pid) => {
+        captured.push(pid);
+        return {
+          conceptsPresentedCount: 0,
+          recallPositiveRate: null,
+          recallTotal: 0,
+          topConcepts: [],
+        };
+      },
+    });
+
+    render(S1AprendizPanel, { api });
+    await waitFor(() => {
+      expect(captured.length).toBeGreaterThanOrEqual(3);
+    });
+    expect(captured.every((p) => p === "yuji")).toBe(true);
+  });
+
+  it("fallback pro tracerSubjectId quando session vazio", async () => {
+    currentSessionId.set(null);
+    tracerSubjectId.set("saki-default");
+    let pid = "";
+    const api = mockApi({
+      getDeclaredObjectives: async (p) => {
+        pid = p;
+        return { objectives: [] };
+      },
+    });
+
+    render(S1AprendizPanel, { api });
+    await waitFor(() => {
+      expect(pid).toBe("saki-default");
+    });
+  });
+});

--- a/packages/ebrota-console-ui/tests/subsystem-panels-render.test.ts
+++ b/packages/ebrota-console-ui/tests/subsystem-panels-render.test.ts
@@ -35,15 +35,14 @@ afterEach(() => {
 });
 
 describe("subsystem panels — smoke render", () => {
-  it("S1AprendizPanel renderiza shell com id correto + placeholder pra objetivos", () => {
+  it("S1AprendizPanel renderiza shell + seções Objetivos/Threads/SK wired", () => {
     render(S1AprendizPanel);
     expect(screen.getByTestId("subsystem-panel-S1")).toBeDefined();
-    // placeholder banner aponta pra spec de objetivos declarados
-    const placeholders = screen.getAllByTestId("placeholder-banner");
-    expect(placeholders.length).toBeGreaterThanOrEqual(2);
-    expect(
-      screen.getByText(/2026-05-26-s1-objetivos-declarados-v0\.md/),
-    ).toBeDefined();
+    // Painel agora consome BFF (PR S1 wiring) — placeholders só aparecem
+    // em error fallback; estado inicial mostra seções com data-testids.
+    expect(screen.getByTestId("s1-objectives")).toBeDefined();
+    expect(screen.getByTestId("s1-threads")).toBeDefined();
+    expect(screen.getByTestId("s1-subject-knowledge")).toBeDefined();
   });
 
   it("S2DoutrinaPanel renderiza shell + 6 jogadas (5 + Recovery)", () => {


### PR DESCRIPTION
## S1 wiring: BFF routes + S1AprendizPanel consome dados reais

Conecta a feature S1 (Declared Objectives + Narrative Threads + Subject Knowledge ledger) ao painel S1AprendizPanel.svelte, substituindo placeholders por dados via BFF.

### BFF — 4 endpoints novos (`packages/ebrota-console-bff/src/routes/s1-routes.ts`)
- `GET /personas/:id/objectives` — lista latest-in-chain de `DeclaredObjective`
- `GET /personas/:id/objectives/:objId/history` — trail completo (ancestrais + sucessores)
- `GET /personas/:id/narrative-threads` — `NarrativeThread[]` por persona
- `GET /personas/:id/subject-knowledge` — summary: count of presented_concepts, recall+ rate, top 5 conceitos recentes

Plugin Fastify isolado em `routes/s1-routes.ts` (não polui server.ts; outros agentes paralelos podem editar sem conflito). DDL idempotente garante schema mesmo sem motor-execucao escrever.

### UI — `S1AprendizPanel.svelte`
- Consome BFF via novo `api.getDeclaredObjectives() / getObjectiveHistory() / getNarrativeThreads() / getSubjectKnowledge()`
- Persona derivada de `$currentSessionId` (formato `persona_id__conversation_id`) com fallback pro `tracerSubjectId`
- Cards de objetivos com statement / target_date (relative) / status badge / axis chip
- Click no card → fetch + expand inline com history trail
- Threads com thread_text / opened_at (relative) / status badge
- Subject Knowledge: presented count + recall+ rate (%) + top 5 conceitos
- Estados graciosos: loading / loaded / empty / error → fallback pra PlaceholderBanner

### Testes
- BFF: `tests/s1-routes.unit.test.ts` — 11 testes (empty states, latest-in-chain, history trail, ledger aggregation, top 5 cap)
- UI: `tests/s1-aprendiz-panel.test.ts` — 7 testes (render real data, loading, click expand, empty, error fallback, persona derivation, tracerSubjectId fallback)
- Atualizado `subsystem-panels-render.test.ts` smoke S1 (PlaceholderBanner → testids `s1-objectives / s1-threads / s1-subject-knowledge`)

### Resultados
- `tsc --noEmit` ✓
- BFF: 18 files / **172 testes ✓**
- UI: 24 files / **177 testes ✓**

### Specs
- `docs/specs/2026-05-26-s1-objetivos-declarados-v0.md` (S1)
- `docs/specs/2026-05-26-b1-hooks-temporais-v0.md` (B1 threads)
- `docs/specs/2026-05-25-subject-knowledge-bridge.md` (SK ledger)

### Não tocado
- `B1SocialPanel`, `B2DrillingPanel`, `ReplayTurnDetail`, `App.svelte`, `Status.svelte` (outros agentes paralelos)
- Código em `motor-drota/`, `planejador/` (sem mudança de motor — só consumir)
- `server.ts`: apenas 1 linha de `fastify.register` adicionada