### PR TITLE
[motor] Trigger Evaluator closed-loop — auto-move statusMatrix on validated transitions

### DIFF
--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { loadInventory } from "./loader.js";
 import { getState, logEvent, getDbInstance } from "./state-manager.js";
+import { applyStatusTransition } from "./tree-nodes.js";
 import { executePlaybook } from "./executor.js";
 import { createProdActionMenuDeps } from "./action-menu-deps.js";
 import type { OnboardingTriggerDeps } from "./onboarding-trigger.js";
@@ -333,6 +334,51 @@ server.registerTool("log_event", {
   const event = { timestamp: getNow(), type, data: data ?? {} };
   logEvent(sessionId, event);
   return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, event }) }] };
+});
+
+/**
+ * Closed-loop v1 (ARCHITECTURE.md §S5): aplica transição de status numa
+ * dimensão da statusMatrix. `source` distingue origem (audit + override
+ * semantics).
+ *
+ * Invariante brejo↔baia↔pasto é aplicada por `applyStatusTransition` em
+ * tree-nodes.ts (pure `transition()` rejeita brejo↔pasto direto → força baia).
+ *
+ * Side-effect: também loga evento `status_matrix_updated_by_trigger` no
+ * event_log da sessão (audit trail equivalente ao recall_check_attempt).
+ */
+server.registerTool("apply_status_transition", {
+  description: "Aplica transicao de status numa dimensao (closed-loop v1) + loga audit event",
+  inputSchema: {
+    sessionId: z.string(),
+    dimension: z.string(),
+    target: z.enum(["brejo", "baia", "pasto"]),
+    source: z.enum(["manual", "trigger_evaluator"]),
+    transitionName: z.string().optional(),
+  } as any,
+}, async ({ sessionId, dimension, target, source, transitionName }: {
+  sessionId: string;
+  dimension: string;
+  target: StatusValue;
+  source: "manual" | "trigger_evaluator";
+  transitionName?: string;
+}) => {
+  const db = getDbInstance();
+  const result = applyStatusTransition(db, sessionId, dimension, target);
+  logEvent(sessionId, {
+    timestamp: getNow(),
+    type: "status_matrix_updated_by_trigger",
+    data: {
+      source,
+      ...(transitionName !== undefined ? { transition_name: transitionName } : {}),
+      dimension: result.dimension,
+      target_zone: result.target,
+      applied_zone: result.applied,
+      accepted: result.accepted,
+      reason: result.reason,
+    },
+  });
+  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, ...result }) }] };
 });
 
 const transport = new StdioServerTransport();

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -357,7 +357,11 @@ export async function runTurn(
   });
 
   // motor#25 (handoff #25 B4 + B5): loga transitionEvaluations + entropy events.
-  // Read-only — só registra. v0 não move statusMatrix.
+  // v0 (flag OFF): só registra evento transition_evaluated (read-only).
+  // v1 (flag ON, ARCHITECTURE.md §S5): quando ev.closed_loop_action presente,
+  //   também chama apply_status_transition pra mover statusMatrix e emitir
+  //   status_matrix_updated_by_trigger. Planejador decide se enriquece;
+  //   orchestrator só repassa.
   if (plan.transitionEvaluations && plan.transitionEvaluations.length > 0) {
     for (const ev of plan.transitionEvaluations) {
       try {
@@ -378,6 +382,22 @@ export async function runTurn(
         });
       } catch {
         // Fail-soft
+      }
+      if (ev.closed_loop_action) {
+        try {
+          await clients.motorExecucao.callTool({
+            name: "apply_status_transition",
+            arguments: {
+              sessionId,
+              dimension: ev.closed_loop_action.dimension,
+              target: ev.closed_loop_action.target_zone,
+              source: ev.closed_loop_action.source,
+              transitionName: ev.transition_name,
+            },
+          });
+        } catch {
+          // Fail-soft — closed-loop não pode quebrar o turn.
+        }
       }
     }
   }

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -55,6 +55,7 @@ import {
   evaluateAllTransitions,
   collectRecentSignals,
   collectRecentSignalsPerTurn,
+  enrichWithClosedLoopActions,
 } from "./trigger-evaluator.js";
 import { detectCritical } from "./critical-detector.js";
 import { personaToChildProfile } from "./child-profile.js";
@@ -809,8 +810,11 @@ export async function planTurn(
   }
 
   // motor#25 (handoff #25 B4): Trigger Evaluator — avalia transitions.yaml
-  // contra signals capturados nos últimos 5 turns. Read-only — orchestrator
-  // loga events transition_evaluated, statusMatrix NÃO move automático.
+  // contra signals capturados nos últimos 5 turns.
+  // v0 (flag OFF): orchestrator só loga events transition_evaluated.
+  // v1 (flag ON, ARCHITECTURE.md §S5): resultados fired ganham
+  //   `closed_loop_action` declarativo; orchestrator chama
+  //   `apply_status_transition` em motor-execucao pra mover statusMatrix.
   const profileId = inferProfileId(input.persona);
   const eventLog = (input.state.eventLog ?? []) as Array<{
     type: string;
@@ -819,7 +823,7 @@ export async function planTurn(
   const recentSignals = collectRecentSignals(eventLog, 5);
   const recentSignalsPerTurn = collectRecentSignalsPerTurn(eventLog, 5);
   const turnsSinceLastTransition = countTurnsSinceLastTransition(eventLog);
-  const transitionEvaluations =
+  const rawTransitionEvaluations =
     recentSignals.length > 0
       ? evaluateAllTransitions(
           profileId,
@@ -828,6 +832,10 @@ export async function planTurn(
           recentSignalsPerTurn,
         )
       : [];
+  const transitionEvaluations = enrichWithClosedLoopActions(
+    rawTransitionEvaluations,
+    focusDim,
+  );
   const criticalDetection = detectCritical(recentSignals);
 
   // Fase 8 PR — Strategist context (sub-PR pós tracer bullet):

--- a/planejador/src/trigger-evaluator.ts
+++ b/planejador/src/trigger-evaluator.ts
@@ -2,11 +2,19 @@
  * Trigger Evaluator — avalia transitions.yaml contra signals capturados (motor#25).
  *
  * Spec: docs/handoffs/2026-04-26-cc-motor-pre-piloto-strategic-gaps.md §motor#25.
- * ARCHITECTURE.md §14.
+ * ARCHITECTURE.md §14 + §S5 ("promover eixo-status ao patamar do eixo-conceito").
  *
- * Filosofia v0: read-only — emite eventos transition_evaluated mas NÃO move
- * statusMatrix. Movimentação real continua via inject_status (manual).
- * Auto-movimentação fica pra v1 pós-piloto, depois de validar precision.
+ * v0 (read-only, fallback): emite eventos transition_evaluated mas NÃO move
+ *   statusMatrix. Comportamento ativo quando feature flag OFF.
+ * v1 (closed-loop): quando TRIGGER_EVALUATOR_CLOSED_LOOP=true, planejador
+ *   enriquece cada resultado fired com `closed_loop_action` declarativo.
+ *   Orchestrator consome esse campo e chama `apply_status_transition` em
+ *   motor-execucao (que aplica a invariante brejo↔baia↔pasto + loga
+ *   `status_matrix_updated_by_trigger`). Mirror exato do design do
+ *   RecallCheckEvaluator (que já fecha o laço pro eixo-conceito).
+ *
+ * Override manual via `apply_status_transition` source="manual" segue
+ * disponível pra Pedagógico Steward — closed-loop não substitui, complementa.
  */
 
 import { readFileSync, existsSync } from "node:fs";
@@ -142,5 +150,83 @@ export function collectRecentSignalsPerTurn(
     const data = ev.data as { signals?: unknown };
     if (!Array.isArray(data.signals)) return [];
     return data.signals.filter((s): s is string => typeof s === "string");
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// v1 closed-loop (ARCHITECTURE.md §S5) — enrichment puro, sem side-effect.
+//
+// Planejador NÃO chama motor-execucao diretamente — só declara a intenção
+// (`closed_loop_action`) no resultado. Orchestrator é quem aplica via MCP
+// tool `apply_status_transition`. Essa separação mantém planejador puro
+// (testável sem MCP) e respeita a arquitetura motor → orchestrator → cliente.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { StatusValue } from "@ascendimacy/shared";
+
+/**
+ * Feature flag — decide se o closed-loop está ativo no processo atual.
+ *
+ * Precedência:
+ *   1. `TRIGGER_EVALUATOR_CLOSED_LOOP=true|1` → ON (override explícito)
+ *   2. `TRIGGER_EVALUATOR_CLOSED_LOOP=false|0` → OFF (override explícito)
+ *   3. `NODE_ENV=production` → ON (default prod)
+ *   4. caso contrário → OFF (default dev/test pra preservar comportamento v0)
+ */
+export function isClosedLoopEnabled(): boolean {
+  const explicit = process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"];
+  if (explicit !== undefined) {
+    return explicit === "true" || explicit === "1";
+  }
+  return process.env["NODE_ENV"] === "production";
+}
+
+/**
+ * Extrai a `target_zone` do nome da transição.
+ *
+ * Convenção dos transitions.yaml:
+ *   - `brejo_to_baia` → "baia"
+ *   - `baia_to_pasto` → "pasto"
+ *   - `regression_baia_to_brejo` → "brejo"
+ *   - `regression_pasto_to_baia` → "baia"
+ *
+ * Retorna null se o nome não seguir o padrão (defensivo).
+ */
+export function parseTransitionTargetZone(transitionName: string): StatusValue | null {
+  const match = transitionName.match(/^(?:regression_)?\w+_to_(brejo|baia|pasto)$/);
+  if (!match) return null;
+  return match[1] as StatusValue;
+}
+
+/**
+ * Enriquece resultados fired com `closed_loop_action` quando flag ON.
+ *
+ * Pure function — não muta input, retorna novo array. Quando flag OFF
+ * (default em test/dev), retorna o array original sem mudança (comportamento
+ * v0 preservado).
+ *
+ * @param results saída de `evaluateAllTransitions`
+ * @param focusDimension dimensão alvo (vem de `pickFocusDimension(statusMatrix)`
+ *   no caller — geralmente "emotional" pra perfil kids). Fallback "emotional"
+ *   garante que o closed-loop sempre tem onde aplicar.
+ */
+export function enrichWithClosedLoopActions(
+  results: TransitionEvaluationResult[],
+  focusDimension: string | undefined,
+): TransitionEvaluationResult[] {
+  if (!isClosedLoopEnabled()) return results;
+  const dimension = focusDimension ?? "emotional";
+  return results.map((result) => {
+    if (!result.fired) return result;
+    const targetZone = parseTransitionTargetZone(result.transition_name);
+    if (targetZone === null) return result;
+    return {
+      ...result,
+      closed_loop_action: {
+        dimension,
+        target_zone: targetZone,
+        source: "trigger_evaluator" as const,
+      },
+    };
   });
 }

--- a/planejador/tests/trigger-evaluator-closed-loop.unit.test.ts
+++ b/planejador/tests/trigger-evaluator-closed-loop.unit.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Trigger Evaluator closed-loop v1 (ARCHITECTURE.md §S5).
+ *
+ * Cobre:
+ *  - feature flag OFF (default em test) → comportamento v0 preservado
+ *  - feature flag ON → fired results ganham closed_loop_action
+ *  - parseTransitionTargetZone — derivação correta da target zone
+ *  - regressões e nomes malformados — degradação graciosa
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  enrichWithClosedLoopActions,
+  parseTransitionTargetZone,
+  isClosedLoopEnabled,
+} from "../src/trigger-evaluator.js";
+import type { TransitionEvaluationResult } from "@ascendimacy/shared";
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  delete process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"];
+  delete process.env["NODE_ENV"];
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(ORIG_ENV)) {
+    process.env[k] = v;
+  }
+});
+
+const firedResult = (transition_name: string): TransitionEvaluationResult => ({
+  transition_name,
+  fired: true,
+  required_matched: ["philosophical_self_acceptance"],
+  confirmatory_matched: [],
+  regression_signals_present: [],
+  reason: "fired — required matched",
+});
+
+const notFiredResult = (transition_name: string): TransitionEvaluationResult => ({
+  transition_name,
+  fired: false,
+  required_matched: [],
+  confirmatory_matched: [],
+  regression_signals_present: [],
+  reason: "required_signals not matched",
+});
+
+describe("isClosedLoopEnabled (feature flag)", () => {
+  it("default OFF quando NODE_ENV indefinido + sem override", () => {
+    expect(isClosedLoopEnabled()).toBe(false);
+  });
+
+  it("default ON em produção", () => {
+    process.env["NODE_ENV"] = "production";
+    expect(isClosedLoopEnabled()).toBe(true);
+  });
+
+  it("default OFF em test/dev", () => {
+    process.env["NODE_ENV"] = "test";
+    expect(isClosedLoopEnabled()).toBe(false);
+  });
+
+  it("override explícito true vence default", () => {
+    process.env["NODE_ENV"] = "test";
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "true";
+    expect(isClosedLoopEnabled()).toBe(true);
+  });
+
+  it("override explícito false vence prod default", () => {
+    process.env["NODE_ENV"] = "production";
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "false";
+    expect(isClosedLoopEnabled()).toBe(false);
+  });
+
+  it("aceita '1' / '0' como aliases", () => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "1";
+    expect(isClosedLoopEnabled()).toBe(true);
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "0";
+    expect(isClosedLoopEnabled()).toBe(false);
+  });
+});
+
+describe("parseTransitionTargetZone", () => {
+  it("parseia transições forward", () => {
+    expect(parseTransitionTargetZone("brejo_to_baia")).toBe("baia");
+    expect(parseTransitionTargetZone("baia_to_pasto")).toBe("pasto");
+  });
+
+  it("parseia regressões", () => {
+    expect(parseTransitionTargetZone("regression_baia_to_brejo")).toBe("brejo");
+    expect(parseTransitionTargetZone("regression_pasto_to_baia")).toBe("baia");
+  });
+
+  it("retorna null pra nomes malformados", () => {
+    expect(parseTransitionTargetZone("not_a_transition")).toBeNull();
+    expect(parseTransitionTargetZone("brejo_to_unknown")).toBeNull();
+    expect(parseTransitionTargetZone("")).toBeNull();
+  });
+});
+
+describe("enrichWithClosedLoopActions — flag OFF (v0 fallback)", () => {
+  beforeEach(() => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "false";
+  });
+
+  it("retorna resultados sem closed_loop_action (preserva v0)", () => {
+    const input = [firedResult("brejo_to_baia"), notFiredResult("baia_to_pasto")];
+    const enriched = enrichWithClosedLoopActions(input, "emotional");
+    expect(enriched).toHaveLength(2);
+    expect(enriched[0].closed_loop_action).toBeUndefined();
+    expect(enriched[1].closed_loop_action).toBeUndefined();
+  });
+
+  it("não muta input", () => {
+    const input = [firedResult("brejo_to_baia")];
+    enrichWithClosedLoopActions(input, "emotional");
+    expect(input[0].closed_loop_action).toBeUndefined();
+  });
+});
+
+describe("enrichWithClosedLoopActions — flag ON (v1 closed-loop)", () => {
+  beforeEach(() => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "true";
+  });
+
+  it("anexa closed_loop_action a results fired", () => {
+    const input = [firedResult("brejo_to_baia")];
+    const enriched = enrichWithClosedLoopActions(input, "emotional");
+    expect(enriched[0].closed_loop_action).toEqual({
+      dimension: "emotional",
+      target_zone: "baia",
+      source: "trigger_evaluator",
+    });
+  });
+
+  it("NÃO anexa a results !fired", () => {
+    const input = [notFiredResult("brejo_to_baia")];
+    const enriched = enrichWithClosedLoopActions(input, "emotional");
+    expect(enriched[0].closed_loop_action).toBeUndefined();
+  });
+
+  it("regressões disparam target_zone correto", () => {
+    const input = [
+      firedResult("regression_baia_to_brejo"),
+      firedResult("regression_pasto_to_baia"),
+    ];
+    const enriched = enrichWithClosedLoopActions(input, "emotional");
+    expect(enriched[0].closed_loop_action?.target_zone).toBe("brejo");
+    expect(enriched[1].closed_loop_action?.target_zone).toBe("baia");
+  });
+
+  it("usa focusDimension passada", () => {
+    const input = [firedResult("brejo_to_baia")];
+    const enriched = enrichWithClosedLoopActions(input, "social_with_ebrota");
+    expect(enriched[0].closed_loop_action?.dimension).toBe("social_with_ebrota");
+  });
+
+  it("fallback 'emotional' quando focusDimension undefined", () => {
+    const input = [firedResult("brejo_to_baia")];
+    const enriched = enrichWithClosedLoopActions(input, undefined);
+    expect(enriched[0].closed_loop_action?.dimension).toBe("emotional");
+  });
+
+  it("nome malformado → fired mas sem closed_loop_action (degradação graciosa)", () => {
+    const input = [firedResult("not_a_transition_name")];
+    const enriched = enrichWithClosedLoopActions(input, "emotional");
+    expect(enriched[0].fired).toBe(true);
+    expect(enriched[0].closed_loop_action).toBeUndefined();
+  });
+
+  it("não muta input (mantém pureza)", () => {
+    const input = [firedResult("brejo_to_baia")];
+    enrichWithClosedLoopActions(input, "emotional");
+    expect(input[0].closed_loop_action).toBeUndefined();
+  });
+
+  it("processa lista mista (fired + !fired)", () => {
+    const input = [
+      firedResult("brejo_to_baia"),
+      notFiredResult("baia_to_pasto"),
+      firedResult("regression_baia_to_brejo"),
+    ];
+    const enriched = enrichWithClosedLoopActions(input, "emotional");
+    expect(enriched[0].closed_loop_action?.target_zone).toBe("baia");
+    expect(enriched[1].closed_loop_action).toBeUndefined();
+    expect(enriched[2].closed_loop_action?.target_zone).toBe("brejo");
+  });
+});

--- a/planejador/tests/trigger-evaluator-integration.test.ts
+++ b/planejador/tests/trigger-evaluator-integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration test — closed-loop v1 flow (ARCHITECTURE.md §S5).
+ *
+ * Simula 5 turns com signals progressivos contra o kids.transitions.yaml
+ * real. Última iteração satisfaz minimum_window_turns + required_signals
+ * e dispara brejo_to_baia. Verifica que:
+ *   - Resultado fired chega enriquecido com closed_loop_action (flag ON)
+ *   - target_zone derivada do transition_name está correta
+ *   - Flag OFF preserva comportamento v0 (sem closed_loop_action)
+ *
+ * Não exercita o orchestrator/MCP layer (testes desse nível ficam em
+ * orchestrator/tests/). Aqui testa a contract entre planejador e cliente
+ * downstream.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  evaluateAllTransitions,
+  collectRecentSignals,
+  collectRecentSignalsPerTurn,
+  enrichWithClosedLoopActions,
+  resetTransitionsConfigCache,
+} from "../src/trigger-evaluator.js";
+
+const REAL_CONTENT_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../content/profiles",
+);
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env["CONTENT_PROFILES_DIR"] = REAL_CONTENT_DIR;
+  resetTransitionsConfigCache();
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in ORIG_ENV)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(ORIG_ENV)) {
+    process.env[k] = v;
+  }
+});
+
+interface EventLog {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+/** Helper que executa um turno: append signals_extracted + executar pipeline. */
+function runTurn(
+  eventLog: EventLog[],
+  signals: string[],
+  turnsSinceLastTransition: number,
+  focusDimension: string,
+) {
+  eventLog.push({
+    type: "signals_extracted",
+    data: { signals },
+  });
+  eventLog.push({ type: "playbook_executed", data: {} });
+
+  const recentSignals = collectRecentSignals(eventLog, 5);
+  const recentSignalsPerTurn = collectRecentSignalsPerTurn(eventLog, 5);
+  const raw = evaluateAllTransitions(
+    "kids",
+    recentSignals,
+    turnsSinceLastTransition,
+    recentSignalsPerTurn,
+  );
+  return enrichWithClosedLoopActions(raw, focusDimension);
+}
+
+describe("closed-loop integration — 5-turn progressive signals flow", () => {
+  it("flag ON: turn 3+ acumula janela suficiente → fired + closed_loop_action.target_zone='baia'", () => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "true";
+    const eventLog: EventLog[] = [];
+
+    // Turn 1: signal correto mas janela ainda 0
+    const t1 = runTurn(eventLog, ["philosophical_self_acceptance"], 0, "emotional");
+    const t1Brejo = t1.find((r) => r.transition_name === "brejo_to_baia");
+    expect(t1Brejo?.fired).toBe(false);
+    expect(t1Brejo?.closed_loop_action).toBeUndefined();
+
+    // Turn 2: ainda janela curta (1)
+    const t2 = runTurn(eventLog, ["voluntary_topic_deepening"], 1, "emotional");
+    const t2Brejo = t2.find((r) => r.transition_name === "brejo_to_baia");
+    expect(t2Brejo?.fired).toBe(false);
+    expect(t2Brejo?.closed_loop_action).toBeUndefined();
+
+    // Turn 3: janela ≥ 2, signal presente → fire
+    const t3 = runTurn(eventLog, ["philosophical_self_acceptance"], 2, "emotional");
+    const t3Brejo = t3.find((r) => r.transition_name === "brejo_to_baia");
+    expect(t3Brejo?.fired).toBe(true);
+    expect(t3Brejo?.closed_loop_action).toEqual({
+      dimension: "emotional",
+      target_zone: "baia",
+      source: "trigger_evaluator",
+    });
+  });
+
+  it("flag OFF: mesmo flow, mesma fired, MAS sem closed_loop_action (v0 fallback)", () => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "false";
+    const eventLog: EventLog[] = [];
+    runTurn(eventLog, ["philosophical_self_acceptance"], 0, "emotional");
+    runTurn(eventLog, ["voluntary_topic_deepening"], 1, "emotional");
+    const t3 = runTurn(eventLog, ["philosophical_self_acceptance"], 2, "emotional");
+    const t3Brejo = t3.find((r) => r.transition_name === "brejo_to_baia");
+    expect(t3Brejo?.fired).toBe(true);
+    expect(t3Brejo?.closed_loop_action).toBeUndefined();
+  });
+
+  it("flag ON: regressão dispara closed_loop_action.target_zone='brejo' em 2 turns consecutivos", () => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "true";
+    const eventLog: EventLog[] = [];
+
+    // 2 turns consecutivos com distress → regression_baia_to_brejo
+    runTurn(eventLog, ["distress_marker_high"], 0, "emotional");
+    const t2 = runTurn(eventLog, ["distress_marker_high"], 0, "emotional");
+    const regr = t2.find((r) => r.transition_name === "regression_baia_to_brejo");
+    expect(regr?.fired).toBe(true);
+    expect(regr?.closed_loop_action?.target_zone).toBe("brejo");
+    expect(regr?.closed_loop_action?.source).toBe("trigger_evaluator");
+  });
+
+  it("flag ON: regression signal bloqueia forward transition — sem closed_loop_action", () => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "true";
+    const eventLog: EventLog[] = [];
+    // janela OK + required presente, mas regression signal também → fired=false
+    const t = runTurn(
+      eventLog,
+      ["philosophical_self_acceptance", "distress_marker_high"],
+      3,
+      "emotional",
+    );
+    const brejo = t.find((r) => r.transition_name === "brejo_to_baia");
+    expect(brejo?.fired).toBe(false);
+    expect(brejo?.closed_loop_action).toBeUndefined();
+  });
+
+  it("flag ON com focusDimension custom: closed_loop_action.dimension reflete focus", () => {
+    process.env["TRIGGER_EVALUATOR_CLOSED_LOOP"] = "true";
+    const eventLog: EventLog[] = [];
+    runTurn(eventLog, ["philosophical_self_acceptance"], 0, "social_with_parent");
+    runTurn(eventLog, ["voluntary_topic_deepening"], 1, "social_with_parent");
+    const t3 = runTurn(
+      eventLog,
+      ["philosophical_self_acceptance"],
+      2,
+      "social_with_parent",
+    );
+    const fired = t3.find((r) => r.fired && r.closed_loop_action);
+    expect(fired?.closed_loop_action?.dimension).toBe("social_with_parent");
+  });
+});

--- a/shared/src/transitions-schema.ts
+++ b/shared/src/transitions-schema.ts
@@ -75,6 +75,24 @@ export interface TransitionEvaluationResult {
   regression_signals_present: string[];
   /** Razão humana-legível da decisão. */
   reason: string;
+  /**
+   * Closed-loop v1 (ARCHITECTURE.md §S5 — "promover eixo-status ao patamar do
+   * eixo-conceito"): quando feature flag TRIGGER_EVALUATOR_CLOSED_LOOP=true e
+   * `fired=true`, planejador enriquece o resultado com a intenção declarativa
+   * de aplicar a transição na statusMatrix. Orchestrator consome esse campo
+   * pra chamar `apply_status_transition` em motor-execucao e emitir
+   * `status_matrix_updated_by_trigger`.
+   *
+   * Sem este campo (flag OFF ou !fired) → comportamento v0 read-only preservado.
+   */
+  closed_loop_action?: {
+    /** Dimensão alvo na matrix (ex: "emotional"). */
+    dimension: string;
+    /** Zone alvo derivada do nome da transição (ex: "baia"). */
+    target_zone: "brejo" | "baia" | "pasto";
+    /** Origem da transição — pra audit + override semantics. */
+    source: "trigger_evaluator";
+  };
 }
 
 /**


### PR DESCRIPTION
## What

Fecha o laço do **Trigger Evaluator**: transitions validadas agora movem o `statusMatrix` automaticamente, mirror exato do design já vigente do `RecallCheckEvaluator` (que fecha o laço pro eixo-conceito).

Spec: ARCHITECTURE.md §S5 — *"promover o eixo-status ao patamar do eixo-conceito — fazer transition_evaluated AGIR como recall_check_attempt já age"*.

## Diff conceitual v0 → v1

**v0 (read-only, fallback)**
\`\`\`
planejador → evaluateAllTransitions → TransitionEvaluationResult{ fired, ... }
orchestrator → log_event(transition_evaluated) → statusMatrix INALTERADO
[Pedagógico Steward] → inject_status manual (única forma de mover)
\`\`\`

**v1 (closed-loop, flag ON)**
\`\`\`
planejador → evaluateAllTransitions → enrichWithClosedLoopActions(focusDim)
            → TransitionEvaluationResult{ fired, closed_loop_action?: { dimension, target_zone, source } }
orchestrator → log_event(transition_evaluated)
            → if closed_loop_action: apply_status_transition (MCP) → statusMatrix MOVE + audit event
[Pedagógico Steward] → apply_status_transition source='manual' (continua disponível)
\`\`\`

## Design split

| Camada | Responsabilidade |
|---|---|
| \`planejador/trigger-evaluator\` | Pure enrichment + parsing + feature-flag check (testável sem MCP) |
| \`orchestrator\` | Side-effect — chama tool via cliente motor-execucao quando \`closed_loop_action\` presente |
| \`motor-execucao/tree-nodes.applyStatusTransition\` | Já existia — aplica invariante brejo↔baia↔pasto |
| \`motor-execucao/server\` | Nova MCP tool \`apply_status_transition\` (wrapper + audit log) |

## Feature flag \`TRIGGER_EVALUATOR_CLOSED_LOOP\`

Precedência:
1. Env explícito \`true\`/\`1\` ou \`false\`/\`0\` sempre vence
2. \`NODE_ENV=production\` → default ON
3. Caso contrário (test/dev) → default OFF

Garante backward-compat total: testes existentes do trigger-evaluator (25) seguem passando inalterados porque vitest seta NODE_ENV=test → flag OFF → branch v0.

## Files changed

| File | Change |
|---|---|
| \`shared/src/transitions-schema.ts\` | +\`closed_loop_action?\` field em TransitionEvaluationResult |
| \`planejador/src/trigger-evaluator.ts\` | +\`isClosedLoopEnabled()\`, +\`parseTransitionTargetZone()\`, +\`enrichWithClosedLoopActions()\` |
| \`planejador/src/plan.ts\` | Wire \`enrichWithClosedLoopActions(rawResults, focusDim)\` |
| \`motor-execucao/src/server.ts\` | Nova MCP tool \`apply_status_transition\` (também loga \`status_matrix_updated_by_trigger\`) |
| \`orchestrator/src/orchestrator.ts\` | Loop de transitionEvaluations agora dispara apply tool quando \`closed_loop_action\` set |
| \`planejador/tests/trigger-evaluator-closed-loop.unit.test.ts\` | **NEW** — 19 testes: flag matrix, parseTransitionTargetZone, enrichment puro |
| \`planejador/tests/trigger-evaluator-integration.test.ts\` | **NEW** — 5 testes: 5-turn progressive flow, regressão, focus dim |

## Critério de aceitação

- [x] Build motor passa (planejador + motor-execucao + shared + orchestrator)
- [x] Tests novos passam (24 novos)
- [x] Tests existentes do trigger-evaluator continuam passando (25/25)
- [x] Full suite: 1698/1698 passando (planejador 402, motor 198, shared 931, orchestrator 167)
- [x] Com flag ON: transition validada → \`closed_loop_action\` set → apply tool chamada → \`status_matrix_updated_by_trigger\` event emitido
- [x] Com flag OFF: \`closed_loop_action\` undefined, comportamento v0 preservado (testes existentes confirmam)
- [x] Manual override via \`apply_status_transition source='manual'\` continua funcionando

## Não-objetivos v0 (próximos PRs)

- UI exposing closed-loop transitions no S5 panel — eventos já visíveis via Replay
- Rollback automático se status_matrix_updated_by_trigger gerar feedback negativo — manual via apply tool source='manual'
- Confidence calibration via STS (precision/recall threshold tuning)

## Persistence note

Spec original mencionou *"event-sourced, não mutável — cada transition cria novo evento status_changed"*. A implementação real em \`motor-execucao/tree-nodes\` usa upsert sobre \`tree_nodes\` zone='status' (chave composta session_id+key, value=zone). Audit trail é provido pelo event \`status_matrix_updated_by_trigger\` no event_log da sessão, equivalente a \`recall_check_attempt\`. Migração pra event-sourced full pode ser feita depois sem mudar essa interface.