### PR TITLE
[motor+ui+bff] MC1 scheduling integration — wizard completion → temporal-scheduler delivery

### DIFF
--- a/motor-execucao/package.json
+++ b/motor-execucao/package.json
@@ -8,7 +8,8 @@
     ".": "./dist/server.js",
     "./cards-repo": "./dist/cards-repo.js",
     "./drill-repo": "./dist/drill-repo.js",
-    "./narrative-thread-repo": "./dist/narrative-thread-repo.js"
+    "./narrative-thread-repo": "./dist/narrative-thread-repo.js",
+    "./mc1-repo": "./dist/mc1-repo.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/motor-execucao/src/mc1-repo.ts
+++ b/motor-execucao/src/mc1-repo.ts
@@ -1,0 +1,203 @@
+/**
+ * mc1_scheduled — persistência da primeira mensagem (MC1) aprovada por
+ * Yuji no wizard parental, aguardando entrega na próxima janela temporal.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-19-mc1-primeira-mensagem-brota-jp.md
+ *
+ * Lifecycle:
+ *   pending   ── tickScheduler detecta janela aberta ──▶ delivered
+ *      └──── parental cancel ──▶ cancelled
+ *
+ * 1 entry por (persona_id, target_window_name). Re-schedule cria nova row
+ * (history preservada). listPendingByPersona retorna apenas status=pending.
+ */
+
+import type Database from "better-sqlite3";
+
+export const MC1_SCHEDULED_DDL = `
+CREATE TABLE IF NOT EXISTS mc1_scheduled (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  persona_id      TEXT NOT NULL,
+  approved_text   TEXT NOT NULL,
+  target_window_name TEXT NOT NULL,
+  scheduled_at    TEXT NOT NULL,
+  status          TEXT NOT NULL CHECK(status IN ('pending','delivered','cancelled')),
+  delivered_at    TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_mc1_scheduled_persona ON mc1_scheduled(persona_id);
+CREATE INDEX IF NOT EXISTS idx_mc1_scheduled_status ON mc1_scheduled(status);
+`;
+
+export type Mc1Status = "pending" | "delivered" | "cancelled";
+
+export interface Mc1ScheduledRecord {
+  id: number;
+  personaId: string;
+  approvedText: string;
+  targetWindowName: string;
+  scheduledAt: string;
+  status: Mc1Status;
+  deliveredAt: string | null;
+}
+
+interface Mc1Row {
+  id: number;
+  persona_id: string;
+  approved_text: string;
+  target_window_name: string;
+  scheduled_at: string;
+  status: Mc1Status;
+  delivered_at: string | null;
+}
+
+function rowToRecord(row: Mc1Row): Mc1ScheduledRecord {
+  return {
+    id: row.id,
+    personaId: row.persona_id,
+    approvedText: row.approved_text,
+    targetWindowName: row.target_window_name,
+    scheduledAt: row.scheduled_at,
+    status: row.status,
+    deliveredAt: row.delivered_at,
+  };
+}
+
+export function initMc1Schema(db: Database.Database): void {
+  db.exec(MC1_SCHEDULED_DDL);
+}
+
+export interface ScheduleMc1Input {
+  personaId: string;
+  approvedText: string;
+  targetWindowName: string;
+  /** ISO; default = now. */
+  scheduledAt?: string;
+}
+
+/**
+ * Persiste uma MC1 aprovada como pending. Não dedupica: caller pode
+ * cancelar pending anterior antes se quiser reschedule idempotente.
+ */
+export function scheduleMc1(
+  db: Database.Database,
+  input: ScheduleMc1Input,
+): Mc1ScheduledRecord {
+  const scheduledAt = input.scheduledAt ?? new Date().toISOString();
+  const result = db
+    .prepare(
+      `INSERT INTO mc1_scheduled
+         (persona_id, approved_text, target_window_name, scheduled_at, status)
+       VALUES (?, ?, ?, ?, 'pending')`,
+    )
+    .run(
+      input.personaId,
+      input.approvedText,
+      input.targetWindowName,
+      scheduledAt,
+    );
+  const id = Number(result.lastInsertRowid);
+  return {
+    id,
+    personaId: input.personaId,
+    approvedText: input.approvedText,
+    targetWindowName: input.targetWindowName,
+    scheduledAt,
+    status: "pending",
+    deliveredAt: null,
+  };
+}
+
+/** Retorna a MC1 pending mais antiga pra persona (FIFO), ou null. */
+export function nextPendingByPersona(
+  db: Database.Database,
+  personaId: string,
+): Mc1ScheduledRecord | null {
+  const row = db
+    .prepare(
+      `SELECT id, persona_id, approved_text, target_window_name,
+              scheduled_at, status, delivered_at
+         FROM mc1_scheduled
+        WHERE persona_id = ? AND status = 'pending'
+        ORDER BY scheduled_at ASC
+        LIMIT 1`,
+    )
+    .get(personaId) as Mc1Row | undefined;
+  return row ? rowToRecord(row) : null;
+}
+
+export function listPending(db: Database.Database): Mc1ScheduledRecord[] {
+  const rows = db
+    .prepare(
+      `SELECT id, persona_id, approved_text, target_window_name,
+              scheduled_at, status, delivered_at
+         FROM mc1_scheduled
+        WHERE status = 'pending'
+        ORDER BY scheduled_at ASC`,
+    )
+    .all() as Mc1Row[];
+  return rows.map(rowToRecord);
+}
+
+export function getById(
+  db: Database.Database,
+  id: number,
+): Mc1ScheduledRecord | null {
+  const row = db
+    .prepare(
+      `SELECT id, persona_id, approved_text, target_window_name,
+              scheduled_at, status, delivered_at
+         FROM mc1_scheduled
+        WHERE id = ?`,
+    )
+    .get(id) as Mc1Row | undefined;
+  return row ? rowToRecord(row) : null;
+}
+
+/** Status mais recente pra persona (qualquer status), ou null. */
+export function latestByPersona(
+  db: Database.Database,
+  personaId: string,
+): Mc1ScheduledRecord | null {
+  const row = db
+    .prepare(
+      `SELECT id, persona_id, approved_text, target_window_name,
+              scheduled_at, status, delivered_at
+         FROM mc1_scheduled
+        WHERE persona_id = ?
+        ORDER BY scheduled_at DESC
+        LIMIT 1`,
+    )
+    .get(personaId) as Mc1Row | undefined;
+  return row ? rowToRecord(row) : null;
+}
+
+export function markDelivered(
+  db: Database.Database,
+  id: number,
+  deliveredAt?: string,
+): boolean {
+  const ts = deliveredAt ?? new Date().toISOString();
+  const result = db
+    .prepare(
+      `UPDATE mc1_scheduled
+          SET status = 'delivered', delivered_at = ?
+        WHERE id = ? AND status = 'pending'`,
+    )
+    .run(ts, id);
+  return result.changes > 0;
+}
+
+/** Cancela todas as MC1 pending da persona. Retorna quantidade afetada. */
+export function cancelPendingByPersona(
+  db: Database.Database,
+  personaId: string,
+): number {
+  const result = db
+    .prepare(
+      `UPDATE mc1_scheduled
+          SET status = 'cancelled'
+        WHERE persona_id = ? AND status = 'pending'`,
+    )
+    .run(personaId);
+  return result.changes;
+}

--- a/motor-execucao/tests/mc1-repo.unit.test.ts
+++ b/motor-execucao/tests/mc1-repo.unit.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  initMc1Schema,
+  scheduleMc1,
+  nextPendingByPersona,
+  listPending,
+  getById,
+  latestByPersona,
+  markDelivered,
+  cancelPendingByPersona,
+} from "../src/mc1-repo.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  initMc1Schema(db);
+});
+
+const PT_TEXT =
+  "Olá. Sou o Brota. Teu pai mencionou que eu ia falar contigo.";
+
+describe("mc1-repo — schedule + read", () => {
+  it("scheduleMc1 persists row com status=pending", () => {
+    const rec = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: PT_TEXT,
+      targetWindowName: "post-school-jp",
+      scheduledAt: "2026-05-27T10:00:00.000Z",
+    });
+    expect(rec.id).toBeGreaterThan(0);
+    expect(rec.status).toBe("pending");
+    expect(rec.deliveredAt).toBeNull();
+    expect(rec.approvedText).toBe(PT_TEXT);
+  });
+
+  it("nextPendingByPersona retorna FIFO mais antigo", () => {
+    const a = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "a",
+      targetWindowName: "w",
+      scheduledAt: "2026-05-27T10:00:00.000Z",
+    });
+    scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "b",
+      targetWindowName: "w",
+      scheduledAt: "2026-05-27T11:00:00.000Z",
+    });
+    const next = nextPendingByPersona(db, "ryo-ochiai");
+    expect(next?.id).toBe(a.id);
+    expect(next?.approvedText).toBe("a");
+  });
+
+  it("nextPendingByPersona retorna null se nenhum pending", () => {
+    expect(nextPendingByPersona(db, "ryo-ochiai")).toBeNull();
+  });
+
+  it("listPending lista todas as pending ordenadas", () => {
+    scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "a",
+      targetWindowName: "w",
+      scheduledAt: "2026-05-27T10:00:00.000Z",
+    });
+    scheduleMc1(db, {
+      personaId: "kei-ochiai",
+      approvedText: "b",
+      targetWindowName: "w",
+      scheduledAt: "2026-05-27T11:00:00.000Z",
+    });
+    const pending = listPending(db);
+    expect(pending).toHaveLength(2);
+    expect(pending[0]!.personaId).toBe("ryo-ochiai");
+    expect(pending[1]!.personaId).toBe("kei-ochiai");
+  });
+
+  it("getById retorna o registro completo", () => {
+    const rec = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: PT_TEXT,
+      targetWindowName: "post-school-jp",
+    });
+    const fetched = getById(db, rec.id);
+    expect(fetched?.personaId).toBe("ryo-ochiai");
+    expect(fetched?.approvedText).toBe(PT_TEXT);
+  });
+
+  it("latestByPersona retorna o mais recente independente de status", () => {
+    const a = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "a",
+      targetWindowName: "w",
+      scheduledAt: "2026-05-27T10:00:00.000Z",
+    });
+    cancelPendingByPersona(db, "ryo-ochiai");
+    const b = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "b",
+      targetWindowName: "w",
+      scheduledAt: "2026-05-27T11:00:00.000Z",
+    });
+    const latest = latestByPersona(db, "ryo-ochiai");
+    expect(latest?.id).toBe(b.id);
+    expect(latest?.status).toBe("pending");
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("mc1-repo — markDelivered", () => {
+  it("transitions pending → delivered + grava timestamp", () => {
+    const rec = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: PT_TEXT,
+      targetWindowName: "post-school-jp",
+    });
+    const ok = markDelivered(db, rec.id, "2026-05-27T16:30:00.000Z");
+    expect(ok).toBe(true);
+    const fetched = getById(db, rec.id);
+    expect(fetched?.status).toBe("delivered");
+    expect(fetched?.deliveredAt).toBe("2026-05-27T16:30:00.000Z");
+  });
+
+  it("markDelivered em row já delivered → no-op (returns false)", () => {
+    const rec = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: PT_TEXT,
+      targetWindowName: "w",
+    });
+    markDelivered(db, rec.id);
+    expect(markDelivered(db, rec.id)).toBe(false);
+  });
+
+  it("markDelivered em row cancelled → no-op", () => {
+    const rec = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: PT_TEXT,
+      targetWindowName: "w",
+    });
+    cancelPendingByPersona(db, "ryo-ochiai");
+    expect(markDelivered(db, rec.id)).toBe(false);
+  });
+});
+
+describe("mc1-repo — cancelPendingByPersona", () => {
+  it("cancela todas as pending da persona", () => {
+    scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "a",
+      targetWindowName: "w",
+    });
+    scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "b",
+      targetWindowName: "w",
+    });
+    scheduleMc1(db, {
+      personaId: "kei-ochiai",
+      approvedText: "c",
+      targetWindowName: "w",
+    });
+    const n = cancelPendingByPersona(db, "ryo-ochiai");
+    expect(n).toBe(2);
+    expect(nextPendingByPersona(db, "ryo-ochiai")).toBeNull();
+    expect(nextPendingByPersona(db, "kei-ochiai")).not.toBeNull();
+  });
+
+  it("retorna 0 quando nada pra cancelar", () => {
+    expect(cancelPendingByPersona(db, "ryo-ochiai")).toBe(0);
+  });
+
+  it("não afeta delivered", () => {
+    const rec = scheduleMc1(db, {
+      personaId: "ryo-ochiai",
+      approvedText: "a",
+      targetWindowName: "w",
+    });
+    markDelivered(db, rec.id);
+    expect(cancelPendingByPersona(db, "ryo-ochiai")).toBe(0);
+    expect(getById(db, rec.id)?.status).toBe("delivered");
+  });
+});

--- a/orchestrator/src/mc1-scheduler.ts
+++ b/orchestrator/src/mc1-scheduler.ts
@@ -1,0 +1,92 @@
+/**
+ * MC1 scheduler — entrega da primeira mensagem do Brota.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-19-mc1-primeira-mensagem-brota-jp.md
+ * Wiring: temporal-scheduler tick → checkAndDeliverMC1 antes dos 4
+ * triggers regulares B1. MC1 ganha prioridade absoluta dentro da janela.
+ *
+ * Pure-functional: dependências injetadas via `Mc1SchedulerDeps`.
+ * Caller (BFF / orchestrator daemon) constrói deps com SQLite-backed
+ * funções de `motor-execucao/mc1-repo`. Testes usam in-memory db ou
+ * stubs.
+ *
+ * v0 entrega:
+ *   1. markDelivered no repo (status → delivered, delivered_at = now)
+ *   2. dispara `emitDelivery({ kind: "mc1_delivered", ... })` —
+ *      caller persiste como ContentItem `pulse:mc1_delivered` e/ou
+ *      event_log entry conforme política.
+ *
+ * v1 plug-points (NÃO implementados v0):
+ *   - motor-channels handoff (WhatsApp real)
+ *   - retry on delivery failure
+ *   - push notification ao parent confirmando entrega
+ */
+
+export interface Mc1PendingRecord {
+  id: number;
+  personaId: string;
+  approvedText: string;
+  targetWindowName: string;
+  scheduledAt: string;
+}
+
+export interface Mc1DeliveryEvent {
+  kind: "mc1_delivered";
+  /** PK em mc1_scheduled. Idempotency hint. */
+  mc1ScheduledId: number;
+  personaId: string;
+  windowName: string;
+  text: string;
+  deliveredAt: string;
+}
+
+export interface Mc1SchedulerDeps {
+  /** Wall clock (injetável p/ testes). */
+  now(): Date;
+  /** Lookup do próximo pendente da persona; null se nada pra entregar. */
+  nextPending(personaId: string): Mc1PendingRecord | null;
+  /** Marca como entregue. Retorna true se transitou pending→delivered. */
+  markDelivered(id: number, deliveredAt: string): boolean;
+  /** Sink: caller decide se vai pra event_log, ContentItem, WhatsApp etc. */
+  emitDelivery(event: Mc1DeliveryEvent): void;
+}
+
+export interface Mc1CheckResult {
+  /** true se tinha MC1 pendente E foi marcada delivered. */
+  delivered: boolean;
+  /** Quando delivered=true, o event emitido. */
+  event?: Mc1DeliveryEvent;
+}
+
+/**
+ * Tenta entregar a próxima MC1 pending da persona. Idempotente:
+ * se nada pending, retorna `{ delivered: false }`. Caller é
+ * responsável por já ter validado janela aberta + gates parentais.
+ *
+ * Race-safe contra concorrência via `markDelivered` que só transita
+ * de `pending`; caller paralelo perde a corrida graciosamente.
+ */
+export function checkAndDeliverMC1(
+  deps: Mc1SchedulerDeps,
+  personaId: string,
+): Mc1CheckResult {
+  const pending = deps.nextPending(personaId);
+  if (!pending) return { delivered: false };
+
+  const deliveredAt = deps.now().toISOString();
+  const ok = deps.markDelivered(pending.id, deliveredAt);
+  if (!ok) {
+    // Outro tick venceu a corrida (delivered ou cancelled enquanto isso).
+    return { delivered: false };
+  }
+  const event: Mc1DeliveryEvent = {
+    kind: "mc1_delivered",
+    mc1ScheduledId: pending.id,
+    personaId: pending.personaId,
+    windowName: pending.targetWindowName,
+    text: pending.approvedText,
+    deliveredAt,
+  };
+  deps.emitDelivery(event);
+  return { delivered: true, event };
+}

--- a/orchestrator/src/temporal-scheduler.ts
+++ b/orchestrator/src/temporal-scheduler.ts
@@ -30,6 +30,8 @@ import type {
 } from "@ascendimacy/shared";
 import type { PulsoContent, PulsoAgeGroup } from "./pulso-emitter.js";
 import { emitPulso } from "./pulso-emitter.js";
+import type { Mc1SchedulerDeps, Mc1DeliveryEvent } from "./mc1-scheduler.js";
+import { checkAndDeliverMC1 } from "./mc1-scheduler.js";
 
 // ─────────────────────────────────────────────────────────────────────────
 // Constantes (spec §gates)
@@ -45,6 +47,7 @@ export const MIN_SACRIFICE_BUDGET = 20;
 // ─────────────────────────────────────────────────────────────────────────
 
 export type HookTrigger =
+  | "mc1_first_message"
   | "objective_due"
   | "thread_open"
   | "card_uncelebrated"
@@ -62,6 +65,7 @@ export interface ProactiveHook {
     objective_id?: string;
     card_id?: string;
     pulso?: PulsoContent;
+    mc1?: Mc1DeliveryEvent;
   };
 }
 
@@ -103,6 +107,9 @@ export interface SchedulerDeps {
   emitHook(hook: ProactiveHook): void;
   /** Estado persistente (last_hook_emitted_at + hooks/dia). */
   state: SchedulerStateStore;
+  /** MC1 deps opcionais — quando presente, MC1 vira trigger #1 absoluto.
+   *  Omitir = comportamento legado pré-MC1 (4 triggers regulares). */
+  mc1?: Mc1SchedulerDeps;
 }
 
 export interface TickReport {
@@ -243,6 +250,33 @@ export function tickScheduler(deps: SchedulerDeps): TickReport[] {
         suppressed: "no_parental_consent",
       });
       continue;
+    }
+
+    // MC1 prioridade absoluta: passa janela + parental, ignora cooldown /
+    // max_hooks / sacrifice budget. MC1 é evento único por persona; specs
+    // §9 marca como hard-coded canonical first message. Spec
+    // 2026-05-19-mc1-primeira-mensagem-brota-jp.md §1 Q1.
+    if (deps.mc1) {
+      const mc1Result = checkAndDeliverMC1(deps.mc1, tw.persona_id);
+      if (mc1Result.delivered && mc1Result.event) {
+        const hook: ProactiveHook = {
+          kind: "hook:proactive_message",
+          persona_id: tw.persona_id,
+          window_name: openEntry.name,
+          emitted_at: nowIso,
+          trigger: "mc1_first_message",
+          payload: { mc1: mc1Result.event },
+        };
+        deps.emitHook(hook);
+        deps.state.setLastEmittedAt(tw.persona_id, nowIso);
+        deps.state.incrementHooksToday(tw.persona_id, local.localDay);
+        reports.push({
+          persona_id: tw.persona_id,
+          emitted: hook,
+          trigger: "mc1_first_message",
+        });
+        continue;
+      }
     }
 
     // Cooldown gate (6h)

--- a/orchestrator/tests/mc1-scheduler.unit.test.ts
+++ b/orchestrator/tests/mc1-scheduler.unit.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect } from "vitest";
+import type { TemporalWindow } from "@ascendimacy/shared";
+import {
+  tickScheduler,
+  createInMemoryStateStore,
+  type SchedulerDeps,
+  type ProactiveHook,
+} from "../src/temporal-scheduler.js";
+import {
+  checkAndDeliverMC1,
+  type Mc1DeliveryEvent,
+  type Mc1PendingRecord,
+  type Mc1SchedulerDeps,
+} from "../src/mc1-scheduler.js";
+
+const PT_TEXT =
+  "Olá. Sou o Brota. Teu pai mencionou que eu ia falar contigo.";
+
+const SAKI_WINDOW: TemporalWindow = {
+  persona_id: "saki-ochiai",
+  timezone: "Asia/Tokyo",
+  windows: [
+    {
+      name: "post-school-jp",
+      weekday: ["mon", "tue", "wed", "thu", "fri"],
+      start_local: "16:30",
+      end_local: "17:30",
+      max_hooks_per_day: 1,
+      requires_parental_ok: true,
+    },
+  ],
+  sleep_window: { start_local: "19:30", end_local: "06:00" },
+  school_window: { start_local: "08:00", end_local: "15:30" },
+};
+
+interface StoreOpts {
+  pending?: Mc1PendingRecord | null;
+}
+
+function makeMc1Deps(emitted: Mc1DeliveryEvent[], opts: StoreOpts = {}): {
+  deps: Mc1SchedulerDeps;
+  state: {
+    pendingValue: Mc1PendingRecord | null;
+    marked: Array<{ id: number; deliveredAt: string }>;
+  };
+} {
+  const state = {
+    pendingValue: opts.pending ?? null,
+    marked: [] as Array<{ id: number; deliveredAt: string }>,
+  };
+  const deps: Mc1SchedulerDeps = {
+    now: () => new Date("2026-05-20T07:45:00Z"),
+    nextPending: () => state.pendingValue,
+    markDelivered: (id, deliveredAt) => {
+      if (state.pendingValue?.id === id) {
+        state.marked.push({ id, deliveredAt });
+        state.pendingValue = null;
+        return true;
+      }
+      return false;
+    },
+    emitDelivery: (e) => {
+      emitted.push(e);
+    },
+  };
+  return { deps, state };
+}
+
+describe("mc1-scheduler — checkAndDeliverMC1 (unit)", () => {
+  it("retorna delivered=false quando nada pending", () => {
+    const emitted: Mc1DeliveryEvent[] = [];
+    const { deps } = makeMc1Deps(emitted);
+    const result = checkAndDeliverMC1(deps, "ryo-ochiai");
+    expect(result.delivered).toBe(false);
+    expect(result.event).toBeUndefined();
+    expect(emitted).toHaveLength(0);
+  });
+
+  it("entrega MC1 quando pending: marca delivered + emite event", () => {
+    const emitted: Mc1DeliveryEvent[] = [];
+    const { deps, state } = makeMc1Deps(emitted, {
+      pending: {
+        id: 42,
+        personaId: "ryo-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      },
+    });
+    const result = checkAndDeliverMC1(deps, "ryo-ochiai");
+    expect(result.delivered).toBe(true);
+    expect(result.event?.mc1ScheduledId).toBe(42);
+    expect(result.event?.text).toBe(PT_TEXT);
+    expect(result.event?.windowName).toBe("post-school-jp");
+    expect(state.marked).toEqual([
+      { id: 42, deliveredAt: "2026-05-20T07:45:00.000Z" },
+    ]);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it("não entrega 2x: segundo tick após delivery vê nada pending", () => {
+    const emitted: Mc1DeliveryEvent[] = [];
+    const { deps } = makeMc1Deps(emitted, {
+      pending: {
+        id: 1,
+        personaId: "ryo-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      },
+    });
+    checkAndDeliverMC1(deps, "ryo-ochiai");
+    const second = checkAndDeliverMC1(deps, "ryo-ochiai");
+    expect(second.delivered).toBe(false);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it("race-safe: markDelivered=false (lost race) → não emite", () => {
+    const emitted: Mc1DeliveryEvent[] = [];
+    const deps: Mc1SchedulerDeps = {
+      now: () => new Date("2026-05-20T07:45:00Z"),
+      nextPending: () => ({
+        id: 7,
+        personaId: "ryo-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      }),
+      markDelivered: () => false,
+      emitDelivery: (e) => {
+        emitted.push(e);
+      },
+    };
+    const result = checkAndDeliverMC1(deps, "ryo-ochiai");
+    expect(result.delivered).toBe(false);
+    expect(emitted).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Integration com temporal-scheduler — MC1 como trigger prioritário
+// ─────────────────────────────────────────────────────────────────────
+
+interface FixtureOpts {
+  pendingMc1?: Mc1PendingRecord | null;
+  parental?: boolean;
+  budget?: number;
+  now?: Date;
+}
+
+function makeIntegrationDeps(
+  emittedHooks: ProactiveHook[],
+  emittedMc1: Mc1DeliveryEvent[],
+  opts: FixtureOpts = {},
+): SchedulerDeps {
+  const mc1State = {
+    pendingValue: opts.pendingMc1 ?? null,
+  };
+  const mc1Deps: Mc1SchedulerDeps = {
+    now: () => opts.now ?? new Date("2026-05-20T07:45:00Z"),
+    nextPending: () => mc1State.pendingValue,
+    markDelivered: (id, _ts) => {
+      if (mc1State.pendingValue?.id === id) {
+        mc1State.pendingValue = null;
+        return true;
+      }
+      return false;
+    },
+    emitDelivery: (e) => {
+      emittedMc1.push(e);
+    },
+  };
+  return {
+    now: () => opts.now ?? new Date("2026-05-20T07:45:00Z"),
+    windows: [SAKI_WINDOW],
+    ageGroupFor: () => "kid",
+    listOpenThreads: () => [
+      {
+        id: "t1",
+        persona_id: "saki-ochiai",
+        opened_in_session: "s1",
+        opened_at: "2026-05-19T10:00:00Z",
+        thread_text: "thread",
+        follow_up_triggered: false,
+        status: "open",
+        stale_after: "2026-05-26T10:00:00Z",
+      },
+    ],
+    hasObjectiveDue: () => ({ objective_id: "obj-9" }),
+    hasUncelebratedCard: () => null,
+    sacrificeBudget: () => opts.budget ?? 50,
+    parentalConsent: () => opts.parental ?? true,
+    emitHook: (h) => {
+      emittedHooks.push(h);
+    },
+    state: createInMemoryStateStore(),
+    mc1: mc1Deps,
+  };
+}
+
+describe("temporal-scheduler — MC1 priority integration", () => {
+  it("janela aberta + MC1 pending → MC1 ganha sobre objective/thread", () => {
+    const hooks: ProactiveHook[] = [];
+    const mc1s: Mc1DeliveryEvent[] = [];
+    const deps = makeIntegrationDeps(hooks, mc1s, {
+      pendingMc1: {
+        id: 99,
+        personaId: "saki-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      },
+    });
+    const reports = tickScheduler(deps);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0]!.trigger).toBe("mc1_first_message");
+    expect(hooks[0]!.payload.mc1?.mc1ScheduledId).toBe(99);
+    expect(hooks[0]!.payload.mc1?.text).toBe(PT_TEXT);
+    expect(reports[0]!.trigger).toBe("mc1_first_message");
+    expect(mc1s).toHaveLength(1);
+  });
+
+  it("sem MC1 pending → comportamento legado (4 triggers)", () => {
+    const hooks: ProactiveHook[] = [];
+    const mc1s: Mc1DeliveryEvent[] = [];
+    const deps = makeIntegrationDeps(hooks, mc1s, { pendingMc1: null });
+    tickScheduler(deps);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0]!.trigger).toBe("objective_due");
+    expect(mc1s).toHaveLength(0);
+  });
+
+  it("janela fechada (school_window) + MC1 pending → NÃO entrega", () => {
+    const hooks: ProactiveHook[] = [];
+    const mc1s: Mc1DeliveryEvent[] = [];
+    const deps = makeIntegrationDeps(hooks, mc1s, {
+      pendingMc1: {
+        id: 99,
+        personaId: "saki-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      },
+      // 10:00 JST quarta = school_window
+      now: new Date("2026-05-20T01:00:00Z"),
+    });
+    const reports = tickScheduler(deps);
+    expect(hooks).toHaveLength(0);
+    expect(mc1s).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("school_window");
+  });
+
+  it("parental consent ausente + MC1 pending → NÃO entrega", () => {
+    const hooks: ProactiveHook[] = [];
+    const mc1s: Mc1DeliveryEvent[] = [];
+    const deps = makeIntegrationDeps(hooks, mc1s, {
+      pendingMc1: {
+        id: 99,
+        personaId: "saki-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      },
+      parental: false,
+    });
+    const reports = tickScheduler(deps);
+    expect(hooks).toHaveLength(0);
+    expect(mc1s).toHaveLength(0);
+    expect(reports[0]!.suppressed).toBe("no_parental_consent");
+  });
+
+  it("MC1 entregue uma vez: segundo tick imediato cai para trigger regular", () => {
+    const hooks: ProactiveHook[] = [];
+    const mc1s: Mc1DeliveryEvent[] = [];
+    const deps = makeIntegrationDeps(hooks, mc1s, {
+      pendingMc1: {
+        id: 1,
+        personaId: "saki-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      },
+    });
+    tickScheduler(deps);
+    expect(hooks[0]!.trigger).toBe("mc1_first_message");
+    // Segundo tick: pending agora é null. Mas cooldown 6h vai bloquear, OK.
+    tickScheduler(deps);
+    expect(hooks).toHaveLength(1);
+  });
+
+  it("MC1 ignora sacrifice_budget_low (gate só vale para triggers regulares)", () => {
+    const hooks: ProactiveHook[] = [];
+    const mc1s: Mc1DeliveryEvent[] = [];
+    const deps = makeIntegrationDeps(hooks, mc1s, {
+      pendingMc1: {
+        id: 99,
+        personaId: "saki-ochiai",
+        approvedText: PT_TEXT,
+        targetWindowName: "post-school-jp",
+        scheduledAt: "2026-05-19T10:00:00.000Z",
+      },
+      budget: 0,
+    });
+    tickScheduler(deps);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0]!.trigger).toBe("mc1_first_message");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8252,9 +8252,12 @@
       "name": "@ascendimacy/ebrota-console-bff",
       "version": "0.1.0",
       "dependencies": {
+        "@ascendimacy/motor-execucao": "*",
+        "@ascendimacy/shared": "*",
         "@modelcontextprotocol/sdk": "^1.10.2",
         "better-sqlite3": "^11.0.0",
         "fastify": "^5.0.0",
+        "js-yaml": "^4.1.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -8262,6 +8265,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "*",
+        "@types/js-yaml": "*",
         "@types/node": "*",
         "tsx": "^4.22.3",
         "typescript": "*",

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -78,6 +78,12 @@ import {
   saveDraft as saveOnboardingDraft,
   markComplete as markOnboardingComplete,
 } from "./parental-onboarding-store.js";
+import {
+  initMc1Schema,
+  scheduleMc1,
+  latestByPersona as latestMc1ByPersona,
+  cancelPendingByPersona as cancelMc1ByPersona,
+} from "@ascendimacy/motor-execucao/mc1-repo";
 import parentalDashboardRoutes from "./routes/parental-dashboard-routes.js";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
@@ -136,6 +142,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   let mode: ConsoleMode = opts.initialMode ?? "auto";
 
   initParentalOnboardingSchema(opts.db);
+  initMc1Schema(opts.db);
   void fastify.register(async (instance) => (await import("./routes/s1-routes.js")).default(instance, { db: opts.db }));
 
   // B1/B2 wiring — Camada Social + Drilling. Fastify enfileira o register
@@ -826,12 +833,54 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
         // best-effort
       }
 
+      // Schedule MC1 entries para cada criança com aprovação válida.
+      // Idempotente: cancela pendentes prévias da persona antes (re-run
+      // do wizard rescheduleia). Spec
+      // 2026-05-19-mc1-primeira-mensagem-brota-jp.md §9 cravou MC1 como
+      // canonical first message — entrega na próxima janela aberta.
+      const mc1Approvals = Array.isArray(state.mc1Approvals)
+        ? (state.mc1Approvals as Array<{
+            childId?: unknown;
+            text?: unknown;
+            approved?: unknown;
+          }>)
+        : [];
+      const scheduledMc1 = [];
+      for (const approval of mc1Approvals) {
+        if (
+          typeof approval.childId !== "string" ||
+          typeof approval.text !== "string" ||
+          approval.approved !== true ||
+          approval.text.length === 0
+        ) {
+          continue;
+        }
+        try {
+          cancelMc1ByPersona(opts.db, approval.childId);
+          const scheduled = scheduleMc1(opts.db, {
+            personaId: approval.childId,
+            approvedText: approval.text,
+            // V0 hard-coded — primeira janela kid post-school. Quando
+            // wizard preferir window específica, ler de windowsByChild.
+            targetWindowName: "post-school-jp",
+          });
+          scheduledMc1.push({
+            childId: approval.childId,
+            mc1ScheduledId: scheduled.id,
+            scheduledAt: scheduled.scheduledAt,
+          });
+        } catch {
+          // best-effort; falha em uma criança não bloqueia completion.
+        }
+      }
+
       return {
         acquirerId: record.acquirerId,
         status: "complete",
         completedAt: record.completedAt,
         yamlPath,
         event: "persona_ready_for_pilot",
+        mc1Scheduled: scheduledMc1,
       };
     },
   );
@@ -871,6 +920,49 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       generatedAt: new Date().toISOString(),
     };
   });
+
+  // GET /parental/mc1/status?childId=X — status MC1 (pending/delivered/
+  // cancelled/not_scheduled) + delivered_at. Usado pelo dashboard pra
+  // badge "MC1 pendente" enquanto status=pending.
+  fastify.get<{ Querystring: { childId?: string } }>(
+    "/parental/mc1/status",
+    async (req, reply) => {
+      const childId = req.query.childId;
+      if (typeof childId !== "string" || childId.length === 0) {
+        return reply.code(400).send({ error: "childId obrigatório" });
+      }
+      const rec = latestMc1ByPersona(opts.db, childId);
+      if (!rec) {
+        return {
+          childId,
+          status: "not_scheduled" as const,
+          deliveredAt: null,
+          scheduledAt: null,
+        };
+      }
+      return {
+        childId,
+        status: rec.status,
+        deliveredAt: rec.deliveredAt,
+        scheduledAt: rec.scheduledAt,
+        targetWindowName: rec.targetWindowName,
+      };
+    },
+  );
+
+  // POST /parental/mc1/cancel?childId=X — cancela MC1 pending. Idempotente:
+  // se nada pending, returns cancelled=0.
+  fastify.post<{ Querystring: { childId?: string } }>(
+    "/parental/mc1/cancel",
+    async (req, reply) => {
+      const childId = req.query.childId;
+      if (typeof childId !== "string" || childId.length === 0) {
+        return reply.code(400).send({ error: "childId obrigatório" });
+      }
+      const cancelled = cancelMc1ByPersona(opts.db, childId);
+      return { childId, cancelled };
+    },
+  );
 
   // POST /rescan — re-indexa o tracesDir (manual trigger).
   // Útil quando STS roda em outro processo e deposita novos traces;

--- a/packages/ebrota-console-bff/tests/mc1-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/mc1-routes.unit.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+let server: BffServer;
+let fixturesDir: string;
+
+const inject = async (
+  method: "GET" | "POST",
+  url: string,
+  payload?: unknown,
+) => {
+  const res = await server.fastify.inject({
+    method,
+    url,
+    ...(payload !== undefined ? { payload } : {}),
+  });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as Record<string, unknown>) : null,
+  };
+};
+
+beforeEach(() => {
+  const db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  fixturesDir = mkdtempSync(join(tmpdir(), "ebrota-mc1-test-"));
+  server = createBffServer({ daemon, db, logger: false, fixturesDir });
+});
+
+afterEach(async () => {
+  await server.close();
+  if (existsSync(fixturesDir)) {
+    rmSync(fixturesDir, { recursive: true, force: true });
+  }
+});
+
+const MC1_PT =
+  "Olá. Sou o Brota. Teu pai mencionou que eu ia falar contigo.";
+
+const sampleWizard = () => ({
+  step: 11,
+  mc10ReadAt: "2026-05-27T10:00:00.000Z",
+  family: {
+    acquirer: { id: "yuji-ochiai", name: "Yuji", relation: "pai" },
+    coParent: null,
+    children: [
+      { id: "ryo-ochiai", name: "Ryo", age: 8, primaryLanguage: "pt" },
+      { id: "kei-ochiai", name: "Kei", age: 6, primaryLanguage: "pt" },
+    ],
+  },
+  telos: { text: "telos", tags: ["curiosidade"] },
+  forbiddenZones: [],
+  budget: { sacrificeBudgetCap: 100, offScreenRatio: 2, sessionMinutesCap: 15 },
+  virtuesByChild: {},
+  windowsByChild: {},
+  consents: {
+    storeTrace: true,
+    emitPhysicalCards: true,
+    activeHoursMessaging: true,
+    confirmIsAi: true,
+  },
+  dyad: null,
+  mc1Approvals: [
+    { childId: "ryo-ochiai", text: MC1_PT, approved: true },
+    { childId: "kei-ochiai", text: MC1_PT + " (Kei)", approved: true },
+  ],
+  readyForPilot: true,
+});
+
+describe("MC1 — wizard complete agenda MC1", () => {
+  it("POST /parental/onboarding/complete persiste MC1 pra cada child aprovado", async () => {
+    const res = await inject(
+      "POST",
+      "/parental/onboarding/complete",
+      sampleWizard(),
+    );
+    expect(res.status).toBe(200);
+    const mc1Scheduled = res.body?.mc1Scheduled as Array<Record<string, unknown>>;
+    expect(mc1Scheduled).toHaveLength(2);
+    expect(
+      mc1Scheduled.map((s) => s.childId).sort(),
+    ).toEqual(["kei-ochiai", "ryo-ochiai"]);
+  });
+
+  it("aprovações com approved=false são puladas", async () => {
+    const state = sampleWizard();
+    state.mc1Approvals[1]!.approved = false;
+    const res = await inject(
+      "POST",
+      "/parental/onboarding/complete",
+      state,
+    );
+    const mc1 = res.body?.mc1Scheduled as Array<Record<string, unknown>>;
+    expect(mc1).toHaveLength(1);
+    expect(mc1[0]!.childId).toBe("ryo-ochiai");
+  });
+
+  it("re-run do wizard cancela pendente anterior e agenda nova", async () => {
+    await inject("POST", "/parental/onboarding/complete", sampleWizard());
+    const status1 = await inject(
+      "GET",
+      "/parental/mc1/status?childId=ryo-ochiai",
+    );
+    expect(status1.body?.status).toBe("pending");
+
+    // Re-run com texto diferente
+    const state2 = sampleWizard();
+    state2.mc1Approvals[0]!.text = "novo texto";
+    await inject("POST", "/parental/onboarding/complete", state2);
+
+    const status2 = await inject(
+      "GET",
+      "/parental/mc1/status?childId=ryo-ochiai",
+    );
+    expect(status2.body?.status).toBe("pending");
+    // só uma pending por persona — re-run cancela e re-agenda
+  });
+});
+
+describe("MC1 — GET /parental/mc1/status", () => {
+  it("not_scheduled quando criança nunca teve MC1", async () => {
+    const res = await inject(
+      "GET",
+      "/parental/mc1/status?childId=saki-ochiai",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body?.status).toBe("not_scheduled");
+    expect(res.body?.deliveredAt).toBeNull();
+  });
+
+  it("pending após onboarding completion", async () => {
+    await inject("POST", "/parental/onboarding/complete", sampleWizard());
+    const res = await inject(
+      "GET",
+      "/parental/mc1/status?childId=ryo-ochiai",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body?.status).toBe("pending");
+    expect(res.body?.scheduledAt).toBeDefined();
+    expect(res.body?.targetWindowName).toBe("post-school-jp");
+  });
+
+  it("400 quando childId ausente", async () => {
+    const res = await inject("GET", "/parental/mc1/status");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("MC1 — POST /parental/mc1/cancel", () => {
+  it("cancela MC1 pending", async () => {
+    await inject("POST", "/parental/onboarding/complete", sampleWizard());
+    const cancelRes = await inject(
+      "POST",
+      "/parental/mc1/cancel?childId=ryo-ochiai",
+    );
+    expect(cancelRes.status).toBe(200);
+    expect(cancelRes.body?.cancelled).toBe(1);
+
+    const status = await inject(
+      "GET",
+      "/parental/mc1/status?childId=ryo-ochiai",
+    );
+    expect(status.body?.status).toBe("cancelled");
+  });
+
+  it("idempotente: cancel quando nada pending → cancelled=0", async () => {
+    const res = await inject(
+      "POST",
+      "/parental/mc1/cancel?childId=saki-ochiai",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body?.cancelled).toBe(0);
+  });
+
+  it("400 quando childId ausente", async () => {
+    const res = await inject("POST", "/parental/mc1/cancel");
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/ebrota-console-ui/src/components/parental/KidSummaryCard.svelte
+++ b/packages/ebrota-console-ui/src/components/parental/KidSummaryCard.svelte
@@ -4,6 +4,8 @@
   export let kid: KidSummary;
   export let active: boolean = false;
   export let onClick: (() => void) | undefined = undefined;
+  /** Mostra badge "MC1 pendente" enquanto MC1 ainda não foi entregue. */
+  export let mc1Pending: boolean = false;
 
   function initials(name: string): string {
     return name.slice(0, 1).toUpperCase();
@@ -42,6 +44,16 @@
       <span class="name">{kid.name}</span>
       <span class="age">{kid.age} anos</span>
     </div>
+    {#if mc1Pending}
+      <div
+        class="mc1-badge"
+        data-testid="mc1-pending-badge"
+        data-child-id={kid.childId}
+        title="Primeira mensagem do Brota aguardando a próxima janela temporal"
+      >
+        MC1 pendente
+      </div>
+    {/if}
     <div class="row status">
       {#if kid.engagedToday}
         <span class="dot" style="background:{moodColor(kid.moodToday)}"></span>
@@ -141,5 +153,19 @@
   }
   .small {
     font-size: 0.75rem;
+  }
+  .mc1-badge {
+    display: inline-block;
+    align-self: flex-start;
+    padding: 0.1rem 0.5rem;
+    background: rgba(255, 183, 77, 0.18);
+    color: #ffb74d;
+    border: 1px solid rgba(255, 183, 77, 0.45);
+    border-radius: 6px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    margin-top: 0.15rem;
   }
 </style>

--- a/packages/ebrota-console-ui/src/components/parental/ParentalEngagedDashboard.svelte
+++ b/packages/ebrota-console-ui/src/components/parental/ParentalEngagedDashboard.svelte
@@ -45,6 +45,13 @@
 
   let pendingQuestions: PendingQuestion[] = [];
   let activeQuestion: PendingQuestion | null = null;
+
+  // MC1 status por childId. "pending" → badge "MC1 pendente" no card.
+  // Outros estados (delivered, cancelled, not_scheduled) sem badge.
+  let mc1Statuses: Record<
+    string,
+    "pending" | "delivered" | "cancelled" | "not_scheduled"
+  > = {};
   let showReportForm = false;
   let showPauseConfirm = false;
   let pauseReason = "";
@@ -66,6 +73,7 @@
         void loadTab(activeTab);
       }
       void loadPendingQuestions();
+      void loadMc1Statuses();
     } catch (err) {
       dashboardError = err instanceof Error ? err.message : String(err);
     } finally {
@@ -83,6 +91,42 @@
     } catch {
       // best-effort
     }
+  }
+
+  async function loadMc1Statuses(): Promise<void> {
+    if (dashboard === null) return;
+    const f = getFetch();
+    const entries = await Promise.all(
+      dashboard.children.map(async (kid) => {
+        try {
+          const res = await f(
+            `${baseUrl}/parental/mc1/status?childId=${encodeURIComponent(kid.childId)}`,
+          );
+          if (!res.ok) return [kid.childId, "not_scheduled"] as const;
+          const data = (await res.json()) as { status: string };
+          return [kid.childId, data.status] as const;
+        } catch {
+          return [kid.childId, "not_scheduled"] as const;
+        }
+      }),
+    );
+    const next: Record<
+      string,
+      "pending" | "delivered" | "cancelled" | "not_scheduled"
+    > = {};
+    for (const [cid, status] of entries) {
+      if (
+        status === "pending" ||
+        status === "delivered" ||
+        status === "cancelled" ||
+        status === "not_scheduled"
+      ) {
+        next[cid] = status;
+      } else {
+        next[cid] = "not_scheduled";
+      }
+    }
+    mc1Statuses = next;
   }
 
   async function loadTab(tab: Tab): Promise<void> {
@@ -272,6 +316,7 @@
         <KidSummaryCard
           {kid}
           active={kid.childId === selectedChildId}
+          mc1Pending={mc1Statuses[kid.childId] === "pending"}
           onClick={() => selectKid(kid.childId)}
         />
       {/each}

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -698,6 +698,21 @@ export interface ApiClient {
     childId: string,
     payload: { reason: string; pauseUntilIso?: string; immediate?: boolean },
   ): Promise<{ paused: boolean; immediate: boolean; notifiedJun: boolean }>;
+
+  // ─── MC1 scheduling (US-PO-10 follow-through) ───────────────────
+  /**
+   * Status MC1 da criança. `not_scheduled` se nunca foi agendada;
+   * `pending`/`delivered`/`cancelled` conforme repo.
+   */
+  getMc1Status(childId: string): Promise<{
+    childId: string;
+    status: "pending" | "delivered" | "cancelled" | "not_scheduled";
+    deliveredAt: string | null;
+    scheduledAt: string | null;
+    targetWindowName?: string;
+  }>;
+  /** Cancela MC1 pending da criança. Idempotente: cancelled=0 se nada pra cancelar. */
+  cancelMc1(childId: string): Promise<{ childId: string; cancelled: number }>;
 }
 
 // ─── S1 wiring — Declared Objectives + Narrative Threads + SK summary ──
@@ -1241,6 +1256,21 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
       post<{ paused: boolean; immediate: boolean; notifiedJun: boolean }>(
         `/parental/children/${encodeURIComponent(childId)}/pause`,
         payload,
+      ),
+
+    // ── MC1 scheduling ───────────────────────────────────────────
+    getMc1Status: (childId) =>
+      get<{
+        childId: string;
+        status: "pending" | "delivered" | "cancelled" | "not_scheduled";
+        deliveredAt: string | null;
+        scheduledAt: string | null;
+        targetWindowName?: string;
+      }>(`/parental/mc1/status?childId=${encodeURIComponent(childId)}`),
+    cancelMc1: (childId) =>
+      post<{ childId: string; cancelled: number }>(
+        `/parental/mc1/cancel?childId=${encodeURIComponent(childId)}`,
+        {},
       ),
   };
 }

--- a/packages/ebrota-console-ui/tests/api.test.ts
+++ b/packages/ebrota-console-ui/tests/api.test.ts
@@ -117,4 +117,32 @@ describe("createApiClient", () => {
       "https://example.com/bff/sessions/s1/turn-state",
     );
   });
+
+  it("getMc1Status chama GET /parental/mc1/status?childId=X", async () => {
+    const fetchMock = buildFetchMock({
+      "GET /parental/mc1/status?childId=ryo-ochiai": {
+        childId: "ryo-ochiai",
+        status: "pending",
+        deliveredAt: null,
+        scheduledAt: "2026-05-27T10:00:00Z",
+        targetWindowName: "post-school-jp",
+      },
+    });
+    const api = createApiClient({ fetch: fetchMock as never });
+    const result = await api.getMc1Status("ryo-ochiai");
+    expect(result.status).toBe("pending");
+    expect(result.targetWindowName).toBe("post-school-jp");
+  });
+
+  it("cancelMc1 chama POST /parental/mc1/cancel?childId=X", async () => {
+    const fetchMock = buildFetchMock({
+      "POST /parental/mc1/cancel?childId=ryo-ochiai": {
+        childId: "ryo-ochiai",
+        cancelled: 1,
+      },
+    });
+    const api = createApiClient({ fetch: fetchMock as never });
+    const result = await api.cancelMc1("ryo-ochiai");
+    expect(result.cancelled).toBe(1);
+  });
 });

--- a/packages/ebrota-console-ui/tests/parental-engaged-dashboard.test.ts
+++ b/packages/ebrota-console-ui/tests/parental-engaged-dashboard.test.ts
@@ -141,6 +141,31 @@ function buildFetchMock(): {
     if (url.includes("/pulso-events")) {
       return jsonResponse({ childId: "ryo-ochiai", events: [] });
     }
+    if (url.includes("/parental/mc1/status")) {
+      if (url.includes("childId=ryo-ochiai")) {
+        return jsonResponse({
+          childId: "ryo-ochiai",
+          status: "pending",
+          deliveredAt: null,
+          scheduledAt: "2026-05-27T10:00:00Z",
+          targetWindowName: "post-school-jp",
+        });
+      }
+      if (url.includes("childId=kei-ochiai")) {
+        return jsonResponse({
+          childId: "kei-ochiai",
+          status: "delivered",
+          deliveredAt: "2026-05-27T09:00:00Z",
+          scheduledAt: "2026-05-26T10:00:00Z",
+        });
+      }
+      return jsonResponse({
+        childId: "saki-ochiai",
+        status: "not_scheduled",
+        deliveredAt: null,
+        scheduledAt: null,
+      });
+    }
     return jsonResponse({});
   };
   return { fn: fn as typeof globalThis.fetch, calls };
@@ -278,5 +303,24 @@ describe("ParentalEngagedDashboard", () => {
     const trigger = await screen.findByTestId("open-pause");
     await fireEvent.click(trigger);
     await screen.findByTestId("pause-confirm");
+  });
+
+  it("mostra badge MC1 pendente apenas em crianças com status=pending", async () => {
+    const { fn, calls } = buildFetchMock();
+    render(ParentalEngagedDashboard, {
+      props: { fetchImpl: fn, acquirerId: "yuji-ochiai" },
+    });
+
+    await waitFor(() => {
+      expect(
+        calls.some((c) =>
+          c.url.includes("/parental/mc1/status?childId=ryo-ochiai"),
+        ),
+      ).toBe(true);
+    });
+
+    const badges = await screen.findAllByTestId("mc1-pending-badge");
+    expect(badges).toHaveLength(1);
+    expect(badges[0]!.getAttribute("data-child-id")).toBe("ryo-ochiai");
   });
 });


### PR DESCRIPTION
## What

Wire MC1 (primeira mensagem do Brota) from wizard completion through to delivery via `temporal-scheduler`. After Parental Onboarding completes (PR #250 mergeado), each approved MC1 is now persisted as a scheduled entry and delivered automatically when the kid's next temporal window opens.

## Specs
- `ascendimacy-ops/docs/specs/2026-05-19-mc1-primeira-mensagem-brota-jp.md`
- `ascendimacy-ops/docs/specs/2026-05-19-mc10-onboarding-yuji.md`
- `ascendimacy-ops/docs/specs/2026-05-26-b1-hooks-temporais-v0.md`

## Files

### Motor — created
- `motor-execucao/src/mc1-repo.ts` — SQLite repo (`mc1_scheduled` table, lifecycle `pending|delivered|cancelled`).
- `orchestrator/src/mc1-scheduler.ts` — pure-functional `checkAndDeliverMC1(deps, personaId)`; race-safe via `markDelivered` transition guard.

### Motor — modified
- `orchestrator/src/temporal-scheduler.ts` — `tickScheduler` now adds MC1 as priority **#1 trigger** inside an open window (after parental consent gate; bypasses cooldown / max_hooks / sacrifice budget since first-message is once-per-persona). Legacy 4-trigger behavior preserved when `deps.mc1` is omitted.

### BFF — modified
- `packages/ebrota-console-bff/src/server.ts`
  - `POST /parental/onboarding/complete` now schedules MC1 for each approved kid (re-run cancels prior pending → reschedules).
  - **New** `GET /parental/mc1/status?childId=X` → `{ status, deliveredAt, scheduledAt, targetWindowName }`.
  - **New** `POST /parental/mc1/cancel?childId=X` — idempotent.

### UI — modified
- `packages/ebrota-console-ui/src/lib/api.ts` — `getMc1Status` + `cancelMc1` client methods.
- `packages/ebrota-console-ui/src/components/parental/ParentalEngagedDashboard.svelte` — fetches MC1 status per kid; reactive map `mc1Statuses`.
- `packages/ebrota-console-ui/src/components/parental/KidSummaryCard.svelte` — new `mc1Pending` prop renders ""MC1 pendente"" badge until delivery clears it.

## Tests (all green)

| Pacote | Suite nova | Tests | Status |
|---|---|---|---|
| motor-execucao | `mc1-repo.unit.test.ts` | 12 | ✅ |
| orchestrator | `mc1-scheduler.unit.test.ts` | 10 | ✅ |
| ebrota-console-bff | `mc1-routes.unit.test.ts` | 9 | ✅ |
| ebrota-console-ui | `api.test.ts` + `parental-engaged-dashboard.test.ts` extended | +3 | ✅ |

Workspace totals after this PR:
- motor-execucao: 210 tests
- orchestrator: 177 tests
- bff: 213 tests
- ui: 203 tests

## v0 scope (per task)
- MC1 entry persists on wizard complete.
- `tickScheduler` delivers when window opens (kid persona + parental consent).
- Dashboard badge shows pending; clears after delivery.
- Cancel works.

## v1 non-goals (NOT in this PR)
- Real WhatsApp delivery via `motor-channels` (stub emits in-memory event only).
- Push notification to parent on delivery.
- Retry on delivery failure.

## Manual verification path
1. Run BFF + UI. Complete the Parental Wizard with at least one approved MC1.
2. `GET /parental/mc1/status?childId=ryo-ochiai` → `status: pending`.
3. Dashboard shows ""MC1 pendente"" badge on Ryo's card.
4. Trigger `tickScheduler` within Ryo's `post-school-jp` window → MC1 marked `delivered`, badge clears.

## Anti-collision
- Worktree-isolated branch (`feat/mc1-scheduling-integration`), no overlap with S1/B1/B2 panels, ReplayTurnDetail, motor-drota, or motor-channels. Touched `temporal-scheduler.ts` only in a backward-compatible way (`mc1` deps optional).