### PR TITLE
[ui+bff] S5 panel — guardrail + STS launcher + longitudinal KPIs

### DIFF
--- a/packages/ebrota-console-bff/src/routes/s5-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/s5-routes.ts
@@ -1,0 +1,490 @@
+/**
+ * S5 wiring — Motor de Avaliação endpoints (guardrail / STS / longitudinal).
+ *
+ * Spec parent: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-user-stories-v0.md
+ * Sub-divisão S5.a/b/c em ascendimacy-ops/docs/architecture-consolidated/ARCHITECTURE.md.
+ *
+ * Endpoints expostos:
+ *   GET  /personas/:id/guardrail-history?limit=N
+ *   GET  /personas/:id/recall-check-history?limit=N
+ *   GET  /personas/:id/trigger-events?limit=N          (stub_v0)
+ *   GET  /personas/:id/kpi-longitudinal                (parcial stub_v0)
+ *   GET  /sts/scenarios                                (lista hardcoded v0)
+ *   GET  /sts/personas                                 (lista hardcoded v0)
+ *   GET  /sts/runs?limit=N
+ *   POST /sts/runs/start                               (stub_v0 — não spawna)
+ *
+ * Estratégia v0: leituras de `subject_knowledge` quando o writer já
+ * persistiu (boundary_event / recall_check_attempt); empty data com
+ * `source: "stub_v0"` quando feature backend não está pronta.
+ */
+
+import type { FastifyPluginAsync } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { randomUUID } from "node:crypto";
+
+export interface S5RoutesOptions {
+  db: DatabaseType;
+}
+
+interface SkRow {
+  id: string;
+  type: string;
+  source: string;
+  confidence: number;
+  payload_json: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+}
+
+export interface GuardrailHistoryEntry {
+  id: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+  topic_category: string;
+  label: string;
+  intensity: number | null;
+  passed: boolean;
+}
+
+export interface RecallCheckHistoryEntry {
+  id: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+  concept_id: string;
+  lineage_anchor: string;
+  outcome: string;
+  intensity: number | null;
+}
+
+export interface TriggerEventEntry {
+  id: string;
+  turn_ref: string;
+  session_id: string;
+  fired_at: string;
+  transition: string;
+}
+
+export interface MoodTrajectoryPoint {
+  session_id: string;
+  started_at: string;
+  mood: number | null;
+}
+
+export interface CaselDelta {
+  month: string;
+  axis: string;
+  delta: number;
+}
+
+export interface KpiLongitudinal {
+  persona_id: string;
+  mood_trajectory: MoodTrajectoryPoint[];
+  casel_deltas: CaselDelta[];
+  concept_retention: {
+    total_attempts: number;
+    positive_rate: number | null;
+    positive_rate_by_week: Array<{ week_start: string; rate: number | null; total: number }>;
+  };
+  trigger_summary: Array<{ transition: string; count: number }>;
+  recall_summary: {
+    items_checked: number;
+    positive_rate: number | null;
+  };
+  source: "real" | "partial_stub_v0" | "stub_v0";
+}
+
+export interface StsScenario {
+  id: string;
+  label: string;
+  description: string;
+  recommended_turns: number;
+  duration_label: string;
+}
+
+export interface StsPersona {
+  id: string;
+  display_name: string;
+  archetype: string;
+  age: number | null;
+  language: string;
+}
+
+export interface StsRunSummary {
+  run_id: string;
+  persona_id: string;
+  scenario_id: string;
+  started_at: string;
+  ended_at: string | null;
+  turn_count: number;
+  score: string | null;
+  trace_path: string | null;
+}
+
+export interface StsRunStartRequest {
+  persona_id: string;
+  scenario_id: string;
+  turns?: number;
+}
+
+export interface StsRunStartResult {
+  run_id: string;
+  status: "dispatched_stub_v0";
+  persona_id: string;
+  scenario_id: string;
+  turns: number;
+  dispatched_at: string;
+  note: string;
+}
+
+const STS_SCENARIOS: StsScenario[] = [
+  {
+    id: "smoke-3d",
+    label: "smoke-3d",
+    description: "Smoke 3 dias — sanity check rápido do walking skeleton.",
+    recommended_turns: 6,
+    duration_label: "T+3d",
+  },
+  {
+    id: "nagareyama-30d",
+    label: "nagareyama-30d",
+    description: "Cenário longitudinal 30 dias Yuji household (Nagareyama).",
+    recommended_turns: 60,
+    duration_label: "T+30d",
+  },
+  {
+    id: "realista",
+    label: "realista",
+    description: "Mix realista de jogadas variadas em ritmo natural.",
+    recommended_turns: 20,
+    duration_label: "T+~7d",
+  },
+  {
+    id: "group-dyad",
+    label: "group-dyad (Ryo+Kei)",
+    description: "WhatsApp group session sintética Ryo+Kei+bot (joint mode).",
+    recommended_turns: 9,
+    duration_label: "T+~1d",
+  },
+];
+
+const STS_PERSONAS: StsPersona[] = [
+  { id: "paula-mendes", display_name: "Paula Mendes", archetype: "curiosa-12a", age: 12, language: "pt-BR" },
+  { id: "paula-30d", display_name: "Paula (30 dias)", archetype: "longitudinal", age: 12, language: "pt-BR" },
+  { id: "ryo-ochiai", display_name: "Ryo Ochiai", archetype: "deflective-11a", age: 11, language: "pt+ja" },
+  { id: "kei-ochiai", display_name: "Kei Ochiai", archetype: "philosophical-9a", age: 9, language: "pt+ja" },
+  { id: "saki-ochiai", display_name: "Saki Ochiai", archetype: "joyful-6a", age: 6, language: "pt+ja" },
+];
+
+function parsePayload(raw: string): Record<string, unknown> {
+  try {
+    const v = JSON.parse(raw) as unknown;
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function listGuardrailHistory(
+  db: DatabaseType,
+  personaId: string,
+  limit: number,
+): GuardrailHistoryEntry[] {
+  const rows = db
+    .prepare(
+      `SELECT id, type, source, confidence, payload_json, turn_ref, session_id, created_at
+       FROM subject_knowledge
+       WHERE subject_id = ? AND type = 'boundary_event'
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .all(personaId, limit) as SkRow[];
+  return rows.map((r) => {
+    const p = parsePayload(r.payload_json);
+    const topic = typeof p["topic_category"] === "string" ? p["topic_category"] : "unknown";
+    const label = typeof p["label"] === "string" ? p["label"] : "";
+    const intensity = typeof p["intensity"] === "number" ? p["intensity"] : null;
+    const passed =
+      typeof p["passed"] === "boolean"
+        ? p["passed"]
+        : intensity === null || intensity < 0.5;
+    return {
+      id: r.id,
+      turn_ref: r.turn_ref,
+      session_id: r.session_id,
+      created_at: r.created_at,
+      topic_category: topic,
+      label,
+      intensity,
+      passed,
+    };
+  });
+}
+
+function listRecallCheckHistory(
+  db: DatabaseType,
+  personaId: string,
+  limit: number,
+): RecallCheckHistoryEntry[] {
+  const rows = db
+    .prepare(
+      `SELECT id, type, source, confidence, payload_json, turn_ref, session_id, created_at
+       FROM subject_knowledge
+       WHERE subject_id = ? AND type = 'recall_check_attempt'
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .all(personaId, limit) as SkRow[];
+  return rows.map((r) => {
+    const p = parsePayload(r.payload_json);
+    return {
+      id: r.id,
+      turn_ref: r.turn_ref,
+      session_id: r.session_id,
+      created_at: r.created_at,
+      concept_id: typeof p["concept_id"] === "string" ? p["concept_id"] : "?",
+      lineage_anchor: typeof p["lineage_anchor"] === "string" ? p["lineage_anchor"] : "?",
+      outcome: typeof p["outcome"] === "string" ? p["outcome"] : "unknown",
+      intensity: typeof p["intensity"] === "number" ? p["intensity"] : null,
+    };
+  });
+}
+
+function computeRecallSummary(
+  db: DatabaseType,
+  personaId: string,
+): { items_checked: number; positive_rate: number | null } {
+  const row = db
+    .prepare(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN json_extract(payload_json, '$.outcome') = 'positive' THEN 1 ELSE 0 END) AS positive
+       FROM subject_knowledge
+       WHERE subject_id = ? AND type = 'recall_check_attempt'`,
+    )
+    .get(personaId) as { total: number; positive: number | null };
+  const total = row.total ?? 0;
+  const positive = row.positive ?? 0;
+  return {
+    items_checked: total,
+    positive_rate: total > 0 ? positive / total : null,
+  };
+}
+
+function computeMoodTrajectory(
+  db: DatabaseType,
+  personaId: string,
+  limit: number,
+): MoodTrajectoryPoint[] {
+  const rows = db
+    .prepare(
+      `SELECT session_id, started_at FROM sessions
+       WHERE persona_id = ?
+       ORDER BY started_at DESC
+       LIMIT ?`,
+    )
+    .all(personaId, limit) as Array<{ session_id: string; started_at: string }>;
+  return rows.map((r) => ({
+    session_id: r.session_id,
+    started_at: r.started_at,
+    mood: null,
+  }));
+}
+
+function computeRetentionByWeek(
+  db: DatabaseType,
+  personaId: string,
+): Array<{ week_start: string; rate: number | null; total: number }> {
+  const rows = db
+    .prepare(
+      `SELECT
+         strftime('%Y-W%W', created_at) AS week,
+         MIN(date(created_at)) AS week_start,
+         COUNT(*) AS total,
+         SUM(CASE WHEN json_extract(payload_json, '$.outcome') = 'positive' THEN 1 ELSE 0 END) AS positive
+       FROM subject_knowledge
+       WHERE subject_id = ? AND type = 'recall_check_attempt'
+       GROUP BY week
+       ORDER BY week_start ASC
+       LIMIT 12`,
+    )
+    .all(personaId) as Array<{ week: string; week_start: string; total: number; positive: number | null }>;
+  return rows.map((r) => ({
+    week_start: r.week_start,
+    total: r.total,
+    rate: r.total > 0 ? (r.positive ?? 0) / r.total : null,
+  }));
+}
+
+function computeKpiLongitudinal(db: DatabaseType, personaId: string): KpiLongitudinal {
+  const trajectory = computeMoodTrajectory(db, personaId, 30);
+  const recallSummary = computeRecallSummary(db, personaId);
+  const retentionByWeek = computeRetentionByWeek(db, personaId);
+
+  const isPartial =
+    trajectory.length === 0 && recallSummary.items_checked === 0;
+
+  return {
+    persona_id: personaId,
+    mood_trajectory: trajectory,
+    casel_deltas: [],
+    concept_retention: {
+      total_attempts: recallSummary.items_checked,
+      positive_rate: recallSummary.positive_rate,
+      positive_rate_by_week: retentionByWeek,
+    },
+    trigger_summary: [],
+    recall_summary: recallSummary,
+    source: isPartial ? "stub_v0" : "partial_stub_v0",
+  };
+}
+
+function listStsRuns(
+  db: DatabaseType,
+  limit: number,
+): StsRunSummary[] {
+  const rows = db
+    .prepare(
+      `SELECT session_id, persona_id, conversation_id, started_at, ended_at,
+              turn_count, trace_path
+       FROM sessions
+       WHERE kind = 'sts'
+       ORDER BY started_at DESC
+       LIMIT ?`,
+    )
+    .all(limit) as Array<{
+      session_id: string;
+      persona_id: string;
+      conversation_id: string;
+      started_at: string;
+      ended_at: string | null;
+      turn_count: number;
+      trace_path: string | null;
+    }>;
+  return rows.map((r) => ({
+    run_id: r.session_id,
+    persona_id: r.persona_id,
+    scenario_id: r.conversation_id,
+    started_at: r.started_at,
+    ended_at: r.ended_at,
+    turn_count: r.turn_count,
+    score: null,
+    trace_path: r.trace_path,
+  }));
+}
+
+const s5Routes: FastifyPluginAsync<S5RoutesOptions> = async (fastify, opts) => {
+  const { db } = opts;
+
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>("/personas/:id/guardrail-history", async (req) => {
+    const limit = req.query.limit ? Math.max(1, Number(req.query.limit)) : 20;
+    const checks = listGuardrailHistory(db, req.params.id, limit);
+    const passed = checks.filter((c) => c.passed).length;
+    return {
+      checks,
+      passed_count: passed,
+      failed_count: checks.length - passed,
+      source: checks.length === 0 ? "stub_v0" : "real",
+    };
+  });
+
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>("/personas/:id/recall-check-history", async (req) => {
+    const limit = req.query.limit ? Math.max(1, Number(req.query.limit)) : 20;
+    const events = listRecallCheckHistory(db, req.params.id, limit);
+    return {
+      events,
+      source: events.length === 0 ? "stub_v0" : "real",
+    };
+  });
+
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>("/personas/:id/trigger-events", async () => {
+    // v0 stub — TriggerEvaluator events vivem em engine_trace_v2
+    // components.planejador.triggerEvaluation. Não persistidos em SQL
+    // ainda; UI mostra "sem dado" + nota source=stub_v0.
+    return {
+      events: [] as TriggerEventEntry[],
+      transitions: [] as Array<{ transition: string; count: number }>,
+      source: "stub_v0",
+    };
+  });
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/kpi-longitudinal",
+    async (req) => computeKpiLongitudinal(db, req.params.id),
+  );
+
+  fastify.get("/sts/scenarios", async () => ({
+    scenarios: STS_SCENARIOS,
+  }));
+
+  fastify.get("/sts/personas", async () => ({
+    personas: STS_PERSONAS,
+  }));
+
+  fastify.get<{ Querystring: { limit?: string } }>(
+    "/sts/runs",
+    async (req) => {
+      const limit = req.query.limit ? Math.max(1, Number(req.query.limit)) : 20;
+      return { runs: listStsRuns(db, limit) };
+    },
+  );
+
+  fastify.post<{ Body: StsRunStartRequest }>(
+    "/sts/runs/start",
+    async (req, reply) => {
+      const body = req.body;
+      if (
+        body === undefined ||
+        typeof body.persona_id !== "string" ||
+        typeof body.scenario_id !== "string"
+      ) {
+        return reply.code(400).send({
+          error: "campos obrigatórios: persona_id, scenario_id",
+        });
+      }
+      const knownPersona = STS_PERSONAS.some((p) => p.id === body.persona_id);
+      const knownScenario = STS_SCENARIOS.some((s) => s.id === body.scenario_id);
+      if (!knownPersona) {
+        return reply.code(400).send({
+          error: `persona_id desconhecida: ${body.persona_id}`,
+        });
+      }
+      if (!knownScenario) {
+        return reply.code(400).send({
+          error: `scenario_id desconhecido: ${body.scenario_id}`,
+        });
+      }
+      const scenario = STS_SCENARIOS.find((s) => s.id === body.scenario_id)!;
+      const turns =
+        typeof body.turns === "number" && body.turns > 0
+          ? Math.floor(body.turns)
+          : scenario.recommended_turns;
+
+      const result: StsRunStartResult = {
+        run_id: randomUUID(),
+        status: "dispatched_stub_v0",
+        persona_id: body.persona_id,
+        scenario_id: body.scenario_id,
+        turns,
+        dispatched_at: new Date().toISOString(),
+        note:
+          "v0 stub — STS spawn real ainda não wired. Rode `node scripts/sts-group-dyad.mjs` ou similar pra disparo manual; este endpoint apenas reserva run_id pra tracking futuro.",
+      };
+      return result;
+    },
+  );
+};
+
+export default s5Routes;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -137,6 +137,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
 
   initParentalOnboardingSchema(opts.db);
   void fastify.register(async (instance) => (await import("./routes/s1-routes.js")).default(instance, { db: opts.db }));
+  void fastify.register(async (instance) => (await import("./routes/s5-routes.js")).default(instance, { db: opts.db }));
 
   // B1/B2 wiring — Camada Social + Drilling. Fastify enfileira o register
   // até .listen()/.ready() resolverem; ok chamar síncrono dentro do factory.

--- a/packages/ebrota-console-bff/tests/s5-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/s5-routes.unit.test.ts
@@ -1,0 +1,288 @@
+/**
+ * S5 routes unit tests — guardrail / recall / trigger / kpi / STS.
+ *
+ * Stubs vs real:
+ *  - guardrail-history e recall-check-history são reais (consultam SK).
+ *  - trigger-events é stub_v0 (TriggerEvaluator não persiste em SQL).
+ *  - kpi-longitudinal é mix real/stub dependendo de dados.
+ *  - sts/scenarios e sts/personas são listas hardcoded v0.
+ *  - sts/runs é real (consulta `sessions` kind='sts').
+ *  - sts/runs/start é stub v0 (não spawna; só reserva run_id).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+let server: BffServer;
+let db: DatabaseType;
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  server = createBffServer({ daemon, db, logger: false });
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+const inject = async (url: string, method: "GET" | "POST" = "GET", body?: unknown) => {
+  const res = await server.fastify.inject({
+    method,
+    url,
+    ...(body !== undefined ? { payload: body } : {}),
+  });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+function insertSk(
+  type: string,
+  payload: Record<string, unknown>,
+  overrides: { subject_id?: string; session_id?: string; created_at?: string } = {},
+): void {
+  db.prepare(
+    `INSERT INTO subject_knowledge
+     (id, subject_id, type, source, confidence, alignment, payload_json, turn_ref, session_id, created_at)
+     VALUES (?, ?, ?, 'motor_inferred', 0.8, 'aligned', ?, 't-0', ?, ?)`,
+  ).run(
+    `sk-${Math.random().toString(36).slice(2, 10)}`,
+    overrides.subject_id ?? "ryo",
+    type,
+    JSON.stringify(payload),
+    overrides.session_id ?? "ryo__sess-A",
+    overrides.created_at ?? new Date().toISOString(),
+  );
+}
+
+function insertSession(
+  sessionId: string,
+  personaId: string,
+  kind: "real" | "sts",
+  startedAt: string,
+): void {
+  db.prepare(
+    `INSERT INTO sessions
+     (session_id, persona_id, conversation_id, kind, started_at, turn_count, has_overrides)
+     VALUES (?, ?, 'conv-1', ?, ?, 5, 0)`,
+  ).run(sessionId, personaId, kind, startedAt);
+}
+
+describe("GET /personas/:id/guardrail-history", () => {
+  it("retorna stub_v0 com lista vazia quando sem boundary_events", async () => {
+    const res = await inject("/personas/ryo/guardrail-history");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      checks: unknown[];
+      passed_count: number;
+      failed_count: number;
+      source: string;
+    };
+    expect(body.checks).toEqual([]);
+    expect(body.passed_count).toBe(0);
+    expect(body.failed_count).toBe(0);
+    expect(body.source).toBe("stub_v0");
+  });
+
+  it("retorna entries reais quando boundary_events existem", async () => {
+    insertSk("boundary_event", {
+      topic_category: "bullying_pt",
+      label: "termo agressivo",
+      intensity: 0.2,
+      passed: true,
+    });
+    insertSk("boundary_event", {
+      topic_category: "scaffold_guard",
+      label: "scaffold falhou",
+      intensity: 0.7,
+      passed: false,
+    });
+    const res = await inject("/personas/ryo/guardrail-history?limit=10");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      checks: Array<{ topic_category: string; passed: boolean }>;
+      passed_count: number;
+      failed_count: number;
+      source: string;
+    };
+    expect(body.checks.length).toBe(2);
+    expect(body.passed_count).toBe(1);
+    expect(body.failed_count).toBe(1);
+    expect(body.source).toBe("real");
+  });
+});
+
+describe("GET /personas/:id/recall-check-history", () => {
+  it("retorna stub_v0 quando vazio", async () => {
+    const res = await inject("/personas/ryo/recall-check-history");
+    expect(res.status).toBe(200);
+    const body = res.body as { events: unknown[]; source: string };
+    expect(body.events).toEqual([]);
+    expect(body.source).toBe("stub_v0");
+  });
+
+  it("retorna events com outcome positive/negative", async () => {
+    insertSk("recall_check_attempt", {
+      concept_id: "dicotomia_controle",
+      lineage_anchor: "estoica/dicotomia_controle",
+      outcome: "positive",
+      intensity: 0.9,
+    });
+    insertSk("recall_check_attempt", {
+      concept_id: "amizade",
+      lineage_anchor: "aristoteles/amizade",
+      outcome: "negative",
+      intensity: 0.3,
+    });
+    const res = await inject("/personas/ryo/recall-check-history?limit=5");
+    const body = res.body as {
+      events: Array<{ concept_id: string; outcome: string }>;
+      source: string;
+    };
+    expect(body.events.length).toBe(2);
+    expect(body.source).toBe("real");
+    const outcomes = body.events.map((e) => e.outcome).sort();
+    expect(outcomes).toEqual(["negative", "positive"]);
+  });
+});
+
+describe("GET /personas/:id/trigger-events", () => {
+  it("retorna sempre stub_v0 (não persistido em SQL ainda)", async () => {
+    const res = await inject("/personas/ryo/trigger-events");
+    expect(res.status).toBe(200);
+    const body = res.body as { events: unknown[]; transitions: unknown[]; source: string };
+    expect(body.events).toEqual([]);
+    expect(body.transitions).toEqual([]);
+    expect(body.source).toBe("stub_v0");
+  });
+});
+
+describe("GET /personas/:id/kpi-longitudinal", () => {
+  it("retorna source=stub_v0 quando persona sem dados", async () => {
+    const res = await inject("/personas/ryo/kpi-longitudinal");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      persona_id: string;
+      mood_trajectory: unknown[];
+      casel_deltas: unknown[];
+      concept_retention: { total_attempts: number; positive_rate: number | null };
+      recall_summary: { items_checked: number; positive_rate: number | null };
+      source: string;
+    };
+    expect(body.persona_id).toBe("ryo");
+    expect(body.mood_trajectory).toEqual([]);
+    expect(body.casel_deltas).toEqual([]);
+    expect(body.concept_retention.total_attempts).toBe(0);
+    expect(body.recall_summary.items_checked).toBe(0);
+    expect(body.source).toBe("stub_v0");
+  });
+
+  it("retorna partial_stub_v0 + mood_trajectory quando há sessões", async () => {
+    insertSession("ryo__s1", "ryo", "real", "2026-05-20T10:00:00Z");
+    insertSession("ryo__s2", "ryo", "sts", "2026-05-22T11:00:00Z");
+    insertSk("recall_check_attempt", { concept_id: "x", outcome: "positive" });
+    const res = await inject("/personas/ryo/kpi-longitudinal");
+    const body = res.body as {
+      mood_trajectory: Array<{ session_id: string }>;
+      concept_retention: { total_attempts: number; positive_rate: number | null };
+      source: string;
+    };
+    expect(body.mood_trajectory.length).toBe(2);
+    expect(body.concept_retention.total_attempts).toBe(1);
+    expect(body.concept_retention.positive_rate).toBe(1);
+    expect(body.source).toBe("partial_stub_v0");
+  });
+});
+
+describe("GET /sts/scenarios", () => {
+  it("retorna lista hardcoded v0 com ≥3 scenarios", async () => {
+    const res = await inject("/sts/scenarios");
+    expect(res.status).toBe(200);
+    const body = res.body as { scenarios: Array<{ id: string; label: string }> };
+    expect(body.scenarios.length).toBeGreaterThanOrEqual(3);
+    const ids = body.scenarios.map((s) => s.id);
+    expect(ids).toContain("smoke-3d");
+    expect(ids).toContain("nagareyama-30d");
+  });
+});
+
+describe("GET /sts/personas", () => {
+  it("retorna personas STS conhecidas (Paula, Ryo, Kei, Saki, paula-30d)", async () => {
+    const res = await inject("/sts/personas");
+    expect(res.status).toBe(200);
+    const body = res.body as { personas: Array<{ id: string }> };
+    const ids = body.personas.map((p) => p.id);
+    expect(ids).toContain("paula-mendes");
+    expect(ids).toContain("ryo-ochiai");
+    expect(ids).toContain("kei-ochiai");
+    expect(ids).toContain("saki-ochiai");
+    expect(ids).toContain("paula-30d");
+  });
+});
+
+describe("GET /sts/runs", () => {
+  it("retorna apenas sessions kind='sts'", async () => {
+    insertSession("ryo__real", "ryo", "real", "2026-05-20T10:00:00Z");
+    insertSession("ryo__sts1", "ryo", "sts", "2026-05-22T10:00:00Z");
+    insertSession("paula__sts1", "paula-mendes", "sts", "2026-05-23T10:00:00Z");
+    const res = await inject("/sts/runs");
+    const body = res.body as { runs: Array<{ run_id: string; persona_id: string }> };
+    expect(body.runs.length).toBe(2);
+    expect(body.runs.every((r) => r.run_id.includes("sts"))).toBe(true);
+  });
+});
+
+describe("POST /sts/runs/start", () => {
+  it("retorna run_id + status=dispatched_stub_v0", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      run_id: string;
+      status: string;
+      turns: number;
+      note: string;
+    };
+    expect(body.run_id.length).toBeGreaterThan(0);
+    expect(body.status).toBe("dispatched_stub_v0");
+    expect(body.turns).toBe(6); // smoke-3d recommended
+    expect(body.note).toContain("v0 stub");
+  });
+
+  it("usa turns custom quando fornecido", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "paula-mendes",
+      scenario_id: "realista",
+      turns: 12,
+    });
+    const body = res.body as { turns: number };
+    expect(body.turns).toBe(12);
+  });
+
+  it("400 quando persona_id desconhecida", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "fulano-inexistente",
+      scenario_id: "smoke-3d",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 quando scenario_id desconhecido", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "cenario-inventado",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 quando body sem campos obrigatórios", async () => {
+    const res = await inject("/sts/runs/start", "POST", {});
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/ebrota-console-ui/src/components/sts/STSLauncherModal.svelte
+++ b/packages/ebrota-console-ui/src/components/sts/STSLauncherModal.svelte
@@ -1,0 +1,418 @@
+<script lang="ts">
+  /**
+   * STSLauncherModal — wizard mínimo pra disparar uma run STS.
+   *
+   * v0 dispatch é stub (POST /sts/runs/start retorna run_id reservado,
+   * spawn real ainda não wired — ver `s5-routes.ts`). Mesmo assim a UI
+   * exibe progress + virtual clock pra validar a forma do contrato.
+   *
+   * Spec: US-S5b-02 (console-ebrota-user-stories-v0.md).
+   */
+  import { createEventDispatcher, onDestroy } from "svelte";
+  import type {
+    ApiClient,
+    StsPersonaLike,
+    StsScenarioLike,
+    StsRunStartResultLike,
+  } from "../../lib/api.js";
+
+  export let api: ApiClient;
+  export let open: boolean = false;
+
+  const dispatch = createEventDispatcher<{ close: void; started: StsRunStartResultLike }>();
+
+  type FormState = "idle" | "loading" | "ready" | "submitting" | "running" | "error";
+  let formState: FormState = "idle";
+  let personas: StsPersonaLike[] = [];
+  let scenarios: StsScenarioLike[] = [];
+  let errMsg = "";
+
+  let personaId = "";
+  let scenarioId = "";
+  let turns = 6;
+
+  let lastResult: StsRunStartResultLike | null = null;
+  let virtualClockTickMs = 1500;
+  let virtualClockTimer: ReturnType<typeof setInterval> | null = null;
+  let virtualClockProgress = 0;
+
+  $: selectedScenario = scenarios.find((s) => s.id === scenarioId) ?? null;
+  $: if (selectedScenario && formState === "ready") {
+    turns = selectedScenario.recommended_turns;
+  }
+
+  function close(): void {
+    stopVirtualClock();
+    dispatch("close");
+  }
+
+  function stopVirtualClock(): void {
+    if (virtualClockTimer !== null) {
+      clearInterval(virtualClockTimer);
+      virtualClockTimer = null;
+    }
+  }
+
+  function startVirtualClock(): void {
+    stopVirtualClock();
+    virtualClockProgress = 0;
+    virtualClockTimer = setInterval(() => {
+      virtualClockProgress = Math.min(virtualClockProgress + 1, turns);
+      if (virtualClockProgress >= turns) {
+        stopVirtualClock();
+      }
+    }, virtualClockTickMs);
+  }
+
+  async function loadOptions(): Promise<void> {
+    formState = "loading";
+    try {
+      const [pRes, sRes] = await Promise.all([
+        api.listStsPersonas(),
+        api.listStsScenarios(),
+      ]);
+      personas = pRes.personas;
+      scenarios = sRes.scenarios;
+      if (personas.length > 0 && personaId === "") personaId = personas[0]!.id;
+      if (scenarios.length > 0 && scenarioId === "") scenarioId = scenarios[0]!.id;
+      if (selectedScenario) turns = selectedScenario.recommended_turns;
+      formState = "ready";
+    } catch (err) {
+      errMsg = err instanceof Error ? err.message : String(err);
+      formState = "error";
+    }
+  }
+
+  async function submit(): Promise<void> {
+    if (personaId === "" || scenarioId === "") return;
+    formState = "submitting";
+    errMsg = "";
+    try {
+      lastResult = await api.startStsRun({
+        persona_id: personaId,
+        scenario_id: scenarioId,
+        turns,
+      });
+      formState = "running";
+      startVirtualClock();
+      dispatch("started", lastResult);
+    } catch (err) {
+      errMsg = err instanceof Error ? err.message : String(err);
+      formState = "error";
+    }
+  }
+
+  function reset(): void {
+    stopVirtualClock();
+    lastResult = null;
+    virtualClockProgress = 0;
+    formState = "ready";
+  }
+
+  let bootstrapped = false;
+  $: if (!bootstrapped) {
+    bootstrapped = true;
+    void loadOptions();
+  }
+
+  $: if (!open) {
+    stopVirtualClock();
+  }
+
+  onDestroy(() => stopVirtualClock());
+
+  function formatVirtualClock(progress: number, total: number, label: string): string {
+    if (total <= 0) return label;
+    const frac = progress / total;
+    const days = Math.round(frac * 30);
+    if (label.includes("3d")) {
+      return `T+${Math.min(Math.round(frac * 3), 3)}d ${Math.round((frac * 72) % 24)}h`;
+    }
+    return `T+${Math.min(days, 30)}d`;
+  }
+</script>
+
+{#if open}
+  <div
+    class="backdrop"
+    role="presentation"
+    on:click|self={close}
+    data-testid="sts-launcher-backdrop"
+  >
+    <div
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="sts-launcher-title"
+      data-testid="sts-launcher-modal"
+    >
+      <header>
+        <h2 id="sts-launcher-title">🚀 Lançar nova run STS</h2>
+        <button
+          type="button"
+          class="close-x"
+          on:click={close}
+          aria-label="fechar"
+          data-testid="sts-launcher-close"
+        >
+          ×
+        </button>
+      </header>
+
+      {#if formState === "loading" || formState === "idle"}
+        <p class="muted" data-testid="sts-launcher-loading">
+          carregando personas + scenarios…
+        </p>
+      {:else if formState === "error"}
+        <p class="error" data-testid="sts-launcher-error">
+          erro: {errMsg}
+        </p>
+        <button type="button" class="action" on:click={loadOptions}>
+          tentar de novo
+        </button>
+      {:else if formState === "running" && lastResult !== null}
+        <div class="running-block" data-testid="sts-launcher-running">
+          <p>
+            <strong>Run em andamento</strong>
+            — run_id <code>{lastResult.run_id.slice(0, 8)}…</code>
+          </p>
+          <p class="muted small">{lastResult.note}</p>
+          <div class="virtual-clock" data-testid="sts-launcher-clock">
+            <span class="vc-label">virtual clock:</span>
+            <span class="vc-value">
+              {formatVirtualClock(
+                virtualClockProgress,
+                turns,
+                selectedScenario?.duration_label ?? "T+?",
+              )}
+            </span>
+            <span class="vc-progress">
+              ({virtualClockProgress}/{turns} turns)
+            </span>
+          </div>
+          <progress max={turns} value={virtualClockProgress} class="progress" />
+          <div class="actions">
+            <button type="button" class="action" on:click={reset}>
+              ↻ nova run
+            </button>
+            <button type="button" class="action primary" on:click={close}>
+              fechar
+            </button>
+          </div>
+        </div>
+      {:else}
+        <form
+          on:submit|preventDefault={submit}
+          data-testid="sts-launcher-form"
+        >
+          <label>
+            <span>Persona</span>
+            <select
+              bind:value={personaId}
+              disabled={formState === "submitting"}
+              data-testid="sts-launcher-persona"
+            >
+              {#each personas as p (p.id)}
+                <option value={p.id}>{p.display_name} — {p.archetype}</option>
+              {/each}
+            </select>
+          </label>
+
+          <label>
+            <span>Scenario</span>
+            <select
+              bind:value={scenarioId}
+              disabled={formState === "submitting"}
+              data-testid="sts-launcher-scenario"
+            >
+              {#each scenarios as s (s.id)}
+                <option value={s.id}>{s.label} ({s.duration_label})</option>
+              {/each}
+            </select>
+            {#if selectedScenario}
+              <small class="hint">{selectedScenario.description}</small>
+            {/if}
+          </label>
+
+          <label>
+            <span>Turns ({turns})</span>
+            <input
+              type="range"
+              min="1"
+              max={Math.max(selectedScenario?.recommended_turns ?? 30, 60)}
+              bind:value={turns}
+              disabled={formState === "submitting"}
+              data-testid="sts-launcher-turns"
+            />
+          </label>
+
+          <div class="actions">
+            <button
+              type="button"
+              class="action"
+              on:click={close}
+              disabled={formState === "submitting"}
+            >
+              cancelar
+            </button>
+            <button
+              type="submit"
+              class="action primary"
+              disabled={formState === "submitting" || personaId === "" || scenarioId === ""}
+              data-testid="sts-launcher-submit"
+            >
+              {formState === "submitting" ? "disparando…" : "🚀 disparar run"}
+            </button>
+          </div>
+        </form>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+  .modal {
+    background: var(--color-bg, #1f1f1f);
+    color: var(--color-fg, #f5f5f5);
+    border: 1px solid rgba(239, 68, 68, 0.5);
+    border-left: 4px solid #ef4444;
+    border-radius: 6px;
+    padding: 1rem 1.2rem;
+    width: min(440px, 92vw);
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  }
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.4rem;
+  }
+  header h2 {
+    margin: 0;
+    font-size: 1rem;
+  }
+  .close-x {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1.4rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 0.3rem;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+  }
+  label > span {
+    font-weight: 600;
+  }
+  select,
+  input[type="range"] {
+    font: inherit;
+    padding: 0.3rem;
+    border-radius: 4px;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    background: transparent;
+    color: inherit;
+  }
+  .hint {
+    opacity: 0.7;
+    font-size: 0.78rem;
+  }
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 0.3rem;
+  }
+  .action {
+    background: transparent;
+    border: 1px solid rgba(239, 68, 68, 0.5);
+    border-radius: 4px;
+    padding: 0.35rem 0.8rem;
+    color: inherit;
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .action:hover:not(:disabled) {
+    background: rgba(239, 68, 68, 0.12);
+  }
+  .action.primary {
+    background: rgba(239, 68, 68, 0.2);
+    border-color: rgba(239, 68, 68, 0.8);
+    font-weight: 600;
+  }
+  .action:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .muted {
+    opacity: 0.6;
+    font-size: 0.85rem;
+    margin: 0;
+  }
+  .error {
+    color: #ef4444;
+    font-size: 0.85rem;
+    margin: 0;
+  }
+  .running-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .virtual-clock {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+  }
+  .vc-label {
+    opacity: 0.7;
+  }
+  .vc-value {
+    font-weight: 700;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    color: #ef4444;
+  }
+  .vc-progress {
+    opacity: 0.6;
+    font-size: 0.78rem;
+  }
+  .progress {
+    width: 100%;
+    height: 6px;
+  }
+  .small {
+    font-size: 0.78rem;
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    background: rgba(127, 127, 127, 0.2);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.82em;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S5AvaliacaoPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S5AvaliacaoPanel.svelte
@@ -3,17 +3,39 @@
    * S5 — Motor de Avaliação (panel).
    * Pergunta: "O motor está funcionando? Como sabemos?"
    *
-   * Estrutura em 3 sub-tabs: Guardrail (S5.a) · STS (S5.b) · Longitudinal
-   * (S5.c). Envelopa Analytics + DebugPanel via toggles.
+   * Sub-tabs:
+   *   - Guardrail (S5.a) — boundary events per turn
+   *   - STS (S5.b)       — run history + launcher modal
+   *   - Longitudinal (S5.c) — mood trajectory, CASEL deltas, retention,
+   *                           Trigger Evaluator, RecallCheck closed-loop
+   *
+   * Spec parent: docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+   * User stories: US-S5a-01, US-S5b-01..03, US-S5c-01..04.
    */
   import {
     analyticsOpen,
     debugPanelOpen,
     llmXrayPanelOpen,
     llmXrayCalls,
+    currentSessionId,
+    tracerSubjectId,
   } from "../../lib/stores.js";
   import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
   import PlaceholderBanner from "./PlaceholderBanner.svelte";
+  import STSLauncherModal from "../sts/STSLauncherModal.svelte";
+  import {
+    createApiClient,
+    type ApiClient,
+    type GuardrailCheckEntryLike,
+    type RecallCheckEntryLike,
+    type TriggerEventEntryLike,
+    type KpiLongitudinalLike,
+    type StsRunSummaryLike,
+    type StsRunStartResultLike,
+  } from "../../lib/api.js";
+
+  /** Permite injetar mock em testes. */
+  export let api: ApiClient = createApiClient();
 
   const COLOR = "#ef4444";
 
@@ -24,26 +46,167 @@
     activeTab = t;
   }
 
-  function openAnalytics(): void {
-    analyticsOpen.set(true);
-  }
-  function openDebug(): void {
-    debugPanelOpen.set(true);
-  }
+  function openAnalytics(): void { analyticsOpen.set(true); }
+  function openDebug(): void { debugPanelOpen.set(true); }
   function openXray(): void {
-    // S5 → role=motor-execucao (evaluators).
     llmXrayCalls.set([]);
     llmXrayPanelOpen.set(true);
   }
 
-  type GuardrailCheck = { id: string; label: string; passed: boolean };
-  // v0 hardcoded — TODO: ligar com trace v2.
-  const guardrailChecks: GuardrailCheck[] = [
-    { id: "sanitize", label: "sanitize: items removidos", passed: true },
-    { id: "bullying", label: "bullying check (PT+JA): 0/5 patterns", passed: true },
-    { id: "scaffold", label: "scaffold guard: ok", passed: true },
-    { id: "parental", label: "parental authorization: 3 camadas ✓", passed: true },
-  ];
+  function derivePersonaId(sessionId: string | null, fallback: string): string {
+    if (sessionId === null || sessionId.length === 0) return fallback;
+    const idx = sessionId.indexOf("__");
+    return idx > 0 ? sessionId.slice(0, idx) : sessionId;
+  }
+
+  $: personaId = derivePersonaId($currentSessionId, $tracerSubjectId);
+
+  type LoadState = "idle" | "loading" | "loaded" | "error";
+
+  // ─── S5.a Guardrail state ────────────────────────────────────────
+  let guardrailState: LoadState = "idle";
+  let guardrailChecks: GuardrailCheckEntryLike[] = [];
+  let guardrailPassed = 0;
+  let guardrailFailed = 0;
+  let guardrailSource: "real" | "stub_v0" = "stub_v0";
+  let guardrailError = "";
+
+  async function loadGuardrail(pid: string): Promise<void> {
+    guardrailState = "loading";
+    try {
+      const res = await api.getGuardrailHistory(pid, 20);
+      guardrailChecks = res.checks;
+      guardrailPassed = res.passed_count;
+      guardrailFailed = res.failed_count;
+      guardrailSource = res.source;
+      guardrailState = "loaded";
+    } catch (err) {
+      guardrailError = err instanceof Error ? err.message : String(err);
+      guardrailState = "error";
+    }
+  }
+
+  // ─── S5.b STS state ──────────────────────────────────────────────
+  let stsRunsState: LoadState = "idle";
+  let stsRuns: StsRunSummaryLike[] = [];
+  let stsRunsError = "";
+  let launcherOpen = false;
+  let lastDispatched: StsRunStartResultLike | null = null;
+
+  // Filters
+  let filterPersona = "";
+  let filterScenario = "";
+
+  $: filteredStsRuns = stsRuns.filter((r) => {
+    if (filterPersona !== "" && r.persona_id !== filterPersona) return false;
+    if (filterScenario !== "" && r.scenario_id !== filterScenario) return false;
+    return true;
+  });
+
+  $: stsPersonaOptions = Array.from(new Set(stsRuns.map((r) => r.persona_id))).sort();
+  $: stsScenarioOptions = Array.from(new Set(stsRuns.map((r) => r.scenario_id))).sort();
+
+  async function loadStsRuns(): Promise<void> {
+    stsRunsState = "loading";
+    try {
+      const res = await api.listStsRuns(50);
+      stsRuns = res.runs;
+      stsRunsState = "loaded";
+    } catch (err) {
+      stsRunsError = err instanceof Error ? err.message : String(err);
+      stsRunsState = "error";
+    }
+  }
+
+  function onStsStarted(ev: CustomEvent<StsRunStartResultLike>): void {
+    lastDispatched = ev.detail;
+    void loadStsRuns();
+  }
+
+  // ─── S5.c Longitudinal state ─────────────────────────────────────
+  let kpiState: LoadState = "idle";
+  let kpi: KpiLongitudinalLike | null = null;
+  let kpiError = "";
+
+  let triggerState: LoadState = "idle";
+  let triggerEvents: TriggerEventEntryLike[] = [];
+  let triggerTransitions: Array<{ transition: string; count: number }> = [];
+  let triggerSource: "real" | "stub_v0" = "stub_v0";
+
+  let recallState: LoadState = "idle";
+  let recallEvents: RecallCheckEntryLike[] = [];
+  let recallSource: "real" | "stub_v0" = "stub_v0";
+
+  async function loadKpi(pid: string): Promise<void> {
+    kpiState = "loading";
+    try {
+      kpi = await api.getKpiLongitudinal(pid);
+      kpiState = "loaded";
+    } catch (err) {
+      kpiError = err instanceof Error ? err.message : String(err);
+      kpiState = "error";
+    }
+  }
+
+  async function loadTriggers(pid: string): Promise<void> {
+    triggerState = "loading";
+    try {
+      const res = await api.getTriggerEvents(pid, 20);
+      triggerEvents = res.events;
+      triggerTransitions = res.transitions;
+      triggerSource = res.source;
+      triggerState = "loaded";
+    } catch {
+      triggerState = "error";
+    }
+  }
+
+  async function loadRecall(pid: string): Promise<void> {
+    recallState = "loading";
+    try {
+      const res = await api.getRecallCheckHistory(pid, 20);
+      recallEvents = res.events;
+      recallSource = res.source;
+      recallState = "loaded";
+    } catch {
+      recallState = "error";
+    }
+  }
+
+  // Trigger initial + re-fetch quando persona muda. lastLoadedFor evita loop.
+  let lastLoadedFor = "";
+  $: if (personaId !== "" && personaId !== lastLoadedFor) {
+    lastLoadedFor = personaId;
+    void loadGuardrail(personaId);
+    void loadStsRuns();
+    void loadKpi(personaId);
+    void loadTriggers(personaId);
+    void loadRecall(personaId);
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────
+  function formatRelative(iso: string): string {
+    const t = Date.parse(iso);
+    if (Number.isNaN(t)) return iso;
+    const diffMs = Date.now() - t;
+    const absSec = Math.round(Math.abs(diffMs) / 1000);
+    if (absSec < 60) return `${absSec}s atrás`;
+    const absMin = Math.round(absSec / 60);
+    if (absMin < 60) return `${absMin}m atrás`;
+    const absH = Math.round(absMin / 60);
+    if (absH < 24) return `${absH}h atrás`;
+    return `${Math.round(absH / 24)}d atrás`;
+  }
+
+  function formatRate(rate: number | null): string {
+    if (rate === null) return "—";
+    return `${Math.round(rate * 100)}%`;
+  }
+
+  function sparklineHeight(rate: number | null): string {
+    if (rate === null) return "5%";
+    return `${Math.max(5, Math.round(rate * 100))}%`;
+  }
 </script>
 
 <SubsystemPanelShell id="S5" title="Motor de Avaliação" color={COLOR}>
@@ -82,46 +245,288 @@
 
   {#if activeTab === "guardrail"}
     <section class="tab-panel" data-testid="s5-pane-guardrail">
-      <h3>S5.a — Guardrail (per turn)</h3>
-      <ul class="checks">
-        {#each guardrailChecks as c (c.id)}
-          <li>
-            <span class="check-badge" class:passed={c.passed} class:failed={!c.passed}>
-              {c.passed ? "✓" : "✗"}
-            </span>
-            <span>{c.label}</span>
-          </li>
-        {/each}
-      </ul>
-      <p class="hint">
-        v0: status hardcoded — TODO ligar com trace v2 guardrail events.
-      </p>
+      <h3>S5.a — Guardrail (boundary events)</h3>
+      {#if guardrailState === "loading"}
+        <p class="muted small" data-testid="guardrail-loading">carregando…</p>
+      {:else if guardrailState === "error"}
+        <p class="error small" data-testid="guardrail-error">
+          erro: {guardrailError}
+        </p>
+        <PlaceholderBanner
+          label="endpoint indisponível — fallback"
+          specPath="docs/specs/2026-05-26-console-ebrota-user-stories-v0.md (US-S5a-01)"
+          color={COLOR}
+        />
+      {:else}
+        <div class="summary-badge" data-testid="guardrail-summary">
+          <span class="check-badge passed">✓ {guardrailPassed} passed</span>
+          {#if guardrailFailed > 0}
+            <span class="check-badge failed">✗ {guardrailFailed} failed</span>
+          {/if}
+          {#if guardrailSource === "stub_v0"}
+            <span class="stub-tag">stub_v0</span>
+          {/if}
+        </div>
+
+        {#if guardrailChecks.length === 0}
+          <p class="muted small" data-testid="guardrail-empty">
+            sem boundary events para esta persona — guardrail v0 cobre
+            sanitize/bullying/scaffold/parental rule-based; eventos só
+            aparecem quando trigger ocorre.
+          </p>
+        {:else}
+          <table class="checks-table" data-testid="guardrail-table">
+            <thead>
+              <tr>
+                <th>turn</th>
+                <th>category</th>
+                <th>label</th>
+                <th>intensity</th>
+                <th>status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each guardrailChecks as c (c.id)}
+                <tr>
+                  <td><code>{c.turn_ref}</code></td>
+                  <td>{c.topic_category}</td>
+                  <td class="label-cell">{c.label}</td>
+                  <td>{c.intensity === null ? "—" : c.intensity.toFixed(2)}</td>
+                  <td>
+                    <span class="check-badge" class:passed={c.passed} class:failed={!c.passed}>
+                      {c.passed ? "✓" : "✗"}
+                    </span>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      {/if}
     </section>
   {:else if activeTab === "sts"}
     <section class="tab-panel" data-testid="s5-pane-sts">
       <h3>S5.b — STS (cross-session)</h3>
-      <p class="hint">
-        STS run history + rubric G1-G5 — envelopado por
-        <code>Analytics</code> quando aberto (Status bar → 📊).
-      </p>
-      <button type="button" class="action" on:click={openAnalytics}>
-        Abrir Analytics
-      </button>
+      <div class="sts-header">
+        <button
+          type="button"
+          class="action primary"
+          on:click={() => { launcherOpen = true; }}
+          data-testid="sts-launch-btn"
+        >
+          🚀 Lançar nova run
+        </button>
+        <button type="button" class="action" on:click={openAnalytics}>
+          📊 Analytics
+        </button>
+      </div>
+
+      {#if lastDispatched !== null}
+        <div class="dispatched-banner" data-testid="sts-last-dispatched">
+          <strong>Última run disparada:</strong>
+          <code>{lastDispatched.run_id.slice(0, 8)}…</code>
+          ({lastDispatched.persona_id} / {lastDispatched.scenario_id})
+        </div>
+      {/if}
+
+      <h4>Histórico de runs</h4>
+      <div class="filters">
+        <label>
+          <span>persona</span>
+          <select bind:value={filterPersona} data-testid="sts-filter-persona">
+            <option value="">todas</option>
+            {#each stsPersonaOptions as p (p)}
+              <option value={p}>{p}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>scenario</span>
+          <select bind:value={filterScenario} data-testid="sts-filter-scenario">
+            <option value="">todos</option>
+            {#each stsScenarioOptions as s (s)}
+              <option value={s}>{s}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+
+      {#if stsRunsState === "loading"}
+        <p class="muted small" data-testid="sts-runs-loading">carregando runs…</p>
+      {:else if stsRunsState === "error"}
+        <p class="error small" data-testid="sts-runs-error">
+          erro: {stsRunsError}
+        </p>
+      {:else if filteredStsRuns.length === 0}
+        <p class="muted small" data-testid="sts-runs-empty">
+          nenhuma run STS persistida (rode <code>node scripts/sts-group-dyad.mjs</code>
+          ou use o launcher acima).
+        </p>
+      {:else}
+        <table class="runs-table" data-testid="sts-runs-table">
+          <thead>
+            <tr>
+              <th>run_id</th>
+              <th>persona</th>
+              <th>scenario</th>
+              <th>started</th>
+              <th>turns</th>
+              <th>score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each filteredStsRuns as r (r.run_id)}
+              <tr>
+                <td><code>{r.run_id.slice(0, 8)}…</code></td>
+                <td>{r.persona_id}</td>
+                <td>{r.scenario_id}</td>
+                <td>{formatRelative(r.started_at)}</td>
+                <td>{r.turn_count}</td>
+                <td>{r.score ?? "—"}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
     </section>
   {:else}
     <section class="tab-panel" data-testid="s5-pane-longitudinal">
       <h3>S5.c — Longitudinal</h3>
-      <PlaceholderBanner
-        label="S5.c em rascunho — KPI dashboard + RecallCheck + Trigger Evaluator"
-        specPath="docs/specs/2026-05-26-s5c-longitudinal-v0.md"
-        color={COLOR}
-      />
-      <p class="hint">
-        Eventos verbose via <code>DebugPanel</code> (Status bar → 🔬 Debug).
+      <p class="spec-ref">
+        spec: <code>docs/specs/2026-05-26-s5c-longitudinal-v0.md</code>
       </p>
-      <button type="button" class="action" on:click={openDebug}>
-        Abrir DebugPanel
-      </button>
+
+      {#if kpiState === "loading"}
+        <p class="muted small" data-testid="kpi-loading">carregando KPIs…</p>
+      {:else if kpiState === "error"}
+        <p class="error small" data-testid="kpi-error">erro: {kpiError}</p>
+      {:else if kpi !== null}
+        {#if kpi.source !== "real"}
+          <p class="stub-note">
+            ⚠ KPI source: <code>{kpi.source}</code> — algumas métricas ainda
+            não calculáveis (mood detector + CASEL aggregator pendentes).
+          </p>
+        {/if}
+
+        <div class="kpi-block" data-testid="kpi-mood">
+          <h4>Mood trajectory (últimas {kpi.mood_trajectory.length} sessões)</h4>
+          {#if kpi.mood_trajectory.length === 0}
+            <p class="muted small">sem sessões registradas</p>
+          {:else}
+            <div class="sparkline" aria-hidden="true">
+              {#each kpi.mood_trajectory.slice().reverse() as point (point.session_id)}
+                <span
+                  class="spark-bar"
+                  style:height={sparklineHeight(point.mood !== null ? point.mood / 10 : 0.3)}
+                  title={`${point.session_id} @ ${point.started_at} mood=${point.mood ?? "?"}`}
+                ></span>
+              {/each}
+            </div>
+            <p class="muted small">
+              mood pendente — sparkline mostra altura uniforme (0.3) até writer
+              de mood escrever em `sessions.mood_average`.
+            </p>
+          {/if}
+        </div>
+
+        <div class="kpi-block" data-testid="kpi-casel">
+          <h4>CASEL deltas (mensal 5×4)</h4>
+          {#if kpi.casel_deltas.length === 0}
+            <p class="muted small">
+              heatmap CASEL pendente — aggregator não wired em v0.
+            </p>
+            <PlaceholderBanner
+              label="CASEL heatmap v0 — orthogonal a doctrine pivot"
+              specPath="docs/specs/2026-05-26-s5c-longitudinal-v0.md"
+              color={COLOR}
+            />
+          {:else}
+            <table class="casel-heatmap">
+              <tbody>
+                {#each kpi.casel_deltas as d (d.month + d.axis)}
+                  <tr>
+                    <td>{d.month}</td>
+                    <td>{d.axis}</td>
+                    <td>{d.delta.toFixed(2)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          {/if}
+        </div>
+
+        <div class="kpi-block" data-testid="kpi-retention">
+          <h4>Concept retention (recall + closed loop)</h4>
+          <p>
+            total attempts: <strong>{kpi.concept_retention.total_attempts}</strong>
+            · positive rate: <strong>{formatRate(kpi.concept_retention.positive_rate)}</strong>
+          </p>
+          {#if kpi.concept_retention.positive_rate_by_week.length > 0}
+            <div class="sparkline" aria-hidden="true">
+              {#each kpi.concept_retention.positive_rate_by_week as w (w.week_start)}
+                <span
+                  class="spark-bar retention"
+                  style:height={sparklineHeight(w.rate)}
+                  title={`${w.week_start}: ${formatRate(w.rate)} (${w.total})`}
+                ></span>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      <div class="kpi-block" data-testid="kpi-trigger">
+        <h4>Trigger Evaluator (read-only)</h4>
+        {#if triggerState === "loading"}
+          <p class="muted small">carregando…</p>
+        {:else}
+          {#if triggerSource === "stub_v0"}
+            <p class="stub-note">
+              ⚠ source: <code>stub_v0</code> — TriggerEvaluator events
+              vivem em <code>engineTrace.components.planejador.triggerEvaluation</code>
+              mas ainda não persistem em SQL pra agregação cross-session.
+            </p>
+          {/if}
+          {#if triggerTransitions.length === 0}
+            <p class="muted small">sem transições registradas</p>
+          {:else}
+            <ul class="transitions">
+              {#each triggerTransitions as t (t.transition)}
+                <li><code>{t.transition}</code> × {t.count}</li>
+              {/each}
+            </ul>
+          {/if}
+        {/if}
+      </div>
+
+      <div class="kpi-block" data-testid="kpi-recall">
+        <h4>RecallCheck closed-loop</h4>
+        {#if recallState === "loading"}
+          <p class="muted small">carregando…</p>
+        {:else if recallEvents.length === 0}
+          <p class="muted small">
+            {recallSource === "stub_v0" ? "sem recall events ainda" : "vazio"}
+          </p>
+        {:else}
+          <ul class="recall-list">
+            {#each recallEvents.slice(0, 8) as e (e.id)}
+              <li>
+                <span class="outcome-badge" class:positive={e.outcome === "positive"} class:negative={e.outcome === "negative"}>
+                  {e.outcome}
+                </span>
+                <code>{e.concept_id}</code>
+                <span class="muted small">{formatRelative(e.created_at)}</span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+
+      <div class="actions">
+        <button type="button" class="action" on:click={openDebug}>
+          🔬 DebugPanel
+        </button>
+      </div>
     </section>
   {/if}
 
@@ -136,6 +541,13 @@
     </button>
   </div>
 </SubsystemPanelShell>
+
+<STSLauncherModal
+  {api}
+  open={launcherOpen}
+  on:close={() => { launcherOpen = false; }}
+  on:started={onStsStarted}
+/>
 
 <style>
   .tabs {
@@ -163,33 +575,29 @@
   .tab-panel {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.6rem;
   }
   h3 {
     margin: 0;
     font-size: 0.95rem;
   }
-  .checks {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-  }
-  .checks li {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+  h4 {
+    margin: 0.4rem 0 0.2rem 0;
     font-size: 0.85rem;
+    opacity: 0.9;
+  }
+  .summary-badge {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
   }
   .check-badge {
     display: inline-block;
     min-width: 1.3rem;
     text-align: center;
     border-radius: 3px;
-    padding: 0.1rem 0.3rem;
-    font-size: 0.8rem;
+    padding: 0.1rem 0.4rem;
+    font-size: 0.78rem;
     font-weight: 700;
   }
   .check-badge.passed {
@@ -200,13 +608,161 @@
     background: rgba(239, 68, 68, 0.2);
     color: #ef4444;
   }
-  .hint {
+  .stub-tag {
+    background: rgba(245, 158, 11, 0.2);
+    color: #f59e0b;
+    font-size: 0.7rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+  .stub-note {
+    background: rgba(245, 158, 11, 0.1);
+    border-left: 3px solid #f59e0b;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.8rem;
+    margin: 0.3rem 0;
+    border-radius: 3px;
+  }
+  .checks-table,
+  .runs-table,
+  .casel-heatmap {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8rem;
+  }
+  .checks-table th,
+  .checks-table td,
+  .runs-table th,
+  .runs-table td,
+  .casel-heatmap td {
+    text-align: left;
+    padding: 0.25rem 0.4rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.18);
+  }
+  .checks-table th,
+  .runs-table th {
+    font-weight: 600;
+    opacity: 0.75;
+  }
+  .label-cell {
+    font-size: 0.78rem;
+    opacity: 0.85;
+  }
+  .sts-header {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+  }
+  .dispatched-banner {
+    background: rgba(16, 185, 129, 0.1);
+    border-left: 3px solid #10b981;
+    padding: 0.4rem 0.6rem;
     font-size: 0.82rem;
-    opacity: 0.78;
+    border-radius: 3px;
+  }
+  .filters {
+    display: flex;
+    gap: 0.7rem;
+    align-items: center;
+  }
+  .filters label {
+    display: flex;
+    gap: 0.3rem;
+    align-items: center;
+    font-size: 0.8rem;
+  }
+  .filters select {
+    font: inherit;
+    padding: 0.2rem;
+    background: transparent;
+    color: inherit;
+    border: 1px solid rgba(127, 127, 127, 0.35);
+    border-radius: 3px;
+  }
+  .kpi-block {
+    border-top: 1px solid rgba(127, 127, 127, 0.18);
+    padding-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .sparkline {
+    display: flex;
+    gap: 2px;
+    align-items: flex-end;
+    height: 50px;
+    padding: 0.2rem 0;
+  }
+  .spark-bar {
+    flex: 1;
+    min-width: 4px;
+    background: linear-gradient(
+      to top,
+      rgba(239, 68, 68, 0.35),
+      rgba(239, 68, 68, 0.9)
+    );
+    border-radius: 2px;
+  }
+  .spark-bar.retention {
+    background: linear-gradient(
+      to top,
+      rgba(16, 185, 129, 0.35),
+      rgba(16, 185, 129, 0.9)
+    );
+  }
+  .transitions,
+  .recall-list {
+    list-style: none;
     margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.8rem;
+  }
+  .recall-list li {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+  }
+  .outcome-badge {
+    background: rgba(127, 127, 127, 0.2);
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+  .outcome-badge.positive {
+    background: rgba(16, 185, 129, 0.2);
+    color: #10b981;
+  }
+  .outcome-badge.negative {
+    background: rgba(239, 68, 68, 0.2);
+    color: #ef4444;
+  }
+  .muted {
+    opacity: 0.6;
+  }
+  .spec-ref {
+    margin: 0;
+    font-size: 0.78rem;
+    opacity: 0.7;
+  }
+  .small {
+    font-size: 0.78rem;
+  }
+  .error {
+    color: #d97706;
+  }
+  .actions {
+    margin-top: 0.4rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.4rem;
   }
   .action {
-    align-self: flex-start;
     padding: 0.3rem 0.7rem;
     background: transparent;
     border: 1px solid rgba(239, 68, 68, 0.6);
@@ -219,10 +775,9 @@
   .action:hover {
     background: rgba(239, 68, 68, 0.12);
   }
-  .actions {
-    margin-top: auto;
-    display: flex;
-    justify-content: flex-end;
+  .action.primary {
+    background: rgba(239, 68, 68, 0.18);
+    font-weight: 600;
   }
   .xray {
     background: transparent;

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -492,6 +492,108 @@ export interface DyadConfigLike {
   source: string;
 }
 
+// ─── S5 Avaliação duck-types (guardrail/STS/longitudinal) ──────────
+
+export interface GuardrailCheckEntryLike {
+  id: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+  topic_category: string;
+  label: string;
+  intensity: number | null;
+  passed: boolean;
+}
+
+export interface RecallCheckEntryLike {
+  id: string;
+  turn_ref: string;
+  session_id: string;
+  created_at: string;
+  concept_id: string;
+  lineage_anchor: string;
+  outcome: string;
+  intensity: number | null;
+}
+
+export interface TriggerEventEntryLike {
+  id: string;
+  turn_ref: string;
+  session_id: string;
+  fired_at: string;
+  transition: string;
+}
+
+export interface MoodTrajectoryPointLike {
+  session_id: string;
+  started_at: string;
+  mood: number | null;
+}
+
+export interface CaselDeltaLike {
+  month: string;
+  axis: string;
+  delta: number;
+}
+
+export interface KpiLongitudinalLike {
+  persona_id: string;
+  mood_trajectory: MoodTrajectoryPointLike[];
+  casel_deltas: CaselDeltaLike[];
+  concept_retention: {
+    total_attempts: number;
+    positive_rate: number | null;
+    positive_rate_by_week: Array<{
+      week_start: string;
+      rate: number | null;
+      total: number;
+    }>;
+  };
+  trigger_summary: Array<{ transition: string; count: number }>;
+  recall_summary: {
+    items_checked: number;
+    positive_rate: number | null;
+  };
+  source: "real" | "partial_stub_v0" | "stub_v0";
+}
+
+export interface StsScenarioLike {
+  id: string;
+  label: string;
+  description: string;
+  recommended_turns: number;
+  duration_label: string;
+}
+
+export interface StsPersonaLike {
+  id: string;
+  display_name: string;
+  archetype: string;
+  age: number | null;
+  language: string;
+}
+
+export interface StsRunSummaryLike {
+  run_id: string;
+  persona_id: string;
+  scenario_id: string;
+  started_at: string;
+  ended_at: string | null;
+  turn_count: number;
+  score: string | null;
+  trace_path: string | null;
+}
+
+export interface StsRunStartResultLike {
+  run_id: string;
+  status: "dispatched_stub_v0";
+  persona_id: string;
+  scenario_id: string;
+  turns: number;
+  dispatched_at: string;
+  note: string;
+}
+
 export interface DrillBankSummaryLike {
   bank_id: string;
   title: string;
@@ -640,6 +742,39 @@ export interface ApiClient {
   ): Promise<{ cards: EmittedCardLike[] }>;
   /** Configuração de dyad ativo (V0: stub null). */
   getDyad(personaId: string): Promise<DyadConfigLike>;
+
+  // ─── S5 Motor de Avaliação (guardrail / STS / longitudinal) ────
+  getGuardrailHistory(
+    personaId: string,
+    limit?: number,
+  ): Promise<{
+    checks: GuardrailCheckEntryLike[];
+    passed_count: number;
+    failed_count: number;
+    source: "real" | "stub_v0";
+  }>;
+  getRecallCheckHistory(
+    personaId: string,
+    limit?: number,
+  ): Promise<{
+    events: RecallCheckEntryLike[];
+    source: "real" | "stub_v0";
+  }>;
+  getTriggerEvents(
+    personaId: string,
+    limit?: number,
+  ): Promise<{
+    events: TriggerEventEntryLike[];
+    transitions: Array<{ transition: string; count: number }>;
+    source: "real" | "stub_v0";
+  }>;
+  getKpiLongitudinal(personaId: string): Promise<KpiLongitudinalLike>;
+  listStsScenarios(): Promise<{ scenarios: StsScenarioLike[] }>;
+  listStsPersonas(): Promise<{ personas: StsPersonaLike[] }>;
+  listStsRuns(limit?: number): Promise<{ runs: StsRunSummaryLike[] }>;
+  startStsRun(
+    input: { persona_id: string; scenario_id: string; turns?: number },
+  ): Promise<StsRunStartResultLike>;
 
   // ─── B2 Drilling ────────────────────────────────────────────────
   /** Lista banks disponíveis em fixtures/banks/. */
@@ -1169,6 +1304,49 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
       get<DyadConfigLike>(
         `/personas/${encodeURIComponent(personaId)}/dyad`,
       ),
+
+    // ─── S5 Motor de Avaliação ──────────────────────────────────────
+    getGuardrailHistory: (personaId, limit) =>
+      get<{
+        checks: GuardrailCheckEntryLike[];
+        passed_count: number;
+        failed_count: number;
+        source: "real" | "stub_v0";
+      }>(
+        `/personas/${encodeURIComponent(personaId)}/guardrail-history${
+          limit !== undefined ? `?limit=${limit}` : ""
+        }`,
+      ),
+    getRecallCheckHistory: (personaId, limit) =>
+      get<{ events: RecallCheckEntryLike[]; source: "real" | "stub_v0" }>(
+        `/personas/${encodeURIComponent(personaId)}/recall-check-history${
+          limit !== undefined ? `?limit=${limit}` : ""
+        }`,
+      ),
+    getTriggerEvents: (personaId, limit) =>
+      get<{
+        events: TriggerEventEntryLike[];
+        transitions: Array<{ transition: string; count: number }>;
+        source: "real" | "stub_v0";
+      }>(
+        `/personas/${encodeURIComponent(personaId)}/trigger-events${
+          limit !== undefined ? `?limit=${limit}` : ""
+        }`,
+      ),
+    getKpiLongitudinal: (personaId) =>
+      get<KpiLongitudinalLike>(
+        `/personas/${encodeURIComponent(personaId)}/kpi-longitudinal`,
+      ),
+    listStsScenarios: () =>
+      get<{ scenarios: StsScenarioLike[] }>("/sts/scenarios"),
+    listStsPersonas: () =>
+      get<{ personas: StsPersonaLike[] }>("/sts/personas"),
+    listStsRuns: (limit) =>
+      get<{ runs: StsRunSummaryLike[] }>(
+        limit !== undefined ? `/sts/runs?limit=${limit}` : "/sts/runs",
+      ),
+    startStsRun: (input) =>
+      post<StsRunStartResultLike>("/sts/runs/start", input),
 
     // ─── B2 ─────────────────────────────────────────────────────────
     listBanks: () => get<{ banks: DrillBankSummaryLike[] }>("/banks"),

--- a/packages/ebrota-console-ui/tests/s5-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/s5-panel.test.ts
@@ -1,0 +1,316 @@
+/**
+ * S5AvaliacaoPanel + STSLauncherModal — wiring tests com mock ApiClient.
+ *
+ * Cobre:
+ *  - render dos 3 sub-tabs (guardrail / sts / longitudinal)
+ *  - troca de tab via click
+ *  - guardrail real data (passed + failed badge)
+ *  - STS runs table render
+ *  - STS launcher modal abre / submita / mostra running
+ *  - longitudinal KPIs renderiza source=stub_v0 com banner
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/svelte";
+import S5AvaliacaoPanel from "../src/components/subsystem-panels/S5AvaliacaoPanel.svelte";
+import STSLauncherModal from "../src/components/sts/STSLauncherModal.svelte";
+import {
+  currentSessionId,
+  tracerSubjectId,
+  expandedSubsystem,
+} from "../src/lib/stores.js";
+import type {
+  ApiClient,
+  GuardrailCheckEntryLike,
+  KpiLongitudinalLike,
+  StsRunSummaryLike,
+} from "../src/lib/api.js";
+
+function mockApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  const stub = (): never => {
+    throw new Error("not stubbed");
+  };
+  return {
+    getStatus: stub,
+    getMode: stub,
+    setMode: stub,
+    startCardSession: stub,
+    getActiveSessions: stub,
+    listOptions: stub,
+    overrideSelection: stub,
+    listDecisions: stub,
+    getPendingApproval: stub,
+    approveOrEdit: stub,
+    endSession: stub,
+    listSessionLibrary: stub,
+    getSessionReplay: stub,
+    listDebugLlmCalls: stub,
+    clearDebugLlmCalls: stub,
+    listAnalyticsPersonas: stub,
+    getPersonaEvolution: stub,
+    turnStateSseUrl: () => "/api/turn-state",
+    listSubjectDiscoveries: stub,
+    listSubjectBoundaries: stub,
+    getBoundariesSummary: stub,
+    getJourneyState: stub,
+    setJourneyOverride: stub,
+    clearJourneyOverride: stub,
+    listFrameworks: stub,
+    getSubjectMaps: stub,
+    getDeclaredObjectives: stub,
+    getObjectiveHistory: stub,
+    getNarrativeThreads: stub,
+    getSubjectKnowledge: stub,
+    getSessionStrategyPlan: stub,
+    listSubjectStrategyPlans: stub,
+    getGuardrailHistory: async () => ({
+      checks: [],
+      passed_count: 0,
+      failed_count: 0,
+      source: "stub_v0",
+    }),
+    getRecallCheckHistory: async () => ({ events: [], source: "stub_v0" }),
+    getTriggerEvents: async () => ({
+      events: [],
+      transitions: [],
+      source: "stub_v0",
+    }),
+    getKpiLongitudinal: async () => ({
+      persona_id: "ryo",
+      mood_trajectory: [],
+      casel_deltas: [],
+      concept_retention: {
+        total_attempts: 0,
+        positive_rate: null,
+        positive_rate_by_week: [],
+      },
+      trigger_summary: [],
+      recall_summary: { items_checked: 0, positive_rate: null },
+      source: "stub_v0",
+    }),
+    listStsScenarios: async () => ({
+      scenarios: [
+        {
+          id: "smoke-3d",
+          label: "smoke-3d",
+          description: "Smoke",
+          recommended_turns: 6,
+          duration_label: "T+3d",
+        },
+      ],
+    }),
+    listStsPersonas: async () => ({
+      personas: [
+        {
+          id: "ryo-ochiai",
+          display_name: "Ryo",
+          archetype: "deflective-11a",
+          age: 11,
+          language: "pt+ja",
+        },
+      ],
+    }),
+    listStsRuns: async () => ({ runs: [] }),
+    startStsRun: async (input) => ({
+      run_id: "test-run-id-12345678",
+      status: "dispatched_stub_v0",
+      persona_id: input.persona_id,
+      scenario_id: input.scenario_id,
+      turns: input.turns ?? 6,
+      dispatched_at: "2026-05-27T10:00:00Z",
+      note: "v0 stub",
+    }),
+    getTemporalWindows: stub,
+    listPulsoEvents: stub,
+    getSacrificeBudget: stub,
+    listEmittedCards: stub,
+    getDyad: stub,
+    listBanks: stub,
+    getBank: stub,
+    listDrillStates: stub,
+    listDrillDue: stub,
+    listDrillMastered: stub,
+    getParentalDashboard: stub,
+    getParentalToday: stub,
+    getParentalWeek: stub,
+    getParentalCards: stub,
+    getParentalConversations: stub,
+    getParentalAlerts: stub,
+    getParentalPulsoEvents: stub,
+    listPendingQuestions: stub,
+    answerPendingQuestion: stub,
+    reportProblem: stub,
+    pauseChild: stub,
+    ...overrides,
+  } as ApiClient;
+}
+
+const sampleCheck: GuardrailCheckEntryLike = {
+  id: "g-1",
+  turn_ref: "t-3",
+  session_id: "ryo__s1",
+  created_at: "2026-05-25T12:00:00Z",
+  topic_category: "bullying_pt",
+  label: "termo agressivo",
+  intensity: 0.7,
+  passed: false,
+};
+
+const sampleRun: StsRunSummaryLike = {
+  run_id: "sts-run-aaaaaaaa-1111",
+  persona_id: "ryo-ochiai",
+  scenario_id: "smoke-3d",
+  started_at: "2026-05-25T10:00:00Z",
+  ended_at: null,
+  turn_count: 6,
+  score: null,
+  trace_path: null,
+};
+
+beforeEach(() => {
+  expandedSubsystem.set("S5");
+  currentSessionId.set("ryo__conv-1");
+  tracerSubjectId.set("ryo");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("S5AvaliacaoPanel — sub-tabs render", () => {
+  it("renderiza guardrail por default + 3 tabs", async () => {
+    const api = mockApi();
+    render(S5AvaliacaoPanel, { api });
+    expect(screen.getByTestId("s5-tab-guardrail")).toBeDefined();
+    expect(screen.getByTestId("s5-tab-sts")).toBeDefined();
+    expect(screen.getByTestId("s5-tab-longitudinal")).toBeDefined();
+    expect(screen.getByTestId("s5-pane-guardrail")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("guardrail-empty")).toBeDefined();
+    });
+  });
+
+  it("renderiza guardrail com dados reais (passed/failed badge + tabela)", async () => {
+    const api = mockApi({
+      getGuardrailHistory: async () => ({
+        checks: [sampleCheck, { ...sampleCheck, id: "g-2", passed: true }],
+        passed_count: 1,
+        failed_count: 1,
+        source: "real",
+      }),
+    });
+    render(S5AvaliacaoPanel, { api });
+    await waitFor(() => {
+      expect(screen.getByTestId("guardrail-table")).toBeDefined();
+    });
+    const summary = screen.getByTestId("guardrail-summary");
+    expect(summary.textContent).toContain("1 passed");
+    expect(summary.textContent).toContain("1 failed");
+  });
+
+  it("troca pra sub-tab STS via click", async () => {
+    const api = mockApi({
+      listStsRuns: async () => ({ runs: [sampleRun] }),
+    });
+    render(S5AvaliacaoPanel, { api });
+    await fireEvent.click(screen.getByTestId("s5-tab-sts"));
+    expect(screen.getByTestId("s5-pane-sts")).toBeDefined();
+    expect(screen.getByTestId("sts-launch-btn")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-runs-table")).toBeDefined();
+    });
+  });
+
+  it("STS empty state quando sem runs", async () => {
+    const api = mockApi();
+    render(S5AvaliacaoPanel, { api });
+    await fireEvent.click(screen.getByTestId("s5-tab-sts"));
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-runs-empty")).toBeDefined();
+    });
+  });
+
+  it("longitudinal mostra stub_v0 note quando source=stub_v0", async () => {
+    const api = mockApi();
+    render(S5AvaliacaoPanel, { api });
+    await fireEvent.click(screen.getByTestId("s5-tab-longitudinal"));
+    expect(screen.getByTestId("s5-pane-longitudinal")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("kpi-mood")).toBeDefined();
+    });
+    expect(screen.getByTestId("kpi-casel")).toBeDefined();
+    expect(screen.getByTestId("kpi-retention")).toBeDefined();
+    expect(screen.getByTestId("kpi-trigger")).toBeDefined();
+    expect(screen.getByTestId("kpi-recall")).toBeDefined();
+  });
+
+  it("longitudinal renderiza KPIs com dados parciais", async () => {
+    const kpi: KpiLongitudinalLike = {
+      persona_id: "ryo",
+      mood_trajectory: [
+        { session_id: "s1", started_at: "2026-05-20T10:00:00Z", mood: null },
+      ],
+      casel_deltas: [],
+      concept_retention: {
+        total_attempts: 5,
+        positive_rate: 0.6,
+        positive_rate_by_week: [
+          { week_start: "2026-05-18", rate: 0.6, total: 5 },
+        ],
+      },
+      trigger_summary: [],
+      recall_summary: { items_checked: 5, positive_rate: 0.6 },
+      source: "partial_stub_v0",
+    };
+    const api = mockApi({ getKpiLongitudinal: async () => kpi });
+    render(S5AvaliacaoPanel, { api });
+    await fireEvent.click(screen.getByTestId("s5-tab-longitudinal"));
+    await waitFor(() => {
+      const retention = screen.getByTestId("kpi-retention");
+      expect(retention.textContent).toContain("60%");
+      expect(retention.textContent).toContain("5");
+    });
+  });
+});
+
+describe("STSLauncherModal", () => {
+  it("carrega personas + scenarios on mount e mostra form", async () => {
+    const api = mockApi();
+    render(STSLauncherModal, { props: { api, open: true } });
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-form")).toBeDefined();
+    });
+    expect(screen.getByTestId("sts-launcher-persona")).toBeDefined();
+    expect(screen.getByTestId("sts-launcher-scenario")).toBeDefined();
+    expect(screen.getByTestId("sts-launcher-submit")).toBeDefined();
+  });
+
+  it("submit dispara startStsRun e exibe running state", async () => {
+    const startMock = vi.fn(async () => ({
+      run_id: "run-abc12345-9999",
+      status: "dispatched_stub_v0" as const,
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+      turns: 6,
+      dispatched_at: "2026-05-27T10:00:00Z",
+      note: "v0 stub",
+    }));
+    const api = mockApi({ startStsRun: startMock });
+    render(STSLauncherModal, { props: { api, open: true } });
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-submit")).toBeDefined();
+    });
+    await fireEvent.submit(screen.getByTestId("sts-launcher-form"));
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-running")).toBeDefined();
+    });
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("sts-launcher-clock")).toBeDefined();
+  });
+
+  it("não renderiza quando open=false", () => {
+    const api = mockApi();
+    render(STSLauncherModal, { props: { api, open: false } });
+    expect(screen.queryByTestId("sts-launcher-modal")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Escopo

Popula `S5AvaliacaoPanel` (PR #247) com dados reais via 8 novos endpoints BFF e introduz `STSLauncherModal` para US-S5b-02.

User stories cobertas: **US-S5a-01, US-S5b-01..03, US-S5c-01..04**.

Specs:
- \`docs/specs/2026-05-26-console-ebrota-user-stories-v0.md\`
- \`docs/architecture-consolidated/ARCHITECTURE.md\` (S5 sub-divisão a/b/c)

## Arquivos

### BFF
- **CREATE** \`packages/ebrota-console-bff/src/routes/s5-routes.ts\` — 8 endpoints
- **CREATE** \`packages/ebrota-console-bff/tests/s5-routes.unit.test.ts\` — 15 tests
- **MODIFY** \`packages/ebrota-console-bff/src/server.ts\` — 1 linha register

### UI
- **MODIFY** \`packages/ebrota-console-ui/src/components/subsystem-panels/S5AvaliacaoPanel.svelte\` — rewrite com 3 sub-tabs reais
- **CREATE** \`packages/ebrota-console-ui/src/components/sts/STSLauncherModal.svelte\` — modal launcher novo
- **MODIFY** \`packages/ebrota-console-ui/src/lib/api.ts\` — 8 métodos + 9 duck-types
- **CREATE** \`packages/ebrota-console-ui/tests/s5-panel.test.ts\` — 9 tests

## Endpoints (v0)

| endpoint | source | nota |
|---|---|---|
| GET /personas/:id/guardrail-history | real | lê \`subject_knowledge\` type=boundary_event |
| GET /personas/:id/recall-check-history | real | lê \`subject_knowledge\` type=recall_check_attempt |
| GET /personas/:id/trigger-events | stub_v0 | TriggerEvaluator events não persistidos em SQL ainda |
| GET /personas/:id/kpi-longitudinal | partial | mood/CASEL pendentes de writer; recall+retention reais |
| GET /sts/scenarios | hardcoded | smoke-3d, nagareyama-30d, realista, group-dyad |
| GET /sts/personas | hardcoded | Paula, Paula-30d, Ryo, Kei, Saki |
| GET /sts/runs | real | filtra \`sessions kind='sts'\` |
| POST /sts/runs/start | stub_v0 | reserva run_id, **não spawna** (nota explícita no response) |

## Sub-tabs do S5 panel

**Guardrail** — badge global \"✓ N passed / ✗ N failed\" + tabela turn/category/label/intensity/status.

**STS** — botão 🚀 \"Lançar nova run\" abre modal (persona/scenario/turns slider) + tabela de runs filtrável por persona/scenario + banner \"última run disparada\".

**Longitudinal** — sparkline mood (cross-session), heatmap CASEL (placeholder banner, casel_deltas vazio em v0), concept retention sparkline + %, Trigger Evaluator transitions (stub_v0 explícito), RecallCheck closed-loop com badges positive/negative.

## STSLauncherModal

Wizard mínimo persona×scenario×turns. Após submit:
- POST \`/sts/runs/start\` → exibe \"Run em andamento — run_id N\"
- Virtual clock progressivo (T+Xd via setInterval, decorativo)
- Botão \"↻ nova run\" pra resetar

Disclaimer explícito: dispatch é stub v0, run real ainda precisa \`node scripts/sts-group-dyad.mjs\`.

## Testes

- **BFF**: \`219/219 passing\` (15 novos + 204 existentes)
- **UI**: \`209/209 passing\` (9 novos + 200 existentes)
- **Build BFF**: tsc OK
- **Build UI**: vite OK (warnings A11y pré-existentes não relacionados)

## Não-objetivos v0 (explícitos)

- Persistência de STS runs (infra existe em \`ascendimacy-sts/\`)
- Métrica-rei composta (precisa definição)
- Real-time updates (polling stub via virtual clock; 5s real polling não wired)
- mood detector / CASEL aggregator real

## Anti-collision

- Branch worktree-isolated em \`/tmp/oc/agent-s5-panel\`
- Tocou apenas: 1 linha \`server.ts\` (register), criou s5-routes.ts/STSLauncherModal/s5-panel.test.ts, reescreveu S5AvaliacaoPanel.svelte, estendeu api.ts
- NÃO tocou: motor-*, planejador, orchestrator, shared, B1/B2/S1-S4 panels, ReplayTurnDetail, ParentalEngagedDashboard, App.svelte