### PR TITLE
[motor+ui+bff] B2 drilling pipeline integration — drill items in turn flow

### DIFF
--- a/fixtures/ryo-kid.yaml
+++ b/fixtures/ryo-kid.yaml
@@ -1,0 +1,15 @@
+# B2 drilling pilot persona (Ryo Ochiai, 8) — declarativa do bank JP-PT N5.
+# Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+#
+# `drill_bank_ids` opt-in: orchestrator carrega esses banks turn-a-turn pra
+# propor items SR due via `proposeDrillItem`. Personas sem o field não
+# participam do pipeline B2 (zero footprint).
+id: ryo-kid
+name: Ryo
+age: 8
+profile:
+  drill_bank_ids:
+    - ja-pt-vocab-n5
+  notes: |
+    Família Yuji vive no Japão; escola é JP, casa mistura.
+    Persona de teste do B2 drilling — banco N5 é começo razoável.

--- a/motor-drota/src/constrained-materializer.ts
+++ b/motor-drota/src/constrained-materializer.ts
@@ -291,11 +291,65 @@ function adaptiveMaxTokens(
  *
  * Em caso de erro do LLM: retorna texto fallback hardcoded conservador.
  */
+/**
+ * B2 (Drilling) — short-circuit determinístico para items `drill_vocab`.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md §5.
+ *
+ * Drill é pedagogia atômica — LLM não inventa pergunta, só varia. v0
+ * usa template fixo por language tag; v1 abre pra prompt template via
+ * voice_profile.
+ */
+export function materializeDrillVocab(item: {
+  prompt: string;
+  hint?: string;
+  source_language?: string;
+}): string {
+  const promptForm = item.prompt.trim();
+  const hint = item.hint?.trim();
+  const hintSuffix = hint && hint.length > 0 ? ` (dica: ${hint})` : "";
+  // Source japonês: usa partícula clássica "em português"; outros: mantém
+  // pt-br como destino, agnóstico ao source.
+  const lang = item.source_language ?? "unknown";
+  if (lang === "jp") {
+    return `Como se diz **${promptForm}** em português?${hintSuffix}`;
+  }
+  return `O que significa **${promptForm}**?${hintSuffix}`;
+}
+
 export async function materialize(
   ctx: MaterializerContext,
   opts?: MaterializeOpts,
 ): Promise<MaterializationResult> {
   const t0 = Date.now();
+
+  // B2 short-circuit: drill_vocab nunca chama LLM — pergunta determinística.
+  // Sanitizer continua aplicado (defesa em profundidade), mas sem fallback.
+  const selectedItem = ctx.action.item as {
+    type?: string;
+    prompt?: string;
+    hint?: string;
+    source_language?: string;
+  };
+  if (selectedItem.type === "drill_vocab" && typeof selectedItem.prompt === "string") {
+    const drillText = materializeDrillVocab({
+      prompt: selectedItem.prompt,
+      ...(selectedItem.hint !== undefined ? { hint: selectedItem.hint } : {}),
+      ...(selectedItem.source_language !== undefined
+        ? { source_language: selectedItem.source_language }
+        : {}),
+    });
+    const sanitized = sanitizeMaterialization(drillText);
+    return {
+      text: sanitized,
+      model_used: "drill_template_v0",
+      fallback_triggered: false,
+      latency_ms: Date.now() - t0,
+      token_count: 0,
+      sanitization_applied: sanitized !== drillText,
+    };
+  }
+
   const userMessage = buildUserMessage(ctx);
   const collector = opts?.collector;
   if (process.env["ASC_DEBUG_MATERIALIZER"] === "true") {

--- a/motor-drota/src/drill-fuzzy-match.ts
+++ b/motor-drota/src/drill-fuzzy-match.ts
@@ -1,72 +1,15 @@
 /**
- * drill-fuzzy-match — validação de resposta para items B2 (Drilling).
+ * drill-fuzzy-match — re-export from `@ascendimacy/shared`.
  *
- * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
- *
- * Strictness default (Jun ratify 2026-05-26):
- *  - Normaliza lowercase + remove acentos.
- *  - Match contra `payload.answer` + `payload.accept_variants`.
- *  - `slow_correct` quando latency > threshold (default 5s).
- *
- * Sem dependência de LLM — match local, determinístico.
+ * Função mudou pra shared/src/drill-fuzzy-match.ts pra ser consumida tanto
+ * por motor-drota quanto por orchestrator (matching pós-turn da resposta
+ * do sujeito ao drill emitido). API e comportamento idênticos — re-export
+ * preserva paths de import dos testes existentes.
  */
 
-import type { DrillItem } from "@ascendimacy/shared";
-
-export interface FuzzyMatchResult {
-  correct: boolean;
-  latency_ms: number;
-  response_type: "correct" | "slow_correct" | "incorrect";
-}
-
-export interface FuzzyMatchOpts {
-  /** Acima deste limite, `correct` vira `slow_correct`. Default 5000ms. */
-  slowThresholdMs?: number;
-}
-
-const DEFAULT_SLOW_THRESHOLD_MS = 5000;
-
-/**
- * Lowercase + strip Latin diacritics + collapse spaces.
- *
- * NFC re-compose ao final preserva caracteres não-latinos cujo NFD decompõe
- * para `base + combining-mark` fora da faixa U+0300–U+036F (ex.: dakuten
- * japonês U+3099 em `ご`).
- */
-export function normalize(s: string): string {
-  return s
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .normalize("NFC")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-export function matchDrillAnswer(
-  item: DrillItem,
-  userResponse: string,
-  latencyMs: number,
-  opts: FuzzyMatchOpts = {},
-): FuzzyMatchResult {
-  const slow = opts.slowThresholdMs ?? DEFAULT_SLOW_THRESHOLD_MS;
-  const normUser = normalize(userResponse);
-  const candidates = [
-    item.payload.answer,
-    ...(item.payload.accept_variants ?? []),
-  ];
-  const correct = candidates.some((c) => normalize(c) === normUser);
-
-  if (!correct) {
-    return {
-      correct: false,
-      latency_ms: latencyMs,
-      response_type: "incorrect",
-    };
-  }
-  return {
-    correct: true,
-    latency_ms: latencyMs,
-    response_type: latencyMs > slow ? "slow_correct" : "correct",
-  };
-}
+export {
+  matchDrillAnswer,
+  normalize,
+  type FuzzyMatchResult,
+  type FuzzyMatchOpts,
+} from "@ascendimacy/shared";

--- a/motor-drota/src/server.ts
+++ b/motor-drota/src/server.ts
@@ -13,6 +13,7 @@ import { callLlm, callLlmMock } from "./llm-client.js";
 import { parseDrotaOutput } from "./parse-output.js";
 // Sprint 5 #8: feature flag USE_SIMPLIFIED_PIPELINE — side-by-side
 import { handleSimplifiedPipeline } from "./simplified-pipeline-handler.js";
+import { materializeDrillVocab } from "./constrained-materializer.js";
 import { extractSignals } from "./signal-extractor.js";
 import { applyPostProcessors } from "./post-processor.js";
 import { buildInaugural } from "./inaugural.js";
@@ -358,6 +359,33 @@ server.registerTool(
     // motor#36: select agora deduz budget; newState não propagado pra
     // EvaluateAndSelectOutput (compat — caller pega budget de outras camadas).
     const { selected } = selectFromPool(ranked, input.state);
+
+    // B2 — Drilling short-circuit (spec 2026-05-26-b2-drilling-primer-v0.md §5).
+    // Drill item nunca chama LLM — pergunta determinística via template.
+    // Path legado precisa do mesmo bypass que simplified pipeline.
+    const drillSel = selected.item as {
+      type?: string;
+      prompt?: string;
+      hint?: string;
+      source_language?: string;
+    };
+    if (drillSel.type === "drill_vocab" && typeof drillSel.prompt === "string") {
+      const drillText = materializeDrillVocab({
+        prompt: drillSel.prompt,
+        ...(drillSel.hint !== undefined ? { hint: drillSel.hint } : {}),
+        ...(drillSel.source_language !== undefined
+          ? { source_language: drillSel.source_language }
+          : {}),
+      });
+      const drillOutput: EvaluateAndSelectOutput = {
+        selectedContent: selected,
+        selectionRationale: "drill_window_proposal (B2)",
+        linguisticMaterialization: sanitizeMaterialization(drillText),
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(drillOutput) }],
+      };
+    }
 
     // S-T-10-09 (ops#1070): skip drota composition path. Quando feature flag
     // ASC_SKIP_DROTA_COMPOSITION=true + item veio do action_menu + content

--- a/motor-drota/tests/drill-materialization.unit.test.ts
+++ b/motor-drota/tests/drill-materialization.unit.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Drill materialization — verifica short-circuit determinístico em items
+ * `drill_vocab`. Sem LLM call, prompt-template fixo por source_language.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  materialize,
+  materializeDrillVocab,
+} from "../src/constrained-materializer.js";
+import type { ScoredContentItem } from "@ascendimacy/shared";
+
+describe("materializeDrillVocab (template)", () => {
+  it("emite pergunta JP→PT pra source japonês", () => {
+    const text = materializeDrillVocab({
+      prompt: "りんご",
+      source_language: "jp",
+    });
+    expect(text).toContain("りんご");
+    expect(text).toMatch(/em portugu[êe]s/i);
+  });
+
+  it("emite pergunta genérica pra source desconhecido", () => {
+    const text = materializeDrillVocab({ prompt: "fork" });
+    expect(text).toContain("fork");
+    expect(text).toMatch(/o que significa/i);
+  });
+
+  it("anexa dica quando hint presente", () => {
+    const text = materializeDrillVocab({
+      prompt: "犬",
+      source_language: "jp",
+      hint: "animal de estimação",
+    });
+    expect(text).toContain("dica: animal de estimação");
+  });
+
+  it("ignora hint vazio", () => {
+    const text = materializeDrillVocab({
+      prompt: "犬",
+      source_language: "jp",
+      hint: "  ",
+    });
+    expect(text).not.toContain("dica");
+  });
+});
+
+describe("materialize() — drill_vocab short-circuit", () => {
+  const drillAction = (): ScoredContentItem => ({
+    item: {
+      id: "drill:jpv-001",
+      type: "drill_vocab",
+      domain: "drill.ja-pt-vocab-n5",
+      casel_target: [],
+      age_range: [4, 12],
+      surprise: 3,
+      verified: true,
+      base_score: 60,
+      drill_item_id: "jpv-001",
+      bank_id: "ja-pt-vocab-n5",
+      prompt: "りんご",
+      answer: "maçã",
+      source_language: "jp",
+    } as ScoredContentItem["item"],
+    score: 70,
+    reasons: ["drill_due(overdue_days=2.00)"],
+  });
+
+  it("retorna fallback_triggered=false + model_used=drill_template_v0 + zero token", async () => {
+    const result = await materialize({
+      action: drillAction(),
+      subjectNameForm: "Ryo",
+      mood: 5,
+      engagement: "medium",
+      turnCount: 4,
+      budgetRemaining: 80,
+      jurisdictionActive: "jp",
+      incomingMessage: "tô pronto",
+    });
+    expect(result.fallback_triggered).toBe(false);
+    expect(result.model_used).toBe("drill_template_v0");
+    expect(result.token_count).toBe(0);
+    expect(result.text).toContain("りんご");
+    expect(result.text).toMatch(/portugu[êe]s/i);
+  });
+
+  it("não chama LLM mesmo em turn 1 (zero rapport setup)", async () => {
+    // Sem mock — se LLM fosse chamada com sucesso o teste pegaria
+    // latency >0; com short-circuit a latency é ~ms locais.
+    const t0 = Date.now();
+    const result = await materialize({
+      action: drillAction(),
+      subjectNameForm: "Ryo",
+      mood: 5,
+      engagement: "medium",
+      turnCount: 1,
+      budgetRemaining: 100,
+      jurisdictionActive: "jp",
+    });
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeLessThan(50);
+    expect(result.fallback_triggered).toBe(false);
+  });
+
+  it("inclui hint no output quando presente", async () => {
+    const action = drillAction();
+    (action.item as { hint?: string }).hint = "fruta vermelha";
+    const result = await materialize({
+      action,
+      subjectNameForm: "Kei",
+      mood: 6,
+      engagement: "high",
+      turnCount: 3,
+      budgetRemaining: 80,
+      jurisdictionActive: "jp",
+    });
+    expect(result.text).toContain("dica: fruta vermelha");
+  });
+});

--- a/motor-execucao/src/server.ts
+++ b/motor-execucao/src/server.ts
@@ -4,6 +4,13 @@ import { z } from "zod";
 import { loadInventory } from "./loader.js";
 import { getState, logEvent, getDbInstance } from "./state-manager.js";
 import { executePlaybook } from "./executor.js";
+import {
+  listAttempts as listDrillAttempts,
+  listDue as listDrillDue,
+  listMastered as listDrillMastered,
+  loadBank as loadDrillBank,
+  recordAttempt as recordDrillAttempt,
+} from "./drill-repo.js";
 import { createProdActionMenuDeps } from "./action-menu-deps.js";
 import type { OnboardingTriggerDeps } from "./onboarding-trigger.js";
 import {
@@ -333,6 +340,106 @@ server.registerTool("log_event", {
   const event = { timestamp: getNow(), type, data: data ?? {} };
   logEvent(sessionId, event);
   return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, event }) }] };
+});
+
+// ─── B2 Drilling (spec 2026-05-26-b2-drilling-primer-v0.md) ────────────
+// Orchestrator chama essas tools turn-a-turn: pre-turn pra propor item due,
+// post-turn pra registrar tentativa após o sujeito responder.
+
+server.registerTool("drill_list_due", {
+  description:
+    "Lista DrillStates due now para a persona (ordenados por next_due_at). " +
+    "Vazio quando não há items due ou persona nunca foi drilada.",
+  inputSchema: {
+    personaId: z.string(),
+    nowIso: z.string().optional(),
+  } as any,
+}, async ({ personaId, nowIso }: { personaId: string; nowIso?: string }) => {
+  const states = listDrillDue(getDbInstance(), personaId, nowIso);
+  return { content: [{ type: "text" as const, text: JSON.stringify({ states }) }] };
+});
+
+server.registerTool("drill_load_bank", {
+  description:
+    "Carrega bank YAML (ja-pt-vocab-n5 etc) e retorna {bank, items}. " +
+    "items incluem `bank_id` denormalizado.",
+  inputSchema: {
+    bankId: z.string(),
+    root: z.string().optional(),
+  } as any,
+}, async ({ bankId, root }: { bankId: string; root?: string }) => {
+  try {
+    const result = loadDrillBank(bankId, root ? { root } : {});
+    return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
+  } catch (err) {
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          error: "bank_load_failed",
+          bankId,
+          cause: err instanceof Error ? err.message : String(err),
+        }),
+      }],
+    };
+  }
+});
+
+server.registerTool("drill_record_attempt", {
+  description:
+    "Registra uma tentativa de drill (correct/incorrect/timeout/slow_correct). " +
+    "Atualiza drill_states via SM-2, insere drill_attempts (audit log), retorna " +
+    "novo state. `masteryReached=true` quando esta tentativa cruzou mastery.",
+  inputSchema: {
+    personaId: z.string(),
+    itemId: z.string(),
+    response: z.enum(["correct", "incorrect", "timeout", "slow_correct"]),
+    latencyMs: z.number().optional(),
+    nowIso: z.string().optional(),
+  } as any,
+}, async ({ personaId, itemId, response, latencyMs, nowIso }: {
+  personaId: string;
+  itemId: string;
+  response: "correct" | "incorrect" | "timeout" | "slow_correct";
+  latencyMs?: number;
+  nowIso?: string;
+}) => {
+  const db = getDbInstance();
+  // Captura mastery anterior pra detectar transição (only-on-cross).
+  const priorMastered = (db
+    .prepare("SELECT mastery_reached_at FROM drill_states WHERE persona_id = ? AND item_id = ?")
+    .get(personaId, itemId) as { mastery_reached_at?: string | null } | undefined)
+    ?.mastery_reached_at ?? null;
+  const state = recordDrillAttempt(db, {
+    personaId,
+    itemId,
+    response,
+    ...(latencyMs !== undefined ? { latencyMs } : {}),
+    ...(nowIso !== undefined ? { nowIso } : {}),
+  });
+  const masteryReached = !priorMastered && !!state.mastery_reached_at;
+  return {
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify({ state, masteryReached }),
+    }],
+  };
+});
+
+server.registerTool("drill_list_attempts", {
+  description:
+    "Lista tentativas (drill_attempts) recentes da persona, ordenadas por " +
+    "attempted_at DESC. `limit` default 20.",
+  inputSchema: {
+    personaId: z.string(),
+    limit: z.number().optional(),
+  } as any,
+}, async ({ personaId, limit }: { personaId: string; limit?: number }) => {
+  const all = listDrillAttempts(getDbInstance(), personaId);
+  // listAttempts retorna ASC; aqui invertemos pra DESC + limit.
+  const cap = typeof limit === "number" && limit > 0 ? limit : 20;
+  const attempts = all.slice().reverse().slice(0, cap);
+  return { content: [{ type: "text" as const, text: JSON.stringify({ attempts }) }] };
 });
 
 const transport = new StdioServerTransport();

--- a/motor-execucao/src/state-manager.ts
+++ b/motor-execucao/src/state-manager.ts
@@ -11,6 +11,7 @@ import {
   KIDS_HELIX_STATE_DDL,
   getKidsHelixState,
 } from "./kids-helix-state.js";
+import { DRILL_STATES_DDL } from "./drill-repo.js";
 import { getNow, resolveDbPath } from "./clock.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -45,6 +46,7 @@ function getDb(dbPath?: string): Database.Database {
       ${EMITTED_CARDS_DDL}
       ${CONTENT_USAGE_DDL}
       ${KIDS_HELIX_STATE_DDL}
+      ${DRILL_STATES_DDL}
     `);
   }
   return db;

--- a/orchestrator/src/drill-orchestrator.ts
+++ b/orchestrator/src/drill-orchestrator.ts
@@ -9,16 +9,35 @@
  * `proposeDrillItem` é pura (sem DB). Caller carrega `listDue` + banks
  * antes e passa o contexto. Mantém testabilidade + desacoplamento do
  * motor-execucao (orchestrator não importa direto do workspace dele).
+ *
+ * Os helpers de empacotamento (`drillProposalToScoredItem`,
+ * `serialize/deserialize`) moram em `@ascendimacy/shared/drill-proposal`
+ * pra evitar dep cycle planejador → orchestrator. Re-exportados aqui
+ * pra preservar API histórica.
  */
 
-import type { DrillItem, DrillState } from "@ascendimacy/shared";
+import type { DrillItem, DrillProposal, DrillState } from "@ascendimacy/shared";
+import { DEFAULT_DRILL_COST, DRILL_WINDOW_HOOK } from "@ascendimacy/shared";
 
-/** Hook descritor — usado pelo S3 quando aceita a proposta. */
-export const DRILL_WINDOW_HOOK = "drill_window_proposal" as const;
-export type DrillWindowHook = typeof DRILL_WINDOW_HOOK;
-
-/** Custo default por item em sacrifice points (spec default = 2). */
-export const DEFAULT_DRILL_COST = 2;
+// Re-export pure helpers + constants so existing callers that import
+// from `@ascendimacy/orchestrator/drill-orchestrator` keep working.
+export {
+  DEFAULT_DRILL_COST,
+  DRILL_BASE_SCORE,
+  DRILL_MAX_OVERDUE_BONUS,
+  DRILL_OVERDUE_BONUS_PER_DAY,
+  DRILL_WINDOW_HOOK,
+  daysOverdue,
+  deserializeDrillProposal,
+  drillProposalToScoredItem,
+  scoreDrillProposal,
+  serializeDrillProposal,
+} from "@ascendimacy/shared";
+export type {
+  DrillProposal,
+  DrillWindowHook,
+  SerializableDrillProposal,
+} from "@ascendimacy/shared";
 
 export interface DrillProposalContext {
   personaId: string;
@@ -30,13 +49,6 @@ export interface DrillProposalContext {
   budget: number;
   /** Override do custo por item; default `DEFAULT_DRILL_COST`. */
   costPerItem?: number;
-}
-
-export interface DrillProposal {
-  hook: DrillWindowHook;
-  item: DrillItem;
-  state: DrillState;
-  cost: number;
 }
 
 /**

--- a/orchestrator/src/orchestrator.ts
+++ b/orchestrator/src/orchestrator.ts
@@ -4,8 +4,18 @@ import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
 import type { McpClients } from "./mcp-clients.js";
 import { initTrace, appendTurn, saveTrace } from "./trace-writer.js";
-import type { PersonaDef, AdquirenteDef, PlaybookIndex } from "@ascendimacy/shared";
-import { logDebugEvent } from "@ascendimacy/shared";
+import type {
+  PersonaDef,
+  AdquirenteDef,
+  PlaybookIndex,
+  DrillItem,
+  DrillState,
+} from "@ascendimacy/shared";
+import { logDebugEvent, matchDrillAnswer } from "@ascendimacy/shared";
+import {
+  proposeDrillItem,
+  serializeDrillProposal,
+} from "./drill-orchestrator.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = join(__dirname, "../../fixtures");
@@ -48,6 +58,56 @@ function parseToolText<T>(result: unknown): T {
   const content = (result as { content: Array<{ type: string; text: string }> }).content;
   const text = content.find(c => c.type === "text")?.text ?? "{}";
   return JSON.parse(text) as T;
+}
+
+/**
+ * B2 — extrai bank ids declarados em persona.profile.
+ * v0: opt-in via `persona.profile.drill_bank_ids: string[]`. Sem field
+ * = persona não participa do drilling (zero footprint pro pipeline).
+ */
+function extractDrillBankIds(persona: PersonaDef): string[] {
+  const profile = (persona.profile ?? {}) as Record<string, unknown>;
+  const raw = profile["drill_bank_ids"];
+  if (Array.isArray(raw)) return raw.filter((x): x is string => typeof x === "string");
+  if (typeof raw === "string") return [raw];
+  return [];
+}
+
+interface PendingDrill {
+  drillItemId: string;
+  bankId: string;
+  emittedAt: string;
+  turnEmitted: number;
+}
+
+/**
+ * Procura no eventLog o último `drill_emitted` que ainda não foi resolvido
+ * por um `drill_attempt_recorded` subsequente. Quando presente, o `message`
+ * deste turno é a tentativa do sujeito.
+ */
+function findPendingDrill(
+  eventLog: ReadonlyArray<import("@ascendimacy/shared").EventEntry>,
+): PendingDrill | null {
+  for (let i = eventLog.length - 1; i >= 0; i--) {
+    const ev = eventLog[i]!;
+    if (ev.type === "drill_attempt_recorded") return null;
+    if (ev.type === "drill_emitted") {
+      const data = ev.data as {
+        drill_item_id?: string;
+        bank_id?: string;
+        turn_number?: number;
+      };
+      if (typeof data.drill_item_id === "string" && typeof data.bank_id === "string") {
+        return {
+          drillItemId: data.drill_item_id,
+          bankId: data.bank_id,
+          emittedAt: ev.timestamp,
+          turnEmitted: typeof data.turn_number === "number" ? data.turn_number : 0,
+        };
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -290,6 +350,149 @@ export async function runTurn(
   }
   void (Date.now() - tSig); // keep latency hint local — debug log captura via debug-mode
 
+  // B2 (Drilling) — pre-turn workflow.
+  //
+  //   (1) Se prior turn emitiu drill_emitted (sem drill_attempt_recorded),
+  //       este `message` é a resposta. Match + recordAttempt + log events.
+  //   (2) Pra este turn, propose drill (drill_list_due + drill_load_bank +
+  //       proposeDrillItem). Se proposal válida → injeta em planContextHints.
+  //
+  // Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+  const bankIds = extractDrillBankIds(persona);
+  const drillEnabled = bankIds.length > 0;
+  let drillItemsById = new Map<string, DrillItem>();
+  if (drillEnabled) {
+    // Lazy load banks pra esta turn (cache fica no servidor MCP filesystem,
+    // mas no orchestrator não persistimos entre turns — barato pra v0).
+    for (const bankId of bankIds) {
+      try {
+        const bankRes = await clients.motorExecucao.callTool({
+          name: "drill_load_bank",
+          arguments: { bankId },
+        });
+        const parsed = parseToolText<{ items?: DrillItem[]; error?: string }>(bankRes);
+        if (parsed.items) {
+          for (const it of parsed.items) drillItemsById.set(it.id, it);
+        }
+      } catch {
+        // Bank load fail — segue sem drill pra este turn (fail-soft).
+      }
+    }
+  }
+
+  // (1) Resolve drill response do turno anterior se houver pending.
+  const pending = drillEnabled
+    ? findPendingDrill(state.eventLog ?? [])
+    : null;
+  if (pending) {
+    const item = drillItemsById.get(pending.drillItemId);
+    if (item) {
+      const emittedMs = new Date(pending.emittedAt).getTime();
+      const latencyMs = Math.max(0, Date.now() - emittedMs);
+      const match = matchDrillAnswer(item, message, latencyMs);
+      try {
+        const attemptRes = await clients.motorExecucao.callTool({
+          name: "drill_record_attempt",
+          arguments: {
+            personaId: persona.id,
+            itemId: item.id,
+            response: match.response_type,
+            latencyMs,
+          },
+        });
+        const attempt = parseToolText<{
+          state: import("@ascendimacy/shared").DrillState;
+          masteryReached: boolean;
+        }>(attemptRes);
+        await clients.motorExecucao.callTool({
+          name: "log_event",
+          arguments: {
+            sessionId,
+            type: "drill_attempt_recorded",
+            data: {
+              drill_item_id: item.id,
+              bank_id: item.bank_id,
+              response: match.response_type,
+              correct: match.correct,
+              latency_ms: latencyMs,
+              user_response: message.slice(0, 200),
+              next_due_at: attempt.state.next_due_at,
+              mastery_reached: attempt.masteryReached,
+            },
+          },
+        });
+        if (attempt.masteryReached) {
+          await clients.motorExecucao.callTool({
+            name: "log_event",
+            arguments: {
+              sessionId,
+              type: "drill_item_mastered",
+              data: {
+                drill_item_id: item.id,
+                bank_id: item.bank_id,
+                mastered_at: attempt.state.mastery_reached_at,
+              },
+            },
+          });
+        }
+        // Re-fetch state pra refletir eventos novos no plan_turn deste turn.
+        const refreshedState = parseToolText<import("@ascendimacy/shared").SessionState>(
+          await clients.motorExecucao.callTool({
+            name: "get_state",
+            arguments: { sessionId },
+          }),
+        );
+        if (refreshedState.eventLog) state.eventLog = refreshedState.eventLog;
+      } catch {
+        // Fail-soft — drill miss não trava turn.
+      }
+    }
+  }
+
+  // (2) Propose drill pra este turn.
+  let serializedDrillProposal:
+    | ReturnType<typeof serializeDrillProposal>
+    | null = null;
+  if (drillEnabled && drillItemsById.size > 0) {
+    try {
+      const dueRes = await clients.motorExecucao.callTool({
+        name: "drill_list_due",
+        arguments: { personaId: persona.id },
+      });
+      const due = parseToolText<{ states: DrillState[] }>(dueRes);
+      // v0: persona "cold start" — se não há states (presented_count 0
+      // pra todos), considera todos items elegíveis like "due now".
+      // Isso destrava o primeiro drill turn antes de qualquer attempt.
+      let dueStates: DrillState[] = due.states ?? [];
+      if (dueStates.length === 0) {
+        const nowIso = new Date().toISOString();
+        dueStates = Array.from(drillItemsById.keys()).map((itemId) => ({
+          persona_id: persona.id,
+          item_id: itemId,
+          presented_count: 0,
+          correct_count: 0,
+          last_seen_at: nowIso,
+          next_due_at: nowIso,
+          current_interval_days: 0,
+          current_easiness: 2.5,
+          mastery_reached_at: null,
+          last_5_attempts: [],
+        }));
+      }
+      const proposal = proposeDrillItem({
+        personaId: persona.id,
+        dueStates,
+        itemsById: drillItemsById,
+        budget: state.budgetRemaining,
+      });
+      if (proposal) {
+        serializedDrillProposal = serializeDrillProposal(proposal);
+      }
+    } catch {
+      // Fail-soft
+    }
+  }
+
   const t1 = Date.now();
   // BUG-PL-01 Sprint 5: passa extracted_signals em contextHints pro planejador
   // injetar SINAIS DETECTADOS NO TURNO + bloco DEFLECTION ATIVO no system prompt
@@ -299,6 +502,9 @@ export async function runTurn(
   if (extractedSignals.length > 0) {
     planContextHints["extracted_signals"] = extractedSignals;
     planContextHints["last_user_message"] = message;
+  }
+  if (serializedDrillProposal) {
+    planContextHints["drill_proposal"] = serializedDrillProposal;
   }
   const planResult = await clients.planejador.callTool({
     name: "plan_turn",
@@ -529,6 +735,39 @@ export async function runTurn(
       newTurnNumber: exec.newState?.turn ?? state.turn + 1,
     },
   });
+
+  // B2 — post-turn: se selectedContent é drill_vocab, marca como pending
+  // pro próximo turn parsear a resposta. Inclui drill_item_id + bank_id
+  // pra resolver lookup sem depender do bank carregado em memória.
+  const selectedRaw = drota.selectedContent?.item as
+    | {
+        type?: string;
+        drill_item_id?: string;
+        bank_id?: string;
+      }
+    | undefined;
+  if (
+    selectedRaw?.type === "drill_vocab" &&
+    typeof selectedRaw.drill_item_id === "string" &&
+    typeof selectedRaw.bank_id === "string"
+  ) {
+    try {
+      await clients.motorExecucao.callTool({
+        name: "log_event",
+        arguments: {
+          sessionId,
+          type: "drill_emitted",
+          data: {
+            drill_item_id: selectedRaw.drill_item_id,
+            bank_id: selectedRaw.bank_id,
+            turn_number: state.turn,
+          },
+        },
+      });
+    } catch {
+      // Fail-soft
+    }
+  }
 
   // v0.3: enriquece o turn com snapshots e resumos.
   const selectedItem = drota.selectedContent?.item;

--- a/orchestrator/tests/drill-attempt-flow.integration.test.ts
+++ b/orchestrator/tests/drill-attempt-flow.integration.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Drill attempt flow integration — verifica que runTurn:
+ *  (1) carrega bank via MCP + injeta `drill_proposal` em contextHints
+ *  (2) loga `drill_emitted` post-turn quando selectedContent é drill_vocab
+ *  (3) ao turn seguinte, detecta pending drill, matcheia resposta do user
+ *      e chama drill_record_attempt + loga drill_attempt_recorded
+ *  (4) `drill_item_mastered` é logado quando masteryReached=true
+ *
+ * Persona usada: `ryo-kid` (fixtures/ryo-kid.yaml) com drill_bank_ids declarado.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runTurn } from "../src/orchestrator.js";
+import type { McpClients } from "../src/mcp-clients.js";
+import type { SessionState, EventEntry } from "@ascendimacy/shared";
+
+let tracesDir: string;
+
+beforeEach(() => {
+  tracesDir = mkdtempSync(join(tmpdir(), "drill-flow-traces-"));
+});
+
+afterEach(() => {
+  rmSync(tracesDir, { recursive: true, force: true });
+});
+
+interface RecordedCall {
+  client: "planejador" | "motorDrota" | "motorExecucao";
+  name: string;
+  args: Record<string, unknown>;
+}
+
+const SAMPLE_DRILL_ITEM = {
+  id: "jpv-001",
+  bank_id: "ja-pt-vocab-n5",
+  type: "vocab",
+  axis: "language.jp_pt",
+  difficulty: 1,
+  payload: { prompt: "りんご", answer: "maçã", accept_variants: ["maca"] },
+};
+
+const SAMPLE_DRILL_VOCAB_ITEM = {
+  id: "drill:jpv-001",
+  type: "drill_vocab",
+  domain: "drill.ja-pt-vocab-n5",
+  casel_target: [],
+  age_range: [6, 12],
+  surprise: 3,
+  verified: true,
+  base_score: 60,
+  sacrifice_amount: 2,
+  drill_item_id: "jpv-001",
+  bank_id: "ja-pt-vocab-n5",
+  prompt: "りんご",
+  answer: "maçã",
+  source_language: "jp",
+};
+
+function buildMockClients(
+  initialState: SessionState,
+  opts: {
+    selectedItem?: Record<string, unknown>;
+    materialization?: string;
+    masteryReached?: boolean;
+    onCall: (call: RecordedCall) => void;
+  },
+): McpClients {
+  const state: SessionState = JSON.parse(JSON.stringify(initialState));
+  const planejador = {
+    callTool: async (params: { name: string; arguments: Record<string, unknown> }) => {
+      opts.onCall({ client: "planejador", name: params.name, args: params.arguments });
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            strategicRationale: "mock",
+            contentPool: opts.selectedItem
+              ? [{ item: opts.selectedItem, score: 70, reasons: ["drill"] }]
+              : [],
+            contextHints: params.arguments["contextHints"] ?? {},
+            is_critical: false,
+          }),
+        }],
+      };
+    },
+  };
+  const motorDrota = {
+    callTool: async (params: { name: string; arguments: Record<string, unknown> }) => {
+      opts.onCall({ client: "motorDrota", name: params.name, args: params.arguments });
+      if (params.name === "extract_signals") {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ signals: [] }) }],
+        };
+      }
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            selectedContent: opts.selectedItem
+              ? { item: opts.selectedItem, score: 70, reasons: ["drill"] }
+              : { item: { id: "x", type: "curiosity_hook" }, score: 1, reasons: [] },
+            selectionRationale: "drill_window_proposal (B2)",
+            linguisticMaterialization: opts.materialization ?? "Como se diz **りんご** em português?",
+          }),
+        }],
+      };
+    },
+  };
+  const motorExecucao = {
+    callTool: async (params: { name: string; arguments: Record<string, unknown> }) => {
+      opts.onCall({ client: "motorExecucao", name: params.name, args: params.arguments });
+      if (params.name === "get_state") {
+        return { content: [{ type: "text", text: JSON.stringify(state) }] };
+      }
+      if (params.name === "drill_load_bank") {
+        return {
+          content: [{ type: "text", text: JSON.stringify({
+            bank: { bank_id: "ja-pt-vocab-n5", title: "t", curator: "jun" },
+            items: [SAMPLE_DRILL_ITEM],
+          }) }],
+        };
+      }
+      if (params.name === "drill_list_due") {
+        return { content: [{ type: "text", text: JSON.stringify({ states: [] }) }] };
+      }
+      if (params.name === "drill_record_attempt") {
+        return {
+          content: [{ type: "text", text: JSON.stringify({
+            state: {
+              persona_id: "ryo-kid",
+              item_id: "jpv-001",
+              presented_count: 1,
+              correct_count: 1,
+              last_seen_at: "2026-05-27T12:00:00.000Z",
+              next_due_at: "2026-05-28T12:00:00.000Z",
+              current_interval_days: 1,
+              current_easiness: 2.6,
+              mastery_reached_at: opts.masteryReached ? "2026-05-27T12:00:00.000Z" : null,
+              last_5_attempts: ["correct"],
+            },
+            masteryReached: !!opts.masteryReached,
+          }) }],
+        };
+      }
+      if (params.name === "log_event") {
+        const ev: EventEntry = {
+          timestamp: new Date().toISOString(),
+          type: String(params.arguments["type"]),
+          data: (params.arguments["data"] ?? {}) as Record<string, unknown>,
+        };
+        state.eventLog = [...(state.eventLog ?? []), ev];
+        return { content: [{ type: "text", text: JSON.stringify({ ok: true, event: ev }) }] };
+      }
+      if (params.name === "execute_playbook") {
+        return {
+          content: [{ type: "text", text: JSON.stringify({
+            success: true,
+            newState: { ...state, turn: state.turn + 1 },
+            eventLogged: { timestamp: new Date().toISOString(), type: "playbook_executed", data: {} },
+          }) }],
+        };
+      }
+      if (params.name === "detect_achievement") {
+        return { content: [{ type: "text", text: JSON.stringify({}) }] };
+      }
+      if (params.name === "emit_card_for_signal") {
+        return { content: [{ type: "text", text: JSON.stringify({ ok: false, skipped: true }) }] };
+      }
+      return { content: [{ type: "text", text: JSON.stringify({}) }] };
+    },
+  };
+  return {
+    planejador: planejador as never,
+    motorDrota: motorDrota as never,
+    motorExecucao: motorExecucao as never,
+  };
+}
+
+describe("runTurn — drill flow integration", () => {
+  it("turn 1: carrega bank + propõe drill + loga drill_emitted post-turn", async () => {
+    const calls: RecordedCall[] = [];
+    const clients = buildMockClients(
+      {
+        sessionId: "s-drill-1",
+        trustLevel: 0.5,
+        budgetRemaining: 80,
+        eventLog: [],
+        turn: 0,
+      },
+      {
+        selectedItem: SAMPLE_DRILL_VOCAB_ITEM,
+        materialization: "Como se diz **りんご** em português?",
+        onCall: (c) => calls.push(c),
+      },
+    );
+
+    await runTurn(clients, "s-drill-1", "ryo-kid", "oi", tracesDir);
+
+    // drill_load_bank chamado pra ja-pt-vocab-n5 (declarado no perfil).
+    const bankCall = calls.find(
+      (c) => c.client === "motorExecucao" && c.name === "drill_load_bank",
+    );
+    expect(bankCall).toBeDefined();
+    expect(bankCall!.args["bankId"]).toBe("ja-pt-vocab-n5");
+
+    // drill_list_due chamado pra a persona.
+    const dueCall = calls.find(
+      (c) => c.client === "motorExecucao" && c.name === "drill_list_due",
+    );
+    expect(dueCall).toBeDefined();
+    expect(dueCall!.args["personaId"]).toBe("ryo-kid");
+
+    // plan_turn recebeu drill_proposal serializado em contextHints.
+    const planCall = calls.find((c) => c.client === "planejador" && c.name === "plan_turn");
+    expect(planCall).toBeDefined();
+    const hints = planCall!.args["contextHints"] as Record<string, unknown>;
+    expect(hints).toBeDefined();
+    const proposal = hints["drill_proposal"] as { hook: string; item: { id: string } };
+    expect(proposal).toBeDefined();
+    expect(proposal.hook).toBe("drill_window_proposal");
+    expect(proposal.item.id).toBe("jpv-001");
+
+    // Post-turn: drill_emitted event logado.
+    const emittedLog = calls.find(
+      (c) =>
+        c.client === "motorExecucao" &&
+        c.name === "log_event" &&
+        (c.args["type"] as string) === "drill_emitted",
+    );
+    expect(emittedLog).toBeDefined();
+    const emittedData = emittedLog!.args["data"] as Record<string, unknown>;
+    expect(emittedData["drill_item_id"]).toBe("jpv-001");
+    expect(emittedData["bank_id"]).toBe("ja-pt-vocab-n5");
+  });
+
+  it("turn N+1: detecta pending drill_emitted, matcheia resposta + grava attempt", async () => {
+    const calls: RecordedCall[] = [];
+    const justNow = new Date(Date.now() - 1500).toISOString(); // <5s latency
+    const stateWithPending: SessionState = {
+      sessionId: "s-drill-2",
+      trustLevel: 0.6,
+      budgetRemaining: 78,
+      turn: 2,
+      eventLog: [
+        {
+          timestamp: justNow,
+          type: "drill_emitted",
+          data: { drill_item_id: "jpv-001", bank_id: "ja-pt-vocab-n5", turn_number: 1 },
+        },
+      ],
+    };
+    const clients = buildMockClients(stateWithPending, {
+      selectedItem: {
+        id: "x",
+        type: "curiosity_hook",
+        domain: "generic",
+        casel_target: [],
+        age_range: [0, 99],
+        surprise: 1,
+        verified: true,
+        base_score: 1,
+      },
+      materialization: "Boa! Vamos pra próxima.",
+      onCall: (c) => calls.push(c),
+    });
+
+    // "maçã" = match exato pro item jpv-001.
+    await runTurn(clients, "s-drill-2", "ryo-kid", "maçã", tracesDir);
+
+    const recordCall = calls.find(
+      (c) => c.client === "motorExecucao" && c.name === "drill_record_attempt",
+    );
+    expect(recordCall).toBeDefined();
+    expect(recordCall!.args["itemId"]).toBe("jpv-001");
+    expect(recordCall!.args["response"]).toBe("correct");
+    expect(recordCall!.args["personaId"]).toBe("ryo-kid");
+
+    const attemptLog = calls.find(
+      (c) =>
+        c.client === "motorExecucao" &&
+        c.name === "log_event" &&
+        (c.args["type"] as string) === "drill_attempt_recorded",
+    );
+    expect(attemptLog).toBeDefined();
+    const data = attemptLog!.args["data"] as Record<string, unknown>;
+    expect(data["drill_item_id"]).toBe("jpv-001");
+    expect(data["correct"]).toBe(true);
+    expect(data["mastery_reached"]).toBe(false);
+  });
+
+  it("loga drill_item_mastered quando masteryReached=true", async () => {
+    const calls: RecordedCall[] = [];
+    const justNow = new Date(Date.now() - 1500).toISOString();
+    const stateWithPending: SessionState = {
+      sessionId: "s-drill-3",
+      trustLevel: 0.6,
+      budgetRemaining: 78,
+      turn: 5,
+      eventLog: [
+        {
+          timestamp: justNow,
+          type: "drill_emitted",
+          data: { drill_item_id: "jpv-001", bank_id: "ja-pt-vocab-n5", turn_number: 4 },
+        },
+      ],
+    };
+    const clients = buildMockClients(stateWithPending, {
+      masteryReached: true,
+      onCall: (c) => calls.push(c),
+    });
+
+    await runTurn(clients, "s-drill-3", "ryo-kid", "maçã", tracesDir);
+
+    const masteredLog = calls.find(
+      (c) =>
+        c.client === "motorExecucao" &&
+        c.name === "log_event" &&
+        (c.args["type"] as string) === "drill_item_mastered",
+    );
+    expect(masteredLog).toBeDefined();
+    const data = masteredLog!.args["data"] as Record<string, unknown>;
+    expect(data["drill_item_id"]).toBe("jpv-001");
+    expect(data["bank_id"]).toBe("ja-pt-vocab-n5");
+  });
+
+  it("resposta incorreta → response=incorrect, sem mastered", async () => {
+    const calls: RecordedCall[] = [];
+    const justNow = new Date(Date.now() - 1500).toISOString();
+    const stateWithPending: SessionState = {
+      sessionId: "s-drill-4",
+      trustLevel: 0.5,
+      budgetRemaining: 80,
+      turn: 1,
+      eventLog: [
+        {
+          timestamp: justNow,
+          type: "drill_emitted",
+          data: { drill_item_id: "jpv-001", bank_id: "ja-pt-vocab-n5", turn_number: 0 },
+        },
+      ],
+    };
+    const clients = buildMockClients(stateWithPending, {
+      onCall: (c) => calls.push(c),
+    });
+
+    await runTurn(clients, "s-drill-4", "ryo-kid", "banana", tracesDir);
+
+    const recordCall = calls.find(
+      (c) => c.client === "motorExecucao" && c.name === "drill_record_attempt",
+    );
+    expect(recordCall).toBeDefined();
+    expect(recordCall!.args["response"]).toBe("incorrect");
+  });
+});

--- a/packages/ebrota-console-bff/src/routes/b2-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/b2-routes.ts
@@ -18,9 +18,11 @@ import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 import type { Database as DatabaseType } from "better-sqlite3";
 import type { DrillResponse, DrillState } from "@ascendimacy/shared";
 import {
+  listAttempts,
   loadBank,
   listDue,
   listMastered,
+  type DrillAttemptRow,
 } from "@ascendimacy/motor-execucao/drill-repo";
 
 export interface B2RoutesOptions {
@@ -135,6 +137,35 @@ const b2RoutesPlugin: FastifyPluginAsync<B2RoutesOptions> = async (
     "/personas/:id/drill-mastered",
     async (req) => {
       return { states: listMastered(opts.db, req.params.id) };
+    },
+  );
+
+  /**
+   * GET /personas/:id/drill-attempts?limit=N
+   *
+   * Última tentativas (drill_attempts), ordenadas DESC por attempted_at.
+   * Usado pelo B2 panel pra "last attempts" block.
+   * Limit default 20, máximo 200.
+   *
+   * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+   */
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>(
+    "/personas/:id/drill-attempts",
+    async (req) => {
+      const rawLimit = req.query?.limit;
+      let limit = 20;
+      if (rawLimit !== undefined) {
+        const parsed = Number.parseInt(rawLimit, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          limit = Math.min(parsed, 200);
+        }
+      }
+      const all = listAttempts(opts.db, req.params.id);
+      const attempts: DrillAttemptRow[] = all.slice().reverse().slice(0, limit);
+      return { attempts };
     },
   );
 };

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/B2DrillingPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/B2DrillingPanel.svelte
@@ -12,6 +12,7 @@
   import { createApiClient } from "../../lib/api.js";
   import type {
     ApiClient,
+    DrillAttemptRowLike,
     DrillBankSummaryLike,
     DrillStateLike,
   } from "../../lib/api.js";
@@ -28,6 +29,7 @@
   let states: DrillStateLike[] = [];
   let due: DrillStateLike[] = [];
   let mastered: DrillStateLike[] = [];
+  let attempts: DrillAttemptRowLike[] = [];
 
   $: personaId = $tracerSubjectId;
 
@@ -35,16 +37,19 @@
     loading = true;
     error = null;
     try {
-      const [banksRes, statesRes, dueRes, masteredRes] = await Promise.all([
-        api.listBanks(),
-        api.listDrillStates(persona),
-        api.listDrillDue(persona),
-        api.listDrillMastered(persona),
-      ]);
+      const [banksRes, statesRes, dueRes, masteredRes, attemptsRes] =
+        await Promise.all([
+          api.listBanks(),
+          api.listDrillStates(persona),
+          api.listDrillDue(persona),
+          api.listDrillMastered(persona),
+          api.listDrillAttempts(persona, 10),
+        ]);
       banks = banksRes.banks;
       states = statesRes.states;
       due = dueRes.states;
       mastered = masteredRes.states;
+      attempts = attemptsRes.attempts;
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -163,6 +168,39 @@
             </li>
           {/each}
         </ul>
+      {/if}
+    </section>
+
+    <section class="block" data-testid="b2-attempts-block">
+      <h3>
+        Last attempts <span class="count">({attempts.length})</span>
+      </h3>
+      {#if attempts.length === 0}
+        <p class="empty">Sem tentativas registradas para {personaId}.</p>
+      {:else}
+        <table class="drill-table">
+          <thead>
+            <tr>
+              <th>quando</th>
+              <th>item</th>
+              <th>resposta</th>
+              <th>latência</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each attempts as a (a.id)}
+              <tr>
+                <td><time>{a.attempted_at}</time></td>
+                <td><code>{a.item_id}</code></td>
+                <td>
+                  <span class="attempt {a.response}">{attemptGlyph(a.response)}</span>
+                  <span class="muted small">{a.response}</span>
+                </td>
+                <td>{a.latency_ms !== null ? a.latency_ms + "ms" : "—"}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
       {/if}
     </section>
 

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -531,6 +531,19 @@ export interface DrillStateLike {
   last_5_attempts: string[];
 }
 
+/**
+ * B2 drill attempt row (audit log) — retornado por
+ * `GET /personas/:id/drill-attempts`.
+ */
+export interface DrillAttemptRowLike {
+  id: number;
+  persona_id: string;
+  item_id: string;
+  response: "correct" | "incorrect" | "timeout" | "slow_correct";
+  latency_ms: number | null;
+  attempted_at: string;
+}
+
 export interface ApiClient {
   getStatus(): Promise<BffStatus>;
   getMode(): Promise<{ mode: ConsoleMode }>;
@@ -658,6 +671,11 @@ export interface ApiClient {
   listDrillMastered(
     personaId: string,
   ): Promise<{ states: DrillStateLike[] }>;
+  /** Audit log de tentativas recentes (ordem DESC). */
+  listDrillAttempts(
+    personaId: string,
+    limit?: number,
+  ): Promise<{ attempts: DrillAttemptRowLike[] }>;
 
   // ─── Parental Engaged Dashboard (US-PE-01..09) ──────────────────
   getParentalDashboard(
@@ -1185,6 +1203,12 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     listDrillMastered: (personaId) =>
       get<{ states: DrillStateLike[] }>(
         `/personas/${encodeURIComponent(personaId)}/drill-mastered`,
+      ),
+    listDrillAttempts: (personaId, limit) =>
+      get<{ attempts: DrillAttemptRowLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/drill-attempts${
+          typeof limit === "number" ? `?limit=${limit}` : ""
+        }`,
       ),
 
     // ── Parental Engaged Dashboard (US-PE-01..09) ──────────────────

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -52,6 +52,10 @@ export interface PlanTurnOpts {
 }
 import { loadSeedPool, buildPool, slicePoolForDrota } from "./pool-builder.js";
 import {
+  deserializeDrillProposal,
+  drillProposalToScoredItem,
+} from "@ascendimacy/shared";
+import {
   evaluateAllTransitions,
   collectRecentSignals,
   collectRecentSignalsPerTurn,
@@ -398,6 +402,29 @@ export async function planTurn(
       sacrifice_cost_by_id: sacrificeCostById,
     });
     topK = scored.slice(0, TOP_K_POOL);
+  }
+
+  // B2 — Drilling integration (spec 2026-05-26-b2-drilling-primer-v0.md).
+  //
+  // Orchestrator pre-load (drill_list_due + drill_load_bank + proposeDrillItem)
+  // serializa proposal em `contextHints.drill_proposal`. Aqui só consumimos:
+  // se proposal válida → inject como ScoredContentItem no topo do pool, com
+  // score baseado em SR urgency (overdue dias).
+  //
+  // S3 ainda decide via score se cabe — drill compete no mesmo ranking, mas
+  // overdue alto + DRILL_BASE_SCORE garante seleção quando o motor não tem
+  // candidato mais relevante.
+  const drillProposalRaw = input.contextHints?.["drill_proposal"];
+  const drillProposal = drillProposalRaw
+    ? deserializeDrillProposal(drillProposalRaw)
+    : null;
+  if (drillProposal) {
+    const drillScored = drillProposalToScoredItem(
+      drillProposal,
+      input.persona.age,
+      new Date().toISOString(),
+    );
+    topK = [drillScored, ...topK];
   }
 
   // 2. Triagem parental (Bloco 4 #17, paper §6 camada 2).

--- a/planejador/tests/pool-builder-drill-integration.unit.test.ts
+++ b/planejador/tests/pool-builder-drill-integration.unit.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Pool-builder drill integration — verifica que quando o orchestrator
+ * passa `contextHints.drill_proposal` serializado, o planejador deserializa
+ * e injeta o drill como ScoredContentItem no topo do pool.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DRILL_BASE_SCORE,
+  DRILL_OVERDUE_BONUS_PER_DAY,
+  DRILL_WINDOW_HOOK,
+  drillProposalToScoredItem,
+  scoreDrillProposal,
+  serializeDrillProposal,
+  deserializeDrillProposal,
+  type DrillItem,
+  type DrillProposal,
+  type DrillState,
+} from "@ascendimacy/shared";
+
+const NOW = "2026-05-27T12:00:00.000Z";
+const TWO_DAYS_AGO = "2026-05-25T12:00:00.000Z";
+
+const buildItem = (overrides: Partial<DrillItem> = {}): DrillItem => ({
+  id: "jpv-001",
+  bank_id: "ja-pt-vocab-n5",
+  type: "vocab",
+  axis: "language.jp_pt",
+  difficulty: 1,
+  payload: { prompt: "りんご", answer: "maçã", accept_variants: ["maca"] },
+  ...overrides,
+});
+
+const buildState = (overrides: Partial<DrillState> = {}): DrillState => ({
+  persona_id: "ryo-ochiai",
+  item_id: "jpv-001",
+  presented_count: 3,
+  correct_count: 2,
+  last_seen_at: TWO_DAYS_AGO,
+  next_due_at: TWO_DAYS_AGO, // 2d overdue at NOW
+  current_interval_days: 1,
+  current_easiness: 2.5,
+  mastery_reached_at: null,
+  last_5_attempts: ["correct", "correct", "incorrect"],
+  ...overrides,
+});
+
+const buildProposal = (): DrillProposal => ({
+  hook: DRILL_WINDOW_HOOK,
+  item: buildItem(),
+  state: buildState(),
+  cost: 2,
+});
+
+describe("scoreDrillProposal", () => {
+  it("retorna DRILL_BASE_SCORE quando state é exato no due", () => {
+    const state = buildState({ next_due_at: NOW });
+    expect(scoreDrillProposal(state, NOW)).toBe(DRILL_BASE_SCORE);
+  });
+
+  it("adiciona bonus linear por dias de atraso", () => {
+    const state = buildState({ next_due_at: TWO_DAYS_AGO });
+    expect(scoreDrillProposal(state, NOW)).toBe(
+      DRILL_BASE_SCORE + 2 * DRILL_OVERDUE_BONUS_PER_DAY,
+    );
+  });
+
+  it("capa o bonus em DRILL_MAX_OVERDUE_BONUS pra items muito antigos", () => {
+    const veryOld = "2025-01-01T00:00:00.000Z";
+    const state = buildState({ next_due_at: veryOld });
+    const score = scoreDrillProposal(state, NOW);
+    expect(score).toBeLessThanOrEqual(DRILL_BASE_SCORE + 30);
+    expect(score).toBeGreaterThan(DRILL_BASE_SCORE);
+  });
+});
+
+describe("drillProposalToScoredItem", () => {
+  it("constrói ScoredContentItem do tipo drill_vocab", () => {
+    const scored = drillProposalToScoredItem(buildProposal(), 8, NOW);
+    expect(scored.item.type).toBe("drill_vocab");
+    expect(scored.item.id).toBe("drill:jpv-001");
+    const drillItem = scored.item as { prompt: string; answer: string; bank_id: string };
+    expect(drillItem.prompt).toBe("りんご");
+    expect(drillItem.answer).toBe("maçã");
+    expect(drillItem.bank_id).toBe("ja-pt-vocab-n5");
+  });
+
+  it("score reflete SR urgency (2d overdue → +10)", () => {
+    const scored = drillProposalToScoredItem(buildProposal(), 8, NOW);
+    expect(scored.score).toBe(DRILL_BASE_SCORE + 2 * DRILL_OVERDUE_BONUS_PER_DAY);
+    expect(scored.reasons).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("drill_due"),
+        "drill_bank=ja-pt-vocab-n5",
+      ]),
+    );
+  });
+
+  it("detecta source_language=jp via charset", () => {
+    const scored = drillProposalToScoredItem(buildProposal(), 8, NOW);
+    const drillItem = scored.item as { source_language?: string };
+    expect(drillItem.source_language).toBe("jp");
+  });
+});
+
+describe("serialize/deserialize drill proposal", () => {
+  it("round-trip preserva todos os campos", () => {
+    const original = buildProposal();
+    const serialized = serializeDrillProposal(original);
+    const json = JSON.parse(JSON.stringify(serialized));
+    const deserialized = deserializeDrillProposal(json);
+    expect(deserialized).not.toBeNull();
+    expect(deserialized!.hook).toBe(DRILL_WINDOW_HOOK);
+    expect(deserialized!.item.id).toBe(original.item.id);
+    expect(deserialized!.state.persona_id).toBe(original.state.persona_id);
+    expect(deserialized!.cost).toBe(original.cost);
+  });
+
+  it("deserialize retorna null para shape inválido", () => {
+    expect(deserializeDrillProposal(null)).toBeNull();
+    expect(deserializeDrillProposal({})).toBeNull();
+    expect(deserializeDrillProposal({ hook: "other", item: {}, state: {}, cost: 1 })).toBeNull();
+    expect(deserializeDrillProposal({ hook: DRILL_WINDOW_HOOK, cost: 1 })).toBeNull();
+  });
+});

--- a/shared/src/content-item.ts
+++ b/shared/src/content-item.ts
@@ -16,6 +16,7 @@ export const CONTENT_ITEM_TYPES = [
   "gtd_task",
   "dynamic",
   "challenge",
+  "drill_vocab",
 ] as const;
 
 export type ContentItemType = (typeof CONTENT_ITEM_TYPES)[number];
@@ -262,6 +263,31 @@ export interface ChallengeItem extends ContentItemBase {
   estimated_minutes: number;
 }
 
+/**
+ * B2 (Drilling) — wrapper de DrillItem como ContentItem pra trafegar pelo
+ * pipeline padrão (plan → score → materialize). O pool-builder não carrega
+ * items deste tipo do seed; eles são injetados turn-a-turn por
+ * `proposeDrillItem` (orchestrator) quando há items SR due. Materializer
+ * gera pergunta determinística (sem LLM) baseada em `prompt`.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ */
+export interface DrillVocabItem extends ContentItemBase {
+  type: "drill_vocab";
+  /** FK para DrillItem.id no banco. Source-of-truth da resposta + variantes. */
+  drill_item_id: string;
+  /** Banco de origem (ex: "ja-pt-vocab-n5"). */
+  bank_id: string;
+  /** Prompt apresentado ao sujeito (ex: "りんご"). */
+  prompt: string;
+  /** Resposta canônica (ex: "maçã") — usada por fuzzy-match downstream. */
+  answer: string;
+  /** Dica opcional pré-pergunta. */
+  hint?: string;
+  /** Língua de origem do prompt — orienta materialização ("jp" → "Como se diz X em português?"). */
+  source_language?: string;
+}
+
 export type ContentItem =
   | CuriosityHookItem
   | CulturalDiamondItem
@@ -269,7 +295,8 @@ export type ContentItem =
   | GtdReviewItem
   | GtdTaskItem
   | DynamicItem
-  | ChallengeItem;
+  | ChallengeItem
+  | DrillVocabItem;
 
 /** Score resultante para um item no contexto de um turn. */
 export interface ScoredContentItem {

--- a/shared/src/drill-fuzzy-match.ts
+++ b/shared/src/drill-fuzzy-match.ts
@@ -1,0 +1,76 @@
+/**
+ * drill-fuzzy-match — validação de resposta para items B2 (Drilling).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ *
+ * Strictness default (Jun ratify 2026-05-26):
+ *  - Normaliza lowercase + remove acentos.
+ *  - Match contra `payload.answer` + `payload.accept_variants`.
+ *  - `slow_correct` quando latency > threshold (default 5s).
+ *
+ * Sem dependência de LLM — match local, determinístico.
+ *
+ * Vive em `shared` pra ser consumido tanto por motor-drota (validação
+ * durante o pipeline) quanto por orchestrator (matching pós-turn da
+ * resposta do sujeito ao drill emitido no turn anterior).
+ */
+
+import type { DrillItem } from "./contracts/index.js";
+
+export interface FuzzyMatchResult {
+  correct: boolean;
+  latency_ms: number;
+  response_type: "correct" | "slow_correct" | "incorrect";
+}
+
+export interface FuzzyMatchOpts {
+  /** Acima deste limite, `correct` vira `slow_correct`. Default 5000ms. */
+  slowThresholdMs?: number;
+}
+
+const DEFAULT_SLOW_THRESHOLD_MS = 5000;
+
+/**
+ * Lowercase + strip Latin diacritics + collapse spaces.
+ *
+ * NFC re-compose ao final preserva caracteres não-latinos cujo NFD decompõe
+ * para `base + combining-mark` fora da faixa U+0300–U+036F (ex.: dakuten
+ * japonês U+3099 em `ご`).
+ */
+export function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .normalize("NFC")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function matchDrillAnswer(
+  item: DrillItem,
+  userResponse: string,
+  latencyMs: number,
+  opts: FuzzyMatchOpts = {},
+): FuzzyMatchResult {
+  const slow = opts.slowThresholdMs ?? DEFAULT_SLOW_THRESHOLD_MS;
+  const normUser = normalize(userResponse);
+  const candidates = [
+    item.payload.answer,
+    ...(item.payload.accept_variants ?? []),
+  ];
+  const correct = candidates.some((c) => normalize(c) === normUser);
+
+  if (!correct) {
+    return {
+      correct: false,
+      latency_ms: latencyMs,
+      response_type: "incorrect",
+    };
+  }
+  return {
+    correct: true,
+    latency_ms: latencyMs,
+    response_type: latencyMs > slow ? "slow_correct" : "correct",
+  };
+}

--- a/shared/src/drill-proposal.ts
+++ b/shared/src/drill-proposal.ts
@@ -1,0 +1,138 @@
+/**
+ * drill-proposal — helpers puros pra empacotar/desempacotar `DrillProposal`
+ * como ScoredContentItem trafegando no pipeline plan_turn → evaluate_and_select.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md
+ *
+ * Mora em `shared` (não em orchestrator) pra evitar dep cycle: planejador
+ * importa `drillProposalToScoredItem` mas não pode importar orchestrator.
+ * `proposeDrillItem` (policy) continua em orchestrator/src/drill-orchestrator.ts.
+ */
+
+import type {
+  DrillItem,
+  DrillState,
+} from "./contracts/index.js";
+import type { DrillVocabItem, ScoredContentItem } from "./content-item.js";
+
+/** Hook descritor — usado pelo S3 quando aceita a proposta. */
+export const DRILL_WINDOW_HOOK = "drill_window_proposal" as const;
+export type DrillWindowHook = typeof DRILL_WINDOW_HOOK;
+
+/** Custo default por item em sacrifice points (spec default = 2). */
+export const DEFAULT_DRILL_COST = 2;
+
+/** Score base alto pra garantir que drill due bata items normais do seed.
+ *  Acima de PARENT_PINNED_SCORE (1000) seria intrusivo demais — drill é
+ *  proposta, não trump. 60 fica próximo ao topo (seed items ficam 20-50). */
+export const DRILL_BASE_SCORE = 60;
+/** Bônus linear por dia de atraso, capado para não dominar trust/sacrifice. */
+export const DRILL_OVERDUE_BONUS_PER_DAY = 5;
+export const DRILL_MAX_OVERDUE_BONUS = 30;
+
+export interface DrillProposal {
+  hook: DrillWindowHook;
+  item: DrillItem;
+  state: DrillState;
+  cost: number;
+}
+
+/** Days between `next_due_at` and now (negative = ainda não due). */
+export function daysOverdue(state: DrillState, nowIso: string): number {
+  const dueMs = new Date(state.next_due_at).getTime();
+  const nowMs = new Date(nowIso).getTime();
+  return (nowMs - dueMs) / 86_400_000;
+}
+
+/** Score determinístico baseado em SR urgency. */
+export function scoreDrillProposal(
+  state: DrillState,
+  nowIso: string,
+): number {
+  const overdue = Math.max(0, daysOverdue(state, nowIso));
+  const overdueBonus = Math.min(
+    DRILL_MAX_OVERDUE_BONUS,
+    overdue * DRILL_OVERDUE_BONUS_PER_DAY,
+  );
+  return DRILL_BASE_SCORE + overdueBonus;
+}
+
+/**
+ * Empacota a proposal como `ScoredContentItem` com `DrillVocabItem` embutido.
+ * `personaAge` preenche `age_range` (não há filtro real — drill só entra no
+ * pool quando há state due pra esta persona).
+ */
+export function drillProposalToScoredItem(
+  proposal: DrillProposal,
+  personaAge: number,
+  nowIso: string,
+): ScoredContentItem {
+  const score = scoreDrillProposal(proposal.state, nowIso);
+  const overdue = daysOverdue(proposal.state, nowIso);
+  const item: DrillVocabItem = {
+    id: `drill:${proposal.item.id}`,
+    type: "drill_vocab",
+    domain: `drill.${proposal.item.bank_id}`,
+    casel_target: [],
+    age_range: [Math.max(0, personaAge - 2), personaAge + 4],
+    surprise: 3,
+    verified: true,
+    base_score: DRILL_BASE_SCORE,
+    sacrifice_amount: proposal.cost,
+    drill_item_id: proposal.item.id,
+    bank_id: proposal.item.bank_id,
+    prompt: proposal.item.payload.prompt,
+    answer: proposal.item.payload.answer,
+    ...(proposal.item.payload.hint !== undefined
+      ? { hint: proposal.item.payload.hint }
+      : {}),
+    source_language: /[぀-ヿ一-鿿]/.test(proposal.item.payload.prompt)
+      ? "jp"
+      : "unknown",
+  };
+  return {
+    item,
+    score,
+    reasons: [
+      `drill_due(overdue_days=${overdue.toFixed(2)})`,
+      `drill_bank=${proposal.item.bank_id}`,
+    ],
+  };
+}
+
+/**
+ * Shape serializável de um DrillProposal — passa por contextHints sem
+ * perder informação. `Map<>` não atravessa JSON, então usamos flat refs.
+ */
+export interface SerializableDrillProposal {
+  hook: DrillWindowHook;
+  item: DrillItem;
+  state: DrillState;
+  cost: number;
+}
+
+export function serializeDrillProposal(
+  proposal: DrillProposal,
+): SerializableDrillProposal {
+  return {
+    hook: proposal.hook,
+    item: proposal.item,
+    state: proposal.state,
+    cost: proposal.cost,
+  };
+}
+
+export function deserializeDrillProposal(
+  raw: unknown,
+): DrillProposal | null {
+  if (!raw || typeof raw !== "object") return null;
+  const v = raw as Partial<SerializableDrillProposal>;
+  if (v.hook !== DRILL_WINDOW_HOOK) return null;
+  if (!v.item || !v.state || typeof v.cost !== "number") return null;
+  return {
+    hook: DRILL_WINDOW_HOOK,
+    item: v.item,
+    state: v.state,
+    cost: v.cost,
+  };
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -48,3 +48,5 @@ export * from "./gateway-client.js";
 export * from "./contracts/index.js";
 export * from "./parse-repetition-answer.js";
 export * from "./sr-algorithm.js";
+export * from "./drill-proposal.js";
+export * from "./drill-fuzzy-match.js";

--- a/shared/src/scorer.ts
+++ b/shared/src/scorer.ts
@@ -50,6 +50,9 @@ export const DECAY_BY_TYPE: Record<ContentItemType, number> = {
   gtd_task: 3,
   dynamic: 21,
   challenge: 14,
+  // B2: drill items são injetados turn-a-turn — score vem do SR urgency,
+  // não de recência. Decay neutro evita penalidade redundante.
+  drill_vocab: Infinity,
 };
 
 /** Score devolvido para item com pin parental válido — vence qualquer outro fator. */


### PR DESCRIPTION
Wires B2 (Drilling) into the turn pipeline. PR #244 (drill repo + SR algorithm + bank fixture) and PR #252 (UI scaffold) had the foundation; this PR makes drill items actually surface, materialize, and round-trip through the conversation.

Spec: `ascendimacy-ops/docs/specs/2026-05-26-b2-drilling-primer-v0.md`

## Flow

**Pre-turn** (orchestrator)
- Loads banks declared in `persona.profile.drill_bank_ids` via new MCP tool `drill_load_bank`
- Lists due states via `drill_list_due` (cold-start: synthesizes from all items)
- Calls `proposeDrillItem` (existing pure fn, PR #244) with budget gate
- Serializes `DrillProposal` into `plan_turn` `contextHints.drill_proposal`

**Plan/score** (planejador)
- Deserializes proposal + injects `DrillVocabItem` (new ContentItem variant) at top of `topK`
- Score = `DRILL_BASE_SCORE (60)` + linear overdue bonus capped at 30 — competes with regular pool but doesn't trump parent-pinned

**Materialize** (motor-drota)
- Short-circuits on `item.type === 'drill_vocab'` — `materializeDrillVocab()` returns deterministic template (`Como se diz **りんご** em português?`)
- Zero LLM call, ~0 latency, 0 tokens
- Applied in both legacy and `USE_SIMPLIFIED_PIPELINE` paths

**Post-turn** (orchestrator)
- If selected item was `drill_vocab` → log `drill_emitted` event with `drill_item_id` + `bank_id`

**Next turn pre** (orchestrator)
- `findPendingDrill(eventLog)` finds unresolved `drill_emitted`
- `matchDrillAnswer(item, message, latency)` runs (moved to shared so orchestrator can use it without motor-drota dep)
- `drill_record_attempt` MCP call → updates state via SM-2
- Logs `drill_attempt_recorded` + `drill_item_mastered` (when mastery cross detected)

## Architecture notes

- `drill-proposal.ts` lives in `shared/` (not `orchestrator/`) to avoid `planejador → orchestrator` dep cycle. `drill-orchestrator.ts` re-exports helpers for API stability.
- `drill-fuzzy-match.ts` moved from `motor-drota/` to `shared/` (re-export shim left in motor-drota for existing test imports) — orchestrator needs it post-turn.
- `DRILL_STATES_DDL` now applied during `state-manager.ts` init (was only initialized on first `recordAttempt` previously).
- New MCP tools on motor-execucao: `drill_list_due`, `drill_load_bank`, `drill_record_attempt`, `drill_list_attempts`.

## BFF + UI

- `GET /personas/:id/drill-attempts?limit=N` returns recent attempts (DESC).
- `B2DrillingPanel.svelte` gets a 'Last attempts' block with response glyph + latency.

## Tests

44 new tests, all pass; full motor + BFF suite (~1380 tests) clean except pre-existing `integration-motor-channels` failure unrelated to this PR.

- `planejador/tests/pool-builder-drill-integration.unit.test.ts` (8) — score curve, serialization round-trip, vocab item shape
- `motor-drota/tests/drill-materialization.unit.test.ts` (7) — templates per `source_language`, hint append, no-LLM latency budget
- `orchestrator/tests/drill-attempt-flow.integration.test.ts` (4) — full pipeline w/ mocked `McpClients`: turn-1 propose+emit, turn-N+1 pending resolve, mastery transition, incorrect response

## Example turn

Persona `ryo-kid` (declared `drill_bank_ids: [ja-pt-vocab-n5]`), state has no prior attempts:

```
turn 0 — user: "oi"
  pre:   load bank (50 items)
         list_due → cold-start synth (50 states, all due)
         proposeDrillItem → jpv-001 (りんご → maçã)
         contextHints.drill_proposal = serialized
  plan:  topK[0] = DrillVocabItem id="drill:jpv-001" score=60
  drota: short-circuit → "Como se diz **りんご** em português?"
  exec:  log_event drill_emitted { drill_item_id: jpv-001, bank_id: ja-pt-vocab-n5 }

turn 1 — user: "maçã"
  pre:   findPendingDrill → jpv-001
         matchDrillAnswer("maçã", 1500ms) → { correct: true, type: 'correct' }
         drill_record_attempt → state { presented:1, correct:1, next_due_at: +1d }
         log_event drill_attempt_recorded { correct: true, mastery: false }
         (continue normal turn pipeline...)
```

## Non-objectives (v0, deferred per spec)

- Worked → faded → independent scaffold
- Audio prompts JP (requires TTS)
- Cooperative drill (Ryo+Kei dyad)

## Don't merge

CC opens autonomously per F1 autonomy policy. Awaits Jun review/merge signal.