### PR TITLE
[feat] S3 panel wiring — decision history + jogada distribution + stats

### DIFF
--- a/packages/ebrota-console-bff/src/routes/s3-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/s3-routes.ts
@@ -1,0 +1,425 @@
+/**
+ * S3 wiring — Motor de Decisão histórico por persona.
+ *
+ * Spec parent: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ *
+ * Endpoints:
+ *   GET /personas/:id/decision-history?limit=20  → últimas N decisões
+ *   GET /personas/:id/jogada-distribution         → histogram jogada+method+register
+ *   GET /personas/:id/decision-stats              → resumo agregado
+ *
+ * Fonte de dados: filesystem walk em EBROTA_BFF_TRACES_DIR (env) OU
+ * opts.tracesDir. Lê engine-trace-v2 JSONs (qualquer *.json no tree),
+ * filtra por persona, agrega.
+ *
+ * Vocabulário jogada (fixo): bridge / espelho / canal / diamante / arena
+ * / recovery. Histogram sempre retorna as 6 chaves (zero quando ausente),
+ * pra UI poder renderizar barras vazias sem branching.
+ */
+
+import type { FastifyPluginAsync } from "fastify";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface S3RoutesOptions {
+  /** Override de EBROTA_BFF_TRACES_DIR pra testes. */
+  tracesDir?: string;
+}
+
+export const JOGADA_VOCAB = [
+  "bridge",
+  "espelho",
+  "canal",
+  "diamante",
+  "arena",
+  "recovery",
+] as const;
+
+export type Jogada = (typeof JOGADA_VOCAB)[number];
+
+export interface TacticDecisionSummary {
+  jogada: string;
+  angle: string;
+  register: string;
+  method: "rule" | "llm" | "fallback";
+}
+
+export interface DecisionRow {
+  turnRef: string;
+  decidedAt: string;
+  decisionPath: string;
+  selectedItemId: string;
+  selectedItemType: string;
+  selectedScore: number | null;
+  poolSize: number;
+  topNScores: number[];
+  tacticDecision: TacticDecisionSummary | null;
+  cacheHit: boolean;
+  skipReason: string | null;
+}
+
+export interface JogadaDistribution {
+  personaId: string;
+  totalDecisions: number;
+  byJogada: Record<Jogada, number>;
+  byMethod: { rule: number; llm: number; fallback: number };
+  byRegister: Record<string, number>;
+  developmentStub: boolean;
+}
+
+export interface DecisionStats {
+  personaId: string;
+  totalTurns: number;
+  cacheHitRate: number;
+  fallbackRate: number;
+  avgPoolSize: number;
+  avgTopScore: number;
+  selectorEscalations: number;
+}
+
+interface RawComponent {
+  inputs?: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  method?: string;
+}
+
+interface RawWarning {
+  component?: string;
+  message?: string;
+}
+
+interface RawLlmCall {
+  prompt_cache_hit?: boolean;
+}
+
+interface RawTurn {
+  turnNumber?: number;
+  turn?: number;
+  timestamp?: string;
+  engineTrace?: {
+    components?: Record<string, RawComponent>;
+    llm_calls?: RawLlmCall[];
+    warnings?: RawWarning[];
+    tactic_decision?: {
+      jogada?: string;
+      angle?: string;
+      rationale?: string;
+      constraints?: { register?: string };
+    };
+  };
+  motorTrace?: {
+    plan?: {
+      contentPool?: Array<{
+        item?: { id?: string; type?: string };
+        score?: number;
+      }>;
+    };
+    drota?: {
+      selectedContent?: {
+        item?: { id?: string; type?: string };
+        score?: number;
+      };
+    };
+  };
+}
+
+interface RawTrace {
+  sessionId?: string;
+  persona?: string;
+  personaId?: string;
+  turns?: RawTurn[];
+}
+
+async function* walkJson(dir: string): AsyncGenerator<string, void, void> {
+  let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+  try {
+    entries = (await readdir(dir, { withFileTypes: true })) as never;
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const name = String(entry.name);
+    const full = join(dir, name);
+    if (entry.isDirectory()) {
+      yield* walkJson(full);
+    } else if (entry.isFile() && name.endsWith(".json")) {
+      yield full;
+    }
+  }
+}
+
+async function loadTracesForPersona(
+  tracesDir: string,
+  personaId: string,
+): Promise<RawTrace[]> {
+  try {
+    await stat(tracesDir);
+  } catch {
+    return [];
+  }
+  const out: RawTrace[] = [];
+  for await (const path of walkJson(tracesDir)) {
+    try {
+      const raw = await readFile(path, "utf-8");
+      const trace = JSON.parse(raw) as RawTrace;
+      const tracePersona = trace.persona ?? trace.personaId;
+      if (tracePersona !== personaId) continue;
+      out.push(trace);
+    } catch {
+      // skip broken file, scan continues
+    }
+  }
+  return out;
+}
+
+function extractDecisionRow(
+  trace: RawTrace,
+  turn: RawTurn,
+): DecisionRow | null {
+  const sessionId = trace.sessionId ?? "unknown";
+  const turnNumber = turn.turnNumber ?? turn.turn ?? 0;
+  const turnRef = `${sessionId}__turn_${turnNumber}`;
+  const decidedAt = turn.timestamp ?? "1970-01-01T00:00:00Z";
+
+  const et = turn.engineTrace ?? {};
+  const selector = et.components?.["pragmatic_selector"];
+  const tactician = et.components?.["tactician"];
+  const motor = turn.motorTrace ?? {};
+  const selected = motor.drota?.selectedContent;
+
+  const selectorOut = selector?.outputs ?? {};
+  const selectedIdFromSelector =
+    typeof selectorOut["selected_id"] === "string"
+      ? selectorOut["selected_id"]
+      : undefined;
+  const selectedItemId =
+    selectedIdFromSelector ??
+    (typeof selected?.item?.id === "string" ? selected.item.id : "");
+
+  if (selectedItemId === "") return null;
+
+  const selectedItemType =
+    typeof selected?.item?.type === "string" ? selected.item.type : "unknown";
+  const selectedScore =
+    typeof selected?.score === "number" ? selected.score : null;
+
+  const pool = motor.plan?.contentPool ?? [];
+  const selectorIn = selector?.inputs ?? {};
+  const poolSize =
+    typeof selectorIn["pool_size"] === "number"
+      ? selectorIn["pool_size"]
+      : pool.length;
+
+  const topNScores = pool
+    .map((p) => (typeof p.score === "number" ? p.score : 0))
+    .sort((a, b) => b - a)
+    .slice(0, 5);
+
+  const td = et.tactic_decision;
+  const tactOut = tactician?.outputs ?? {};
+  let tacticDecision: TacticDecisionSummary | null = null;
+  const method = normalizeMethod(tactician?.method);
+  const jogada =
+    (typeof td?.jogada === "string" ? td.jogada : undefined) ??
+    (typeof tactOut["jogada"] === "string" ? tactOut["jogada"] : undefined);
+  if (jogada !== undefined) {
+    const angle =
+      (typeof td?.angle === "string" ? td.angle : undefined) ??
+      (typeof tactOut["angle"] === "string" ? tactOut["angle"] : "") ??
+      "";
+    const register =
+      typeof td?.constraints?.register === "string"
+        ? td.constraints.register
+        : "neutro";
+    tacticDecision = { jogada, angle, register, method };
+  }
+
+  const decisionPath =
+    tacticDecision !== null
+      ? "tactician_split"
+      : "pragmatic_selector_default";
+
+  const cacheHit =
+    Array.isArray(et.llm_calls) &&
+    et.llm_calls.some((c) => c.prompt_cache_hit === true);
+
+  const skipReason = findSkipReason(et.warnings);
+
+  return {
+    turnRef,
+    decidedAt,
+    decisionPath,
+    selectedItemId,
+    selectedItemType,
+    selectedScore,
+    poolSize,
+    topNScores,
+    tacticDecision,
+    cacheHit,
+    skipReason,
+  };
+}
+
+function normalizeMethod(
+  method: string | undefined,
+): "rule" | "llm" | "fallback" {
+  if (method === "rule" || method === "llm" || method === "fallback") {
+    return method;
+  }
+  return "rule";
+}
+
+function findSkipReason(warnings: RawWarning[] | undefined): string | null {
+  if (!Array.isArray(warnings)) return null;
+  for (const w of warnings) {
+    if (
+      typeof w.message === "string" &&
+      w.message.toLowerCase().includes("materializer")
+    ) {
+      return "materializer_fallback";
+    }
+  }
+  return null;
+}
+
+function collectDecisions(traces: RawTrace[]): DecisionRow[] {
+  const rows: DecisionRow[] = [];
+  for (const t of traces) {
+    for (const turn of t.turns ?? []) {
+      const row = extractDecisionRow(t, turn);
+      if (row !== null) rows.push(row);
+    }
+  }
+  // ordem decrescente por decidedAt; estável por turnRef como tie-breaker
+  rows.sort((a, b) => {
+    if (a.decidedAt !== b.decidedAt) {
+      return a.decidedAt < b.decidedAt ? 1 : -1;
+    }
+    return a.turnRef < b.turnRef ? 1 : -1;
+  });
+  return rows;
+}
+
+function buildJogadaDistribution(
+  personaId: string,
+  rows: DecisionRow[],
+): JogadaDistribution {
+  const byJogada: Record<Jogada, number> = {
+    bridge: 0,
+    espelho: 0,
+    canal: 0,
+    diamante: 0,
+    arena: 0,
+    recovery: 0,
+  };
+  const byMethod = { rule: 0, llm: 0, fallback: 0 };
+  const byRegister: Record<string, number> = {};
+  let totalDecisions = 0;
+
+  for (const row of rows) {
+    if (row.tacticDecision === null) continue;
+    totalDecisions += 1;
+    const j = row.tacticDecision.jogada;
+    if (isJogada(j)) byJogada[j] += 1;
+    byMethod[row.tacticDecision.method] += 1;
+    const reg = row.tacticDecision.register;
+    byRegister[reg] = (byRegister[reg] ?? 0) + 1;
+  }
+
+  return {
+    personaId,
+    totalDecisions,
+    byJogada,
+    byMethod,
+    byRegister,
+    developmentStub: totalDecisions === 0,
+  };
+}
+
+function isJogada(s: string): s is Jogada {
+  return (JOGADA_VOCAB as readonly string[]).includes(s);
+}
+
+function buildStats(personaId: string, rows: DecisionRow[]): DecisionStats {
+  const totalTurns = rows.length;
+  if (totalTurns === 0) {
+    return {
+      personaId,
+      totalTurns: 0,
+      cacheHitRate: 0,
+      fallbackRate: 0,
+      avgPoolSize: 0,
+      avgTopScore: 0,
+      selectorEscalations: 0,
+    };
+  }
+  let cacheHits = 0;
+  let fallbacks = 0;
+  let poolSizeSum = 0;
+  let topScoreSum = 0;
+  let topScoreCount = 0;
+  let escalations = 0;
+  for (const r of rows) {
+    if (r.cacheHit) cacheHits += 1;
+    if (r.tacticDecision?.method === "fallback") fallbacks += 1;
+    if (r.tacticDecision?.method === "llm") escalations += 1;
+    poolSizeSum += r.poolSize;
+    if (r.selectedScore !== null) {
+      topScoreSum += r.selectedScore;
+      topScoreCount += 1;
+    }
+  }
+  return {
+    personaId,
+    totalTurns,
+    cacheHitRate: cacheHits / totalTurns,
+    fallbackRate: fallbacks / totalTurns,
+    avgPoolSize: poolSizeSum / totalTurns,
+    avgTopScore: topScoreCount > 0 ? topScoreSum / topScoreCount : 0,
+    selectorEscalations: escalations,
+  };
+}
+
+const s3Routes: FastifyPluginAsync<S3RoutesOptions> = async (fastify, opts) => {
+  const tracesDir =
+    opts.tracesDir ?? process.env["EBROTA_BFF_TRACES_DIR"] ?? "";
+
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>("/personas/:id/decision-history", async (req) => {
+    if (tracesDir === "") {
+      return { personaId: req.params.id, decisions: [] };
+    }
+    const limit = req.query.limit ? Math.max(1, Number(req.query.limit)) : 20;
+    const traces = await loadTracesForPersona(tracesDir, req.params.id);
+    const rows = collectDecisions(traces).slice(0, limit);
+    return { personaId: req.params.id, decisions: rows };
+  });
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/jogada-distribution",
+    async (req) => {
+      if (tracesDir === "") {
+        return buildJogadaDistribution(req.params.id, []);
+      }
+      const traces = await loadTracesForPersona(tracesDir, req.params.id);
+      const rows = collectDecisions(traces);
+      return buildJogadaDistribution(req.params.id, rows);
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/decision-stats",
+    async (req) => {
+      if (tracesDir === "") {
+        return buildStats(req.params.id, []);
+      }
+      const traces = await loadTracesForPersona(tracesDir, req.params.id);
+      const rows = collectDecisions(traces);
+      return buildStats(req.params.id, rows);
+    },
+  );
+};
+
+export default s3Routes;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -144,6 +144,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   initParentalOnboardingSchema(opts.db);
   initMc1Schema(opts.db);
   void fastify.register(async (instance) => (await import("./routes/s1-routes.js")).default(instance, { db: opts.db }));
+  void fastify.register(async (instance) => (await import("./routes/s3-routes.js")).default(instance, opts.tracesDir !== undefined ? { tracesDir: opts.tracesDir } : {}));
   void fastify.register(async (instance) => (await import("./routes/s5-routes.js")).default(instance, { db: opts.db }));
 
   // B1/B2 wiring — Camada Social + Drilling. Fastify enfileira o register

--- a/packages/ebrota-console-bff/tests/fixtures/engine-trace-saki.json
+++ b/packages/ebrota-console-bff/tests/fixtures/engine-trace-saki.json
@@ -1,0 +1,51 @@
+{
+  "sessionId": "saki__sess-fixture-1",
+  "persona": "saki",
+  "startedAt": "2026-05-25T11:00:00Z",
+  "endedAt": "2026-05-25T11:10:00Z",
+  "turns": [
+    {
+      "turnNumber": 1,
+      "incomingMessage": "oi",
+      "finalResponse": "olá!",
+      "timestamp": "2026-05-25T11:00:00Z",
+      "engineTrace": {
+        "schema_version": 2,
+        "components": {
+          "pragmatic_selector": {
+            "inputs": { "pool_size": 6 },
+            "outputs": { "selected_id": "card.canal.simple" }
+          },
+          "tactician": {
+            "outputs": {
+              "jogada": "canal",
+              "angle": "direto ao ponto",
+              "rationale": "saki simples"
+            },
+            "method": "rule"
+          }
+        },
+        "llm_calls": [],
+        "tactic_decision": {
+          "jogada": "canal",
+          "angle": "direto ao ponto",
+          "constraints": { "register": "firme" },
+          "rationale": "saki simples"
+        }
+      },
+      "motorTrace": {
+        "plan": {
+          "contentPool": [
+            { "item": { "id": "a", "type": "card_catalog" }, "score": 0.80 }
+          ]
+        },
+        "drota": {
+          "selectedContent": {
+            "item": { "id": "card.canal.simple", "type": "card_catalog" },
+            "score": 0.80
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/ebrota-console-bff/tests/fixtures/engine-trace-sample.json
+++ b/packages/ebrota-console-bff/tests/fixtures/engine-trace-sample.json
@@ -1,0 +1,225 @@
+{
+  "sessionId": "ryo__sess-fixture-1",
+  "persona": "ryo",
+  "startedAt": "2026-05-25T10:00:00Z",
+  "endedAt": "2026-05-25T10:30:00Z",
+  "turns": [
+    {
+      "turnNumber": 1,
+      "incomingMessage": "oi",
+      "finalResponse": "olá!",
+      "timestamp": "2026-05-25T10:00:00Z",
+      "engineTrace": {
+        "schema_version": 2,
+        "components": {
+          "pragmatic_selector": {
+            "inputs": { "pool_size": 12, "mood": 6, "budget": 15 },
+            "outputs": { "selected_id": "card.bridge.curiosity", "pool_remaining": ["a","b"] }
+          },
+          "tactician": {
+            "outputs": {
+              "jogada": "bridge",
+              "selected_item_id": "card.bridge.curiosity",
+              "angle": "começar pela curiosidade",
+              "rationale": "energia alta, abrir espaço"
+            },
+            "method": "rule"
+          }
+        },
+        "llm_calls": [
+          { "id": "c1", "role": "assessor", "provider": "anthropic", "model": "haiku", "prompt": "p", "response": "r", "duration_ms": 100, "prompt_cache_hit": true }
+        ],
+        "tactic_decision": {
+          "jogada": "bridge",
+          "selected_item_id": "card.bridge.curiosity",
+          "angle": "começar pela curiosidade",
+          "constraints": { "register": "lúdico" },
+          "rationale": "energia alta"
+        },
+        "warnings": []
+      },
+      "motorTrace": {
+        "plan": {
+          "contentPool": [
+            { "item": { "id": "a", "type": "card_catalog" }, "score": 0.85 },
+            { "item": { "id": "b", "type": "card_catalog" }, "score": 0.72 },
+            { "item": { "id": "c", "type": "card_catalog" }, "score": 0.61 },
+            { "item": { "id": "d", "type": "card_catalog" }, "score": 0.55 },
+            { "item": { "id": "e", "type": "card_catalog" }, "score": 0.50 },
+            { "item": { "id": "f", "type": "card_catalog" }, "score": 0.42 }
+          ]
+        },
+        "drota": {
+          "selectedContent": {
+            "item": { "id": "card.bridge.curiosity", "type": "card_catalog" },
+            "score": 0.85
+          }
+        }
+      }
+    },
+    {
+      "turnNumber": 2,
+      "incomingMessage": "tá",
+      "finalResponse": "interessante",
+      "timestamp": "2026-05-25T10:05:00Z",
+      "engineTrace": {
+        "schema_version": 2,
+        "components": {
+          "pragmatic_selector": {
+            "inputs": { "pool_size": 10 },
+            "outputs": { "selected_id": "card.espelho.feeling" }
+          },
+          "tactician": {
+            "outputs": {
+              "jogada": "espelho",
+              "angle": "refletir o sentimento",
+              "rationale": "criança hesitante"
+            },
+            "method": "rule"
+          }
+        },
+        "llm_calls": [],
+        "tactic_decision": {
+          "jogada": "espelho",
+          "angle": "refletir o sentimento",
+          "constraints": { "register": "neutro" },
+          "rationale": "criança hesitante"
+        }
+      },
+      "motorTrace": {
+        "plan": {
+          "contentPool": [
+            { "item": { "id": "a", "type": "card_catalog" }, "score": 0.78 },
+            { "item": { "id": "b", "type": "card_catalog" }, "score": 0.65 }
+          ]
+        },
+        "drota": {
+          "selectedContent": {
+            "item": { "id": "card.espelho.feeling", "type": "card_catalog" },
+            "score": 0.78
+          }
+        }
+      }
+    },
+    {
+      "turnNumber": 3,
+      "incomingMessage": "conta uma história",
+      "finalResponse": "...",
+      "timestamp": "2026-05-25T10:10:00Z",
+      "engineTrace": {
+        "schema_version": 2,
+        "components": {
+          "pragmatic_selector": {
+            "inputs": { "pool_size": 14 },
+            "outputs": { "selected_id": "card.bridge.story" }
+          },
+          "tactician": {
+            "outputs": {
+              "jogada": "bridge",
+              "angle": "narrar caminho",
+              "rationale": "criança puxou história"
+            },
+            "method": "llm"
+          }
+        },
+        "llm_calls": [
+          { "id": "c3", "role": "tactician", "provider": "infomaniak", "model": "qwen3", "prompt": "p", "response": "r", "duration_ms": 200, "prompt_cache_hit": false }
+        ],
+        "tactic_decision": {
+          "jogada": "bridge",
+          "angle": "narrar caminho",
+          "constraints": { "register": "lúdico" },
+          "rationale": "criança puxou história"
+        }
+      },
+      "motorTrace": {
+        "plan": {
+          "contentPool": [
+            { "item": { "id": "a", "type": "card_catalog" }, "score": 0.91 }
+          ]
+        },
+        "drota": {
+          "selectedContent": {
+            "item": { "id": "card.bridge.story", "type": "card_catalog" },
+            "score": 0.91
+          }
+        }
+      }
+    },
+    {
+      "turnNumber": 4,
+      "incomingMessage": "blah",
+      "finalResponse": "ok",
+      "timestamp": "2026-05-25T10:15:00Z",
+      "engineTrace": {
+        "schema_version": 2,
+        "components": {
+          "pragmatic_selector": {
+            "inputs": { "pool_size": 8 },
+            "outputs": { "selected_id": "card.diamond.x" }
+          }
+        },
+        "llm_calls": []
+      },
+      "motorTrace": {
+        "plan": {
+          "contentPool": [
+            { "item": { "id": "x", "type": "card_catalog" }, "score": 0.70 }
+          ]
+        },
+        "drota": {
+          "selectedContent": {
+            "item": { "id": "card.diamond.x", "type": "card_catalog" },
+            "score": 0.70
+          }
+        }
+      }
+    },
+    {
+      "turnNumber": 5,
+      "incomingMessage": "tá ruim",
+      "finalResponse": "ok",
+      "timestamp": "2026-05-25T10:20:00Z",
+      "engineTrace": {
+        "schema_version": 2,
+        "components": {
+          "pragmatic_selector": {
+            "inputs": { "pool_size": 5 },
+            "outputs": { "selected_id": "card.recovery.calm" }
+          },
+          "tactician": {
+            "outputs": {
+              "jogada": "recovery",
+              "angle": "desacelerar",
+              "rationale": "sinal vermelho"
+            },
+            "method": "fallback"
+          }
+        },
+        "llm_calls": [],
+        "tactic_decision": {
+          "jogada": "recovery",
+          "angle": "desacelerar",
+          "constraints": { "register": "acolhedor" },
+          "rationale": "sinal vermelho"
+        },
+        "warnings": [
+          { "component": "constrained_materializer", "message": "materializer_fallback used", "recoverable": true }
+        ]
+      },
+      "motorTrace": {
+        "plan": {
+          "contentPool": [
+            { "item": { "id": "r", "type": "card_catalog" }, "score": 0.60 }
+          ]
+        },
+        "drota": {
+          "selectedContent": {
+            "item": { "id": "card.recovery.calm", "type": "card_catalog" },
+            "score": 0.60
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/ebrota-console-bff/tests/s3-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/s3-routes.unit.test.ts
@@ -1,0 +1,240 @@
+/**
+ * S3 routes — unit tests com fixture filesystem.
+ *
+ * Spec: docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ *
+ * Cobre: happy path, persona sem trace, limit param, agregação correta,
+ * jogada vocab fixo (6 valores), traces dir env vazio, cache hit detection,
+ * fallback rate, selector escalations, decision path split.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { resolve } from "node:path";
+import s3Routes from "../src/routes/s3-routes.js";
+
+const FIXTURES_DIR = resolve(__dirname, "fixtures");
+
+async function buildApp(opts: { tracesDir?: string } = {}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(s3Routes, opts);
+  await app.ready();
+  return app;
+}
+
+let app: FastifyInstance;
+
+afterEach(async () => {
+  if (app) await app.close();
+});
+
+const inject = async (url: string) => {
+  const res = await app.inject({ method: "GET", url });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+describe("GET /personas/:id/decision-history", () => {
+  beforeEach(async () => {
+    app = await buildApp({ tracesDir: FIXTURES_DIR });
+  });
+
+  it("happy path: retorna 5 decisões da fixture ryo", async () => {
+    const res = await inject("/personas/ryo/decision-history");
+    expect(res.status).toBe(200);
+    const body = res.body as { personaId: string; decisions: Array<unknown> };
+    expect(body.personaId).toBe("ryo");
+    expect(body.decisions).toHaveLength(5);
+  });
+
+  it("ordem desc por decidedAt (turn 5 vem primeiro)", async () => {
+    const res = await inject("/personas/ryo/decision-history");
+    const body = res.body as { decisions: Array<{ turnRef: string }> };
+    expect(body.decisions[0]!.turnRef).toContain("turn_5");
+    expect(body.decisions[4]!.turnRef).toContain("turn_1");
+  });
+
+  it("limit param respeitado", async () => {
+    const res = await inject("/personas/ryo/decision-history?limit=2");
+    const body = res.body as { decisions: unknown[] };
+    expect(body.decisions).toHaveLength(2);
+  });
+
+  it("persona sem trace → array vazio", async () => {
+    const res = await inject("/personas/inexistente/decision-history");
+    const body = res.body as { decisions: unknown[] };
+    expect(body.decisions).toEqual([]);
+  });
+
+  it("filtra por persona (saki não aparece em ryo)", async () => {
+    const res = await inject("/personas/ryo/decision-history");
+    const body = res.body as {
+      decisions: Array<{ tacticDecision: { jogada: string } | null }>;
+    };
+    const jogadas = body.decisions
+      .map((d) => d.tacticDecision?.jogada)
+      .filter((j): j is string => j !== undefined);
+    expect(jogadas).not.toContain("canal");
+  });
+
+  it("decisionPath: tactician_split quando tactic_decision presente", async () => {
+    const res = await inject("/personas/ryo/decision-history");
+    const body = res.body as {
+      decisions: Array<{ decisionPath: string; tacticDecision: unknown | null }>;
+    };
+    const turn1 = body.decisions.find((d) => /turn_1$/.test(""));
+    void turn1;
+    const withTactic = body.decisions.filter((d) => d.tacticDecision !== null);
+    expect(
+      withTactic.every((d) => d.decisionPath === "tactician_split"),
+    ).toBe(true);
+    const withoutTactic = body.decisions.filter((d) => d.tacticDecision === null);
+    expect(
+      withoutTactic.every((d) => d.decisionPath === "pragmatic_selector_default"),
+    ).toBe(true);
+  });
+
+  it("cacheHit detection via llm_calls[].prompt_cache_hit", async () => {
+    const res = await inject("/personas/ryo/decision-history");
+    const body = res.body as {
+      decisions: Array<{ turnRef: string; cacheHit: boolean }>;
+    };
+    const turn1 = body.decisions.find((d) => d.turnRef.endsWith("turn_1"));
+    expect(turn1?.cacheHit).toBe(true);
+    const turn3 = body.decisions.find((d) => d.turnRef.endsWith("turn_3"));
+    expect(turn3?.cacheHit).toBe(false);
+  });
+
+  it("skipReason detectado em warnings materializer", async () => {
+    const res = await inject("/personas/ryo/decision-history");
+    const body = res.body as {
+      decisions: Array<{ turnRef: string; skipReason: string | null }>;
+    };
+    const turn5 = body.decisions.find((d) => d.turnRef.endsWith("turn_5"));
+    expect(turn5?.skipReason).toBe("materializer_fallback");
+    const turn1 = body.decisions.find((d) => d.turnRef.endsWith("turn_1"));
+    expect(turn1?.skipReason).toBeNull();
+  });
+
+  it("topNScores limita a 5 e ordena desc", async () => {
+    const res = await inject("/personas/ryo/decision-history");
+    const body = res.body as {
+      decisions: Array<{ turnRef: string; topNScores: number[] }>;
+    };
+    const turn1 = body.decisions.find((d) => d.turnRef.endsWith("turn_1"))!;
+    expect(turn1.topNScores).toHaveLength(5);
+    // strict desc order
+    for (let i = 1; i < turn1.topNScores.length; i++) {
+      expect(turn1.topNScores[i]).toBeLessThanOrEqual(turn1.topNScores[i - 1]!);
+    }
+    expect(turn1.topNScores[0]).toBeCloseTo(0.85);
+  });
+});
+
+describe("GET /personas/:id/jogada-distribution", () => {
+  beforeEach(async () => {
+    app = await buildApp({ tracesDir: FIXTURES_DIR });
+  });
+
+  it("retorna 6 chaves jogada fixas mesmo com vocab parcial", async () => {
+    const res = await inject("/personas/ryo/jogada-distribution");
+    const body = res.body as {
+      byJogada: Record<string, number>;
+    };
+    const keys = Object.keys(body.byJogada).sort();
+    expect(keys).toEqual([
+      "arena",
+      "bridge",
+      "canal",
+      "diamante",
+      "espelho",
+      "recovery",
+    ]);
+  });
+
+  it("agregação correta: ryo tem 2 bridge + 1 espelho + 1 recovery", async () => {
+    const res = await inject("/personas/ryo/jogada-distribution");
+    const body = res.body as {
+      totalDecisions: number;
+      byJogada: Record<string, number>;
+    };
+    expect(body.totalDecisions).toBe(4); // turn 4 não tem tactic_decision
+    expect(body.byJogada["bridge"]).toBe(2);
+    expect(body.byJogada["espelho"]).toBe(1);
+    expect(body.byJogada["recovery"]).toBe(1);
+    expect(body.byJogada["canal"]).toBe(0);
+    expect(body.byJogada["arena"]).toBe(0);
+    expect(body.byJogada["diamante"]).toBe(0);
+  });
+
+  it("byMethod: 2 rule + 1 llm + 1 fallback (ryo)", async () => {
+    const res = await inject("/personas/ryo/jogada-distribution");
+    const body = res.body as {
+      byMethod: { rule: number; llm: number; fallback: number };
+    };
+    expect(body.byMethod).toEqual({ rule: 2, llm: 1, fallback: 1 });
+  });
+
+  it("byRegister inclui valores do trace", async () => {
+    const res = await inject("/personas/ryo/jogada-distribution");
+    const body = res.body as { byRegister: Record<string, number> };
+    expect(body.byRegister["lúdico"]).toBe(2);
+    expect(body.byRegister["neutro"]).toBe(1);
+    expect(body.byRegister["acolhedor"]).toBe(1);
+  });
+
+  it("developmentStub=true quando totalDecisions=0", async () => {
+    const res = await inject("/personas/inexistente/jogada-distribution");
+    const body = res.body as { totalDecisions: number; developmentStub: boolean };
+    expect(body.totalDecisions).toBe(0);
+    expect(body.developmentStub).toBe(true);
+  });
+});
+
+describe("GET /personas/:id/decision-stats", () => {
+  beforeEach(async () => {
+    app = await buildApp({ tracesDir: FIXTURES_DIR });
+  });
+
+  it("totalTurns=5 e métricas calculadas pra ryo", async () => {
+    const res = await inject("/personas/ryo/decision-stats");
+    const body = res.body as {
+      totalTurns: number;
+      cacheHitRate: number;
+      fallbackRate: number;
+      avgPoolSize: number;
+      avgTopScore: number;
+      selectorEscalations: number;
+    };
+    expect(body.totalTurns).toBe(5);
+    expect(body.cacheHitRate).toBeCloseTo(0.2); // 1/5
+    expect(body.fallbackRate).toBeCloseTo(0.2); // 1/5
+    expect(body.avgPoolSize).toBeCloseTo((12 + 10 + 14 + 8 + 5) / 5);
+    expect(body.avgTopScore).toBeCloseTo((0.85 + 0.78 + 0.91 + 0.7 + 0.6) / 5);
+    expect(body.selectorEscalations).toBe(1); // turn 3 method=llm
+  });
+
+  it("persona sem trace → zeros", async () => {
+    const res = await inject("/personas/inexistente/decision-stats");
+    const body = res.body as { totalTurns: number; cacheHitRate: number };
+    expect(body.totalTurns).toBe(0);
+    expect(body.cacheHitRate).toBe(0);
+  });
+});
+
+describe("env var EBROTA_BFF_TRACES_DIR vazio", () => {
+  it("retorna empty results sem erro quando tracesDir não configurado", async () => {
+    app = await buildApp({});
+    const h = await inject("/personas/ryo/decision-history");
+    expect(h.status).toBe(200);
+    expect((h.body as { decisions: unknown[] }).decisions).toEqual([]);
+    const d = await inject("/personas/ryo/jogada-distribution");
+    expect(d.status).toBe(200);
+    expect((d.body as { totalDecisions: number }).totalDecisions).toBe(0);
+    const s = await inject("/personas/ryo/decision-stats");
+    expect(s.status).toBe(200);
+    expect((s.body as { totalTurns: number }).totalTurns).toBe(0);
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -18,7 +18,7 @@
   import SubsystemGrid from "./components/SubsystemGrid.svelte";
   import S1AprendizPanel from "./components/subsystem-panels/S1AprendizPanel.svelte";
   import S2DoutrinaPanel from "./components/subsystem-panels/S2DoutrinaPanel.svelte";
-  import S3DecisaoTurnPanel from "./components/subsystem-panels/S3DecisaoTurnPanel.svelte";
+  import S3DecisaoPanel from "./components/subsystem-panels/S3DecisaoPanel.svelte";
   import S4ExpressaoTurnPanel from "./components/subsystem-panels/S4ExpressaoTurnPanel.svelte";
   import S5AvaliacaoPanel from "./components/subsystem-panels/S5AvaliacaoPanel.svelte";
   import B1SocialPanel from "./components/subsystem-panels/B1SocialPanel.svelte";
@@ -178,7 +178,7 @@
           {:else if $expandedSubsystem === "S2"}
             <S2DoutrinaPanel />
           {:else if $expandedSubsystem === "S3"}
-            <S3DecisaoTurnPanel />
+            <S3DecisaoPanel {api} />
           {:else if $expandedSubsystem === "S4"}
             <S4ExpressaoTurnPanel />
           {:else if $expandedSubsystem === "S5"}

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S3DecisaoPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S3DecisaoPanel.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+  /**
+   * S3 — Motor de Decisão (panel, per-persona aggregate).
+   * Pergunta: "Como persona X tem decidido ao longo das sessões?"
+   *
+   * 3 sub-blocks:
+   *   - Decision history table (colapsável, click-expand pra detalhes)
+   *   - Jogada histogram (bar chart CSS, no lib externa)
+   *   - Stats card (totais agregados)
+   *
+   * Per-turn drill-down → S3DecisaoTurnPanel (vive separado, mesmo COLOR).
+   *
+   * Spec: docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+   */
+  import { currentSessionId, tracerSubjectId } from "../../lib/stores.js";
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+  import {
+    createApiClient,
+    type ApiClient,
+    type DecisionRowLike,
+    type JogadaDistributionLike,
+    type DecisionStatsLike,
+  } from "../../lib/api.js";
+
+  export let api: ApiClient = createApiClient();
+
+  const COLOR = "#eab308";
+
+  type LoadState = "idle" | "loading" | "loaded" | "error";
+
+  function derivePersonaId(sessionId: string | null, fallback: string): string {
+    if (sessionId === null || sessionId.length === 0) return fallback;
+    const idx = sessionId.indexOf("__");
+    return idx > 0 ? sessionId.slice(0, idx) : sessionId;
+  }
+
+  $: personaId = derivePersonaId($currentSessionId, $tracerSubjectId);
+
+  let historyState: LoadState = "idle";
+  let history: DecisionRowLike[] = [];
+  let historyError = "";
+
+  let distState: LoadState = "idle";
+  let distribution: JogadaDistributionLike | null = null;
+
+  let statsState: LoadState = "idle";
+  let stats: DecisionStatsLike | null = null;
+
+  let expandedRow: string | null = null;
+
+  function toggleRow(ref: string): void {
+    expandedRow = expandedRow === ref ? null : ref;
+  }
+
+  async function loadHistory(pid: string): Promise<void> {
+    historyState = "loading";
+    try {
+      const res = await api.getDecisionHistory(pid, 20);
+      history = res.decisions;
+      historyState = "loaded";
+    } catch (err) {
+      historyError = err instanceof Error ? err.message : String(err);
+      historyState = "error";
+    }
+  }
+
+  async function loadDistribution(pid: string): Promise<void> {
+    distState = "loading";
+    try {
+      distribution = await api.getJogadaDistribution(pid);
+      distState = "loaded";
+    } catch {
+      distState = "error";
+    }
+  }
+
+  async function loadStats(pid: string): Promise<void> {
+    statsState = "loading";
+    try {
+      stats = await api.getDecisionStats(pid);
+      statsState = "loaded";
+    } catch {
+      statsState = "error";
+    }
+  }
+
+  let lastLoadedFor = "";
+  $: if (personaId !== "" && personaId !== lastLoadedFor) {
+    lastLoadedFor = personaId;
+    void loadHistory(personaId);
+    void loadDistribution(personaId);
+    void loadStats(personaId);
+  }
+
+  function formatRate(v: number): string {
+    return `${Math.round(v * 100)}%`;
+  }
+
+  function formatScore(v: number | null): string {
+    return v === null ? "—" : v.toFixed(2);
+  }
+
+  function jogadaBarWidth(count: number, max: number): string {
+    if (max === 0) return "0%";
+    return `${Math.round((count / max) * 100)}%`;
+  }
+
+  $: histogramMax = distribution
+    ? Math.max(1, ...Object.values(distribution.byJogada))
+    : 1;
+</script>
+
+<SubsystemPanelShell id="S3" title="Motor de Decisão (histórico)" color={COLOR}>
+  <section class="block" data-testid="s3-history">
+    <h3>Histórico de decisões</h3>
+    {#if historyState === "loading"}
+      <p class="muted small" data-testid="s3-history-loading">carregando…</p>
+    {:else if historyState === "error"}
+      <p class="error small" data-testid="s3-history-error">
+        erro: {historyError}
+      </p>
+    {:else if history.length === 0}
+      <p class="muted small" data-testid="s3-history-empty">
+        Persona ainda não tem decisões registradas
+      </p>
+    {:else}
+      <table class="history-table" data-testid="s3-history-table">
+        <thead>
+          <tr>
+            <th>turn</th>
+            <th>jogada</th>
+            <th>method</th>
+            <th>item</th>
+            <th>score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each history as row (row.turnRef)}
+            <tr
+              class="history-row"
+              class:expanded={expandedRow === row.turnRef}
+              on:click={() => toggleRow(row.turnRef)}
+              data-testid="s3-history-row"
+            >
+              <td><code>{row.turnRef.split("__turn_")[1] ?? "?"}</code></td>
+              <td>{row.tacticDecision?.jogada ?? "—"}</td>
+              <td>{row.tacticDecision?.method ?? "—"}</td>
+              <td class="item-cell"><code>{row.selectedItemId}</code></td>
+              <td>{formatScore(row.selectedScore)}</td>
+            </tr>
+            {#if expandedRow === row.turnRef}
+              <tr class="history-detail" data-testid="s3-history-detail">
+                <td colspan="5">
+                  <dl>
+                    <dt>decisionPath</dt>
+                    <dd><code>{row.decisionPath}</code></dd>
+                    <dt>poolSize</dt>
+                    <dd>{row.poolSize}</dd>
+                    <dt>topNScores</dt>
+                    <dd>{row.topNScores.map((s) => s.toFixed(2)).join(", ")}</dd>
+                    <dt>cacheHit</dt>
+                    <dd>{row.cacheHit ? "✓" : "✗"}</dd>
+                    {#if row.skipReason !== null}
+                      <dt>skipReason</dt>
+                      <dd><code>{row.skipReason}</code></dd>
+                    {/if}
+                    {#if row.tacticDecision !== null}
+                      <dt>angle</dt>
+                      <dd>{row.tacticDecision.angle}</dd>
+                      <dt>register</dt>
+                      <dd>{row.tacticDecision.register}</dd>
+                    {/if}
+                  </dl>
+                </td>
+              </tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  <section class="block" data-testid="s3-histogram">
+    <h3>Jogada distribution</h3>
+    {#if distState === "loading"}
+      <p class="muted small">carregando…</p>
+    {:else if distribution !== null}
+      {#if distribution.developmentStub}
+        <p class="muted small" data-testid="s3-histogram-stub">
+          sem decisões agregáveis (tactic_decision ausente)
+        </p>
+      {/if}
+      <div class="histogram" data-testid="s3-histogram-bars">
+        {#each Object.entries(distribution.byJogada) as [name, count] (name)}
+          <div class="bar-row" data-testid="s3-bar-{name}">
+            <span class="bar-label">{name}</span>
+            <div class="bar-track">
+              <div
+                class="bar-fill"
+                style:width={jogadaBarWidth(count, histogramMax)}
+              ></div>
+            </div>
+            <span class="bar-count">{count}</span>
+          </div>
+        {/each}
+      </div>
+      <p class="small muted" data-testid="s3-histogram-meta">
+        total decisões: <strong>{distribution.totalDecisions}</strong>
+        · rule: {distribution.byMethod.rule}
+        · llm: {distribution.byMethod.llm}
+        · fallback: {distribution.byMethod.fallback}
+      </p>
+    {/if}
+  </section>
+
+  <section class="block stats-block" data-testid="s3-stats">
+    <h3>Stats</h3>
+    {#if statsState === "loading"}
+      <p class="muted small">carregando…</p>
+    {:else if stats !== null}
+      <div class="stats-grid">
+        <div class="stat">
+          <span class="stat-label">total turns</span>
+          <span class="stat-value">{stats.totalTurns}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">cache hit</span>
+          <span class="stat-value">{formatRate(stats.cacheHitRate)}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">fallback</span>
+          <span class="stat-value">{formatRate(stats.fallbackRate)}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">avg pool</span>
+          <span class="stat-value">{stats.avgPoolSize.toFixed(1)}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">avg top score</span>
+          <span class="stat-value">{stats.avgTopScore.toFixed(2)}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">escalations</span>
+          <span class="stat-value">{stats.selectorEscalations}</span>
+        </div>
+      </div>
+    {/if}
+  </section>
+</SubsystemPanelShell>
+
+<style>
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+  }
+  .muted {
+    opacity: 0.6;
+  }
+  .small {
+    font-size: 0.78rem;
+  }
+  .error {
+    color: #d97706;
+  }
+
+  .history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8rem;
+  }
+  .history-table th,
+  .history-table td {
+    text-align: left;
+    padding: 0.25rem 0.4rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.18);
+  }
+  .history-table th {
+    font-weight: 600;
+    opacity: 0.75;
+  }
+  .history-row {
+    cursor: pointer;
+  }
+  .history-row:hover {
+    background: rgba(234, 179, 8, 0.08);
+  }
+  .history-row.expanded {
+    background: rgba(234, 179, 8, 0.12);
+  }
+  .item-cell {
+    font-size: 0.75rem;
+    max-width: 14rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .history-detail dl {
+    display: grid;
+    grid-template-columns: 8rem 1fr;
+    gap: 0.2rem 0.5rem;
+    margin: 0.3rem 0;
+    font-size: 0.78rem;
+  }
+  .history-detail dt {
+    opacity: 0.65;
+    font-weight: 500;
+  }
+  .history-detail dd {
+    margin: 0;
+  }
+
+  .histogram {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .bar-row {
+    display: grid;
+    grid-template-columns: 5rem 1fr 2rem;
+    gap: 0.4rem;
+    align-items: center;
+    font-size: 0.78rem;
+  }
+  .bar-label {
+    opacity: 0.85;
+  }
+  .bar-track {
+    background: rgba(127, 127, 127, 0.18);
+    height: 14px;
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .bar-fill {
+    background: linear-gradient(
+      to right,
+      rgba(234, 179, 8, 0.5),
+      rgba(234, 179, 8, 0.95)
+    );
+    height: 100%;
+    transition: width 0.2s ease;
+  }
+  .bar-count {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.4rem;
+  }
+  .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid rgba(127, 127, 127, 0.2);
+    border-radius: 4px;
+    background: rgba(234, 179, 8, 0.05);
+  }
+  .stat-label {
+    font-size: 0.72rem;
+    opacity: 0.7;
+  }
+  .stat-value {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #eab308;
+    font-variant-numeric: tabular-nums;
+  }
+
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -492,6 +492,55 @@ export interface DyadConfigLike {
   source: string;
 }
 
+// ─── S3 Decisão duck-types (decision history, jogada histogram, stats) ──
+
+export interface TacticDecisionSummaryLike {
+  jogada: string;
+  angle: string;
+  register: string;
+  method: "rule" | "llm" | "fallback";
+}
+
+export interface DecisionRowLike {
+  turnRef: string;
+  decidedAt: string;
+  decisionPath: string;
+  selectedItemId: string;
+  selectedItemType: string;
+  selectedScore: number | null;
+  poolSize: number;
+  topNScores: number[];
+  tacticDecision: TacticDecisionSummaryLike | null;
+  cacheHit: boolean;
+  skipReason: string | null;
+}
+
+export interface JogadaDistributionLike {
+  personaId: string;
+  totalDecisions: number;
+  byJogada: {
+    bridge: number;
+    espelho: number;
+    canal: number;
+    diamante: number;
+    arena: number;
+    recovery: number;
+  };
+  byMethod: { rule: number; llm: number; fallback: number };
+  byRegister: Record<string, number>;
+  developmentStub: boolean;
+}
+
+export interface DecisionStatsLike {
+  personaId: string;
+  totalTurns: number;
+  cacheHitRate: number;
+  fallbackRate: number;
+  avgPoolSize: number;
+  avgTopScore: number;
+  selectorEscalations: number;
+}
+
 // ─── S5 Avaliação duck-types (guardrail/STS/longitudinal) ──────────
 
 export interface GuardrailCheckEntryLike {
@@ -755,6 +804,14 @@ export interface ApiClient {
   ): Promise<{ cards: EmittedCardLike[] }>;
   /** Configuração de dyad ativo (V0: stub null). */
   getDyad(personaId: string): Promise<DyadConfigLike>;
+
+  // ─── S3 Motor de Decisão (history / jogada distribution / stats) ─
+  getDecisionHistory(
+    personaId: string,
+    limit?: number,
+  ): Promise<{ personaId: string; decisions: DecisionRowLike[] }>;
+  getJogadaDistribution(personaId: string): Promise<JogadaDistributionLike>;
+  getDecisionStats(personaId: string): Promise<DecisionStatsLike>;
 
   // ─── S5 Motor de Avaliação (guardrail / STS / longitudinal) ────
   getGuardrailHistory(
@@ -1336,6 +1393,22 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     getDyad: (personaId) =>
       get<DyadConfigLike>(
         `/personas/${encodeURIComponent(personaId)}/dyad`,
+      ),
+
+    // ─── S3 Motor de Decisão ────────────────────────────────────────
+    getDecisionHistory: (personaId, limit) =>
+      get<{ personaId: string; decisions: DecisionRowLike[] }>(
+        `/personas/${encodeURIComponent(personaId)}/decision-history${
+          limit !== undefined ? `?limit=${limit}` : ""
+        }`,
+      ),
+    getJogadaDistribution: (personaId) =>
+      get<JogadaDistributionLike>(
+        `/personas/${encodeURIComponent(personaId)}/jogada-distribution`,
+      ),
+    getDecisionStats: (personaId) =>
+      get<DecisionStatsLike>(
+        `/personas/${encodeURIComponent(personaId)}/decision-stats`,
       ),
 
     // ─── S5 Motor de Avaliação ──────────────────────────────────────

--- a/packages/ebrota-console-ui/tests/s3-decisao-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/s3-decisao-panel.test.ts
@@ -1,0 +1,285 @@
+/**
+ * S3DecisaoPanel — wiring tests com mock ApiClient.
+ *
+ * Cobre:
+ *  - loading state
+ *  - 3 sub-blocks rendered (history, histogram, stats)
+ *  - empty state quando persona sem decisões
+ *  - histogram width % via inline style
+ *  - row expand on click
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/svelte";
+import S3DecisaoPanel from "../src/components/subsystem-panels/S3DecisaoPanel.svelte";
+import {
+  currentSessionId,
+  tracerSubjectId,
+  expandedSubsystem,
+} from "../src/lib/stores.js";
+import type {
+  ApiClient,
+  DecisionRowLike,
+  DecisionStatsLike,
+  JogadaDistributionLike,
+} from "../src/lib/api.js";
+
+function mockApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  const stub = (): never => {
+    throw new Error("not stubbed");
+  };
+  return {
+    getStatus: stub,
+    getMode: stub,
+    setMode: stub,
+    startCardSession: stub,
+    getActiveSessions: stub,
+    listOptions: stub,
+    overrideSelection: stub,
+    listDecisions: stub,
+    getPendingApproval: stub,
+    approveOrEdit: stub,
+    endSession: stub,
+    listSessionLibrary: stub,
+    getSessionReplay: stub,
+    listDebugLlmCalls: stub,
+    clearDebugLlmCalls: stub,
+    listAnalyticsPersonas: stub,
+    getPersonaEvolution: stub,
+    turnStateSseUrl: () => "/api/turn-state",
+    listSubjectDiscoveries: stub,
+    listSubjectBoundaries: stub,
+    getBoundariesSummary: stub,
+    getJourneyState: stub,
+    setJourneyOverride: stub,
+    clearJourneyOverride: stub,
+    listFrameworks: stub,
+    getSubjectMaps: stub,
+    getDeclaredObjectives: stub,
+    getObjectiveHistory: stub,
+    getNarrativeThreads: stub,
+    getSubjectKnowledge: stub,
+    getSessionStrategyPlan: stub,
+    listSubjectStrategyPlans: stub,
+    getDecisionHistory: async () => ({ personaId: "ryo", decisions: [] }),
+    getJogadaDistribution: async () => ({
+      personaId: "ryo",
+      totalDecisions: 0,
+      byJogada: {
+        bridge: 0,
+        espelho: 0,
+        canal: 0,
+        diamante: 0,
+        arena: 0,
+        recovery: 0,
+      },
+      byMethod: { rule: 0, llm: 0, fallback: 0 },
+      byRegister: {},
+      developmentStub: true,
+    }),
+    getDecisionStats: async () => ({
+      personaId: "ryo",
+      totalTurns: 0,
+      cacheHitRate: 0,
+      fallbackRate: 0,
+      avgPoolSize: 0,
+      avgTopScore: 0,
+      selectorEscalations: 0,
+    }),
+    getGuardrailHistory: stub,
+    getRecallCheckHistory: stub,
+    getTriggerEvents: stub,
+    getKpiLongitudinal: stub,
+    listStsScenarios: stub,
+    listStsPersonas: stub,
+    listStsRuns: stub,
+    startStsRun: stub,
+    getTemporalWindows: stub,
+    listPulsoEvents: stub,
+    getSacrificeBudget: stub,
+    listEmittedCards: stub,
+    getDyad: stub,
+    listBanks: stub,
+    getBank: stub,
+    listDrillStates: stub,
+    listDrillDue: stub,
+    listDrillMastered: stub,
+    listDrillAttempts: stub,
+    getParentalDashboard: stub,
+    getParentalToday: stub,
+    getParentalWeek: stub,
+    getParentalCards: stub,
+    getParentalConversations: stub,
+    getParentalAlerts: stub,
+    getParentalPulsoEvents: stub,
+    listPendingQuestions: stub,
+    answerPendingQuestion: stub,
+    reportProblem: stub,
+    pauseChild: stub,
+    getMc1Status: stub,
+    cancelMc1: stub,
+    ...overrides,
+  } as ApiClient;
+}
+
+const sampleRow: DecisionRowLike = {
+  turnRef: "ryo__sess1__turn_3",
+  decidedAt: "2026-05-25T10:10:00Z",
+  decisionPath: "tactician_split",
+  selectedItemId: "card.bridge.story",
+  selectedItemType: "card_catalog",
+  selectedScore: 0.91,
+  poolSize: 14,
+  topNScores: [0.91, 0.72, 0.61],
+  tacticDecision: {
+    jogada: "bridge",
+    angle: "narrar caminho",
+    register: "lúdico",
+    method: "llm",
+  },
+  cacheHit: false,
+  skipReason: null,
+};
+
+const sampleDist: JogadaDistributionLike = {
+  personaId: "ryo",
+  totalDecisions: 4,
+  byJogada: {
+    bridge: 2,
+    espelho: 1,
+    canal: 0,
+    diamante: 0,
+    arena: 0,
+    recovery: 1,
+  },
+  byMethod: { rule: 2, llm: 1, fallback: 1 },
+  byRegister: { lúdico: 2, neutro: 1, acolhedor: 1 },
+  developmentStub: false,
+};
+
+const sampleStats: DecisionStatsLike = {
+  personaId: "ryo",
+  totalTurns: 5,
+  cacheHitRate: 0.2,
+  fallbackRate: 0.2,
+  avgPoolSize: 9.8,
+  avgTopScore: 0.768,
+  selectorEscalations: 1,
+};
+
+beforeEach(() => {
+  expandedSubsystem.set("S3");
+  currentSessionId.set("ryo__conv-1");
+  tracerSubjectId.set("ryo");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("S3DecisaoPanel", () => {
+  it("renderiza 3 sub-blocks (history, histogram, stats)", async () => {
+    const api = mockApi({
+      getDecisionHistory: async () => ({ personaId: "ryo", decisions: [sampleRow] }),
+      getJogadaDistribution: async () => sampleDist,
+      getDecisionStats: async () => sampleStats,
+    });
+    render(S3DecisaoPanel, { api });
+    await waitFor(() => {
+      expect(screen.getByTestId("s3-history")).toBeDefined();
+      expect(screen.getByTestId("s3-histogram")).toBeDefined();
+      expect(screen.getByTestId("s3-stats")).toBeDefined();
+    });
+  });
+
+  it("mostra loading antes de resolver", async () => {
+    let resolveHistory: (v: { personaId: string; decisions: DecisionRowLike[] }) => void = () => {};
+    const api = mockApi({
+      getDecisionHistory: () =>
+        new Promise((res) => {
+          resolveHistory = res;
+        }),
+    });
+    render(S3DecisaoPanel, { api });
+    await waitFor(() => {
+      expect(screen.getByTestId("s3-history-loading")).toBeDefined();
+    });
+    resolveHistory({ personaId: "ryo", decisions: [] });
+  });
+
+  it("empty state quando persona sem decisões", async () => {
+    const api = mockApi();
+    render(S3DecisaoPanel, { api });
+    await waitFor(() => {
+      const empty = screen.getByTestId("s3-history-empty");
+      expect(empty.textContent).toContain("Persona ainda não tem decisões");
+    });
+  });
+
+  it("histogram renderiza com width % via inline style", async () => {
+    const api = mockApi({
+      getJogadaDistribution: async () => sampleDist,
+    });
+    render(S3DecisaoPanel, { api });
+    await waitFor(() => {
+      expect(screen.getByTestId("s3-bar-bridge")).toBeDefined();
+    });
+    const bridgeBar = screen.getByTestId("s3-bar-bridge");
+    const fill = bridgeBar.querySelector(".bar-fill") as HTMLElement | null;
+    expect(fill).not.toBeNull();
+    // bridge=2, max=2 → 100%
+    expect(fill!.style.width).toBe("100%");
+    const espelhoBar = screen.getByTestId("s3-bar-espelho");
+    const espelhoFill = espelhoBar.querySelector(".bar-fill") as HTMLElement;
+    // espelho=1, max=2 → 50%
+    expect(espelhoFill.style.width).toBe("50%");
+    const canalBar = screen.getByTestId("s3-bar-canal");
+    const canalFill = canalBar.querySelector(".bar-fill") as HTMLElement;
+    expect(canalFill.style.width).toBe("0%");
+  });
+
+  it("histogram renderiza todas as 6 chaves de jogada", async () => {
+    const api = mockApi({
+      getJogadaDistribution: async () => sampleDist,
+    });
+    render(S3DecisaoPanel, { api });
+    await waitFor(() => {
+      expect(screen.getByTestId("s3-bar-bridge")).toBeDefined();
+    });
+    for (const name of ["bridge", "espelho", "canal", "diamante", "arena", "recovery"]) {
+      expect(screen.getByTestId(`s3-bar-${name}`)).toBeDefined();
+    }
+  });
+
+  it("click em row expande detalhe", async () => {
+    const api = mockApi({
+      getDecisionHistory: async () => ({ personaId: "ryo", decisions: [sampleRow] }),
+    });
+    render(S3DecisaoPanel, { api });
+    await waitFor(() => {
+      expect(screen.getByTestId("s3-history-row")).toBeDefined();
+    });
+    expect(screen.queryByTestId("s3-history-detail")).toBeNull();
+    await fireEvent.click(screen.getByTestId("s3-history-row"));
+    await waitFor(() => {
+      expect(screen.getByTestId("s3-history-detail")).toBeDefined();
+    });
+    const detail = screen.getByTestId("s3-history-detail");
+    expect(detail.textContent).toContain("tactician_split");
+    expect(detail.textContent).toContain("narrar caminho");
+  });
+
+  it("stats card mostra valores formatados", async () => {
+    const api = mockApi({
+      getDecisionStats: async () => sampleStats,
+    });
+    render(S3DecisaoPanel, { api });
+    await waitFor(() => {
+      expect(screen.getByTestId("s3-stats")).toBeDefined();
+    });
+    const stats = screen.getByTestId("s3-stats");
+    expect(stats.textContent).toContain("20%"); // cacheHitRate
+    expect(stats.textContent).toContain("9.8"); // avgPoolSize
+    expect(stats.textContent).toContain("0.77"); // avgTopScore
+  });
+});


### PR DESCRIPTION
## Summary

Wires S3 (Motor de Decisão) panel from placeholders to real decision history via 3 new BFF endpoints + new aggregate S3DecisaoPanel UI component.

Spec: `docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md` (E5-J).

## Changes

### Backend (BFF)
- `packages/ebrota-console-bff/src/routes/s3-routes.ts` — new plugin
  - `GET /personas/:id/decision-history?limit=20` — últimas N decisões com selectionResult + tactic_decision quando split presente
  - `GET /personas/:id/jogada-distribution` — histogram fixo 6 jogadas (bridge/espelho/canal/diamante/arena/recovery) + byMethod + byRegister
  - `GET /personas/:id/decision-stats` — totalTurns, cacheHitRate, fallbackRate, avgPoolSize, avgTopScore, selectorEscalations
- Fonte: walks `EBROTA_BFF_TRACES_DIR` env (ou opts.tracesDir), parseia engine-trace-v2 JSONs, filtra por persona, agrega
- Plugin registrado em `server.ts` ao lado de s1-routes/s5-routes

### Frontend
- `packages/ebrota-console-ui/src/components/subsystem-panels/S3DecisaoPanel.svelte` — NEW
  - 3 sub-blocks: history table (colapsável, click-expand), jogada histogram (CSS bars width %), stats card
  - Empty state: "Persona ainda não tem decisões registradas"
- `packages/ebrota-console-ui/src/lib/api.ts` — adiciona `DecisionRowLike`, `JogadaDistributionLike`, `DecisionStatsLike` duck-types + 3 client methods
- `packages/ebrota-console-ui/src/App.svelte` — swap `S3DecisaoTurnPanel` → `S3DecisaoPanel` no expand de S3 (per-turn panel permanece como component disponível)

### Fixtures
- `packages/ebrota-console-bff/tests/fixtures/engine-trace-sample.json` — 5 turns ryo (bridge×2, espelho, recovery, e 1 turn sem tactic_decision)
- `packages/ebrota-console-bff/tests/fixtures/engine-trace-saki.json` — 1 turn saki pra teste de filtragem por persona

## Tests

- BFF (`s3-routes.unit.test.ts`): **17 tests** cobrindo happy path, ordem desc, limit param, persona sem trace, persona filtering, decisionPath split, cacheHit detection, skipReason warnings, topNScores top-5 desc, vocab jogada fixo, agregação byMethod/byRegister, developmentStub flag, stats calculation, env var vazio fallback
- UI (`s3-decisao-panel.test.ts`): **7 tests** cobrindo 3 sub-blocks render, loading state, empty state, histogram width %, todas as 6 chaves jogada presentes, row click-expand, stats formatting

Suite BFF: 245/245 passing. Suite UI: 215/219 (4 pré-existentes em b2-drilling-panel não relacionadas, confirmado via stash).

## Validação manual via screenshot textual

```
┌─ S3 — Motor de Decisão (histórico) ───────────────────────────────┐
│                                                                   │
│ Histórico de decisões                                             │
│ ┌───────┬─────────┬─────────┬──────────────────────┬───────┐      │
│ │ turn  │ jogada  │ method  │ item                 │ score │      │
│ ├───────┼─────────┼─────────┼──────────────────────┼───────┤      │
│ │ 5     │ recovery│ fallback│ card.recovery.calm   │ 0.60  │      │
│ │ 4     │ —       │ —       │ card.diamond.x       │ 0.70  │      │
│ │ 3     │ bridge  │ llm     │ card.bridge.story    │ 0.91  │ ◄ ex │
│ │   └─ decisionPath: tactician_split                       │      │
│ │      poolSize: 14                                        │      │
│ │      topNScores: 0.91                                    │      │
│ │      cacheHit: ✗                                         │      │
│ │      angle: narrar caminho                               │      │
│ │      register: lúdico                                    │      │
│ │ 2     │ espelho │ rule    │ card.espelho.feeling │ 0.78  │      │
│ │ 1     │ bridge  │ rule    │ card.bridge.curios.. │ 0.85  │      │
│ └───────┴─────────┴─────────┴──────────────────────┴───────┘      │
│                                                                   │
│ Jogada distribution                                               │
│ bridge     ████████████████████ 2                                 │
│ espelho    ██████████           1                                 │
│ canal                            0                                │
│ diamante                         0                                │
│ arena                            0                                │
│ recovery   ██████████           1                                 │
│ total decisões: 4 · rule: 2 · llm: 1 · fallback: 1                │
│                                                                   │
│ Stats                                                             │
│ ┌──────────┬──────────┬──────────┐                                │
│ │ total    │ cache hit│ fallback │                                │
│ │ turns    │  20%     │  20%     │                                │
│ │  5       │          │          │                                │
│ ├──────────┼──────────┼──────────┤                                │
│ │ avg pool │ avg top  │ escalat. │                                │
│ │  9.8     │  score   │  1       │                                │
│ │          │  0.77    │          │                                │
│ └──────────┴──────────┴──────────┘                                │
└───────────────────────────────────────────────────────────────────┘
```

## NÃO MERGEAR — só PR open.