### PR TITLE
[ui+bff] S2 Doutrina panel wiring — playbook + journey + drota

### DIFF
--- a/packages/ebrota-console-bff/src/routes/s2-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/s2-routes.ts
@@ -1,0 +1,275 @@
+/**
+ * S2 wiring — Modelo Pedagógico endpoints (playbook ativo / journey
+ * stage / drota config). Substitui placeholders hardcoded no painel S2
+ * por leituras reais do estado da persona.
+ *
+ * Spec parent: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ *
+ * Endpoints:
+ *   GET /personas/:id/active-playbook
+ *   GET /personas/:id/journey-stage
+ *   GET /personas/:id/drota-config
+ *
+ * Plugin separado pra não inflar `server.ts` (outros agentes paralelos
+ * editando) — sibling pattern de s1-routes/s5-routes.
+ *
+ * Persona origin v0: child.id dentro de `parental_onboarding.state_json.
+ * family.children[]`. `personas` table dedicada ainda não existe; quando
+ * existir, substituir `findChildInWizard` por SELECT direto.
+ */
+
+import type { FastifyPluginAsync } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { readOrComputeJourneyState } from "../journey-state-repo.js";
+
+const DEFAULT_PLAYBOOK_ID = "kids.brota.v1";
+
+export interface S2RoutesOptions {
+  db: DatabaseType;
+  /** Diretório raiz dos YAMLs de playbook. Default = `playbooks/` no
+   *  cwd; testes injetam dir temporário. */
+  playbooksDir?: string;
+  /** Process env injetável (split drota toggle). */
+  env?: NodeJS.ProcessEnv;
+}
+
+interface OnboardingRow {
+  acquirer_id: string;
+  status: "in_progress" | "complete";
+  state_json: string;
+  completed_at: string | null;
+  updated_at: string;
+}
+
+interface WizardChild {
+  id?: string;
+  name?: string;
+  age?: number;
+  playbook_id?: string;
+}
+
+function findChildInWizard(
+  db: DatabaseType,
+  personaId: string,
+): { child: WizardChild; record: OnboardingRow } | null {
+  const rows = db
+    .prepare(
+      `SELECT acquirer_id, status, state_json, completed_at, updated_at
+       FROM parental_onboarding`,
+    )
+    .all() as OnboardingRow[];
+  for (const row of rows) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(row.state_json);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const family = ((parsed as Record<string, unknown>).family ?? {}) as Record<
+      string,
+      unknown
+    >;
+    const children = Array.isArray(family.children) ? family.children : [];
+    for (const c of children) {
+      if (
+        c !== null &&
+        typeof c === "object" &&
+        (c as WizardChild).id === personaId
+      ) {
+        return { child: c as WizardChild, record: row };
+      }
+    }
+  }
+  return null;
+}
+
+interface YamlPlaybookMeta {
+  name: string;
+  version: string;
+}
+
+function tryReadPlaybookYaml(
+  playbooksDir: string,
+  playbookId: string,
+): YamlPlaybookMeta | null {
+  const candidates = [
+    join(playbooksDir, `${playbookId}.yaml`),
+    join(playbooksDir, `${playbookId}.playbook.yaml`),
+  ];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    try {
+      const raw = readFileSync(path, "utf8");
+      const parsed = yaml.load(raw) as Record<string, unknown> | null;
+      if (parsed !== null && typeof parsed === "object") {
+        const name =
+          typeof parsed.name === "string" ? parsed.name : playbookId;
+        const version =
+          typeof parsed.version === "string" ? parsed.version : "0.0.0";
+        return { name, version };
+      }
+    } catch {
+      // Malformed YAML — caller cai pro stub.
+    }
+  }
+  return null;
+}
+
+const s2Routes: FastifyPluginAsync<S2RoutesOptions> = async (fastify, opts) => {
+  const { db } = opts;
+  const env = opts.env ?? process.env;
+  const playbooksDir = opts.playbooksDir ?? join(process.cwd(), "playbooks");
+
+  // GET /personas/:id/active-playbook
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/active-playbook",
+    async (req) => {
+      const personaId = req.params.id;
+      const found = findChildInWizard(db, personaId);
+
+      let playbookId = DEFAULT_PLAYBOOK_ID;
+      let appliedReason:
+        | "default_at_persona_create"
+        | "wizard_complete"
+        | "manual_override" = "default_at_persona_create";
+      let appliedAt = new Date().toISOString();
+
+      if (found !== null) {
+        if (
+          typeof found.child.playbook_id === "string" &&
+          found.child.playbook_id.length > 0
+        ) {
+          playbookId = found.child.playbook_id;
+          appliedReason = "manual_override";
+        } else if (found.record.status === "complete") {
+          appliedReason = "wizard_complete";
+        }
+        appliedAt = found.record.completed_at ?? found.record.updated_at;
+      }
+
+      const meta = tryReadPlaybookYaml(playbooksDir, playbookId);
+      if (meta !== null) {
+        return {
+          personaId,
+          playbookId,
+          playbookName: meta.name,
+          version: meta.version,
+          appliedAt,
+          appliedReason,
+          developmentStub: false,
+        };
+      }
+      return {
+        personaId,
+        playbookId,
+        playbookName: "unknown_playbook",
+        version: "0.0.0",
+        appliedAt,
+        appliedReason,
+        developmentStub: true,
+      };
+    },
+  );
+
+  // GET /personas/:id/journey-stage
+  // turnsInStage v0: count de subject_knowledge entries com created_at >=
+  // stage_entered_at — proxy de "atividade desde transição" enquanto não
+  // há contagem canônica de turnos por stage.
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/journey-stage",
+    async (req) => {
+      const personaId = req.params.id;
+      const state = readOrComputeJourneyState(db, personaId);
+
+      const turnRow = db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM subject_knowledge
+           WHERE subject_id = ? AND created_at >= ?`,
+        )
+        .get(personaId, state.stage_entered_at) as { n: number };
+
+      let nextStageHint:
+        | "mapping_ready"
+        | "applied_double_helix"
+        | null = null;
+      let blockedBy:
+        | null
+        | "insufficient_discoveries"
+        | "consent_required" = null;
+
+      if (state.stage === "discovery_only") {
+        nextStageHint = "mapping_ready";
+        // Quando o repo já avalia auto-transição: se ainda está em
+        // discovery_only sem override forçando, é por falta de discoveries.
+        if (state.override_by_parent?.forced_stage !== "discovery_only") {
+          blockedBy = "insufficient_discoveries";
+        }
+      } else if (state.stage === "mapping_ready") {
+        nextStageHint = "applied_double_helix";
+        // applied_double_helix exige ratificação parental (não auto).
+        blockedBy = "consent_required";
+      }
+
+      return {
+        personaId,
+        stage: state.stage,
+        stageEnteredAt: state.stage_entered_at,
+        turnsInStage: turnRow.n,
+        nextStageHint,
+        blockedBy,
+      };
+    },
+  );
+
+  // GET /personas/:id/drota-config
+  // v0: drotaProfile inferido por idade do child (≤12 kids, ≥18 eprumo,
+  // resto drota-mestre). Split toggle vem do env. Persona overrides
+  // ainda não suportadas — splitDrotaSource sempre 'env'.
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/drota-config",
+    async (req) => {
+      const personaId = req.params.id;
+      const found = findChildInWizard(db, personaId);
+
+      const splitDrotaEnabled = env.USE_SPLIT_DROTA === "true";
+      const splitDrotaSource: "env" | "persona_override" = "env";
+
+      const age =
+        typeof found?.child.age === "number" ? found.child.age : null;
+
+      let drotaProfile: "kids" | "eprumo" | "drota-mestre";
+      let registerDefault: string;
+      let developmentStub = false;
+
+      if (age === null) {
+        drotaProfile = "kids";
+        registerDefault = "lúdico";
+        developmentStub = true;
+      } else if (age <= 12) {
+        drotaProfile = "kids";
+        registerDefault = "lúdico";
+      } else if (age >= 18) {
+        drotaProfile = "eprumo";
+        registerDefault = "profissional";
+      } else {
+        drotaProfile = "drota-mestre";
+        registerDefault = "formal";
+      }
+
+      return {
+        personaId,
+        drotaProfile,
+        splitDrotaEnabled,
+        splitDrotaSource,
+        registerDefault,
+        developmentStub,
+      };
+    },
+  );
+};
+
+export default s2Routes;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -144,6 +144,7 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   initParentalOnboardingSchema(opts.db);
   initMc1Schema(opts.db);
   void fastify.register(async (instance) => (await import("./routes/s1-routes.js")).default(instance, { db: opts.db }));
+  void fastify.register(async (instance) => (await import("./routes/s2-routes.js")).default(instance, { db: opts.db }));
   void fastify.register(async (instance) => (await import("./routes/s3-routes.js")).default(instance, opts.tracesDir !== undefined ? { tracesDir: opts.tracesDir } : {}));
   void fastify.register(async (instance) => (await import("./routes/s5-routes.js")).default(instance, { db: opts.db }));
 

--- a/packages/ebrota-console-bff/tests/s2-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/s2-routes.unit.test.ts
@@ -1,0 +1,284 @@
+/**
+ * S2 routes — unit tests com SQLite :memory: + playbooks dir temporário.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ *
+ * Cobre:
+ *  - active-playbook: default stub / wizard complete / manual override / YAML resolvido
+ *  - journey-stage: default discovery_only / mapping_ready / applied_double_helix
+ *  - drota-config: stub sem idade / kids / eprumo / drota-mestre / split env toggle
+ *  - 404 implícito em rotas inexistentes (Fastify default)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { initParentalOnboardingSchema, saveDraft, markComplete } from "../src/parental-onboarding-store.js";
+import s2Routes from "../src/routes/s2-routes.js";
+
+let app: FastifyInstance;
+let db: DatabaseType;
+let playbooksDir: string;
+
+beforeEach(async () => {
+  db = initDb({ dbPath: ":memory:" });
+  initParentalOnboardingSchema(db);
+  playbooksDir = mkdtempSync(join(tmpdir(), "s2-playbooks-"));
+  app = Fastify({ logger: false });
+  await app.register(s2Routes, {
+    db,
+    playbooksDir,
+    env: {},
+  });
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  db.close();
+  rmSync(playbooksDir, { recursive: true, force: true });
+});
+
+const inject = async (url: string) => {
+  const res = await app.inject({ method: "GET", url });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as Record<string, unknown>) : null,
+  };
+};
+
+function writePlaybook(filename: string, body: string): void {
+  writeFileSync(join(playbooksDir, filename), body, "utf8");
+}
+
+function seedWizard(opts: {
+  acquirerId: string;
+  children: Array<{ id: string; name: string; age?: number; playbook_id?: string }>;
+  complete?: boolean;
+}): void {
+  const state = {
+    family: {
+      acquirer: { id: opts.acquirerId, name: opts.acquirerId },
+      children: opts.children,
+    },
+  };
+  if (opts.complete) {
+    markComplete(db, state);
+  } else {
+    saveDraft(db, state);
+  }
+}
+
+describe("GET /personas/:id/active-playbook", () => {
+  it("retorna dev stub quando persona não está em wizard e YAML default ausente", async () => {
+    const res = await inject("/personas/ryo/active-playbook");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      personaId: "ryo",
+      playbookId: "kids.brota.v1",
+      playbookName: "unknown_playbook",
+      version: "0.0.0",
+      appliedReason: "default_at_persona_create",
+      developmentStub: true,
+    });
+  });
+
+  it("retorna playbook real quando YAML existe (name+version)", async () => {
+    writePlaybook(
+      "kids.brota.v1.playbook.yaml",
+      `name: "Brota — Kids tutor v1"\nversion: "1.0.0"\n`,
+    );
+    const res = await inject("/personas/ryo/active-playbook");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      playbookId: "kids.brota.v1",
+      playbookName: "Brota — Kids tutor v1",
+      version: "1.0.0",
+      developmentStub: false,
+    });
+  });
+
+  it("appliedReason='wizard_complete' quando onboarding marcado complete", async () => {
+    writePlaybook("kids.brota.v1.yaml", `name: "Brota Kids"\nversion: "1.0.0"\n`);
+    seedWizard({
+      acquirerId: "yuji",
+      children: [{ id: "ryo", name: "Ryo", age: 9 }],
+      complete: true,
+    });
+    const res = await inject("/personas/ryo/active-playbook");
+    expect(res.body).toMatchObject({
+      personaId: "ryo",
+      appliedReason: "wizard_complete",
+      developmentStub: false,
+    });
+    expect(typeof (res.body as { appliedAt: string }).appliedAt).toBe("string");
+  });
+
+  it("appliedReason='manual_override' quando child.playbook_id explícito", async () => {
+    writePlaybook("kids.custom.yaml", `name: "Custom"\nversion: "2.0.0"\n`);
+    seedWizard({
+      acquirerId: "yuji",
+      children: [{ id: "ryo", name: "Ryo", age: 9, playbook_id: "kids.custom" }],
+      complete: true,
+    });
+    const res = await inject("/personas/ryo/active-playbook");
+    expect(res.body).toMatchObject({
+      playbookId: "kids.custom",
+      playbookName: "Custom",
+      version: "2.0.0",
+      appliedReason: "manual_override",
+      developmentStub: false,
+    });
+  });
+});
+
+describe("GET /personas/:id/journey-stage", () => {
+  it("default state = discovery_only + blockedBy=insufficient_discoveries", async () => {
+    const res = await inject("/personas/ryo/journey-stage");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      personaId: "ryo",
+      stage: "discovery_only",
+      turnsInStage: 0,
+      nextStageHint: "mapping_ready",
+      blockedBy: "insufficient_discoveries",
+    });
+  });
+
+  it("conta turnsInStage como subject_knowledge >= stage_entered_at", async () => {
+    // Força um row em journey_state com stage_entered_at fixo no passado.
+    const past = "2026-01-01T00:00:00.000Z";
+    db.prepare(
+      `INSERT INTO journey_state
+       (subject_id, stage, stage_entered_at, discoveries_count, families_covered, last_updated_at)
+       VALUES ('ryo', 'discovery_only', ?, 0, '[]', ?)`,
+    ).run(past, past);
+
+    // Insere 3 entries depois do stage_entered_at e 1 antes (não conta).
+    for (let i = 0; i < 3; i++) {
+      db.prepare(
+        `INSERT INTO subject_knowledge
+         (id, subject_id, type, source, confidence, alignment, payload_json,
+          turn_ref, session_id, created_at)
+         VALUES (?, 'ryo', 'interest', 'self_declared', 1.0, 'unknown', '{}',
+                 't1', 'sess-A', ?)`,
+      ).run(`sk-after-${i}`, "2026-02-01T00:00:00.000Z");
+    }
+    db.prepare(
+      `INSERT INTO subject_knowledge
+       (id, subject_id, type, source, confidence, alignment, payload_json,
+        turn_ref, session_id, created_at)
+       VALUES ('sk-before', 'ryo', 'interest', 'self_declared', 1.0, 'unknown', '{}',
+               't0', 'sess-A', '2025-12-01T00:00:00.000Z')`,
+    ).run();
+
+    const res = await inject("/personas/ryo/journey-stage");
+    expect((res.body as { turnsInStage: number }).turnsInStage).toBe(3);
+  });
+
+  it("override forçando applied_double_helix → blockedBy=null + nextStageHint=null", async () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO journey_state
+       (subject_id, stage, stage_entered_at, discoveries_count, families_covered,
+        override_by_parent, last_updated_at)
+       VALUES ('ryo', 'applied_double_helix', ?, 0, '[]', ?, ?)`,
+    ).run(
+      now,
+      JSON.stringify({
+        forced_stage: "applied_double_helix",
+        reason: "test",
+        timestamp: now,
+      }),
+      now,
+    );
+    const res = await inject("/personas/ryo/journey-stage");
+    expect(res.body).toMatchObject({
+      stage: "applied_double_helix",
+      nextStageHint: null,
+      blockedBy: null,
+    });
+  });
+});
+
+describe("GET /personas/:id/drota-config", () => {
+  it("dev stub quando idade desconhecida (persona não em wizard)", async () => {
+    const res = await inject("/personas/ghost/drota-config");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      personaId: "ghost",
+      drotaProfile: "kids",
+      registerDefault: "lúdico",
+      developmentStub: true,
+      splitDrotaEnabled: false,
+      splitDrotaSource: "env",
+    });
+  });
+
+  it("infere kids quando age ≤ 12", async () => {
+    seedWizard({
+      acquirerId: "yuji",
+      children: [{ id: "ryo", name: "Ryo", age: 9 }],
+    });
+    const res = await inject("/personas/ryo/drota-config");
+    expect(res.body).toMatchObject({
+      drotaProfile: "kids",
+      registerDefault: "lúdico",
+      developmentStub: false,
+    });
+  });
+
+  it("infere eprumo quando age ≥ 18", async () => {
+    seedWizard({
+      acquirerId: "yuji",
+      children: [{ id: "adult", name: "Adult", age: 30 }],
+    });
+    const res = await inject("/personas/adult/drota-config");
+    expect(res.body).toMatchObject({
+      drotaProfile: "eprumo",
+      registerDefault: "profissional",
+      developmentStub: false,
+    });
+  });
+
+  it("infere drota-mestre na faixa intermediária (13-17)", async () => {
+    seedWizard({
+      acquirerId: "yuji",
+      children: [{ id: "teen", name: "Teen", age: 15 }],
+    });
+    const res = await inject("/personas/teen/drota-config");
+    expect(res.body).toMatchObject({
+      drotaProfile: "drota-mestre",
+      registerDefault: "formal",
+    });
+  });
+
+  it("splitDrotaEnabled=true quando env USE_SPLIT_DROTA='true'", async () => {
+    // Re-bootstrap app com env injetado — o beforeEach default usa env={}.
+    await app.close();
+    app = Fastify({ logger: false });
+    await app.register(s2Routes, {
+      db,
+      playbooksDir,
+      env: { USE_SPLIT_DROTA: "true" },
+    });
+    await app.ready();
+
+    const res = await inject("/personas/ryo/drota-config");
+    expect(res.body).toMatchObject({
+      splitDrotaEnabled: true,
+      splitDrotaSource: "env",
+    });
+  });
+});
+
+describe("S2 routes — 404 fallthrough", () => {
+  it("rotas não declaradas em /personas/:id retornam 404 Fastify default", async () => {
+    const res = await inject("/personas/ryo/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S2DoutrinaPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S2DoutrinaPanel.svelte
@@ -3,13 +3,35 @@
    * S2 — Modelo Pedagógico (panel).
    * Pergunta: "Como o motor crê que deve ensinar [persona] agora?"
    *
-   * v0: charter resumo + jogadas catalog (5 + Recovery hardcoded) +
-   * envelopa JourneyPanel via toggle + placeholders pra
-   * transitions/phases.
+   * Wired (não mais hardcoded):
+   *   - GET /personas/:id/active-playbook   (id+name+version+reason)
+   *   - GET /personas/:id/journey-stage     (timeline 3 stages)
+   *   - GET /personas/:id/drota-config      (profile + split toggle)
+   *
+   * Persona ativa derivada de `$currentSessionId` (split `__`) com
+   * fallback pra `$tracerSubjectId`. Padrão `lastLoadedFor` evita
+   * re-fetch em loop. Jogadas catalog + transitions/phases placeholders
+   * permanecem hardcoded (escopo S2 fora deste wiring).
+   *
+   * Spec parent: docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
    */
-  import { journeyPanelOpen } from "../../lib/stores.js";
+  import {
+    journeyPanelOpen,
+    tracerSubjectId,
+    currentSessionId,
+  } from "../../lib/stores.js";
   import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
   import PlaceholderBanner from "./PlaceholderBanner.svelte";
+  import {
+    createApiClient,
+    type ApiClient,
+    type ActivePlaybookLike,
+    type JourneyStageInfoLike,
+    type DrotaConfigLike,
+  } from "../../lib/api.js";
+
+  /** Permite injetar mock em testes; default = real BFF client. */
+  export let api: ApiClient = createApiClient();
 
   const COLOR = "#10b981";
 
@@ -19,7 +41,6 @@
     short: string;
   };
 
-  // Hardcoded v0 — descrição curta canônica.
   const JOGADAS: Jogada[] = [
     { id: "bridge", name: "Bridge", short: "abrir ponte do mundo externo pro tema" },
     { id: "espelho", name: "Espelho", short: "refletir afeto/intenção do aprendiz" },
@@ -29,25 +50,250 @@
     { id: "recovery", name: "Recovery", short: "voltar ao seguro quando tensão cresce" },
   ];
 
+  const JOURNEY_STAGES: Array<{
+    id: "discovery_only" | "mapping_ready" | "applied_double_helix";
+    label: string;
+  }> = [
+    { id: "discovery_only", label: "Discovery" },
+    { id: "mapping_ready", label: "Mapping" },
+    { id: "applied_double_helix", label: "Applied" },
+  ];
+
   function openJourney(): void {
     journeyPanelOpen.set(true);
+  }
+
+  function derivePersonaId(sessionId: string | null, fallback: string): string {
+    if (sessionId === null || sessionId.length === 0) return fallback;
+    const idx = sessionId.indexOf("__");
+    return idx > 0 ? sessionId.slice(0, idx) : sessionId;
+  }
+
+  $: personaId = derivePersonaId($currentSessionId, $tracerSubjectId);
+
+  type LoadState = "idle" | "loading" | "loaded" | "error";
+
+  let playbookState: LoadState = "idle";
+  let playbook: ActivePlaybookLike | null = null;
+  let playbookError = "";
+
+  let stageState: LoadState = "idle";
+  let stageInfo: JourneyStageInfoLike | null = null;
+  let stageError = "";
+
+  let drotaState: LoadState = "idle";
+  let drota: DrotaConfigLike | null = null;
+  let drotaError = "";
+
+  async function loadPlaybook(pid: string): Promise<void> {
+    playbookState = "loading";
+    try {
+      playbook = await api.getActivePlaybook(pid);
+      playbookState = "loaded";
+    } catch (err) {
+      playbookError = err instanceof Error ? err.message : String(err);
+      playbookState = "error";
+    }
+  }
+
+  async function loadStage(pid: string): Promise<void> {
+    stageState = "loading";
+    try {
+      stageInfo = await api.getJourneyStage(pid);
+      stageState = "loaded";
+    } catch (err) {
+      stageError = err instanceof Error ? err.message : String(err);
+      stageState = "error";
+    }
+  }
+
+  async function loadDrota(pid: string): Promise<void> {
+    drotaState = "loading";
+    try {
+      drota = await api.getDrotaConfig(pid);
+      drotaState = "loaded";
+    } catch (err) {
+      drotaError = err instanceof Error ? err.message : String(err);
+      drotaState = "error";
+    }
+  }
+
+  // Trigger inicial + re-fetch quando persona muda. Mesmo padrão S1.
+  let lastLoadedFor = "";
+  $: if (personaId !== "" && personaId !== lastLoadedFor) {
+    lastLoadedFor = personaId;
+    void loadPlaybook(personaId);
+    void loadStage(personaId);
+    void loadDrota(personaId);
+  }
+
+  function stageIndex(
+    id: "discovery_only" | "mapping_ready" | "applied_double_helix",
+  ): number {
+    return JOURNEY_STAGES.findIndex((s) => s.id === id);
+  }
+
+  function isCurrent(
+    id: "discovery_only" | "mapping_ready" | "applied_double_helix",
+    current: JourneyStageInfoLike | null,
+  ): boolean {
+    return current !== null && current.stage === id;
+  }
+
+  function isNextHint(
+    id: "discovery_only" | "mapping_ready" | "applied_double_helix",
+    current: JourneyStageInfoLike | null,
+  ): boolean {
+    return current !== null && current.nextStageHint === id;
+  }
+
+  function reasonLabel(reason: ActivePlaybookLike["appliedReason"]): string {
+    switch (reason) {
+      case "wizard_complete":
+        return "wizard";
+      case "manual_override":
+        return "override";
+      default:
+        return "default";
+    }
+  }
+
+  function blockedLabel(blocked: JourneyStageInfoLike["blockedBy"]): string {
+    switch (blocked) {
+      case "insufficient_discoveries":
+        return "aguarda discoveries";
+      case "consent_required":
+        return "aguarda ratificação parental";
+      default:
+        return "";
+    }
   }
 </script>
 
 <SubsystemPanelShell id="S2" title="Modelo Pedagógico" color={COLOR}>
-  <section class="block">
-    <h3>Charter ativo</h3>
-    <p class="charter">
-      <strong>Brota Mestre Core</strong> + overlay <code>kids</code>
-    </p>
-    <a
-      class="spec-link"
-      href="https://github.com/ascendimacy/ascendimacy-ops/blob/main/docs/playbooks/brota-mestre.md"
-      target="_blank"
-      rel="noopener"
-    >
-      ler charter completo →
-    </a>
+  <section class="block" data-testid="s2-playbook">
+    <h3>Playbook ativo</h3>
+    {#if playbookState === "loading"}
+      <p class="muted small" data-testid="playbook-loading">carregando…</p>
+    {:else if playbookState === "error"}
+      <p class="error small" data-testid="playbook-error">
+        falha: {playbookError}
+      </p>
+      <PlaceholderBanner
+        label="endpoint indisponível — fallback"
+        specPath="docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md"
+        color={COLOR}
+      />
+    {:else if playbook !== null}
+      <article class="card playbook-card" data-testid="playbook-card">
+        <div class="card-head">
+          <strong class="playbook-name">{playbook.playbookName}</strong>
+          <span
+            class="reason-badge"
+            data-testid="playbook-reason"
+            class:reason-default={playbook.appliedReason === "default_at_persona_create"}
+            class:reason-wizard={playbook.appliedReason === "wizard_complete"}
+            class:reason-override={playbook.appliedReason === "manual_override"}
+          >
+            {reasonLabel(playbook.appliedReason)}
+          </span>
+        </div>
+        <dl class="card-meta">
+          <dt>id</dt><dd><code>{playbook.playbookId}</code></dd>
+          <dt>version</dt><dd>{playbook.version}</dd>
+        </dl>
+        {#if playbook.developmentStub}
+          <p class="muted small" data-testid="playbook-stub-note">
+            (development stub — YAML não resolvido)
+          </p>
+        {/if}
+      </article>
+    {/if}
+  </section>
+
+  <section class="block" data-testid="s2-journey">
+    <h3>Journey stage</h3>
+    {#if stageState === "loading"}
+      <p class="muted small" data-testid="stage-loading">carregando…</p>
+    {:else if stageState === "error"}
+      <p class="error small" data-testid="stage-error">
+        falha: {stageError}
+      </p>
+      <PlaceholderBanner
+        label="endpoint indisponível — fallback"
+        specPath="docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md"
+        color={COLOR}
+      />
+    {:else if stageInfo !== null}
+      <ol
+        class="stage-timeline"
+        data-testid="stage-timeline"
+        aria-label="journey stage timeline"
+      >
+        {#each JOURNEY_STAGES as st, i (st.id)}
+          <li
+            class="stage-pill"
+            class:stage-current={isCurrent(st.id, stageInfo)}
+            class:stage-next-hint={isNextHint(st.id, stageInfo) && !isCurrent(st.id, stageInfo)}
+            class:stage-past={stageIndex(stageInfo.stage) > i}
+            data-testid={`stage-${st.id}`}
+            data-current={isCurrent(st.id, stageInfo) ? "true" : "false"}
+          >
+            <span class="stage-num">{i + 1}</span>
+            <span class="stage-label">{st.label}</span>
+          </li>
+        {/each}
+      </ol>
+      <dl class="card-meta">
+        <dt>turnos no stage</dt><dd>{stageInfo.turnsInStage}</dd>
+        {#if stageInfo.blockedBy}
+          <dt>bloqueio</dt>
+          <dd data-testid="stage-blocked">{blockedLabel(stageInfo.blockedBy)}</dd>
+        {/if}
+      </dl>
+      <button type="button" class="action" on:click={openJourney}>
+        Abrir JourneyPanel
+      </button>
+    {/if}
+  </section>
+
+  <section class="block" data-testid="s2-drota">
+    <h3>Drota config</h3>
+    {#if drotaState === "loading"}
+      <p class="muted small" data-testid="drota-loading">carregando…</p>
+    {:else if drotaState === "error"}
+      <p class="error small" data-testid="drota-error">
+        falha: {drotaError}
+      </p>
+      <PlaceholderBanner
+        label="endpoint indisponível — fallback"
+        specPath="docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md"
+        color={COLOR}
+      />
+    {:else if drota !== null}
+      <article class="card drota-card" data-testid="drota-card">
+        <div class="card-head">
+          <strong>{drota.drotaProfile}</strong>
+          <span
+            class="split-badge"
+            data-testid="drota-split-badge"
+            class:split-on={drota.splitDrotaEnabled}
+            class:split-off={!drota.splitDrotaEnabled}
+          >
+            split: {drota.splitDrotaEnabled ? "on" : "off"}
+          </span>
+        </div>
+        <dl class="card-meta">
+          <dt>register</dt><dd>{drota.registerDefault}</dd>
+          <dt>fonte split</dt><dd><code>{drota.splitDrotaSource}</code></dd>
+        </dl>
+        {#if drota.developmentStub}
+          <p class="muted small" data-testid="drota-stub-note">
+            (development stub — idade desconhecida)
+          </p>
+        {/if}
+      </article>
+    {/if}
   </section>
 
   <section class="block">
@@ -60,16 +306,6 @@
         </article>
       {/each}
     </div>
-  </section>
-
-  <section class="block">
-    <h3>Journey (stage atual + transições)</h3>
-    <p class="hint">
-      Stage + override parental via <code>JourneyPanel</code>.
-    </p>
-    <button type="button" class="action" on:click={openJourney}>
-      Abrir JourneyPanel
-    </button>
   </section>
 
   <section class="block">
@@ -103,18 +339,124 @@
     border-bottom: 1px solid rgba(127, 127, 127, 0.25);
     padding-bottom: 0.2rem;
   }
-  .charter {
+  .muted {
+    opacity: 0.55;
+    font-size: 0.78rem;
+  }
+  .small {
+    font-size: 0.75rem;
     margin: 0;
-    font-size: 0.9rem;
   }
-  .spec-link {
-    align-self: flex-start;
-    font-size: 0.8rem;
-    color: #10b981;
-    text-decoration: none;
+  .error {
+    color: #d97706;
+    font-size: 0.78rem;
+    margin: 0;
   }
-  .spec-link:hover {
-    text-decoration: underline;
+  .card {
+    border: 1px solid rgba(16, 185, 129, 0.4);
+    border-left: 3px solid #10b981;
+    border-radius: 4px;
+    padding: 0.5rem 0.65rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    background: rgba(16, 185, 129, 0.05);
+  }
+  .card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+  .playbook-name {
+    font-size: 0.92rem;
+  }
+  .card-meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 0.8rem;
+    row-gap: 0.15rem;
+    margin: 0;
+    font-size: 0.82rem;
+  }
+  .card-meta dt {
+    font-weight: 600;
+    opacity: 0.75;
+  }
+  .card-meta dd {
+    margin: 0;
+  }
+  .reason-badge {
+    font-size: 0.7rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: rgba(127, 127, 127, 0.2);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+  .reason-wizard {
+    background: rgba(34, 197, 94, 0.22);
+  }
+  .reason-override {
+    background: rgba(168, 85, 247, 0.22);
+  }
+  .reason-default {
+    background: rgba(127, 127, 127, 0.22);
+  }
+  .stage-timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 0.4rem;
+    align-items: stretch;
+  }
+  .stage-pill {
+    flex: 1;
+    border: 1px solid rgba(127, 127, 127, 0.25);
+    border-radius: 4px;
+    padding: 0.4rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    opacity: 0.45;
+    background: rgba(127, 127, 127, 0.05);
+  }
+  .stage-pill.stage-current {
+    opacity: 1;
+    border-color: #10b981;
+    background: rgba(16, 185, 129, 0.18);
+    font-weight: 600;
+  }
+  .stage-pill.stage-next-hint {
+    opacity: 0.75;
+    border-style: dashed;
+    border-color: rgba(16, 185, 129, 0.6);
+  }
+  .stage-pill.stage-past {
+    opacity: 0.6;
+  }
+  .stage-num {
+    font-size: 0.7rem;
+    opacity: 0.7;
+  }
+  .stage-label {
+    font-size: 0.82rem;
+  }
+  .split-badge {
+    font-size: 0.7rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+  .split-on {
+    background: rgba(34, 197, 94, 0.22);
+  }
+  .split-off {
+    background: rgba(127, 127, 127, 0.22);
   }
   .jogadas-grid {
     display: grid;
@@ -136,11 +478,6 @@
     margin: 0;
     font-size: 0.75rem;
     opacity: 0.85;
-  }
-  .hint {
-    font-size: 0.85rem;
-    opacity: 0.85;
-    margin: 0;
   }
   .action {
     align-self: flex-start;

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -762,6 +762,11 @@ export interface ApiClient {
     frameworkIds?: string[],
   ): Promise<{ maps: SubjectMapLike }>;
 
+  // ─── S2 wiring — Playbook ativo + Journey stage + Drota config ──
+  getActivePlaybook(personaId: string): Promise<ActivePlaybookLike>;
+  getJourneyStage(personaId: string): Promise<JourneyStageInfoLike>;
+  getDrotaConfig(personaId: string): Promise<DrotaConfigLike>;
+
   // ─── S1 wiring — Declared Objectives + Threads + SK summary ─────
   getDeclaredObjectives(
     personaId: string,
@@ -923,6 +928,36 @@ export interface ApiClient {
   }>;
   /** Cancela MC1 pending da criança. Idempotente: cancelled=0 se nada pra cancelar. */
   cancelMc1(childId: string): Promise<{ childId: string; cancelled: number }>;
+}
+
+// ─── S2 wiring — Playbook ativo + Journey stage + Drota config ─────
+
+export interface ActivePlaybookLike {
+  personaId: string;
+  playbookId: string;
+  playbookName: string;
+  version: string;
+  appliedAt: string;
+  appliedReason: "default_at_persona_create" | "wizard_complete" | "manual_override";
+  developmentStub: boolean;
+}
+
+export interface JourneyStageInfoLike {
+  personaId: string;
+  stage: "discovery_only" | "mapping_ready" | "applied_double_helix";
+  stageEnteredAt: string;
+  turnsInStage: number;
+  nextStageHint: "mapping_ready" | "applied_double_helix" | null;
+  blockedBy: null | "insufficient_discoveries" | "consent_required";
+}
+
+export interface DrotaConfigLike {
+  personaId: string;
+  drotaProfile: "kids" | "eprumo" | "drota-mestre";
+  splitDrotaEnabled: boolean;
+  splitDrotaSource: "env" | "persona_override";
+  registerDefault: string;
+  developmentStub: boolean;
 }
 
 // ─── S1 wiring — Declared Objectives + Narrative Threads + SK summary ──
@@ -1321,6 +1356,18 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
         `/subjects/${encodeURIComponent(subjectId)}/maps${q ? `?${q}` : ""}`,
       );
     },
+    getActivePlaybook: (personaId) =>
+      get<ActivePlaybookLike>(
+        `/personas/${encodeURIComponent(personaId)}/active-playbook`,
+      ),
+    getJourneyStage: (personaId) =>
+      get<JourneyStageInfoLike>(
+        `/personas/${encodeURIComponent(personaId)}/journey-stage`,
+      ),
+    getDrotaConfig: (personaId) =>
+      get<DrotaConfigLike>(
+        `/personas/${encodeURIComponent(personaId)}/drota-config`,
+      ),
     getDeclaredObjectives: (personaId) =>
       get<{ objectives: DeclaredObjectiveLike[] }>(
         `/personas/${encodeURIComponent(personaId)}/objectives`,

--- a/packages/ebrota-console-ui/tests/s2-doutrina-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/s2-doutrina-panel.test.ts
@@ -1,0 +1,191 @@
+/**
+ * S2DoutrinaPanel — wiring tests com mock ApiClient.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ *
+ * Cobre:
+ *  - Loading state (3 sub-cards)
+ *  - 3 sub-cards renderizados com dados reais
+ *  - Journey timeline highlight correto por stage
+ *  - Error fallback pra PlaceholderBanner
+ *  - Stub note quando developmentStub=true
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/svelte";
+import S2DoutrinaPanel from "../src/components/subsystem-panels/S2DoutrinaPanel.svelte";
+import {
+  currentSessionId,
+  tracerSubjectId,
+  expandedSubsystem,
+} from "../src/lib/stores.js";
+import type {
+  ApiClient,
+  ActivePlaybookLike,
+  JourneyStageInfoLike,
+  DrotaConfigLike,
+} from "../src/lib/api.js";
+
+function mockApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  const stub = (): never => {
+    throw new Error("not stubbed");
+  };
+  return {
+    getStatus: stub,
+    getMode: stub,
+    setMode: stub,
+    startCardSession: stub,
+    getActiveSessions: stub,
+    listOptions: stub,
+    overrideSelection: stub,
+    listDecisions: stub,
+    getPendingApproval: stub,
+    approveOrEdit: stub,
+    endSession: stub,
+    listSessionLibrary: stub,
+    getSessionReplay: stub,
+    listDebugLlmCalls: stub,
+    clearDebugLlmCalls: stub,
+    listAnalyticsPersonas: stub,
+    getPersonaEvolution: stub,
+    turnStateSseUrl: () => "/api/turn-state",
+    getActivePlaybook: async () => samplePlaybook,
+    getJourneyStage: async () => sampleStage,
+    getDrotaConfig: async () => sampleDrota,
+    ...overrides,
+  } as ApiClient;
+}
+
+const samplePlaybook: ActivePlaybookLike = {
+  personaId: "ryo",
+  playbookId: "kids.brota.v1",
+  playbookName: "Brota — Kids tutor v1",
+  version: "1.0.0",
+  appliedAt: "2026-05-27T10:00:00Z",
+  appliedReason: "wizard_complete",
+  developmentStub: false,
+};
+
+const sampleStage: JourneyStageInfoLike = {
+  personaId: "ryo",
+  stage: "mapping_ready",
+  stageEnteredAt: "2026-05-20T10:00:00Z",
+  turnsInStage: 12,
+  nextStageHint: "applied_double_helix",
+  blockedBy: "consent_required",
+};
+
+const sampleDrota: DrotaConfigLike = {
+  personaId: "ryo",
+  drotaProfile: "kids",
+  splitDrotaEnabled: false,
+  splitDrotaSource: "env",
+  registerDefault: "lúdico",
+  developmentStub: false,
+};
+
+beforeEach(() => {
+  expandedSubsystem.set("S2");
+  currentSessionId.set("ryo__conv-1");
+  tracerSubjectId.set("ryo");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("S2DoutrinaPanel — wiring", () => {
+  it("loading state visível em 3 sub-cards durante fetch", () => {
+    const never = new Promise<never>(() => {});
+    const api = mockApi({
+      getActivePlaybook: () => never as Promise<ActivePlaybookLike>,
+      getJourneyStage: () => never as Promise<JourneyStageInfoLike>,
+      getDrotaConfig: () => never as Promise<DrotaConfigLike>,
+    });
+
+    render(S2DoutrinaPanel, { api });
+
+    expect(screen.getByTestId("playbook-loading")).toBeDefined();
+    expect(screen.getByTestId("stage-loading")).toBeDefined();
+    expect(screen.getByTestId("drota-loading")).toBeDefined();
+  });
+
+  it("renderiza 3 sub-cards com dados reais (playbook + journey + drota)", async () => {
+    const api = mockApi();
+    render(S2DoutrinaPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playbook-card")).toBeDefined();
+    });
+    expect(screen.getByText("Brota — Kids tutor v1")).toBeDefined();
+    expect(screen.getByText("kids.brota.v1")).toBeDefined();
+    expect(screen.getByTestId("stage-timeline")).toBeDefined();
+    expect(screen.getByTestId("drota-card")).toBeDefined();
+    expect(screen.getByText(/lúdico/)).toBeDefined();
+  });
+
+  it("timeline destaca stage atual e marca next como hint", async () => {
+    const api = mockApi();
+    render(S2DoutrinaPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stage-mapping_ready")).toBeDefined();
+    });
+
+    const current = screen.getByTestId("stage-mapping_ready");
+    expect(current.getAttribute("data-current")).toBe("true");
+    expect(current.className).toContain("stage-current");
+
+    const next = screen.getByTestId("stage-applied_double_helix");
+    expect(next.getAttribute("data-current")).toBe("false");
+    expect(next.className).toContain("stage-next-hint");
+
+    const past = screen.getByTestId("stage-discovery_only");
+    expect(past.className).toContain("stage-past");
+  });
+
+  it("error → fallback pra PlaceholderBanner em cada sub-card", async () => {
+    const api = mockApi({
+      getActivePlaybook: async () => {
+        throw new Error("BFF offline");
+      },
+      getJourneyStage: async () => {
+        throw new Error("BFF offline");
+      },
+      getDrotaConfig: async () => {
+        throw new Error("BFF offline");
+      },
+    });
+
+    render(S2DoutrinaPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playbook-error")).toBeDefined();
+    });
+    expect(screen.getByTestId("stage-error")).toBeDefined();
+    expect(screen.getByTestId("drota-error")).toBeDefined();
+  });
+
+  it("developmentStub render nota e badge default", async () => {
+    const api = mockApi({
+      getActivePlaybook: async () => ({
+        ...samplePlaybook,
+        playbookName: "unknown_playbook",
+        appliedReason: "default_at_persona_create",
+        developmentStub: true,
+      }),
+      getDrotaConfig: async () => ({
+        ...sampleDrota,
+        developmentStub: true,
+      }),
+    });
+
+    render(S2DoutrinaPanel, { api });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playbook-stub-note")).toBeDefined();
+    });
+    expect(screen.getByTestId("drota-stub-note")).toBeDefined();
+    expect(screen.getByTestId("playbook-reason").textContent).toMatch(/default/);
+  });
+});


### PR DESCRIPTION
Substitui placeholders no S2DoutrinaPanel por dados reais consumidos do BFF.

## BFF — novo plugin \`s2-routes.ts\`

Três endpoints novos sob \`/personas/:id/\`:

- **\`GET /active-playbook\`** — lê \`parental_onboarding.state_json.family.children[]\` por \`child.id === personaId\`. Resolve YAML em \`playbooks/{id}.yaml\` ou \`{id}.playbook.yaml\` pra ler \`name\`+\`version\`. Default \`kids.brota.v1\`. \`appliedReason\`: \`manual_override\` quando child tem \`playbook_id\` explícito, \`wizard_complete\` quando onboarding completo, \`default_at_persona_create\` caso contrário. \`developmentStub: true\` quando YAML não resolve.
- **\`GET /journey-stage\`** — consome \`readOrComputeJourneyState\` (já existente). \`turnsInStage\` derivado de \`COUNT(subject_knowledge)\` com \`created_at >= stage_entered_at\`. \`nextStageHint\` e \`blockedBy\` derivados do stage + override.
- **\`GET /drota-config\`** — infere \`drotaProfile\` por idade do child (≤12 kids / ≥18 eprumo / resto drota-mestre). \`splitDrotaEnabled\` lido de \`env.USE_SPLIT_DROTA\`. \`developmentStub: true\` quando idade desconhecida.

Plugin registrado em \`server.ts\` no mesmo bloco de S1/S5.

## UI — \`S2DoutrinaPanel.svelte\` wired

- Prop \`api\` injetável (default \`createApiClient()\`)
- Padrão \`lastLoadedFor\` igual S1 (impede re-fetch loop em reactive \`$:\`)
- Persona derivada de \`$currentSessionId\` (split \`__\`) → fallback \`$tracerSubjectId\`
- 3 sub-cards novos: \`playbook-card\`, \`stage-timeline\` (3 stages com current+next+past), \`drota-card\` com split badge
- Empty/error fallback pra \`PlaceholderBanner\` cada
- Jogadas catalog + transitions/phases placeholders preservados (out of scope)

## \`lib/api.ts\`

- 3 novos duck-types: \`ActivePlaybookLike\`, \`JourneyStageInfoLike\`, \`DrotaConfigLike\`
- 3 novos métodos: \`getActivePlaybook\`, \`getJourneyStage\`, \`getDrotaConfig\`

## Testes

- **\`s2-routes.unit.test.ts\`** — 13 testes (BFF) cobrindo: dev stub default, YAML real, \`wizard_complete\`/\`manual_override\`, journey default \`discovery_only\`+blocked, \`turnsInStage\` window, override \`applied_double_helix\` clear, drota stub sem idade, kids/eprumo/drota-mestre by age, split env toggle, 404 fallthrough.
- **\`s2-doutrina-panel.test.ts\`** — 5 testes (UI): loading state (3 cards), render real data, journey timeline highlight, error fallback, developmentStub note + badge.

## Validação local

\`\`\`
npm run build -w shared          ✓
npm run build -w motor-execucao  ✓
npm run build -w packages/ebrota-console-bff   ✓
npm run build -w packages/ebrota-console-ui    ✓ (a11y warnings pré-existentes)
npm test     -w packages/ebrota-console-bff    ✓ 241/241 passing
npm test     -w packages/ebrota-console-ui     ✓ 213/217 (4 falhas em b2-drilling-panel.test.ts pré-existentes, não relacionadas)
\`\`\`

## Notas

- \`personas\` table dedicada não existe ainda (spec menciona); persona origin v0 vem de \`parental_onboarding.state_json.family.children[]\`. Comentário no plugin indica troca por SELECT direto quando tabela existir.
- Pre-existing build issue: \`motor-execucao\` resolve \`@ascendimacy/shared\` via symlink absoluto pra \`/home/alexa/ascendimacy-motor/shared\`. Foi necessário rebuildar shared/dist no path da main worktree pra build passar — não afeta runtime, só local DX.

Part of batch 5 piloto-ready I.