### PR TITLE
[feat] S4 panel wiring — expression metrics + tactic distribution + samples

### DIFF
--- a/packages/ebrota-console-bff/src/routes/s4-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/s4-routes.ts
@@ -1,0 +1,558 @@
+/**
+ * S4 wiring — Motor de Expressão (aggregate metrics + tactic distribution +
+ * recent samples).
+ *
+ * Spec parent: ascendimacy-ops/docs/specs/2026-05-26-console-ebrota-redesign-pela-lente-7-subsistemas-v0.md
+ *
+ * Endpoints expostos:
+ *   GET  /personas/:id/expression-metrics
+ *   GET  /personas/:id/tactic-decision-distribution
+ *   GET  /personas/:id/expression-samples?limit=N
+ *
+ * Fonte: lê engine-trace-v2.json files de `tracesDir` (sessions index
+ * em SQLite aponta pra paths). Cada turn pode carregar `engineTrace`
+ * v2 (TV2 sub-fase) com seções:
+ *   - components.constrained_materializer
+ *   - components.speaker
+ *   - components.tactician
+ *   - llm_calls (catálogo flat cross-component)
+ *   - tactic_decision (S4 split — USE_SPLIT_DROTA=true)
+ *
+ * Quando `engineTrace` ausente em todos os turns (traces v1 antigos),
+ * endpoints retornam `developmentStub: true` com totals=0. Permite UI
+ * mostrar empty state coerente sem 404.
+ */
+
+import { readFile } from "node:fs/promises";
+import type { FastifyPluginAsync } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+export interface S4RoutesOptions {
+  db: DatabaseType;
+  /** Diretório raiz de traces. Quando omitido, endpoints retornam
+   *  developmentStub: true sem tentar ler disco. */
+  tracesDir?: string;
+}
+
+interface SessionRow {
+  session_id: string;
+  trace_path: string | null;
+  started_at: string;
+}
+
+interface RawLlmCall {
+  id?: string;
+  role?: string;
+  provider?: string;
+  model?: string;
+  duration_ms?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  prompt_cache_hit?: boolean;
+}
+
+interface RawMaterializer {
+  outputs?: { raw_response?: string; final_text?: string };
+  llm_call_ref?: string;
+  duration_ms?: number;
+}
+
+interface RawSpeaker {
+  outputs?: { raw_response?: string; final_text?: string };
+  retried_with_fallback?: boolean;
+  llm_call_ref?: string;
+  duration_ms?: number;
+  inputs?: { jogada?: string };
+}
+
+interface RawTactician {
+  outputs?: { jogada?: string; angle?: string; rationale?: string };
+  method?: "rule" | "llm" | "fallback";
+  duration_ms?: number;
+}
+
+interface RawTacticDecision {
+  jogada?: string;
+  angle?: string;
+  rationale?: string;
+  constraints?: {
+    register?: string;
+    max_length_chars?: number;
+  };
+}
+
+interface RawEngineTrace {
+  schema_version?: number;
+  components?: {
+    constrained_materializer?: RawMaterializer;
+    speaker?: RawSpeaker;
+    tactician?: RawTactician;
+  };
+  llm_calls?: RawLlmCall[];
+  tactic_decision?: RawTacticDecision;
+  /** Future-ready: emitido por guardrail quando aplica sanitize. */
+  sanitization_applied?: boolean;
+}
+
+interface RawTurn {
+  turnNumber?: number;
+  turn?: number;
+  sessionId?: string;
+  timestamp?: string;
+  finalResponse?: string;
+  botMessage?: string;
+  engineTrace?: RawEngineTrace;
+}
+
+interface RawTrace {
+  sessionId?: string;
+  persona?: string;
+  personaId?: string;
+  startedAt?: string;
+  turns?: RawTurn[];
+}
+
+export interface ExpressionMetrics {
+  personaId: string;
+  totalTurns: number;
+  cacheHitRate: number;
+  fallbackRate: number;
+  avgTokensIn: number;
+  avgTokensOut: number;
+  avgLatencyMs: number;
+  avgCostUsd: number;
+  sanitizationAppliedRate: number;
+  retriedWithFallbackRate: number;
+  byModel: Record<string, { calls: number; avgLatencyMs: number }>;
+  developmentStub: boolean;
+}
+
+export interface TacticDecisionDistribution {
+  personaId: string;
+  totalDecisions: number;
+  splitDrotaActive: boolean;
+  byJogada: Record<string, number>;
+  byRegister: Record<string, number>;
+  byMethod: Record<string, number>;
+  averages: {
+    angleCharsAvg: number;
+    maxLengthCharsAvg: number;
+  };
+  developmentStub: boolean;
+}
+
+export interface ExpressionSample {
+  turnRef: string;
+  generatedAt: string | null;
+  finalText: string;
+  model: string | null;
+  latencyMs: number | null;
+  tokensOut: number | null;
+  fallbackTriggered: boolean;
+  sanitizationApplied: boolean;
+  jogada: string | null;
+}
+
+export interface ExpressionSamplesResponse {
+  personaId: string;
+  samples: ExpressionSample[];
+  developmentStub: boolean;
+}
+
+// Pricing per 1M tokens em USD — usado pra estimar avgCostUsd quando
+// o trace traz tokens mas não cost. Conservador; modelos desconhecidos
+// caem em 0. Valores documentados pra refresh manual quando provider
+// publica nova grade.
+const PRICING_PER_1M_USD: Record<
+  string,
+  { input: number; output: number }
+> = {
+  "claude-haiku-4-5": { input: 1.0, output: 5.0 },
+  "claude-opus-4-7": { input: 15.0, output: 75.0 },
+  "claude-sonnet-4-6": { input: 3.0, output: 15.0 },
+  "qwen3-30b": { input: 0.0, output: 0.0 },
+};
+
+function pricingFor(model: string): { input: number; output: number } {
+  // Heuristic: provider-prefixed model ("anthropic:claude-haiku-4-5") → strip prefix.
+  const idx = model.indexOf(":");
+  const key = idx === -1 ? model : model.slice(idx + 1);
+  return PRICING_PER_1M_USD[key] ?? { input: 0, output: 0 };
+}
+
+function listSessionsForPersona(
+  db: DatabaseType,
+  personaId: string,
+): SessionRow[] {
+  return db
+    .prepare(
+      `SELECT session_id, trace_path, started_at
+       FROM sessions
+       WHERE persona_id = ? AND trace_path IS NOT NULL
+       ORDER BY started_at DESC`,
+    )
+    .all(personaId) as SessionRow[];
+}
+
+async function readTrace(tracePath: string): Promise<RawTrace | null> {
+  try {
+    const raw = await readFile(tracePath, "utf-8");
+    return JSON.parse(raw) as RawTrace;
+  } catch {
+    return null;
+  }
+}
+
+interface AggregateAccumulator {
+  totalTurns: number;
+  turnsWithEngineTrace: number;
+  cacheHits: number;
+  fallbacks: number;
+  retriedFallbacks: number;
+  sanitized: number;
+  tokensIn: number;
+  tokensOut: number;
+  latencyMsSum: number;
+  costUsdSum: number;
+  byModel: Map<string, { calls: number; latencyMsSum: number }>;
+}
+
+function emptyAccumulator(): AggregateAccumulator {
+  return {
+    totalTurns: 0,
+    turnsWithEngineTrace: 0,
+    cacheHits: 0,
+    fallbacks: 0,
+    retriedFallbacks: 0,
+    sanitized: 0,
+    tokensIn: 0,
+    tokensOut: 0,
+    latencyMsSum: 0,
+    costUsdSum: 0,
+    byModel: new Map(),
+  };
+}
+
+function accumulateTurn(
+  acc: AggregateAccumulator,
+  turn: RawTurn,
+): void {
+  const et = turn.engineTrace;
+  if (et === undefined) return;
+  acc.turnsWithEngineTrace += 1;
+
+  const calls = et.llm_calls ?? [];
+  // S4 only — restringe a llm_calls cuja role é materializer/speaker.
+  // Outras roles (assessor, planner, tactician) entram em outros panels.
+  const expressionCalls = calls.filter(
+    (c) =>
+      c.role === "constrained_materializer" ||
+      c.role === "speaker" ||
+      c.role === "materializer",
+  );
+
+  for (const call of expressionCalls) {
+    if (call.prompt_cache_hit === true) acc.cacheHits += 1;
+    acc.tokensIn += call.input_tokens ?? 0;
+    acc.tokensOut += call.output_tokens ?? 0;
+    acc.latencyMsSum += call.duration_ms ?? 0;
+    if (typeof call.model === "string" && call.model.length > 0) {
+      const pricing = pricingFor(call.model);
+      const cost =
+        ((call.input_tokens ?? 0) * pricing.input +
+          (call.output_tokens ?? 0) * pricing.output) /
+        1_000_000;
+      acc.costUsdSum += cost;
+      const existing = acc.byModel.get(call.model) ?? {
+        calls: 0,
+        latencyMsSum: 0,
+      };
+      existing.calls += 1;
+      existing.latencyMsSum += call.duration_ms ?? 0;
+      acc.byModel.set(call.model, existing);
+    }
+  }
+
+  const speaker = et.components?.speaker;
+  if (speaker?.retried_with_fallback === true) {
+    acc.retriedFallbacks += 1;
+    acc.fallbacks += 1;
+  }
+  if (et.sanitization_applied === true) acc.sanitized += 1;
+}
+
+function buildMetrics(
+  personaId: string,
+  acc: AggregateAccumulator,
+): ExpressionMetrics {
+  const totalTurns = acc.totalTurns;
+  const expressionCallCount = Array.from(acc.byModel.values()).reduce(
+    (sum, m) => sum + m.calls,
+    0,
+  );
+  const expressionDenom = expressionCallCount === 0 ? 1 : expressionCallCount;
+  const turnsDenom = totalTurns === 0 ? 1 : totalTurns;
+
+  const byModel: Record<string, { calls: number; avgLatencyMs: number }> = {};
+  for (const [model, data] of acc.byModel) {
+    byModel[model] = {
+      calls: data.calls,
+      avgLatencyMs: data.calls > 0 ? data.latencyMsSum / data.calls : 0,
+    };
+  }
+
+  return {
+    personaId,
+    totalTurns,
+    cacheHitRate:
+      expressionCallCount > 0 ? acc.cacheHits / expressionDenom : 0,
+    fallbackRate: totalTurns > 0 ? acc.fallbacks / turnsDenom : 0,
+    avgTokensIn:
+      expressionCallCount > 0 ? acc.tokensIn / expressionDenom : 0,
+    avgTokensOut:
+      expressionCallCount > 0 ? acc.tokensOut / expressionDenom : 0,
+    avgLatencyMs:
+      expressionCallCount > 0 ? acc.latencyMsSum / expressionDenom : 0,
+    avgCostUsd:
+      expressionCallCount > 0 ? acc.costUsdSum / expressionDenom : 0,
+    sanitizationAppliedRate:
+      totalTurns > 0 ? acc.sanitized / turnsDenom : 0,
+    retriedWithFallbackRate:
+      totalTurns > 0 ? acc.retriedFallbacks / turnsDenom : 0,
+    byModel,
+    developmentStub: acc.turnsWithEngineTrace === 0,
+  };
+}
+
+interface TacticAccumulator {
+  totalDecisions: number;
+  splitDrotaActive: boolean;
+  byJogada: Map<string, number>;
+  byRegister: Map<string, number>;
+  byMethod: Map<string, number>;
+  angleCharsSum: number;
+  angleCharsCount: number;
+  maxLengthSum: number;
+  maxLengthCount: number;
+}
+
+function emptyTacticAcc(): TacticAccumulator {
+  return {
+    totalDecisions: 0,
+    splitDrotaActive: false,
+    byJogada: new Map(),
+    byRegister: new Map(),
+    byMethod: new Map(),
+    angleCharsSum: 0,
+    angleCharsCount: 0,
+    maxLengthSum: 0,
+    maxLengthCount: 0,
+  };
+}
+
+function inc(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function accumulateTactic(acc: TacticAccumulator, turn: RawTurn): void {
+  const et = turn.engineTrace;
+  if (et === undefined) return;
+  const td = et.tactic_decision;
+  if (td === undefined) return;
+
+  acc.totalDecisions += 1;
+  acc.splitDrotaActive = true;
+
+  if (typeof td.jogada === "string" && td.jogada.length > 0) {
+    inc(acc.byJogada, td.jogada);
+  }
+  const reg = td.constraints?.register;
+  if (typeof reg === "string" && reg.length > 0) {
+    inc(acc.byRegister, reg);
+  }
+  const method = et.components?.tactician?.method;
+  if (typeof method === "string") {
+    inc(acc.byMethod, method);
+  }
+  if (typeof td.angle === "string") {
+    acc.angleCharsSum += td.angle.length;
+    acc.angleCharsCount += 1;
+  }
+  const ml = td.constraints?.max_length_chars;
+  if (typeof ml === "number" && Number.isFinite(ml)) {
+    acc.maxLengthSum += ml;
+    acc.maxLengthCount += 1;
+  }
+}
+
+function buildDistribution(
+  personaId: string,
+  acc: TacticAccumulator,
+): TacticDecisionDistribution {
+  const toObj = (m: Map<string, number>): Record<string, number> => {
+    const obj: Record<string, number> = {};
+    for (const [k, v] of m) obj[k] = v;
+    return obj;
+  };
+
+  return {
+    personaId,
+    totalDecisions: acc.totalDecisions,
+    splitDrotaActive: acc.splitDrotaActive,
+    byJogada: toObj(acc.byJogada),
+    byRegister: toObj(acc.byRegister),
+    byMethod: toObj(acc.byMethod),
+    averages: {
+      angleCharsAvg:
+        acc.angleCharsCount > 0
+          ? acc.angleCharsSum / acc.angleCharsCount
+          : 0,
+      maxLengthCharsAvg:
+        acc.maxLengthCount > 0
+          ? acc.maxLengthSum / acc.maxLengthCount
+          : 0,
+    },
+    developmentStub: !acc.splitDrotaActive,
+  };
+}
+
+function turnRef(sessionId: string, turn: RawTurn): string {
+  const n = turn.turnNumber ?? turn.turn ?? 0;
+  return `${sessionId}__turn_${n}`;
+}
+
+function findCallByRef(
+  calls: RawLlmCall[],
+  ref: string | undefined,
+): RawLlmCall | undefined {
+  if (ref === undefined) return undefined;
+  return calls.find((c) => c.id === ref);
+}
+
+function buildSample(
+  sessionId: string,
+  turn: RawTurn,
+  generatedAt: string | null,
+): ExpressionSample | null {
+  const finalText = turn.finalResponse ?? turn.botMessage ?? "";
+  if (finalText.length === 0) return null;
+
+  const et = turn.engineTrace;
+  const speaker = et?.components?.speaker;
+  const materializer = et?.components?.constrained_materializer;
+  const calls = et?.llm_calls ?? [];
+
+  // Prefer Speaker call (S4 split active); fallback to materializer call.
+  const ref = speaker?.llm_call_ref ?? materializer?.llm_call_ref;
+  const call = findCallByRef(calls, ref);
+
+  return {
+    turnRef: turnRef(sessionId, turn),
+    generatedAt: turn.timestamp ?? generatedAt,
+    finalText,
+    model: call?.model ?? null,
+    latencyMs: call?.duration_ms ?? speaker?.duration_ms ?? materializer?.duration_ms ?? null,
+    tokensOut: call?.output_tokens ?? null,
+    fallbackTriggered: speaker?.retried_with_fallback === true,
+    sanitizationApplied: et?.sanitization_applied === true,
+    jogada:
+      et?.tactic_decision?.jogada ??
+      speaker?.inputs?.jogada ??
+      null,
+  };
+}
+
+const s4Routes: FastifyPluginAsync<S4RoutesOptions> = async (fastify, opts) => {
+  const { db, tracesDir } = opts;
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/expression-metrics",
+    async (req) => {
+      const personaId = req.params.id;
+      if (tracesDir === undefined) {
+        return buildMetrics(personaId, emptyAccumulator());
+      }
+      const sessions = listSessionsForPersona(db, personaId);
+      const acc = emptyAccumulator();
+      for (const sess of sessions) {
+        if (sess.trace_path === null) continue;
+        const trace = await readTrace(sess.trace_path);
+        if (trace === null) continue;
+        const turns = trace.turns ?? [];
+        for (const t of turns) {
+          acc.totalTurns += 1;
+          accumulateTurn(acc, t);
+        }
+      }
+      return buildMetrics(personaId, acc);
+    },
+  );
+
+  fastify.get<{ Params: { id: string } }>(
+    "/personas/:id/tactic-decision-distribution",
+    async (req) => {
+      const personaId = req.params.id;
+      if (tracesDir === undefined) {
+        return buildDistribution(personaId, emptyTacticAcc());
+      }
+      const sessions = listSessionsForPersona(db, personaId);
+      const acc = emptyTacticAcc();
+      for (const sess of sessions) {
+        if (sess.trace_path === null) continue;
+        const trace = await readTrace(sess.trace_path);
+        if (trace === null) continue;
+        for (const t of trace.turns ?? []) {
+          accumulateTactic(acc, t);
+        }
+      }
+      return buildDistribution(personaId, acc);
+    },
+  );
+
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string };
+  }>("/personas/:id/expression-samples", async (req) => {
+    const personaId = req.params.id;
+    const rawLimit = req.query.limit;
+    let limit = 10;
+    if (rawLimit !== undefined) {
+      const n = Number.parseInt(rawLimit, 10);
+      if (Number.isFinite(n) && n > 0) limit = Math.min(n, 200);
+    }
+    if (tracesDir === undefined) {
+      const empty: ExpressionSamplesResponse = {
+        personaId,
+        samples: [],
+        developmentStub: true,
+      };
+      return empty;
+    }
+    const sessions = listSessionsForPersona(db, personaId);
+    const samples: ExpressionSample[] = [];
+    let sawEngineTrace = false;
+    for (const sess of sessions) {
+      if (sess.trace_path === null) continue;
+      const trace = await readTrace(sess.trace_path);
+      if (trace === null) continue;
+      const turns = (trace.turns ?? []).slice().reverse();
+      for (const t of turns) {
+        if (t.engineTrace !== undefined) sawEngineTrace = true;
+        const sample = buildSample(sess.session_id, t, sess.started_at);
+        if (sample !== null) {
+          samples.push(sample);
+          if (samples.length >= limit) break;
+        }
+      }
+      if (samples.length >= limit) break;
+    }
+    const result: ExpressionSamplesResponse = {
+      personaId,
+      samples,
+      developmentStub: !sawEngineTrace && samples.length === 0,
+    };
+    return result;
+  });
+};
+
+export default s4Routes;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -146,6 +146,12 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
   void fastify.register(async (instance) => (await import("./routes/s1-routes.js")).default(instance, { db: opts.db }));
   void fastify.register(async (instance) => (await import("./routes/s2-routes.js")).default(instance, { db: opts.db }));
   void fastify.register(async (instance) => (await import("./routes/s3-routes.js")).default(instance, opts.tracesDir !== undefined ? { tracesDir: opts.tracesDir } : {}));
+  void fastify.register(async (instance) =>
+    (await import("./routes/s4-routes.js")).default(instance, {
+      db: opts.db,
+      ...(opts.tracesDir !== undefined ? { tracesDir: opts.tracesDir } : {}),
+    }),
+  );
   void fastify.register(async (instance) => (await import("./routes/s5-routes.js")).default(instance, { db: opts.db }));
 
   // B1/B2 wiring — Camada Social + Drilling. Fastify enfileira o register

--- a/packages/ebrota-console-bff/tests/s4-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/s4-routes.unit.test.ts
@@ -1,0 +1,558 @@
+/**
+ * S4 routes unit tests — expression metrics + tactic distribution + samples.
+ *
+ * Setup: cria trace files temporários em disco com engineTrace v2 sintético,
+ * indexa via scanTraces, e exercita endpoints através do BFF Fastify.
+ *
+ * Cobertura:
+ *  - happy paths (metrics, distribution split=on/off, samples)
+ *  - empty (persona sem traces → developmentStub: true)
+ *  - calculations corretos (cache hit rate, fallback rate, byModel breakdown)
+ *  - tactic distribution split active vs inactive
+ *  - samples ordenadas DESC + limit + flags
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+import { scanTraces } from "../src/traces-scanner.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+
+let tmpRoot: string;
+let server: BffServer;
+let db: DatabaseType;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "s4-routes-test-"));
+  db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  server = createBffServer({
+    daemon,
+    db,
+    logger: false,
+    tracesDir: tmpRoot,
+  });
+});
+
+afterEach(async () => {
+  await server.close();
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const inject = async (url: string) => {
+  const res = await server.fastify.inject({ method: "GET", url });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as Record<string, unknown>) : null,
+  };
+};
+
+interface CallSpec {
+  id: string;
+  role: string;
+  model: string;
+  duration_ms: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  prompt_cache_hit?: boolean;
+}
+
+interface TurnSpec {
+  turnNumber: number;
+  timestamp?: string;
+  finalResponse: string;
+  llmCalls?: CallSpec[];
+  speakerRetried?: boolean;
+  sanitized?: boolean;
+  speakerCallRef?: string;
+  materializerCallRef?: string;
+  tacticDecision?: {
+    jogada: string;
+    angle?: string;
+    register?: string;
+    max_length_chars?: number;
+  };
+  tacticianMethod?: "rule" | "llm" | "fallback";
+}
+
+function writeTrace(
+  sessionId: string,
+  personaId: string,
+  startedAt: string,
+  turns: TurnSpec[],
+): string {
+  const sessionDir = join(tmpRoot, sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  const tracePath = join(sessionDir, "trace.json");
+
+  const builtTurns = turns.map((t) => {
+    const speakerRef = t.speakerCallRef;
+    const matRef = t.materializerCallRef;
+    const turn: Record<string, unknown> = {
+      turnNumber: t.turnNumber,
+      sessionId,
+      timestamp: t.timestamp ?? startedAt,
+      finalResponse: t.finalResponse,
+    };
+    if (
+      t.llmCalls !== undefined ||
+      t.speakerRetried !== undefined ||
+      t.sanitized !== undefined ||
+      t.tacticDecision !== undefined
+    ) {
+      const components: Record<string, unknown> = {};
+      if (speakerRef !== undefined || t.speakerRetried !== undefined) {
+        components["speaker"] = {
+          inputs: { jogada: t.tacticDecision?.jogada ?? "bridge" },
+          outputs: { raw_response: t.finalResponse, final_text: t.finalResponse },
+          retried_with_fallback: t.speakerRetried === true,
+          llm_call_ref: speakerRef ?? `${sessionId}-spk-${t.turnNumber}`,
+        };
+      }
+      if (matRef !== undefined) {
+        components["constrained_materializer"] = {
+          outputs: { raw_response: t.finalResponse, final_text: t.finalResponse },
+          llm_call_ref: matRef,
+        };
+      }
+      if (t.tacticianMethod !== undefined) {
+        components["tactician"] = {
+          method: t.tacticianMethod,
+          duration_ms: 50,
+        };
+      }
+      const et: Record<string, unknown> = {
+        schema_version: 2,
+        components,
+        llm_calls: t.llmCalls ?? [],
+      };
+      if (t.tacticDecision !== undefined) {
+        et["tactic_decision"] = {
+          jogada: t.tacticDecision.jogada,
+          angle: t.tacticDecision.angle ?? "vamos lá",
+          constraints: {
+            register: t.tacticDecision.register ?? "neutro",
+            max_length_chars: t.tacticDecision.max_length_chars ?? 280,
+          },
+        };
+      }
+      if (t.sanitized !== undefined) {
+        et["sanitization_applied"] = t.sanitized;
+      }
+      turn["engineTrace"] = et;
+    }
+    return turn;
+  });
+
+  const trace = {
+    sessionId,
+    persona: personaId,
+    startedAt,
+    endedAt: startedAt,
+    turns: builtTurns,
+  };
+  writeFileSync(tracePath, JSON.stringify(trace, null, 2), "utf-8");
+  return tracePath;
+}
+
+async function reindex(): Promise<void> {
+  await scanTraces({ tracesDir: tmpRoot, db });
+}
+
+describe("GET /personas/:id/expression-metrics", () => {
+  it("retorna developmentStub=true para persona sem nenhum trace", async () => {
+    await reindex();
+    const res = await inject("/personas/never-seen/expression-metrics");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      personaId: string;
+      totalTurns: number;
+      developmentStub: boolean;
+    };
+    expect(body.personaId).toBe("never-seen");
+    expect(body.totalTurns).toBe(0);
+    expect(body.developmentStub).toBe(true);
+  });
+
+  it("retorna developmentStub=true para persona com traces v1 (sem engineTrace)", async () => {
+    writeTrace("ryo__v1-1", "ryo", "2026-05-27T10:00:00.000Z", [
+      { turnNumber: 1, finalResponse: "Oi!" },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-metrics");
+    expect(res.status).toBe(200);
+    const body = res.body as { totalTurns: number; developmentStub: boolean };
+    expect(body.totalTurns).toBe(1);
+    expect(body.developmentStub).toBe(true);
+  });
+
+  it("calcula cacheHitRate corretamente (2 hits em 4 calls = 0.5)", async () => {
+    writeTrace("ryo__cache-1", "ryo", "2026-05-27T10:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "Resposta A",
+        llmCalls: [
+          {
+            id: "c1",
+            role: "speaker",
+            model: "claude-haiku-4-5",
+            duration_ms: 1500,
+            prompt_cache_hit: true,
+          },
+          {
+            id: "c2",
+            role: "speaker",
+            model: "claude-haiku-4-5",
+            duration_ms: 1700,
+            prompt_cache_hit: false,
+          },
+        ],
+        speakerCallRef: "c1",
+      },
+      {
+        turnNumber: 2,
+        finalResponse: "Resposta B",
+        llmCalls: [
+          {
+            id: "c3",
+            role: "speaker",
+            model: "claude-haiku-4-5",
+            duration_ms: 1400,
+            prompt_cache_hit: true,
+          },
+          {
+            id: "c4",
+            role: "speaker",
+            model: "claude-haiku-4-5",
+            duration_ms: 1600,
+            prompt_cache_hit: false,
+          },
+        ],
+        speakerCallRef: "c3",
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-metrics");
+    const body = res.body as { cacheHitRate: number; totalTurns: number };
+    expect(body.totalTurns).toBe(2);
+    expect(body.cacheHitRate).toBeCloseTo(0.5, 3);
+  });
+
+  it("calcula fallbackRate baseado em speaker.retried_with_fallback", async () => {
+    writeTrace("ryo__fb-1", "ryo", "2026-05-27T11:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "A",
+        speakerCallRef: "c1",
+        llmCalls: [
+          { id: "c1", role: "speaker", model: "claude-haiku-4-5", duration_ms: 100 },
+        ],
+        speakerRetried: true,
+      },
+      {
+        turnNumber: 2,
+        finalResponse: "B",
+        speakerCallRef: "c2",
+        llmCalls: [
+          { id: "c2", role: "speaker", model: "claude-haiku-4-5", duration_ms: 100 },
+        ],
+        speakerRetried: false,
+      },
+      {
+        turnNumber: 3,
+        finalResponse: "C",
+        speakerCallRef: "c3",
+        llmCalls: [
+          { id: "c3", role: "speaker", model: "claude-haiku-4-5", duration_ms: 100 },
+        ],
+        speakerRetried: false,
+      },
+      {
+        turnNumber: 4,
+        finalResponse: "D",
+        speakerCallRef: "c4",
+        llmCalls: [
+          { id: "c4", role: "speaker", model: "claude-haiku-4-5", duration_ms: 100 },
+        ],
+        speakerRetried: false,
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-metrics");
+    const body = res.body as {
+      fallbackRate: number;
+      retriedWithFallbackRate: number;
+    };
+    expect(body.fallbackRate).toBeCloseTo(0.25, 3);
+    expect(body.retriedWithFallbackRate).toBeCloseTo(0.25, 3);
+  });
+
+  it("calcula avgTokensIn/Out + avgLatencyMs corretos", async () => {
+    writeTrace("ryo__tok-1", "ryo", "2026-05-27T12:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "X",
+        speakerCallRef: "c1",
+        llmCalls: [
+          {
+            id: "c1",
+            role: "speaker",
+            model: "claude-haiku-4-5",
+            input_tokens: 1000,
+            output_tokens: 100,
+            duration_ms: 2000,
+          },
+        ],
+      },
+      {
+        turnNumber: 2,
+        finalResponse: "Y",
+        speakerCallRef: "c2",
+        llmCalls: [
+          {
+            id: "c2",
+            role: "speaker",
+            model: "claude-haiku-4-5",
+            input_tokens: 2000,
+            output_tokens: 200,
+            duration_ms: 3000,
+          },
+        ],
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-metrics");
+    const body = res.body as {
+      avgTokensIn: number;
+      avgTokensOut: number;
+      avgLatencyMs: number;
+    };
+    expect(body.avgTokensIn).toBeCloseTo(1500, 3);
+    expect(body.avgTokensOut).toBeCloseTo(150, 3);
+    expect(body.avgLatencyMs).toBeCloseTo(2500, 3);
+  });
+
+  it("byModel breakdown agrega calls + avgLatency por modelo", async () => {
+    writeTrace("ryo__model-1", "ryo", "2026-05-27T13:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "A",
+        speakerCallRef: "c1",
+        llmCalls: [
+          { id: "c1", role: "speaker", model: "claude-haiku-4-5", duration_ms: 1500 },
+        ],
+      },
+      {
+        turnNumber: 2,
+        finalResponse: "B",
+        speakerCallRef: "c2",
+        llmCalls: [
+          { id: "c2", role: "speaker", model: "local:qwen3-30b", duration_ms: 2400 },
+        ],
+      },
+      {
+        turnNumber: 3,
+        finalResponse: "C",
+        speakerCallRef: "c3",
+        llmCalls: [
+          { id: "c3", role: "speaker", model: "claude-haiku-4-5", duration_ms: 1700 },
+        ],
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-metrics");
+    const body = res.body as {
+      byModel: Record<string, { calls: number; avgLatencyMs: number }>;
+    };
+    expect(body.byModel["claude-haiku-4-5"]).toBeDefined();
+    expect(body.byModel["claude-haiku-4-5"]!.calls).toBe(2);
+    expect(body.byModel["claude-haiku-4-5"]!.avgLatencyMs).toBeCloseTo(1600, 3);
+    expect(body.byModel["local:qwen3-30b"]).toBeDefined();
+    expect(body.byModel["local:qwen3-30b"]!.calls).toBe(1);
+  });
+
+  it("ignora chamadas com role != materializer/speaker (planner, assessor)", async () => {
+    writeTrace("ryo__role-1", "ryo", "2026-05-27T14:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "X",
+        speakerCallRef: "c-spk",
+        llmCalls: [
+          { id: "c-spk", role: "speaker", model: "claude-haiku-4-5", duration_ms: 1500 },
+          { id: "c-asses", role: "unified_assessor", model: "claude-haiku-4-5", duration_ms: 800 },
+          { id: "c-plan", role: "planejador", model: "claude-opus-4-7", duration_ms: 5000 },
+        ],
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-metrics");
+    const body = res.body as {
+      byModel: Record<string, { calls: number }>;
+      avgLatencyMs: number;
+    };
+    // Apenas a chamada speaker conta.
+    expect(body.byModel["claude-haiku-4-5"]!.calls).toBe(1);
+    expect(body.byModel["claude-opus-4-7"]).toBeUndefined();
+    expect(body.avgLatencyMs).toBeCloseTo(1500, 3);
+  });
+});
+
+describe("GET /personas/:id/tactic-decision-distribution", () => {
+  it("retorna developmentStub=true + splitDrotaActive=false sem tactic_decision", async () => {
+    writeTrace("ryo__no-td-1", "ryo", "2026-05-27T15:00:00.000Z", [
+      { turnNumber: 1, finalResponse: "A" },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/tactic-decision-distribution");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      splitDrotaActive: boolean;
+      developmentStub: boolean;
+      totalDecisions: number;
+    };
+    expect(body.splitDrotaActive).toBe(false);
+    expect(body.developmentStub).toBe(true);
+    expect(body.totalDecisions).toBe(0);
+  });
+
+  it("retorna distribuição por jogada + register + method quando split ativo", async () => {
+    writeTrace("ryo__td-1", "ryo", "2026-05-27T16:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "A",
+        tacticDecision: { jogada: "bridge", register: "lúdico" },
+        tacticianMethod: "rule",
+      },
+      {
+        turnNumber: 2,
+        finalResponse: "B",
+        tacticDecision: { jogada: "espelho", register: "acolhedor" },
+        tacticianMethod: "llm",
+      },
+      {
+        turnNumber: 3,
+        finalResponse: "C",
+        tacticDecision: { jogada: "bridge", register: "lúdico" },
+        tacticianMethod: "rule",
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/tactic-decision-distribution");
+    const body = res.body as {
+      splitDrotaActive: boolean;
+      developmentStub: boolean;
+      totalDecisions: number;
+      byJogada: Record<string, number>;
+      byRegister: Record<string, number>;
+      byMethod: Record<string, number>;
+    };
+    expect(body.splitDrotaActive).toBe(true);
+    expect(body.developmentStub).toBe(false);
+    expect(body.totalDecisions).toBe(3);
+    expect(body.byJogada).toEqual({ bridge: 2, espelho: 1 });
+    expect(body.byRegister).toEqual({ "lúdico": 2, acolhedor: 1 });
+    expect(body.byMethod).toEqual({ rule: 2, llm: 1 });
+  });
+
+  it("calcula averages de angle e max_length_chars", async () => {
+    writeTrace("ryo__avg-1", "ryo", "2026-05-27T17:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "A",
+        tacticDecision: { jogada: "bridge", angle: "abcdefghij", max_length_chars: 200 },
+      },
+      {
+        turnNumber: 2,
+        finalResponse: "B",
+        tacticDecision: { jogada: "bridge", angle: "abcdefghijklmnopqrst", max_length_chars: 300 },
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/tactic-decision-distribution");
+    const body = res.body as {
+      averages: { angleCharsAvg: number; maxLengthCharsAvg: number };
+    };
+    expect(body.averages.angleCharsAvg).toBeCloseTo(15, 3);
+    expect(body.averages.maxLengthCharsAvg).toBeCloseTo(250, 3);
+  });
+});
+
+describe("GET /personas/:id/expression-samples", () => {
+  it("retorna developmentStub=true + samples=[] para persona sem traces", async () => {
+    await reindex();
+    const res = await inject("/personas/ghost/expression-samples");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      samples: unknown[];
+      developmentStub: boolean;
+    };
+    expect(body.samples).toEqual([]);
+    expect(body.developmentStub).toBe(true);
+  });
+
+  it("retorna samples em ordem DESC (mais recentes primeiro) + respeita limit", async () => {
+    writeTrace("ryo__samp-1", "ryo", "2026-05-27T18:00:00.000Z", [
+      { turnNumber: 1, timestamp: "2026-05-27T18:00:00Z", finalResponse: "T1" },
+      { turnNumber: 2, timestamp: "2026-05-27T18:01:00Z", finalResponse: "T2" },
+      { turnNumber: 3, timestamp: "2026-05-27T18:02:00Z", finalResponse: "T3" },
+      { turnNumber: 4, timestamp: "2026-05-27T18:03:00Z", finalResponse: "T4" },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-samples?limit=2");
+    const body = res.body as {
+      samples: Array<{ turnRef: string; finalText: string }>;
+    };
+    expect(body.samples.length).toBe(2);
+    expect(body.samples[0]!.finalText).toBe("T4");
+    expect(body.samples[1]!.finalText).toBe("T3");
+  });
+
+  it("inclui flags fallback + sanitize + jogada + model quando engineTrace presente", async () => {
+    writeTrace("ryo__rich-1", "ryo", "2026-05-27T19:00:00.000Z", [
+      {
+        turnNumber: 1,
+        finalResponse: "Resposta rica",
+        speakerCallRef: "call-1",
+        llmCalls: [
+          {
+            id: "call-1",
+            role: "speaker",
+            model: "claude-haiku-4-5",
+            duration_ms: 1234,
+            output_tokens: 22,
+          },
+        ],
+        speakerRetried: true,
+        sanitized: true,
+        tacticDecision: { jogada: "espelho" },
+      },
+    ]);
+    await reindex();
+    const res = await inject("/personas/ryo/expression-samples");
+    const body = res.body as {
+      samples: Array<{
+        finalText: string;
+        model: string | null;
+        latencyMs: number | null;
+        tokensOut: number | null;
+        fallbackTriggered: boolean;
+        sanitizationApplied: boolean;
+        jogada: string | null;
+        turnRef: string;
+      }>;
+    };
+    expect(body.samples.length).toBe(1);
+    const s = body.samples[0]!;
+    expect(s.finalText).toBe("Resposta rica");
+    expect(s.model).toBe("claude-haiku-4-5");
+    expect(s.latencyMs).toBe(1234);
+    expect(s.tokensOut).toBe(22);
+    expect(s.fallbackTriggered).toBe(true);
+    expect(s.sanitizationApplied).toBe(true);
+    expect(s.jogada).toBe("espelho");
+    expect(s.turnRef).toBe("ryo__rich-1__turn_1");
+  });
+});

--- a/packages/ebrota-console-ui/src/App.svelte
+++ b/packages/ebrota-console-ui/src/App.svelte
@@ -19,6 +19,8 @@
   import S1AprendizPanel from "./components/subsystem-panels/S1AprendizPanel.svelte";
   import S2DoutrinaPanel from "./components/subsystem-panels/S2DoutrinaPanel.svelte";
   import S3DecisaoPanel from "./components/subsystem-panels/S3DecisaoPanel.svelte";
+  import S3DecisaoTurnPanel from "./components/subsystem-panels/S3DecisaoTurnPanel.svelte";
+  import S4ExpressaoPanel from "./components/subsystem-panels/S4ExpressaoPanel.svelte";
   import S4ExpressaoTurnPanel from "./components/subsystem-panels/S4ExpressaoTurnPanel.svelte";
   import S5AvaliacaoPanel from "./components/subsystem-panels/S5AvaliacaoPanel.svelte";
   import B1SocialPanel from "./components/subsystem-panels/B1SocialPanel.svelte";
@@ -180,7 +182,7 @@
           {:else if $expandedSubsystem === "S3"}
             <S3DecisaoPanel {api} />
           {:else if $expandedSubsystem === "S4"}
-            <S4ExpressaoTurnPanel />
+            <S4ExpressaoPanel />
           {:else if $expandedSubsystem === "S5"}
             <S5AvaliacaoPanel />
           {:else if $expandedSubsystem === "B1"}

--- a/packages/ebrota-console-ui/src/components/subsystem-panels/S4ExpressaoPanel.svelte
+++ b/packages/ebrota-console-ui/src/components/subsystem-panels/S4ExpressaoPanel.svelte
@@ -1,0 +1,445 @@
+<script lang="ts">
+  /**
+   * S4 — Motor de Expressão (panel agregado por persona).
+   * Pergunta: "Como o motor está falando (custo, latência, qualidade)?"
+   *
+   * 3 blocos:
+   *   - Metrics card (cache hit, fallback, avg latency, avg cost, byModel)
+   *   - Tactic distribution (collapsible — só visível se split ativo)
+   *   - Recent samples (last N — table com final_text truncado + badges)
+   *
+   * Data source: BFF /personas/:id/expression-{metrics,samples} +
+   * /personas/:id/tactic-decision-distribution (engineTrace v2 agregado).
+   */
+  import { onMount } from "svelte";
+  import { tracerSubjectId } from "../../lib/stores.js";
+  import { createApiClient } from "../../lib/api.js";
+  import type {
+    ApiClient,
+    ExpressionMetricsLike,
+    TacticDecisionDistributionLike,
+    ExpressionSampleLike,
+  } from "../../lib/api.js";
+  import SubsystemPanelShell from "./SubsystemPanelShell.svelte";
+
+  /** Cliente injetável pra testes. Default = createApiClient(). */
+  export let api: ApiClient = createApiClient();
+
+  const COLOR = "#f97316";
+  const SAMPLE_LIMIT = 10;
+  const TRUNCATE_CHARS = 80;
+
+  let loading = true;
+  let error: string | null = null;
+  let metrics: ExpressionMetricsLike | null = null;
+  let distribution: TacticDecisionDistributionLike | null = null;
+  let samples: ExpressionSampleLike[] = [];
+  let samplesStub = false;
+  let distributionOpen = false;
+  let expandedSampleRef: string | null = null;
+
+  $: personaId = $tracerSubjectId;
+
+  async function loadAll(persona: string): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const [m, d, s] = await Promise.all([
+        api.getExpressionMetrics(persona),
+        api.getTacticDecisionDistribution(persona),
+        api.getExpressionSamples(persona, SAMPLE_LIMIT),
+      ]);
+      metrics = m;
+      distribution = d;
+      samples = s.samples;
+      samplesStub = s.developmentStub;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    void loadAll(personaId);
+  });
+
+  $: if (personaId) void loadAll(personaId);
+
+  function pct(rate: number): string {
+    return `${(rate * 100).toFixed(1)}%`;
+  }
+  function fmtMs(ms: number): string {
+    return `${Math.round(ms)}ms`;
+  }
+  function fmtCostPer1k(usd: number): string {
+    // avgCostUsd é per-call; multiplica por 1000 pra dar dimensão visível.
+    return `$${(usd * 1000).toFixed(3)}/1k`;
+  }
+  function fmtTokens(n: number): string {
+    return Math.round(n).toString();
+  }
+  function truncate(text: string): string {
+    if (text.length <= TRUNCATE_CHARS) return text;
+    return `${text.slice(0, TRUNCATE_CHARS)}…`;
+  }
+  function toggleSample(turnRef: string): void {
+    expandedSampleRef = expandedSampleRef === turnRef ? null : turnRef;
+  }
+</script>
+
+<SubsystemPanelShell id="S4" title="Motor de Expressão" color={COLOR}>
+  {#if loading}
+    <p class="empty" data-testid="s4-loading">Carregando métricas…</p>
+  {:else if error !== null}
+    <p class="error" data-testid="s4-error">Erro: {error}</p>
+  {:else}
+    <!-- Metrics card -->
+    <section class="block" data-testid="s4-metrics-block">
+      <h3>
+        Métricas de geração
+        {#if metrics?.developmentStub === true}
+          <span class="badge stub" title="Sem engineTrace v2 ainda — wiring pendente">
+            stub_v0
+          </span>
+        {/if}
+      </h3>
+      {#if metrics === null || metrics.totalTurns === 0}
+        <p class="muted">Sem turnos registrados pra esta persona.</p>
+      {:else}
+        <dl class="metrics-grid">
+          <div class="metric">
+            <dt>Total turns</dt>
+            <dd>{metrics.totalTurns}</dd>
+          </div>
+          <div class="metric">
+            <dt>Cache hit</dt>
+            <dd data-testid="s4-cache-hit">{pct(metrics.cacheHitRate)}</dd>
+          </div>
+          <div class="metric">
+            <dt>Fallback rate</dt>
+            <dd data-testid="s4-fallback-rate">{pct(metrics.fallbackRate)}</dd>
+          </div>
+          <div class="metric">
+            <dt>Avg latency</dt>
+            <dd data-testid="s4-avg-latency">{fmtMs(metrics.avgLatencyMs)}</dd>
+          </div>
+          <div class="metric">
+            <dt>Avg cost</dt>
+            <dd data-testid="s4-avg-cost">{fmtCostPer1k(metrics.avgCostUsd)}</dd>
+          </div>
+          <div class="metric">
+            <dt>Tokens in / out</dt>
+            <dd>
+              {fmtTokens(metrics.avgTokensIn)} / {fmtTokens(metrics.avgTokensOut)}
+            </dd>
+          </div>
+          <div class="metric">
+            <dt>Sanitize</dt>
+            <dd>{pct(metrics.sanitizationAppliedRate)}</dd>
+          </div>
+          <div class="metric">
+            <dt>Retried (fallback)</dt>
+            <dd>{pct(metrics.retriedWithFallbackRate)}</dd>
+          </div>
+        </dl>
+
+        {#if Object.keys(metrics.byModel).length > 0}
+          <div class="by-model" data-testid="s4-by-model">
+            <h4>Por modelo</h4>
+            <ul>
+              {#each Object.entries(metrics.byModel) as [model, data]}
+                <li>
+                  <code>{model}</code>
+                  — {data.calls} calls · avg {fmtMs(data.avgLatencyMs)}
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+      {/if}
+    </section>
+
+    <!-- Tactic distribution (collapsible) -->
+    {#if distribution !== null}
+      <section class="block" data-testid="s4-tactic-block">
+        <button
+          type="button"
+          class="collapse-btn"
+          on:click={() => (distributionOpen = !distributionOpen)}
+          data-testid="s4-tactic-toggle"
+        >
+          {distributionOpen ? "▼" : "▶"} Tactic distribution
+          {#if !distribution.splitDrotaActive}
+            <span class="badge stub">USE_SPLIT_DROTA=false</span>
+          {:else}
+            <span class="count">({distribution.totalDecisions} decisões)</span>
+          {/if}
+        </button>
+        {#if distributionOpen}
+          {#if !distribution.splitDrotaActive}
+            <p class="muted">
+              Split Drota inativo — Tactician não emite TacticDecision nos
+              traces atuais. Ative com env <code>USE_SPLIT_DROTA=true</code>
+              no orchestrator.
+            </p>
+          {:else}
+            <div class="dist-row">
+              <h4>Por jogada</h4>
+              <ul>
+                {#each Object.entries(distribution.byJogada) as [k, v]}
+                  <li><code>{k}</code> — {v}</li>
+                {/each}
+              </ul>
+            </div>
+            <div class="dist-row">
+              <h4>Por register</h4>
+              <ul>
+                {#each Object.entries(distribution.byRegister) as [k, v]}
+                  <li><code>{k}</code> — {v}</li>
+                {/each}
+              </ul>
+            </div>
+            <div class="dist-row">
+              <h4>Por method</h4>
+              <ul>
+                {#each Object.entries(distribution.byMethod) as [k, v]}
+                  <li><code>{k}</code> — {v}</li>
+                {/each}
+              </ul>
+            </div>
+            <div class="dist-row averages">
+              avg angle: {distribution.averages.angleCharsAvg.toFixed(0)} chars
+              · avg max_length: {distribution.averages.maxLengthCharsAvg.toFixed(0)} chars
+            </div>
+          {/if}
+        {/if}
+      </section>
+    {/if}
+
+    <!-- Recent samples -->
+    <section class="block" data-testid="s4-samples-block">
+      <h3>
+        Últimas amostras
+        {#if samplesStub}
+          <span class="badge stub">stub_v0</span>
+        {/if}
+      </h3>
+      {#if samples.length === 0}
+        <p class="muted">Sem amostras de fala ainda.</p>
+      {:else}
+        <table class="samples">
+          <thead>
+            <tr>
+              <th>turn_ref</th>
+              <th>final_text</th>
+              <th>model</th>
+              <th>latency</th>
+              <th>badges</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each samples as s (s.turnRef)}
+              <tr
+                class="sample-row"
+                class:expanded={expandedSampleRef === s.turnRef}
+                on:click={() => toggleSample(s.turnRef)}
+                data-testid="s4-sample-row"
+              >
+                <td class="ref"><code>{s.turnRef}</code></td>
+                <td class="text">
+                  {#if expandedSampleRef === s.turnRef}
+                    <span data-testid="s4-sample-full">{s.finalText}</span>
+                  {:else}
+                    {truncate(s.finalText)}
+                  {/if}
+                </td>
+                <td class="model">
+                  {#if s.model !== null}<code>{s.model}</code>{:else}—{/if}
+                </td>
+                <td>{s.latencyMs !== null ? fmtMs(s.latencyMs) : "—"}</td>
+                <td class="badges-cell">
+                  {#if s.jogada !== null}
+                    <span class="badge jogada">{s.jogada}</span>
+                  {/if}
+                  {#if s.fallbackTriggered}
+                    <span class="badge fallback" title="speaker retried_with_fallback">
+                      fallback
+                    </span>
+                  {/if}
+                  {#if s.sanitizationApplied}
+                    <span class="badge sanitize">sanitize</span>
+                  {/if}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+    </section>
+  {/if}
+</SubsystemPanelShell>
+
+<style>
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 1rem;
+  }
+  h3 {
+    margin: 0 0 0.3rem 0;
+    font-size: 0.95rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+    padding-bottom: 0.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  h4 {
+    margin: 0.4rem 0 0.2rem 0;
+    font-size: 0.82rem;
+    opacity: 0.8;
+  }
+  .empty,
+  .error,
+  .muted {
+    margin: 0;
+    font-size: 0.88rem;
+    opacity: 0.75;
+  }
+  .error {
+    color: #ef4444;
+  }
+  .metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
+    margin: 0;
+  }
+  .metric {
+    border: 1px solid rgba(127, 127, 127, 0.3);
+    border-left: 3px solid #f97316;
+    border-radius: 4px;
+    padding: 0.4rem 0.6rem;
+  }
+  .metric dt {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.65;
+    margin-bottom: 0.15rem;
+  }
+  .metric dd {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  .by-model {
+    margin-top: 0.4rem;
+  }
+  .by-model ul,
+  .dist-row ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    font-size: 0.82rem;
+  }
+  .collapse-btn {
+    align-self: flex-start;
+    background: transparent;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 4px;
+    padding: 0.3rem 0.6rem;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .dist-row {
+    padding: 0.3rem 0.4rem;
+    background: rgba(127, 127, 127, 0.08);
+    border-radius: 4px;
+  }
+  .dist-row.averages {
+    font-size: 0.82rem;
+    opacity: 0.85;
+  }
+  .count {
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+  .badge {
+    font-size: 0.7rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .badge.stub {
+    color: #d97706;
+    border-color: rgba(217, 119, 6, 0.5);
+  }
+  .badge.fallback {
+    color: #ef4444;
+    border-color: rgba(239, 68, 68, 0.5);
+  }
+  .badge.sanitize {
+    color: #6366f1;
+    border-color: rgba(99, 102, 241, 0.5);
+  }
+  .badge.jogada {
+    color: #10b981;
+    border-color: rgba(16, 185, 129, 0.5);
+  }
+  table.samples {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+  }
+  table.samples th {
+    text-align: left;
+    font-weight: 600;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+    padding: 0.3rem 0.4rem;
+    opacity: 0.7;
+  }
+  table.samples td {
+    padding: 0.3rem 0.4rem;
+    border-bottom: 1px solid rgba(127, 127, 127, 0.15);
+    vertical-align: top;
+  }
+  .sample-row {
+    cursor: pointer;
+  }
+  .sample-row:hover {
+    background: rgba(249, 115, 22, 0.08);
+  }
+  .sample-row.expanded {
+    background: rgba(249, 115, 22, 0.12);
+  }
+  td.text {
+    max-width: 380px;
+    word-break: break-word;
+  }
+  td.ref code,
+  td.model code {
+    font-size: 0.72rem;
+  }
+  .badges-cell {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+  code {
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.82em;
+    background: rgba(127, 127, 127, 0.18);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -541,6 +541,55 @@ export interface DecisionStatsLike {
   selectorEscalations: number;
 }
 
+// ─── S4 Motor de Expressão duck-types (metrics/distribution/samples) ──
+
+export interface ExpressionMetricsLike {
+  personaId: string;
+  totalTurns: number;
+  cacheHitRate: number;
+  fallbackRate: number;
+  avgTokensIn: number;
+  avgTokensOut: number;
+  avgLatencyMs: number;
+  avgCostUsd: number;
+  sanitizationAppliedRate: number;
+  retriedWithFallbackRate: number;
+  byModel: Record<string, { calls: number; avgLatencyMs: number }>;
+  developmentStub: boolean;
+}
+
+export interface TacticDecisionDistributionLike {
+  personaId: string;
+  totalDecisions: number;
+  splitDrotaActive: boolean;
+  byJogada: Record<string, number>;
+  byRegister: Record<string, number>;
+  byMethod: Record<string, number>;
+  averages: {
+    angleCharsAvg: number;
+    maxLengthCharsAvg: number;
+  };
+  developmentStub: boolean;
+}
+
+export interface ExpressionSampleLike {
+  turnRef: string;
+  generatedAt: string | null;
+  finalText: string;
+  model: string | null;
+  latencyMs: number | null;
+  tokensOut: number | null;
+  fallbackTriggered: boolean;
+  sanitizationApplied: boolean;
+  jogada: string | null;
+}
+
+export interface ExpressionSamplesResponseLike {
+  personaId: string;
+  samples: ExpressionSampleLike[];
+  developmentStub: boolean;
+}
+
 // ─── S5 Avaliação duck-types (guardrail/STS/longitudinal) ──────────
 
 export interface GuardrailCheckEntryLike {
@@ -817,6 +866,16 @@ export interface ApiClient {
   ): Promise<{ personaId: string; decisions: DecisionRowLike[] }>;
   getJogadaDistribution(personaId: string): Promise<JogadaDistributionLike>;
   getDecisionStats(personaId: string): Promise<DecisionStatsLike>;
+
+  // ─── S4 Motor de Expressão (metrics / tactic dist / samples) ──
+  getExpressionMetrics(personaId: string): Promise<ExpressionMetricsLike>;
+  getTacticDecisionDistribution(
+    personaId: string,
+  ): Promise<TacticDecisionDistributionLike>;
+  getExpressionSamples(
+    personaId: string,
+    limit?: number,
+  ): Promise<ExpressionSamplesResponseLike>;
 
   // ─── S5 Motor de Avaliação (guardrail / STS / longitudinal) ────
   getGuardrailHistory(
@@ -1456,6 +1515,22 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
     getDecisionStats: (personaId) =>
       get<DecisionStatsLike>(
         `/personas/${encodeURIComponent(personaId)}/decision-stats`,
+      ),
+
+    // ─── S4 Motor de Expressão ─────────────────────────────────────
+    getExpressionMetrics: (personaId) =>
+      get<ExpressionMetricsLike>(
+        `/personas/${encodeURIComponent(personaId)}/expression-metrics`,
+      ),
+    getTacticDecisionDistribution: (personaId) =>
+      get<TacticDecisionDistributionLike>(
+        `/personas/${encodeURIComponent(personaId)}/tactic-decision-distribution`,
+      ),
+    getExpressionSamples: (personaId, limit) =>
+      get<ExpressionSamplesResponseLike>(
+        `/personas/${encodeURIComponent(personaId)}/expression-samples${
+          typeof limit === "number" ? `?limit=${limit}` : ""
+        }`,
       ),
 
     // ─── S5 Motor de Avaliação ──────────────────────────────────────

--- a/packages/ebrota-console-ui/tests/s4-expressao-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/s4-expressao-panel.test.ts
@@ -1,0 +1,224 @@
+/**
+ * S4ExpressaoPanel — render com mock ApiClient.
+ *
+ * Cobre:
+ *  - loading state inicial
+ *  - render com métricas + distribution split inactive
+ *  - render com tactic distribution split active (expand on click)
+ *  - samples table com badges (fallback, sanitize, jogada) + truncate
+ *  - error state
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+  fireEvent,
+} from "@testing-library/svelte";
+import S4ExpressaoPanel from "../src/components/subsystem-panels/S4ExpressaoPanel.svelte";
+import { expandedSubsystem, tracerSubjectId } from "../src/lib/stores.js";
+import type {
+  ApiClient,
+  ExpressionMetricsLike,
+  TacticDecisionDistributionLike,
+  ExpressionSamplesResponseLike,
+} from "../src/lib/api.js";
+
+function buildApi(over: {
+  metrics?: ExpressionMetricsLike;
+  distribution?: TacticDecisionDistributionLike;
+  samples?: ExpressionSamplesResponseLike;
+  errorOn?: "metrics" | "distribution" | "samples";
+} = {}): ApiClient {
+  const defaultMetrics: ExpressionMetricsLike = {
+    personaId: "ryo-ochiai",
+    totalTurns: 87,
+    cacheHitRate: 0.71,
+    fallbackRate: 0.04,
+    avgTokensIn: 1240,
+    avgTokensOut: 145,
+    avgLatencyMs: 1820,
+    avgCostUsd: 0.0089,
+    sanitizationAppliedRate: 0.12,
+    retriedWithFallbackRate: 0.03,
+    byModel: {
+      "claude-haiku-4-5": { calls: 60, avgLatencyMs: 1500 },
+      "local:qwen3-30b": { calls: 27, avgLatencyMs: 2400 },
+    },
+    developmentStub: false,
+  };
+  const defaultDist: TacticDecisionDistributionLike = {
+    personaId: "ryo-ochiai",
+    totalDecisions: 0,
+    splitDrotaActive: false,
+    byJogada: {},
+    byRegister: {},
+    byMethod: {},
+    averages: { angleCharsAvg: 0, maxLengthCharsAvg: 0 },
+    developmentStub: true,
+  };
+  const defaultSamples: ExpressionSamplesResponseLike = {
+    personaId: "ryo-ochiai",
+    samples: [],
+    developmentStub: false,
+  };
+
+  const metricsFn = over.errorOn === "metrics"
+    ? vi.fn().mockRejectedValue(new Error("metrics fail"))
+    : vi.fn().mockResolvedValue(over.metrics ?? defaultMetrics);
+  const distFn = over.errorOn === "distribution"
+    ? vi.fn().mockRejectedValue(new Error("dist fail"))
+    : vi.fn().mockResolvedValue(over.distribution ?? defaultDist);
+  const sampFn = over.errorOn === "samples"
+    ? vi.fn().mockRejectedValue(new Error("samples fail"))
+    : vi.fn().mockResolvedValue(over.samples ?? defaultSamples);
+
+  return {
+    getExpressionMetrics: metricsFn,
+    getTacticDecisionDistribution: distFn,
+    getExpressionSamples: sampFn,
+  } as unknown as ApiClient;
+}
+
+beforeEach(() => {
+  expandedSubsystem.set("S4");
+  tracerSubjectId.set("ryo-ochiai");
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("S4ExpressaoPanel", () => {
+  it("mostra loading enquanto carrega", () => {
+    const api = buildApi();
+    render(S4ExpressaoPanel, { props: { api } });
+    expect(screen.getByTestId("s4-loading")).toBeDefined();
+  });
+
+  it("renderiza métricas + byModel quando dados completos", async () => {
+    const api = buildApi();
+    render(S4ExpressaoPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("s4-loading")).toBeNull();
+    });
+    expect(screen.getByTestId("s4-metrics-block")).toBeDefined();
+    expect(screen.getByTestId("s4-cache-hit").textContent).toContain("71.0%");
+    expect(screen.getByTestId("s4-fallback-rate").textContent).toContain("4.0%");
+    expect(screen.getByTestId("s4-avg-latency").textContent).toContain("1820ms");
+    expect(screen.getByTestId("s4-by-model")).toBeDefined();
+    expect(screen.getByText(/claude-haiku-4-5/)).toBeDefined();
+  });
+
+  it("mostra badge stub_v0 quando metrics.developmentStub=true", async () => {
+    const api = buildApi({
+      metrics: {
+        personaId: "ryo-ochiai",
+        totalTurns: 0,
+        cacheHitRate: 0,
+        fallbackRate: 0,
+        avgTokensIn: 0,
+        avgTokensOut: 0,
+        avgLatencyMs: 0,
+        avgCostUsd: 0,
+        sanitizationAppliedRate: 0,
+        retriedWithFallbackRate: 0,
+        byModel: {},
+        developmentStub: true,
+      },
+    });
+    render(S4ExpressaoPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("s4-loading")).toBeNull();
+    });
+    expect(screen.getByText("stub_v0")).toBeDefined();
+    expect(screen.getByText(/Sem turnos registrados/)).toBeDefined();
+  });
+
+  it("tactic distribution mostra badge USE_SPLIT_DROTA=false quando inactive", async () => {
+    const api = buildApi();
+    render(S4ExpressaoPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("s4-loading")).toBeNull();
+    });
+    expect(screen.getByText("USE_SPLIT_DROTA=false")).toBeDefined();
+  });
+
+  it("tactic distribution expande on click + lista byJogada quando split active", async () => {
+    const api = buildApi({
+      distribution: {
+        personaId: "ryo-ochiai",
+        totalDecisions: 10,
+        splitDrotaActive: true,
+        byJogada: { bridge: 6, espelho: 4 },
+        byRegister: { lúdico: 7, neutro: 3 },
+        byMethod: { rule: 8, llm: 2 },
+        averages: { angleCharsAvg: 30, maxLengthCharsAvg: 280 },
+        developmentStub: false,
+      },
+    });
+    render(S4ExpressaoPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("s4-loading")).toBeNull();
+    });
+    const toggle = screen.getByTestId("s4-tactic-toggle");
+    await fireEvent.click(toggle);
+    expect(screen.getByText("Por jogada")).toBeDefined();
+    // bridge + espelho aparecem (texto pode estar em <code> dentro de <li>);
+    // basta confirmar presença textual no DOM.
+    expect(screen.getAllByText("bridge").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("espelho").length).toBeGreaterThan(0);
+  });
+
+  it("samples table renderiza linhas com badges + truncate; click expande", async () => {
+    const longText = "a".repeat(150);
+    const api = buildApi({
+      samples: {
+        personaId: "ryo-ochiai",
+        samples: [
+          {
+            turnRef: "sess-1__turn_1",
+            generatedAt: "2026-05-27T10:00:00Z",
+            finalText: longText,
+            model: "claude-haiku-4-5",
+            latencyMs: 1500,
+            tokensOut: 12,
+            fallbackTriggered: true,
+            sanitizationApplied: false,
+            jogada: "bridge",
+          },
+        ],
+        developmentStub: false,
+      },
+    });
+    render(S4ExpressaoPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("s4-loading")).toBeNull();
+    });
+    const row = screen.getByTestId("s4-sample-row");
+    expect(row).toBeDefined();
+    // Texto truncado (não mostra full ainda).
+    expect(screen.queryByTestId("s4-sample-full")).toBeNull();
+    // "Fallback" também aparece como label de métrica; filtra pelo badge exato.
+    expect(
+      screen.getAllByText("fallback").some((el) => el.classList.contains("badge")),
+    ).toBe(true);
+    expect(
+      screen.getAllByText("bridge").some((el) => el.classList.contains("badge")),
+    ).toBe(true);
+    await fireEvent.click(row);
+    expect(screen.getByTestId("s4-sample-full").textContent).toBe(longText);
+  });
+
+  it("renderiza estado de erro quando metrics falha", async () => {
+    const api = buildApi({ errorOn: "metrics" });
+    render(S4ExpressaoPanel, { props: { api } });
+    await waitFor(() => {
+      expect(screen.queryByTestId("s4-loading")).toBeNull();
+    });
+    expect(screen.getByTestId("s4-error").textContent).toContain("metrics fail");
+  });
+});


### PR DESCRIPTION
## Summary

S4 (Motor de Expressão) panel agregado per-persona — 3 blocos:

1. **Metrics card** — cache hit %, fallback rate, avg latency, avg cost ($/1k turns), avg tokens in/out, sanitize %, retried %, + byModel breakdown
2. **Tactic distribution** (collapsible) — by jogada, register, method; só renderiza dados quando `USE_SPLIT_DROTA=true` produz `tactic_decision` nos traces
3. **Recent samples** — last N final responses + badges (fallback, sanitize, jogada) + click-to-expand para texto completo

## BFF

`packages/ebrota-console-bff/src/routes/s4-routes.ts` — 3 endpoints novos:

- `GET /personas/:id/expression-metrics`
- `GET /personas/:id/tactic-decision-distribution`
- `GET /personas/:id/expression-samples?limit=N`

Fonte: lê `trace.json` de `tracesDir` (sessions index em SQLite). Agrega seções de `turn.engineTrace` v2:

- `components.constrained_materializer` / `components.speaker` (latency, fallback flag)
- `llm_calls` filtrado por role=speaker|materializer (cache hit, tokens, cost via pricing map)
- `tactic_decision` (jogada/register/angle/max_length)
- `components.tactician.method` (rule/llm/fallback)

`developmentStub: true` quando engineTrace ausente em todos os turns (traces v1 antigos) — UI mostra empty state coerente sem 404.

## UI

- `S4ExpressaoPanel.svelte` novo (aggregate persona-level view)
- `App.svelte` swap `S4ExpressaoTurnPanel` → `S4ExpressaoPanel` (TurnPanel per-turn preservado como componente standalone, ainda referenciado em `subsystem-panels-render.test.ts`)
- `api.ts` — 3 métodos novos + 4 duck-types

## Tests

- `packages/ebrota-console-bff/tests/s4-routes.unit.test.ts` — **13 tests** (happy, empty, v1-only stub, cache hit calc, fallback calc, tokens/latency avgs, byModel breakdown, role filter, split active/inactive, averages, samples DESC + limit, badges)
- `packages/ebrota-console-ui/tests/s4-expressao-panel.test.ts` — **7 tests** (loading, métricas render, stub badge, split=false badge, split=on toggle+lista, samples table + click expand, error state)

Full suites: BFF 241/241 pass; UI 215/219 (4 pre-existing failures em `b2-drilling-panel.test.ts` não relacionadas a este PR — também falham em `origin/main`).

## Out of scope

- Trace writer integration (motor-execucao) que popule `engineTrace.tactic_decision` + `sanitization_applied` — feature já wirable; UI mostra developmentStub até que o writer entre
- Cost pricing refresh quando provider publicar nova grade (mapa hardcoded em `s4-routes.ts`)