### PR TITLE
[feat] STS launcher spawn real — subprocess + sts_runs persistence + polling (E5-L batch 5)

### DIFF
--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -171,6 +171,33 @@ CREATE TABLE IF NOT EXISTS strategy_plans (
 );
 CREATE INDEX IF NOT EXISTS idx_strategy_plans_subject
   ON strategy_plans(subject_id);
+
+-- STS run tracking (S5.b launcher real spawn — substitui stub do PR #258).
+-- Row criada em POST /sts/runs/start; status transita pending→running→
+-- succeeded/failed/cancelled conforme subprocess termina ou é killed.
+-- stdout_path/stderr_path apontam pra arquivos sob STS_LOG_DIR.
+CREATE TABLE IF NOT EXISTS sts_runs (
+  run_id TEXT PRIMARY KEY,
+  persona_id TEXT NOT NULL,
+  scenario_id TEXT NOT NULL,
+  turns_requested INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK (status IN (
+    'pending','running','succeeded','failed','cancelled'
+  )),
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  pid INTEGER,
+  exit_code INTEGER,
+  stdout_path TEXT,
+  stderr_path TEXT,
+  turns_completed INTEGER NOT NULL DEFAULT 0,
+  last_progress_at TEXT,
+  error_message TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sts_runs_started_at
+  ON sts_runs(started_at);
+CREATE INDEX IF NOT EXISTS idx_sts_runs_status
+  ON sts_runs(status);
 `;
 
 export interface InitDbOptions {

--- a/packages/ebrota-console-bff/src/routes/s5-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/s5-routes.ts
@@ -11,20 +11,34 @@
  *   GET  /personas/:id/kpi-longitudinal                (parcial stub_v0)
  *   GET  /sts/scenarios                                (lista hardcoded v0)
  *   GET  /sts/personas                                 (lista hardcoded v0)
- *   GET  /sts/runs?limit=N
- *   POST /sts/runs/start                               (stub_v0 — não spawna)
- *
- * Estratégia v0: leituras de `subject_knowledge` quando o writer já
- * persistiu (boundary_event / recall_check_attempt); empty data com
- * `source: "stub_v0"` quando feature backend não está pronta.
+ *   GET  /sts/runs?limit=N                             (sts_runs table)
+ *   GET  /sts/runs/:runId/status                       (status + tail logs)
+ *   POST /sts/runs/start                               (spawn real subprocess)
+ *   POST /sts/runs/:runId/cancel                       (SIGTERM)
  */
 
 import type { FastifyPluginAsync } from "fastify";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, openSync, closeSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 
 export interface S5RoutesOptions {
   db: DatabaseType;
+  /**
+   * Caller-injectable override pra testes. Em prod, segue
+   * STS_REPO_ROOT (env) || "/home/alexa/ascendimacy-motor".
+   */
+  stsRepoRoot?: string;
+  /** Diretório onde stdout/stderr logs ficam. Default: STS_LOG_DIR || $TMPDIR/sts-runs. */
+  stsLogDir?: string;
+  /**
+   * Whether to inherit current `process.env` plus `USE_MOCK_LLM=true`. Default true.
+   * Testes podem desligar.
+   */
+  defaultUseMockLlm?: boolean;
 }
 
 interface SkRow {
@@ -36,6 +50,23 @@ interface SkRow {
   turn_ref: string;
   session_id: string;
   created_at: string;
+}
+
+interface StsRunRow {
+  run_id: string;
+  persona_id: string;
+  scenario_id: string;
+  turns_requested: number;
+  status: "pending" | "running" | "succeeded" | "failed" | "cancelled";
+  started_at: string;
+  ended_at: string | null;
+  pid: number | null;
+  exit_code: number | null;
+  stdout_path: string | null;
+  stderr_path: string | null;
+  turns_completed: number;
+  last_progress_at: string | null;
+  error_message: string | null;
 }
 
 export interface GuardrailHistoryEntry {
@@ -122,6 +153,9 @@ export interface StsRunSummary {
   turn_count: number;
   score: string | null;
   trace_path: string | null;
+  status?: StsRunRow["status"];
+  turns_requested?: number;
+  turns_completed?: number;
 }
 
 export interface StsRunStartRequest {
@@ -132,12 +166,30 @@ export interface StsRunStartRequest {
 
 export interface StsRunStartResult {
   run_id: string;
-  status: "dispatched_stub_v0";
+  status: StsRunRow["status"];
   persona_id: string;
   scenario_id: string;
   turns: number;
   dispatched_at: string;
-  note: string;
+  pid: number | null;
+  note?: string;
+}
+
+export interface StsRunStatusResult {
+  run_id: string;
+  status: StsRunRow["status"];
+  persona_id: string;
+  scenario_id: string;
+  turns_requested: number;
+  turns_completed: number;
+  started_at: string;
+  ended_at: string | null;
+  pid: number | null;
+  exit_code: number | null;
+  error_message: string | null;
+  last_progress_at: string | null;
+  stdout_tail: string[];
+  stderr_tail: string[];
 }
 
 const STS_SCENARIOS: StsScenario[] = [
@@ -168,6 +220,13 @@ const STS_SCENARIOS: StsScenario[] = [
     description: "WhatsApp group session sintética Ryo+Kei+bot (joint mode).",
     recommended_turns: 9,
     duration_label: "T+~1d",
+  },
+  {
+    id: "fail-fast",
+    label: "fail-fast (test)",
+    description: "Scenario de teste que falha intencionalmente — usado em integration tests do BFF.",
+    recommended_turns: 4,
+    duration_label: "T+test",
   },
 ];
 
@@ -342,42 +401,283 @@ function computeKpiLongitudinal(db: DatabaseType, personaId: string): KpiLongitu
   };
 }
 
-function listStsRuns(
-  db: DatabaseType,
-  limit: number,
-): StsRunSummary[] {
+function rowToSummary(r: StsRunRow): StsRunSummary {
+  return {
+    run_id: r.run_id,
+    persona_id: r.persona_id,
+    scenario_id: r.scenario_id,
+    started_at: r.started_at,
+    ended_at: r.ended_at,
+    turn_count: r.turns_completed,
+    score: null,
+    trace_path: null,
+    status: r.status,
+    turns_requested: r.turns_requested,
+    turns_completed: r.turns_completed,
+  };
+}
+
+function listStsRuns(db: DatabaseType, limit: number): StsRunSummary[] {
   const rows = db
     .prepare(
-      `SELECT session_id, persona_id, conversation_id, started_at, ended_at,
-              turn_count, trace_path
-       FROM sessions
-       WHERE kind = 'sts'
+      `SELECT * FROM sts_runs
        ORDER BY started_at DESC
        LIMIT ?`,
     )
-    .all(limit) as Array<{
-      session_id: string;
-      persona_id: string;
-      conversation_id: string;
-      started_at: string;
-      ended_at: string | null;
-      turn_count: number;
-      trace_path: string | null;
-    }>;
-  return rows.map((r) => ({
-    run_id: r.session_id,
-    persona_id: r.persona_id,
-    scenario_id: r.conversation_id,
-    started_at: r.started_at,
-    ended_at: r.ended_at,
-    turn_count: r.turn_count,
-    score: null,
-    trace_path: r.trace_path,
-  }));
+    .all(limit) as StsRunRow[];
+  return rows.map(rowToSummary);
+}
+
+function getRunRow(db: DatabaseType, runId: string): StsRunRow | null {
+  const r = db
+    .prepare(`SELECT * FROM sts_runs WHERE run_id = ?`)
+    .get(runId) as StsRunRow | undefined;
+  return r ?? null;
+}
+
+function tailFile(path: string | null, maxLines = 100): string[] {
+  if (path === null || !existsSync(path)) return [];
+  try {
+    const stat = statSync(path);
+    if (stat.size === 0) return [];
+    // Read whole file when small; for v0 stub logs are short (<10KB).
+    const max = 256 * 1024;
+    const buf = readFileSync(path, "utf8");
+    const trimmed = buf.length > max ? buf.slice(buf.length - max) : buf;
+    const lines = trimmed.split(/\r?\n/).filter((l) => l.length > 0);
+    return lines.slice(-maxLines);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Tracks live child processes keyed by run_id so we can SIGTERM on cancel.
+ * Module-level: shared across requests within the same Fastify instance.
+ * Cleared on `exit`/`error`.
+ */
+type RunHandles = Map<string, ChildProcess>;
+
+function spawnStsRun(args: {
+  db: DatabaseType;
+  repoRoot: string;
+  logDir: string;
+  runHandles: RunHandles;
+  runId: string;
+  personaId: string;
+  scenarioId: string;
+  turnsRequested: number;
+  defaultUseMockLlm: boolean;
+  shutdownState: { closed: boolean };
+}): { pid: number | null; status: StsRunRow["status"] } {
+  const {
+    db,
+    repoRoot,
+    logDir,
+    runHandles,
+    runId,
+    personaId,
+    scenarioId,
+    turnsRequested,
+    defaultUseMockLlm,
+    shutdownState,
+  } = args;
+
+  if (!existsSync(logDir)) {
+    mkdirSync(logDir, { recursive: true });
+  }
+  const stdoutPath = join(logDir, `${runId}.stdout.log`);
+  const stderrPath = join(logDir, `${runId}.stderr.log`);
+  const stdoutFd = openSync(stdoutPath, "a");
+  const stderrFd = openSync(stderrPath, "a");
+
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (defaultUseMockLlm) {
+    env.USE_MOCK_LLM = "true";
+  }
+
+  const scriptPath = resolve(repoRoot, "scripts/run-sts.mjs");
+  let proc: ChildProcess;
+  try {
+    proc = spawn(
+      "node",
+      [
+        scriptPath,
+        "--persona",
+        personaId,
+        "--scenario",
+        scenarioId,
+        "--turns",
+        String(turnsRequested),
+        "--run-id",
+        runId,
+      ],
+      {
+        cwd: repoRoot,
+        env,
+        stdio: ["ignore", stdoutFd, stderrFd],
+        detached: false,
+      },
+    );
+  } catch (err) {
+    closeSync(stdoutFd);
+    closeSync(stderrFd);
+    db.prepare(
+      `UPDATE sts_runs
+       SET status='failed', ended_at=?, error_message=?
+       WHERE run_id = ?`,
+    ).run(
+      new Date().toISOString(),
+      err instanceof Error ? err.message : String(err),
+      runId,
+    );
+    return { pid: null, status: "failed" };
+  }
+
+  const pid = proc.pid ?? null;
+
+  db.prepare(
+    `UPDATE sts_runs
+     SET status='running', pid=?, stdout_path=?, stderr_path=?
+     WHERE run_id = ?`,
+  ).run(pid, stdoutPath, stderrPath, runId);
+
+  if (pid !== null) {
+    runHandles.set(runId, proc);
+  }
+
+  // Parse stdout to update turns_completed. spawn() with stdio targeting
+  // file descriptors disables piping into the parent, so we re-read the
+  // log file lightly on a small interval. For v0 stub this is sufficient.
+  const tickProgress = (): void => {
+    if (shutdownState.closed) return;
+    const lines = tailFile(stdoutPath, 200);
+    let completed = 0;
+    for (const l of lines) {
+      const m = l.match(/^turn (\d+)\/\d+/);
+      if (m && m[1] !== undefined) {
+        const n = Number.parseInt(m[1], 10);
+        if (!Number.isNaN(n) && n > completed) completed = n;
+      }
+    }
+    try {
+      db.prepare(
+        `UPDATE sts_runs
+         SET turns_completed=?, last_progress_at=?
+         WHERE run_id = ? AND status='running'`,
+      ).run(completed, new Date().toISOString(), runId);
+    } catch {
+      /* DB may be closed mid-shutdown */
+    }
+  };
+  const progressTimer: NodeJS.Timeout = setInterval(tickProgress, 500);
+  if (typeof progressTimer.unref === "function") progressTimer.unref();
+
+  proc.on("error", (err) => {
+    clearInterval(progressTimer);
+    runHandles.delete(runId);
+    try { closeSync(stdoutFd); } catch { /* ignore */ }
+    try { closeSync(stderrFd); } catch { /* ignore */ }
+    if (shutdownState.closed) return;
+    try {
+      const current = getRunRow(db, runId);
+      if (current === null || current.status === "running" || current.status === "pending") {
+        db.prepare(
+          `UPDATE sts_runs
+           SET status='failed', ended_at=?, error_message=?
+           WHERE run_id = ?`,
+        ).run(new Date().toISOString(), err.message, runId);
+      }
+    } catch {
+      /* DB closed */
+    }
+  });
+
+  proc.on("exit", (code, signal) => {
+    clearInterval(progressTimer);
+    runHandles.delete(runId);
+    try { closeSync(stdoutFd); } catch { /* ignore */ }
+    try { closeSync(stderrFd); } catch { /* ignore */ }
+    if (shutdownState.closed) return;
+    tickProgress();
+    try {
+      const current = getRunRow(db, runId);
+      // Don't override cancelled state set by /cancel endpoint.
+      if (current !== null && current.status === "cancelled") return;
+      const endedAt = new Date().toISOString();
+      if (signal === "SIGTERM" || signal === "SIGINT") {
+        db.prepare(
+          `UPDATE sts_runs
+           SET status='cancelled', ended_at=?, exit_code=?
+           WHERE run_id = ?`,
+        ).run(endedAt, code ?? null, runId);
+        return;
+      }
+      if (code === 0) {
+        db.prepare(
+          `UPDATE sts_runs
+           SET status='succeeded', ended_at=?, exit_code=0
+           WHERE run_id = ?`,
+        ).run(endedAt, runId);
+      } else {
+        const tail = tailFile(stderrPath, 5).join(" / ");
+        db.prepare(
+          `UPDATE sts_runs
+           SET status='failed', ended_at=?, exit_code=?, error_message=?
+           WHERE run_id = ?`,
+        ).run(endedAt, code ?? null, tail || `exit code ${code ?? "null"}`, runId);
+      }
+    } catch {
+      /* DB closed */
+    }
+  });
+
+  return { pid, status: "running" };
 }
 
 const s5Routes: FastifyPluginAsync<S5RoutesOptions> = async (fastify, opts) => {
   const { db } = opts;
+  const stsRepoRoot =
+    opts.stsRepoRoot ?? process.env.STS_REPO_ROOT ?? "/home/alexa/ascendimacy-motor";
+  const stsLogDir =
+    opts.stsLogDir ?? process.env.STS_LOG_DIR ?? join(tmpdir(), "sts-runs");
+  const defaultUseMockLlm = opts.defaultUseMockLlm ?? true;
+  const runHandles: RunHandles = new Map();
+  // Wired to onClose so post-shutdown subprocess exit handlers can no-op
+  // instead of crashing on a closed DB (issue surfaced em integration suite).
+  const shutdownState = { closed: false };
+
+  // Best-effort cleanup if Fastify shuts down mid-run.
+  fastify.addHook("onClose", async () => {
+    shutdownState.closed = true;
+    const procs = Array.from(runHandles.values());
+    for (const proc of procs) {
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+    }
+    // Wait briefly for processes to actually exit so their exit listeners
+    // fire BEFORE the DB closes downstream. 200ms é suficiente pro stub.
+    await Promise.all(
+      procs.map(
+        (p) =>
+          new Promise<void>((resolve) => {
+            if (p.exitCode !== null) {
+              resolve();
+              return;
+            }
+            const timer = setTimeout(() => resolve(), 200);
+            p.once("exit", () => {
+              clearTimeout(timer);
+              resolve();
+            });
+          }),
+      ),
+    );
+    runHandles.clear();
+  });
 
   fastify.get<{
     Params: { id: string };
@@ -436,8 +736,62 @@ const s5Routes: FastifyPluginAsync<S5RoutesOptions> = async (fastify, opts) => {
   fastify.get<{ Querystring: { limit?: string } }>(
     "/sts/runs",
     async (req) => {
-      const limit = req.query.limit ? Math.max(1, Number(req.query.limit)) : 20;
+      const limit = req.query.limit ? Math.max(1, Number(req.query.limit)) : 50;
       return { runs: listStsRuns(db, limit) };
+    },
+  );
+
+  fastify.get<{ Params: { runId: string } }>(
+    "/sts/runs/:runId/status",
+    async (req, reply) => {
+      const row = getRunRow(db, req.params.runId);
+      if (row === null) {
+        return reply.code(404).send({ error: "run_id desconhecido" });
+      }
+      const result: StsRunStatusResult = {
+        run_id: row.run_id,
+        status: row.status,
+        persona_id: row.persona_id,
+        scenario_id: row.scenario_id,
+        turns_requested: row.turns_requested,
+        turns_completed: row.turns_completed,
+        started_at: row.started_at,
+        ended_at: row.ended_at,
+        pid: row.pid,
+        exit_code: row.exit_code,
+        error_message: row.error_message,
+        last_progress_at: row.last_progress_at,
+        stdout_tail: tailFile(row.stdout_path, 100),
+        stderr_tail: tailFile(row.stderr_path, 100),
+      };
+      return result;
+    },
+  );
+
+  fastify.post<{ Params: { runId: string } }>(
+    "/sts/runs/:runId/cancel",
+    async (req, reply) => {
+      const row = getRunRow(db, req.params.runId);
+      if (row === null) {
+        return reply.code(404).send({ error: "run_id desconhecido" });
+      }
+      if (row.status !== "running" && row.status !== "pending") {
+        return { run_id: row.run_id, status: row.status, cancelled: false };
+      }
+      const proc = runHandles.get(row.run_id);
+      if (proc !== undefined && proc.pid !== undefined) {
+        try {
+          proc.kill("SIGTERM");
+        } catch {
+          /* process already exited */
+        }
+      }
+      db.prepare(
+        `UPDATE sts_runs
+         SET status='cancelled', ended_at=?
+         WHERE run_id = ?`,
+      ).run(new Date().toISOString(), row.run_id);
+      return { run_id: row.run_id, status: "cancelled", cancelled: true };
     },
   );
 
@@ -472,15 +826,36 @@ const s5Routes: FastifyPluginAsync<S5RoutesOptions> = async (fastify, opts) => {
           ? Math.floor(body.turns)
           : scenario.recommended_turns;
 
+      const runId = randomUUID();
+      const now = new Date().toISOString();
+
+      db.prepare(
+        `INSERT INTO sts_runs
+         (run_id, persona_id, scenario_id, turns_requested, status, started_at, turns_completed)
+         VALUES (?, ?, ?, ?, 'pending', ?, 0)`,
+      ).run(runId, body.persona_id, body.scenario_id, turns, now);
+
+      const { pid, status } = spawnStsRun({
+        db,
+        repoRoot: stsRepoRoot,
+        logDir: stsLogDir,
+        runHandles,
+        runId,
+        personaId: body.persona_id,
+        scenarioId: body.scenario_id,
+        turnsRequested: turns,
+        defaultUseMockLlm,
+        shutdownState,
+      });
+
       const result: StsRunStartResult = {
-        run_id: randomUUID(),
-        status: "dispatched_stub_v0",
+        run_id: runId,
+        status,
         persona_id: body.persona_id,
         scenario_id: body.scenario_id,
         turns,
-        dispatched_at: new Date().toISOString(),
-        note:
-          "v0 stub — STS spawn real ainda não wired. Rode `node scripts/sts-group-dyad.mjs` ou similar pra disparo manual; este endpoint apenas reserva run_id pra tracking futuro.",
+        dispatched_at: now,
+        pid,
       };
       return result;
     },

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -119,6 +119,18 @@ export interface CreateBffServerOptions {
    * o draft no SQLite mas não escreve YAML em disco.
    */
   fixturesDir?: string;
+  /**
+   * STS launcher (S5.b) — repositório raiz onde `scripts/run-sts.mjs` mora.
+   * Default `STS_REPO_ROOT` env || "/home/alexa/ascendimacy-motor".
+   * Tests pass own repo root pointing at a controlled stub.
+   */
+  stsRepoRoot?: string;
+  /** STS launcher (S5.b) — diretório de logs stdout/stderr. Default
+   *  `STS_LOG_DIR` env || `$TMPDIR/sts-runs`. */
+  stsLogDir?: string;
+  /** STS launcher (S5.b) — adiciona `USE_MOCK_LLM=true` ao env do
+   *  subprocess. Default true. */
+  stsDefaultUseMockLlm?: boolean;
 }
 
 export interface BffServer {
@@ -152,7 +164,16 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
       ...(opts.tracesDir !== undefined ? { tracesDir: opts.tracesDir } : {}),
     }),
   );
-  void fastify.register(async (instance) => (await import("./routes/s5-routes.js")).default(instance, { db: opts.db }));
+  void fastify.register(async (instance) =>
+    (await import("./routes/s5-routes.js")).default(instance, {
+      db: opts.db,
+      ...(opts.stsRepoRoot !== undefined ? { stsRepoRoot: opts.stsRepoRoot } : {}),
+      ...(opts.stsLogDir !== undefined ? { stsLogDir: opts.stsLogDir } : {}),
+      ...(opts.stsDefaultUseMockLlm !== undefined
+        ? { defaultUseMockLlm: opts.stsDefaultUseMockLlm }
+        : {}),
+    }),
+  );
 
   // B1/B2 wiring — Camada Social + Drilling. Fastify enfileira o register
   // até .listen()/.ready() resolverem; ok chamar síncrono dentro do factory.

--- a/packages/ebrota-console-bff/tests/s5-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/s5-routes.unit.test.ts
@@ -224,47 +224,20 @@ describe("GET /sts/personas", () => {
   });
 });
 
+// /sts/runs e /sts/runs/start agora bate na nova tabela `sts_runs` + spawn
+// real. Os contratos GET vazio / validation são cobertos aqui; spawn end-
+// to-end vive em `sts-spawn.integration.test.ts`.
+
 describe("GET /sts/runs", () => {
-  it("retorna apenas sessions kind='sts'", async () => {
-    insertSession("ryo__real", "ryo", "real", "2026-05-20T10:00:00Z");
-    insertSession("ryo__sts1", "ryo", "sts", "2026-05-22T10:00:00Z");
-    insertSession("paula__sts1", "paula-mendes", "sts", "2026-05-23T10:00:00Z");
+  it("retorna lista vazia quando sts_runs vazio", async () => {
     const res = await inject("/sts/runs");
-    const body = res.body as { runs: Array<{ run_id: string; persona_id: string }> };
-    expect(body.runs.length).toBe(2);
-    expect(body.runs.every((r) => r.run_id.includes("sts"))).toBe(true);
+    expect(res.status).toBe(200);
+    const body = res.body as { runs: unknown[] };
+    expect(body.runs).toEqual([]);
   });
 });
 
-describe("POST /sts/runs/start", () => {
-  it("retorna run_id + status=dispatched_stub_v0", async () => {
-    const res = await inject("/sts/runs/start", "POST", {
-      persona_id: "ryo-ochiai",
-      scenario_id: "smoke-3d",
-    });
-    expect(res.status).toBe(200);
-    const body = res.body as {
-      run_id: string;
-      status: string;
-      turns: number;
-      note: string;
-    };
-    expect(body.run_id.length).toBeGreaterThan(0);
-    expect(body.status).toBe("dispatched_stub_v0");
-    expect(body.turns).toBe(6); // smoke-3d recommended
-    expect(body.note).toContain("v0 stub");
-  });
-
-  it("usa turns custom quando fornecido", async () => {
-    const res = await inject("/sts/runs/start", "POST", {
-      persona_id: "paula-mendes",
-      scenario_id: "realista",
-      turns: 12,
-    });
-    const body = res.body as { turns: number };
-    expect(body.turns).toBe(12);
-  });
-
+describe("POST /sts/runs/start (validation)", () => {
   it("400 quando persona_id desconhecida", async () => {
     const res = await inject("/sts/runs/start", "POST", {
       persona_id: "fulano-inexistente",

--- a/packages/ebrota-console-bff/tests/sts-spawn.integration.test.ts
+++ b/packages/ebrota-console-bff/tests/sts-spawn.integration.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration tests for S5 STS launcher spawn (real subprocess).
+ *
+ * Spawns `scripts/run-sts.mjs` via the BFF `/sts/runs/start` endpoint, then
+ * polls `/sts/runs/:id/status` until terminal. Uses `--turns=2` and tiny
+ * tick interval so each test completes in <10s.
+ *
+ * Repo root is computed at runtime — points at the actual monorepo so the
+ * stub script (committed under `scripts/run-sts.mjs`) is resolvable.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// tests/ live in packages/ebrota-console-bff/tests → repo root 3 levels up.
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+let server: BffServer;
+let db: DatabaseType;
+let logDir: string;
+
+beforeAll(() => {
+  // sanity: stub script must exist
+  expect(existsSync(join(REPO_ROOT, "scripts", "run-sts.mjs"))).toBe(true);
+});
+
+beforeEach(() => {
+  db = initDb({ dbPath: ":memory:" });
+  logDir = mkdtempSync(join(tmpdir(), "sts-spawn-test-"));
+  const daemon = createMockDaemonClient();
+  // STS_STUB_TICK_MS speeds up the stub so each turn elapses ~80ms.
+  process.env.STS_STUB_TICK_MS = "80";
+  server = createBffServer({
+    daemon,
+    db,
+    logger: false,
+    stsRepoRoot: REPO_ROOT,
+    stsLogDir: logDir,
+    stsDefaultUseMockLlm: true,
+  });
+});
+
+afterEach(async () => {
+  // Kill any lingering child processes via Fastify onClose hook.
+  await server.close();
+  delete process.env.STS_STUB_TICK_MS;
+});
+
+const inject = async (
+  url: string,
+  method: "GET" | "POST" = "GET",
+  body?: unknown,
+) => {
+  const res = await server.fastify.inject({
+    method,
+    url,
+    ...(body !== undefined ? { payload: body } : {}),
+  });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as unknown) : null,
+  };
+};
+
+async function pollUntilTerminal(
+  runId: string,
+  timeoutMs = 8000,
+): Promise<{
+  status: string;
+  exit_code: number | null;
+  turns_completed: number;
+  error_message: string | null;
+  stdout_tail: string[];
+  stderr_tail: string[];
+}> {
+  const startedAt = Date.now();
+  let last: {
+    status: string;
+    exit_code: number | null;
+    turns_completed: number;
+    error_message: string | null;
+    stdout_tail: string[];
+    stderr_tail: string[];
+  } | null = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    const res = await inject(`/sts/runs/${runId}/status`);
+    last = res.body as typeof last;
+    if (
+      last !== null &&
+      (last.status === "succeeded" ||
+        last.status === "failed" ||
+        last.status === "cancelled")
+    ) {
+      return last;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(
+    `pollUntilTerminal timed out after ${timeoutMs}ms; last=${JSON.stringify(last)}`,
+  );
+}
+
+describe("STS spawn — DDL", () => {
+  it("DDL é idempotente (init duas vezes não joga)", () => {
+    // Second init on the same in-memory DB is impossible because each
+    // call creates a new instance; instead re-run schema directly.
+    expect(() => initDb({ dbPath: ":memory:" })).not.toThrow();
+    expect(() => initDb({ dbPath: ":memory:" })).not.toThrow();
+  });
+
+  it("sts_runs table existe após init", () => {
+    const row = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='sts_runs'`,
+      )
+      .get() as { name: string } | undefined;
+    expect(row?.name).toBe("sts_runs");
+  });
+});
+
+describe("POST /sts/runs/start (spawn real)", () => {
+  it("cria row em sts_runs + spawna processo + retorna runId/pid/status", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+      turns: 2,
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      run_id: string;
+      status: string;
+      pid: number | null;
+      turns: number;
+    };
+    expect(body.run_id.length).toBeGreaterThan(0);
+    expect(body.status).toBe("running");
+    expect(body.pid).not.toBeNull();
+    expect(body.turns).toBe(2);
+
+    const row = db
+      .prepare(`SELECT * FROM sts_runs WHERE run_id = ?`)
+      .get(body.run_id) as {
+        status: string;
+        pid: number | null;
+        turns_requested: number;
+      };
+    expect(row.status).toBe("running");
+    expect(row.pid).toBe(body.pid);
+    expect(row.turns_requested).toBe(2);
+
+    // Let the process finish so afterEach doesn't leak.
+    await pollUntilTerminal(body.run_id);
+  });
+});
+
+describe("status transitions pending → running → succeeded", () => {
+  it("smoke-3d com turns=2 termina com status=succeeded + exit_code=0", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+      turns: 2,
+    });
+    const { run_id } = res.body as { run_id: string };
+    const terminal = await pollUntilTerminal(run_id);
+    expect(terminal.status).toBe("succeeded");
+    expect(terminal.exit_code).toBe(0);
+    expect(terminal.turns_completed).toBe(2);
+    const stdoutJoined = terminal.stdout_tail.join("\n");
+    expect(stdoutJoined).toContain("STS RUN STARTED");
+    expect(stdoutJoined).toContain("STS RUN COMPLETED");
+  });
+});
+
+describe("POST /sts/runs/:id/cancel via SIGTERM", () => {
+  it("cancela run em andamento → status=cancelled", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      // Many turns so we have time to cancel before completion.
+      scenario_id: "nagareyama-30d",
+      turns: 50,
+    });
+    const { run_id } = res.body as { run_id: string };
+
+    // Give the child a moment to actually start before we cancel.
+    await new Promise((r) => setTimeout(r, 150));
+
+    const cancelRes = await inject(`/sts/runs/${run_id}/cancel`, "POST");
+    expect(cancelRes.status).toBe(200);
+    const cancelBody = cancelRes.body as { status: string; cancelled: boolean };
+    expect(cancelBody.status).toBe("cancelled");
+    expect(cancelBody.cancelled).toBe(true);
+
+    // Status endpoint should report cancelled persistently.
+    const statusRes = await inject(`/sts/runs/${run_id}/status`);
+    const statusBody = statusRes.body as { status: string };
+    expect(statusBody.status).toBe("cancelled");
+  });
+});
+
+describe("failure path (scenario=fail-fast)", () => {
+  it("captura exit code != 0 + error_message + status=failed", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "fail-fast",
+      turns: 5,
+    });
+    const { run_id } = res.body as { run_id: string };
+    const terminal = await pollUntilTerminal(run_id);
+    expect(terminal.status).toBe("failed");
+    expect(terminal.exit_code).toBe(1);
+    expect(terminal.error_message).not.toBeNull();
+    // stderr should include the FAIL marker emitted by stub.
+    const stderrJoined = terminal.stderr_tail.join("\n");
+    expect(stderrJoined).toContain("STS RUN FAILED");
+  });
+});
+
+describe("GET /sts/runs lista ordenada", () => {
+  it("retorna runs em ordem started_at DESC", async () => {
+    // Spawn 3 quick runs.
+    const a = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+      turns: 2,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const b = await inject("/sts/runs/start", "POST", {
+      persona_id: "paula-mendes",
+      scenario_id: "smoke-3d",
+      turns: 2,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const c = await inject("/sts/runs/start", "POST", {
+      persona_id: "kei-ochiai",
+      scenario_id: "smoke-3d",
+      turns: 2,
+    });
+
+    const list = await inject("/sts/runs?limit=10");
+    const body = list.body as {
+      runs: Array<{ run_id: string; started_at: string }>;
+    };
+    expect(body.runs.length).toBe(3);
+    // Most recent first.
+    expect(body.runs[0]?.run_id).toBe((c.body as { run_id: string }).run_id);
+    expect(body.runs[2]?.run_id).toBe((a.body as { run_id: string }).run_id);
+
+    // Drain processes.
+    await Promise.all([
+      pollUntilTerminal((a.body as { run_id: string }).run_id),
+      pollUntilTerminal((b.body as { run_id: string }).run_id),
+      pollUntilTerminal((c.body as { run_id: string }).run_id),
+    ]);
+  });
+});
+
+describe("GET /sts/runs/:id/status edge cases", () => {
+  it("404 quando run_id desconhecido", async () => {
+    const res = await inject("/sts/runs/nope-nope-nope/status");
+    expect(res.status).toBe(404);
+  });
+
+  it("status retorna stdout_tail/stderr_tail após terminal", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+      turns: 2,
+    });
+    const { run_id } = res.body as { run_id: string };
+    const terminal = await pollUntilTerminal(run_id);
+    expect(Array.isArray(terminal.stdout_tail)).toBe(true);
+    expect(terminal.stdout_tail.length).toBeGreaterThan(0);
+  });
+});
+
+describe("POST /sts/runs/:id/cancel edge cases", () => {
+  it("404 quando run_id desconhecido", async () => {
+    const res = await inject("/sts/runs/inexistente/cancel", "POST");
+    expect(res.status).toBe(404);
+  });
+
+  it("idempotente: cancel em run já terminal retorna cancelled=false", async () => {
+    const res = await inject("/sts/runs/start", "POST", {
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+      turns: 2,
+    });
+    const { run_id } = res.body as { run_id: string };
+    await pollUntilTerminal(run_id);
+    const cancelRes = await inject(`/sts/runs/${run_id}/cancel`, "POST");
+    expect(cancelRes.status).toBe(200);
+    const body = cancelRes.body as { cancelled: boolean; status: string };
+    expect(body.cancelled).toBe(false);
+    expect(body.status).toBe("succeeded");
+  });
+});

--- a/packages/ebrota-console-ui/src/components/sts/STSLauncherModal.svelte
+++ b/packages/ebrota-console-ui/src/components/sts/STSLauncherModal.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   /**
-   * STSLauncherModal — wizard mínimo pra disparar uma run STS.
+   * STSLauncherModal — wizard pra disparar uma run STS.
    *
-   * v0 dispatch é stub (POST /sts/runs/start retorna run_id reservado,
-   * spawn real ainda não wired — ver `s5-routes.ts`). Mesmo assim a UI
-   * exibe progress + virtual clock pra validar a forma do contrato.
+   * Backend (s5-routes.ts) faz spawn real de scripts/run-sts.mjs.
+   * UI poll-a `GET /sts/runs/:id/status` a cada 2s até status terminal
+   * (succeeded/failed/cancelled). Botão "cancelar" envia SIGTERM.
    *
    * Spec: US-S5b-02 (console-ebrota-user-stories-v0.md).
    */
@@ -14,14 +14,25 @@
     StsPersonaLike,
     StsScenarioLike,
     StsRunStartResultLike,
+    StsRunStatusResultLike,
+    StsRunStatus,
   } from "../../lib/api.js";
 
   export let api: ApiClient;
   export let open: boolean = false;
+  /** Polling interval em ms — exposto pra testes. */
+  export let pollMs: number = 2000;
 
   const dispatch = createEventDispatcher<{ close: void; started: StsRunStartResultLike }>();
 
-  type FormState = "idle" | "loading" | "ready" | "submitting" | "running" | "error";
+  type FormState =
+    | "idle"
+    | "loading"
+    | "ready"
+    | "submitting"
+    | "running"
+    | "finished"
+    | "error";
   let formState: FormState = "idle";
   let personas: StsPersonaLike[] = [];
   let scenarios: StsScenarioLike[] = [];
@@ -32,36 +43,52 @@
   let turns = 6;
 
   let lastResult: StsRunStartResultLike | null = null;
-  let virtualClockTickMs = 1500;
-  let virtualClockTimer: ReturnType<typeof setInterval> | null = null;
-  let virtualClockProgress = 0;
+  let lastStatus: StsRunStatusResultLike | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
 
   $: selectedScenario = scenarios.find((s) => s.id === scenarioId) ?? null;
   $: if (selectedScenario && formState === "ready") {
     turns = selectedScenario.recommended_turns;
   }
 
+  $: runStatus = (lastStatus?.status ?? lastResult?.status ?? "pending") as StsRunStatus;
+  $: turnsCompleted = lastStatus?.turns_completed ?? 0;
+
   function close(): void {
-    stopVirtualClock();
+    stopPolling();
     dispatch("close");
   }
 
-  function stopVirtualClock(): void {
-    if (virtualClockTimer !== null) {
-      clearInterval(virtualClockTimer);
-      virtualClockTimer = null;
+  function stopPolling(): void {
+    if (pollTimer !== null) {
+      clearInterval(pollTimer);
+      pollTimer = null;
     }
   }
 
-  function startVirtualClock(): void {
-    stopVirtualClock();
-    virtualClockProgress = 0;
-    virtualClockTimer = setInterval(() => {
-      virtualClockProgress = Math.min(virtualClockProgress + 1, turns);
-      if (virtualClockProgress >= turns) {
-        stopVirtualClock();
+  async function pollOnce(): Promise<void> {
+    if (lastResult === null) return;
+    try {
+      const status = await api.getStsRunStatus(lastResult.run_id);
+      lastStatus = status;
+      if (
+        status.status === "succeeded" ||
+        status.status === "failed" ||
+        status.status === "cancelled"
+      ) {
+        formState = "finished";
+        stopPolling();
       }
-    }, virtualClockTickMs);
+    } catch (err) {
+      errMsg = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function startPolling(): void {
+    stopPolling();
+    // Primeiro poll imediato + intervalo
+    void pollOnce();
+    pollTimer = setInterval(() => void pollOnce(), pollMs);
   }
 
   async function loadOptions(): Promise<void> {
@@ -87,6 +114,7 @@
     if (personaId === "" || scenarioId === "") return;
     formState = "submitting";
     errMsg = "";
+    lastStatus = null;
     try {
       lastResult = await api.startStsRun({
         persona_id: personaId,
@@ -94,7 +122,7 @@
         turns,
       });
       formState = "running";
-      startVirtualClock();
+      startPolling();
       dispatch("started", lastResult);
     } catch (err) {
       errMsg = err instanceof Error ? err.message : String(err);
@@ -102,10 +130,25 @@
     }
   }
 
+  async function cancelRun(): Promise<void> {
+    if (lastResult === null) return;
+    try {
+      const res = await api.cancelStsRun(lastResult.run_id);
+      // Force a status refresh so tail/exit info loads.
+      void pollOnce();
+      if (res.cancelled) {
+        formState = "finished";
+        stopPolling();
+      }
+    } catch (err) {
+      errMsg = err instanceof Error ? err.message : String(err);
+    }
+  }
+
   function reset(): void {
-    stopVirtualClock();
+    stopPolling();
     lastResult = null;
-    virtualClockProgress = 0;
+    lastStatus = null;
     formState = "ready";
   }
 
@@ -116,19 +159,26 @@
   }
 
   $: if (!open) {
-    stopVirtualClock();
+    stopPolling();
   }
 
-  onDestroy(() => stopVirtualClock());
+  onDestroy(() => stopPolling());
 
-  function formatVirtualClock(progress: number, total: number, label: string): string {
-    if (total <= 0) return label;
-    const frac = progress / total;
-    const days = Math.round(frac * 30);
-    if (label.includes("3d")) {
-      return `T+${Math.min(Math.round(frac * 3), 3)}d ${Math.round((frac * 72) % 24)}h`;
+  function statusLabel(s: StsRunStatus): string {
+    switch (s) {
+      case "pending":
+        return "⏳ pending";
+      case "running":
+        return "▶ running";
+      case "succeeded":
+        return "✓ succeeded";
+      case "failed":
+        return "✗ failed";
+      case "cancelled":
+        return "⊘ cancelled";
+      default:
+        return s;
     }
-    return `T+${Math.min(days, 30)}d`;
   }
 </script>
 
@@ -170,31 +220,66 @@
         <button type="button" class="action" on:click={loadOptions}>
           tentar de novo
         </button>
-      {:else if formState === "running" && lastResult !== null}
-        <div class="running-block" data-testid="sts-launcher-running">
+      {:else if (formState === "running" || formState === "finished") && lastResult !== null}
+        <div
+          class="running-block"
+          data-testid={formState === "running" ? "sts-launcher-running" : "sts-launcher-finished"}
+        >
           <p>
-            <strong>Run em andamento</strong>
+            <strong>{statusLabel(runStatus)}</strong>
             — run_id <code>{lastResult.run_id.slice(0, 8)}…</code>
+            {#if lastResult.pid !== null && lastResult.pid !== undefined}
+              <span class="muted small">pid {lastResult.pid}</span>
+            {/if}
           </p>
-          <p class="muted small">{lastResult.note}</p>
           <div class="virtual-clock" data-testid="sts-launcher-clock">
-            <span class="vc-label">virtual clock:</span>
-            <span class="vc-value">
-              {formatVirtualClock(
-                virtualClockProgress,
-                turns,
-                selectedScenario?.duration_label ?? "T+?",
-              )}
-            </span>
-            <span class="vc-progress">
-              ({virtualClockProgress}/{turns} turns)
+            <span class="vc-label">progress:</span>
+            <span class="vc-value" data-testid="sts-launcher-progress">
+              {turnsCompleted}/{turns} turns
             </span>
           </div>
-          <progress max={turns} value={virtualClockProgress} class="progress" />
+          <progress
+            max={turns}
+            value={turnsCompleted}
+            class="progress"
+            data-testid="sts-launcher-progress-bar"
+          />
+          {#if lastStatus !== null && lastStatus.exit_code !== null}
+            <p class="muted small" data-testid="sts-launcher-exit-code">
+              exit code: <code>{lastStatus.exit_code}</code>
+            </p>
+          {/if}
+          {#if lastStatus !== null && lastStatus.error_message !== null}
+            <p class="error small" data-testid="sts-launcher-error-message">
+              {lastStatus.error_message}
+            </p>
+          {/if}
+          {#if formState === "finished" && lastStatus !== null && (lastStatus.stdout_tail.length > 0 || lastStatus.stderr_tail.length > 0)}
+            <details class="logs" data-testid="sts-launcher-logs">
+              <summary>logs (tail)</summary>
+              {#if lastStatus.stdout_tail.length > 0}
+                <pre class="log-block">{lastStatus.stdout_tail.join("\n")}</pre>
+              {/if}
+              {#if lastStatus.stderr_tail.length > 0}
+                <pre class="log-block stderr">{lastStatus.stderr_tail.join("\n")}</pre>
+              {/if}
+            </details>
+          {/if}
           <div class="actions">
-            <button type="button" class="action" on:click={reset}>
-              ↻ nova run
-            </button>
+            {#if formState === "running"}
+              <button
+                type="button"
+                class="action"
+                on:click={cancelRun}
+                data-testid="sts-launcher-cancel"
+              >
+                ⊘ cancelar
+              </button>
+            {:else}
+              <button type="button" class="action" on:click={reset}>
+                ↻ nova run
+              </button>
+            {/if}
             <button type="button" class="action primary" on:click={close}>
               fechar
             </button>
@@ -397,13 +482,34 @@
     font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
     color: #ef4444;
   }
-  .vc-progress {
-    opacity: 0.6;
-    font-size: 0.78rem;
-  }
   .progress {
     width: 100%;
     height: 6px;
+  }
+  .logs {
+    font-size: 0.78rem;
+    background: rgba(127, 127, 127, 0.1);
+    border-radius: 3px;
+    padding: 0.4rem;
+  }
+  .logs summary {
+    cursor: pointer;
+    opacity: 0.75;
+  }
+  .log-block {
+    margin: 0.3rem 0 0 0;
+    padding: 0.4rem;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 3px;
+    overflow-x: auto;
+    max-height: 160px;
+    font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    line-height: 1.3;
+    white-space: pre;
+  }
+  .log-block.stderr {
+    border-left: 3px solid #ef4444;
   }
   .small {
     font-size: 0.78rem;

--- a/packages/ebrota-console-ui/src/lib/api.ts
+++ b/packages/ebrota-console-ui/src/lib/api.ts
@@ -671,6 +671,13 @@ export interface StsPersonaLike {
   language: string;
 }
 
+export type StsRunStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
 export interface StsRunSummaryLike {
   run_id: string;
   persona_id: string;
@@ -680,16 +687,43 @@ export interface StsRunSummaryLike {
   turn_count: number;
   score: string | null;
   trace_path: string | null;
+  status?: StsRunStatus;
+  turns_requested?: number;
+  turns_completed?: number;
 }
 
 export interface StsRunStartResultLike {
   run_id: string;
-  status: "dispatched_stub_v0";
+  status: StsRunStatus;
   persona_id: string;
   scenario_id: string;
   turns: number;
   dispatched_at: string;
-  note: string;
+  pid?: number | null;
+  note?: string;
+}
+
+export interface StsRunStatusResultLike {
+  run_id: string;
+  status: StsRunStatus;
+  persona_id: string;
+  scenario_id: string;
+  turns_requested: number;
+  turns_completed: number;
+  started_at: string;
+  ended_at: string | null;
+  pid: number | null;
+  exit_code: number | null;
+  error_message: string | null;
+  last_progress_at: string | null;
+  stdout_tail: string[];
+  stderr_tail: string[];
+}
+
+export interface StsRunCancelResultLike {
+  run_id: string;
+  status: StsRunStatus;
+  cancelled: boolean;
 }
 
 export interface DrillBankSummaryLike {
@@ -909,6 +943,8 @@ export interface ApiClient {
   startStsRun(
     input: { persona_id: string; scenario_id: string; turns?: number },
   ): Promise<StsRunStartResultLike>;
+  getStsRunStatus(runId: string): Promise<StsRunStatusResultLike>;
+  cancelStsRun(runId: string): Promise<StsRunCancelResultLike>;
 
   // ─── B2 Drilling ────────────────────────────────────────────────
   /** Lista banks disponíveis em fixtures/banks/. */
@@ -1575,6 +1611,14 @@ export function createApiClient(opts: ApiClientOptions = {}): ApiClient {
       ),
     startStsRun: (input) =>
       post<StsRunStartResultLike>("/sts/runs/start", input),
+    getStsRunStatus: (runId) =>
+      get<StsRunStatusResultLike>(
+        `/sts/runs/${encodeURIComponent(runId)}/status`,
+      ),
+    cancelStsRun: (runId) =>
+      post<StsRunCancelResultLike>(
+        `/sts/runs/${encodeURIComponent(runId)}/cancel`,
+      ),
 
     // ─── B2 ─────────────────────────────────────────────────────────
     listBanks: () => get<{ banks: DrillBankSummaryLike[] }>("/banks"),

--- a/packages/ebrota-console-ui/tests/s5-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/s5-panel.test.ts
@@ -112,12 +112,33 @@ function mockApi(overrides: Partial<ApiClient> = {}): ApiClient {
     listStsRuns: async () => ({ runs: [] }),
     startStsRun: async (input) => ({
       run_id: "test-run-id-12345678",
-      status: "dispatched_stub_v0",
+      status: "running",
       persona_id: input.persona_id,
       scenario_id: input.scenario_id,
       turns: input.turns ?? 6,
       dispatched_at: "2026-05-27T10:00:00Z",
-      note: "v0 stub",
+      pid: 99999,
+    }),
+    getStsRunStatus: async (runId) => ({
+      run_id: runId,
+      status: "running",
+      persona_id: "ryo-ochiai",
+      scenario_id: "smoke-3d",
+      turns_requested: 6,
+      turns_completed: 1,
+      started_at: "2026-05-27T10:00:00Z",
+      ended_at: null,
+      pid: 99999,
+      exit_code: null,
+      error_message: null,
+      last_progress_at: null,
+      stdout_tail: [],
+      stderr_tail: [],
+    }),
+    cancelStsRun: async (runId) => ({
+      run_id: runId,
+      status: "cancelled",
+      cancelled: true,
     }),
     getTemporalWindows: stub,
     listPulsoEvents: stub,
@@ -288,12 +309,12 @@ describe("STSLauncherModal", () => {
   it("submit dispara startStsRun e exibe running state", async () => {
     const startMock = vi.fn(async () => ({
       run_id: "run-abc12345-9999",
-      status: "dispatched_stub_v0" as const,
+      status: "running" as const,
       persona_id: "ryo-ochiai",
       scenario_id: "smoke-3d",
       turns: 6,
       dispatched_at: "2026-05-27T10:00:00Z",
-      note: "v0 stub",
+      pid: 99999,
     }));
     const api = mockApi({ startStsRun: startMock });
     render(STSLauncherModal, { props: { api, open: true } });

--- a/packages/ebrota-console-ui/tests/sts-launcher-modal.test.ts
+++ b/packages/ebrota-console-ui/tests/sts-launcher-modal.test.ts
@@ -1,0 +1,286 @@
+/**
+ * STSLauncherModal — real spawn polling tests.
+ *
+ * Cobre o flow novo (PR substitui stub do #258):
+ *  - submit dispara startStsRun → polling status a cada pollMs
+ *  - progress bar reflete turns_completed
+ *  - cancel button visível em running; chama cancelStsRun
+ *  - estado terminal (succeeded/failed/cancelled) mostra exit code + tail
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/svelte";
+import STSLauncherModal from "../src/components/sts/STSLauncherModal.svelte";
+import type {
+  ApiClient,
+  StsRunStatusResultLike,
+  StsRunStartResultLike,
+  StsRunCancelResultLike,
+} from "../src/lib/api.js";
+
+function baseMockApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  const stub = (): never => {
+    throw new Error("not stubbed");
+  };
+  return {
+    getStatus: stub,
+    getMode: stub,
+    setMode: stub,
+    startCardSession: stub,
+    getActiveSessions: stub,
+    listOptions: stub,
+    overrideSelection: stub,
+    listDecisions: stub,
+    getPendingApproval: stub,
+    approveOrEdit: stub,
+    endSession: stub,
+    listSessionLibrary: stub,
+    getSessionReplay: stub,
+    listDebugLlmCalls: stub,
+    clearDebugLlmCalls: stub,
+    listAnalyticsPersonas: stub,
+    getPersonaEvolution: stub,
+    turnStateSseUrl: () => "/api/turn-state",
+    listSubjectDiscoveries: stub,
+    listSubjectBoundaries: stub,
+    getBoundariesSummary: stub,
+    getJourneyState: stub,
+    setJourneyOverride: stub,
+    clearJourneyOverride: stub,
+    listFrameworks: stub,
+    getSubjectMaps: stub,
+    getDeclaredObjectives: stub,
+    getObjectiveHistory: stub,
+    getNarrativeThreads: stub,
+    getSubjectKnowledge: stub,
+    getSessionStrategyPlan: stub,
+    listSubjectStrategyPlans: stub,
+    getGuardrailHistory: stub,
+    getRecallCheckHistory: stub,
+    getTriggerEvents: stub,
+    getKpiLongitudinal: stub,
+    listStsScenarios: async () => ({
+      scenarios: [
+        {
+          id: "smoke-3d",
+          label: "smoke-3d",
+          description: "Smoke",
+          recommended_turns: 6,
+          duration_label: "T+3d",
+        },
+      ],
+    }),
+    listStsPersonas: async () => ({
+      personas: [
+        {
+          id: "ryo-ochiai",
+          display_name: "Ryo",
+          archetype: "deflective-11a",
+          age: 11,
+          language: "pt+ja",
+        },
+      ],
+    }),
+    listStsRuns: async () => ({ runs: [] }),
+    startStsRun: async (input) => ({
+      run_id: "test-run-id-9999",
+      status: "running",
+      persona_id: input.persona_id,
+      scenario_id: input.scenario_id,
+      turns: input.turns ?? 6,
+      dispatched_at: "2026-05-27T10:00:00Z",
+      pid: 99999,
+    }),
+    getStsRunStatus: stub,
+    cancelStsRun: stub,
+    getTemporalWindows: stub,
+    listPulsoEvents: stub,
+    getSacrificeBudget: stub,
+    listEmittedCards: stub,
+    getDyad: stub,
+    listBanks: stub,
+    getBank: stub,
+    listDrillStates: stub,
+    listDrillDue: stub,
+    listDrillMastered: stub,
+    listDrillAttempts: stub,
+    getParentalDashboard: stub,
+    getParentalToday: stub,
+    getParentalWeek: stub,
+    getParentalCards: stub,
+    getParentalConversations: stub,
+    getParentalAlerts: stub,
+    getParentalPulsoEvents: stub,
+    listPendingQuestions: stub,
+    answerPendingQuestion: stub,
+    reportProblem: stub,
+    pauseChild: stub,
+    getMc1Status: stub,
+    cancelMc1: stub,
+    ...overrides,
+  } as ApiClient;
+}
+
+function statusResp(
+  overrides: Partial<StsRunStatusResultLike> = {},
+): StsRunStatusResultLike {
+  return {
+    run_id: "test-run-id-9999",
+    status: "running",
+    persona_id: "ryo-ochiai",
+    scenario_id: "smoke-3d",
+    turns_requested: 6,
+    turns_completed: 0,
+    started_at: "2026-05-27T10:00:00Z",
+    ended_at: null,
+    pid: 99999,
+    exit_code: null,
+    error_message: null,
+    last_progress_at: null,
+    stdout_tail: [],
+    stderr_tail: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("STSLauncherModal — polling + real spawn", () => {
+  it("após submit, chama getStsRunStatus em loop até succeeded", async () => {
+    let callCount = 0;
+    const getStatus = vi.fn(async (): Promise<StsRunStatusResultLike> => {
+      callCount += 1;
+      if (callCount < 3) {
+        return statusResp({ turns_completed: callCount, status: "running" });
+      }
+      return statusResp({
+        turns_completed: 6,
+        status: "succeeded",
+        exit_code: 0,
+        ended_at: "2026-05-27T10:00:10Z",
+        stdout_tail: ["STS RUN STARTED", "STS RUN COMPLETED"],
+      });
+    });
+
+    const api = baseMockApi({ getStsRunStatus: getStatus });
+    render(STSLauncherModal, { props: { api, open: true, pollMs: 20 } });
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-submit")).toBeDefined();
+    });
+    await fireEvent.submit(screen.getByTestId("sts-launcher-form"));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("sts-launcher-finished")).toBeDefined();
+      },
+      { timeout: 2000 },
+    );
+    expect(getStatus.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("progress bar reflete turns_completed", async () => {
+    const getStatus = vi.fn(async () =>
+      statusResp({ turns_completed: 4, status: "running" }),
+    );
+    const api = baseMockApi({ getStsRunStatus: getStatus });
+    render(STSLauncherModal, { props: { api, open: true, pollMs: 20 } });
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-submit")).toBeDefined();
+    });
+    await fireEvent.submit(screen.getByTestId("sts-launcher-form"));
+
+    await waitFor(() => {
+      const progress = screen.getByTestId("sts-launcher-progress");
+      expect(progress.textContent).toContain("4/6");
+    });
+    const bar = screen.getByTestId("sts-launcher-progress-bar") as HTMLProgressElement;
+    expect(bar.value).toBe(4);
+    expect(bar.max).toBe(6);
+  });
+
+  it("botão cancel visível em running e chama cancelStsRun", async () => {
+    const getStatus = vi.fn(async () =>
+      statusResp({ status: "running", turns_completed: 1 }),
+    );
+    const cancelMock = vi.fn(
+      async (): Promise<StsRunCancelResultLike> => ({
+        run_id: "test-run-id-9999",
+        status: "cancelled",
+        cancelled: true,
+      }),
+    );
+    const api = baseMockApi({
+      getStsRunStatus: getStatus,
+      cancelStsRun: cancelMock,
+    });
+    render(STSLauncherModal, { props: { api, open: true, pollMs: 50 } });
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-submit")).toBeDefined();
+    });
+    await fireEvent.submit(screen.getByTestId("sts-launcher-form"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-cancel")).toBeDefined();
+    });
+    await fireEvent.click(screen.getByTestId("sts-launcher-cancel"));
+    expect(cancelMock).toHaveBeenCalledWith("test-run-id-9999");
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-finished")).toBeDefined();
+    });
+  });
+
+  it("estado finished mostra exit code + logs tail", async () => {
+    const getStatus = vi.fn(
+      async (): Promise<StsRunStatusResultLike> =>
+        statusResp({
+          status: "succeeded",
+          turns_completed: 6,
+          exit_code: 0,
+          ended_at: "2026-05-27T10:00:10Z",
+          stdout_tail: ["STS RUN STARTED", "turn 1/6", "STS RUN COMPLETED"],
+          stderr_tail: [],
+        }),
+    );
+    const api = baseMockApi({ getStsRunStatus: getStatus });
+    render(STSLauncherModal, { props: { api, open: true, pollMs: 20 } });
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-submit")).toBeDefined();
+    });
+    await fireEvent.submit(screen.getByTestId("sts-launcher-form"));
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-finished")).toBeDefined();
+    });
+    expect(screen.getByTestId("sts-launcher-exit-code").textContent).toContain("0");
+    expect(screen.getByTestId("sts-launcher-logs")).toBeDefined();
+  });
+
+  it("estado failed mostra error_message", async () => {
+    const getStatus = vi.fn(
+      async (): Promise<StsRunStatusResultLike> =>
+        statusResp({
+          status: "failed",
+          exit_code: 1,
+          error_message: "STS RUN FAILED scenario=fail-fast turn=3",
+          stderr_tail: ["STS RUN FAILED"],
+        }),
+    );
+    const api = baseMockApi({ getStsRunStatus: getStatus });
+    render(STSLauncherModal, { props: { api, open: true, pollMs: 20 } });
+    await waitFor(() => {
+      expect(screen.getByTestId("sts-launcher-submit")).toBeDefined();
+    });
+    await fireEvent.submit(screen.getByTestId("sts-launcher-form"));
+    await waitFor(() => {
+      const errEl = screen.getByTestId("sts-launcher-error-message");
+      expect(errEl.textContent).toContain("STS RUN FAILED");
+    });
+  });
+});

--- a/scripts/run-sts.mjs
+++ b/scripts/run-sts.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * STS run script — stub v0 invoked by BFF spawn (POST /sts/runs/start).
+ *
+ * Args:
+ *   --persona <id>     persona STS id (ex: ryo-ochiai)
+ *   --scenario <id>    scenario id (ex: smoke-3d, fail-fast)
+ *   --turns <N>        número de turnos a iterar
+ *   --run-id <uuid>    run identifier (BFF-provided)
+ *
+ * Comportamento v0:
+ *   - Imprime "STS RUN STARTED ..." e cada 2s emite "turn N/total".
+ *   - scenario=fail-fast → exit 1 na 3ª iteração (testa failure path).
+ *   - Caso contrário roda --turns iterações e exits 0 com "STS RUN COMPLETED".
+ *
+ * Implementação real (spawn motor + traces) virá em fase posterior; aqui
+ * apenas dá ao BFF um processo real pra spawn/track/cancel.
+ */
+import { argv, exit, stdout, stderr } from "node:process";
+
+function parseArgs(argList) {
+  const out = {};
+  for (let i = 0; i < argList.length; i += 1) {
+    const arg = argList[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const next = argList[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        out[key] = next;
+        i += 1;
+      } else {
+        out[key] = "true";
+      }
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(argv.slice(2));
+const persona = args.persona ?? "(no-persona)";
+const scenario = args.scenario ?? "(no-scenario)";
+const turns = Number.parseInt(args.turns ?? "6", 10);
+const runId = args["run-id"] ?? "(no-run-id)";
+const tickMs = Number.parseInt(process.env.STS_STUB_TICK_MS ?? "2000", 10);
+
+stdout.write(
+  `STS RUN STARTED run_id=${runId} persona=${persona} scenario=${scenario} turns=${turns}\n`,
+);
+
+let cancelled = false;
+const onSig = (sig) => {
+  cancelled = true;
+  stdout.write(`STS RUN CANCELLED signal=${sig}\n`);
+  exit(143);
+};
+process.on("SIGTERM", () => onSig("SIGTERM"));
+process.on("SIGINT", () => onSig("SIGINT"));
+
+let i = 0;
+const interval = setInterval(() => {
+  if (cancelled) {
+    clearInterval(interval);
+    return;
+  }
+  i += 1;
+  stdout.write(`turn ${i}/${turns}\n`);
+  if (scenario === "fail-fast" && i === 3) {
+    clearInterval(interval);
+    stderr.write(`STS RUN FAILED scenario=fail-fast turn=${i}\n`);
+    exit(1);
+  }
+  if (i >= turns) {
+    clearInterval(interval);
+    stdout.write(`STS RUN COMPLETED run_id=${runId} turns=${turns}\n`);
+    exit(0);
+  }
+}, tickMs);


### PR DESCRIPTION
## Summary

Substitui o stub de `POST /sts/runs/start` (PR #258) por **spawn real** de `scripts/run-sts.mjs` com persistência completa do ciclo de vida em nova table `sts_runs`. Bate o último gap do S5.b launcher pra deixar o painel atuar de ponta-a-ponta na console.

## Backend (`packages/ebrota-console-bff`)

- **`db.ts`**: nova table `sts_runs` (run_id, persona_id, scenario_id, status, pid, exit_code, stdout_path, stderr_path, turns_completed, error_message) + índices `started_at` + `status`. DDL idempotente.
- **`routes/s5-routes.ts`** (re-escrita):
  - `POST /sts/runs/start`: insere row `pending`, `spawn("node", ["scripts/run-sts.mjs", ...])` com stdio redirecionando pra arquivos, captura `pid`, transiciona `pending → running`; `exit`/`error` listeners atualizam pra `succeeded/failed/cancelled` + capturam `exit_code` + stderr tail.
  - `GET /sts/runs/:runId/status`: status snapshot + tail stdout/stderr (≤100 linhas).
  - `POST /sts/runs/:runId/cancel`: `SIGTERM` no PID + idempotente (cancelled=false em runs já terminais).
  - `GET /sts/runs`: agora SELECT em `sts_runs ORDER BY started_at DESC`.
  - `shutdownState.closed` flag pra no-op das writes pós-Fastify close (resolveu unhandled error nos integration tests).
- **`server.ts`**: expõe `stsRepoRoot / stsLogDir / stsDefaultUseMockLlm` via `CreateBffServerOptions` pra testes injetarem própria raiz.

## Script (`scripts/run-sts.mjs`, NOVO)

Stub v0 do runner — não vincula motor ainda. Aceita `--persona / --scenario / --turns / --run-id`. A cada `STS_STUB_TICK_MS` (default 2000) imprime `turn N/total`, ao fim emite `STS RUN COMPLETED` exit 0. `scenario=fail-fast` exit 1 na 3ª turn pra testar failure path. Trata `SIGTERM/SIGINT` pra cancellation.

Spawn real do motor virá em fase posterior; aqui o objetivo é dar ao BFF um processo real pra orquestrar.

## Frontend (`packages/ebrota-console-ui`)

- **`lib/api.ts`**: novo `StsRunStatus` union (`pending|running|succeeded|failed|cancelled`), `StsRunStatusResultLike`, `StsRunCancelResultLike`; `ApiClient.getStsRunStatus / cancelStsRun` adicionados.
- **`components/sts/STSLauncherModal.svelte`**:
  - Polling `getStsRunStatus(run_id)` a cada `pollMs` (default 2000) até status terminal.
  - Progress bar real: `turns_completed / turns_requested`.
  - Botão **Cancelar** visível em `running` → `cancelStsRun(run_id)`.
  - Estado finished mostra exit code, error_message, e `<details>` com tail stdout/stderr.
  - Virtual clock dummy removido (replaced by real progress).

## Tests (3-camadas)

### BFF — 24 testes (13 unit + 11 integration), todos passando

- `tests/s5-routes.unit.test.ts`: adaptado pra novo contrato (validação 400 ainda; `status: "dispatched_stub_v0"` removido).
- `tests/sts-spawn.integration.test.ts` **NOVO**:
  - DDL idempotente
  - `sts_runs` table existe pós-init
  - spawn cria row + processo + retorna pid/status
  - status transitions `pending → running → succeeded` (smoke-3d turns=2)
  - cancel via SIGTERM → status=cancelled
  - failure path (`scenario=fail-fast`) → status=failed + exit_code=1 + error_message + stderr tail
  - GET /sts/runs ordenado DESC
  - 404 em status / cancel desconhecido
  - cancel idempotente em runs terminais

`STS_STUB_TICK_MS=80` → cada teste completa em <3s; suite inteira em <4s.

### UI — 14 testes, todos passando

- `tests/sts-launcher-modal.test.ts` **NOVO** (5 testes): polling loop, progress bar, cancel button, finished state, error_message exibido em failed.
- `tests/s5-panel.test.ts` (9 testes existentes): atualizado pra novo shape.

## Build

- `npm run build -w shared`: OK
- `npm run build -w packages/ebrota-console-bff`: OK
- `npm run build -w packages/ebrota-console-ui`: OK (apenas warnings A11y pré-existentes)

## Smoke manual

```
$ node scripts/run-sts.mjs --persona ryo-ochiai --scenario smoke-3d --turns 2 --run-id test1
STS RUN STARTED run_id=test1 persona=ryo-ochiai scenario=smoke-3d turns=2
turn 1/2
turn 2/2
STS RUN COMPLETED run_id=test1 turns=2  (exit 0)

$ STS_STUB_TICK_MS=50 node scripts/run-sts.mjs --scenario fail-fast --turns 5 --run-id fail-test
STS RUN STARTED ...
turn 1/5
turn 2/5
turn 3/5
STS RUN FAILED scenario=fail-fast turn=3  (exit 1)
```

## UI estados (textual screenshot)

**Pending/Initial**: persona/scenario dropdowns + turns slider + botão `🚀 disparar run`.

**Running**: `▶ running — run_id abc12345… pid 99999` + `progress: 2/6 turns` + `<progress max=6 value=2>` + botão `⊘ cancelar`.

**Succeeded**: `✓ succeeded — run_id abc12345…` + `progress: 6/6 turns` + `exit code: 0` + `<details>logs (tail)</details>` + botões `↻ nova run / fechar`.

**Failed**: `✗ failed — run_id abc12345…` + `exit code: 1` + error_message vermelho + stderr tail no `<details>`.

**Cancelled**: `⊘ cancelled — ...` igual succeeded mas com status differente.

## DoR / DoD

- [x] Spec inline cumprida (BFF endpoints + UI polling + cancel + failure path)
- [x] DDL idempotente
- [x] Cleanup: kill child processes em afterEach + onClose await child exits
- [x] ≥8 integration testes (11 entregues)
- [x] ≥4 UI testes launcher modal (5 entregues)
- [x] scripts/run-sts.mjs roda manual sem travar
- [x] Build clean (BFF + UI)
- [ ] **NÃO MERGEAR** — Jun decide

🤖 Generated with [Claude Code](https://claude.com/claude-code)