### PR TITLE
[feat] MC10 mobile onboarding flow — 7 canonical prompts + state machine + BFF endpoints

### DIFF
--- a/packages/ebrota-console-bff/src/db.ts
+++ b/packages/ebrota-console-bff/src/db.ts
@@ -198,6 +198,22 @@ CREATE INDEX IF NOT EXISTS idx_sts_runs_started_at
   ON sts_runs(started_at);
 CREATE INDEX IF NOT EXISTS idx_sts_runs_status
   ON sts_runs(status);
+
+-- MC10 mobile onboarding (alternativa mobile-first ao wizard web). State
+-- machine de 7 prompts canônicos via WhatsApp. Feature flag
+-- MC10_MOBILE_ONBOARDING=true habilita os endpoints.
+CREATE TABLE IF NOT EXISTS mc10_mobile_sessions (
+  session_id TEXT PRIMARY KEY,
+  started_at TEXT NOT NULL,
+  current_step TEXT NOT NULL,
+  replies_json TEXT NOT NULL DEFAULT '{}',
+  completed_at TEXT,
+  completion_payload_json TEXT,
+  child_name TEXT,
+  child_age INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_mc10_mobile_started_at
+  ON mc10_mobile_sessions(started_at);
 `;
 
 export interface InitDbOptions {

--- a/packages/ebrota-console-bff/src/mc10-mobile-flow.ts
+++ b/packages/ebrota-console-bff/src/mc10-mobile-flow.ts
@@ -1,0 +1,348 @@
+/**
+ * MC10 Mobile Onboarding Flow — state machine pra coleta de parental_telos
+ * via WhatsApp (alternativa mobile-first ao wizard web de US-PO-01..11).
+ *
+ * Sequência de 7 prompts canônicos. Cada estado declara o prompt enviado
+ * ao pai, o shape esperado da resposta, e o próximo step. Pure functions
+ * sem side effects de framework — `mc10-routes.ts` faz o wrapping HTTP.
+ *
+ * Feature flag: `MC10_MOBILE_ONBOARDING=true` no env do BFF habilita
+ * endpoints. Twilio webhook integration é out-of-scope deste PR.
+ */
+
+export type Mc10StepId =
+  | "welcome"
+  | "child_name"
+  | "child_age"
+  | "child_languages"
+  | "parental_telos_short"
+  | "daily_window"
+  | "consent_confirm"
+  | "complete";
+
+export type Mc10ExpectedShape =
+  | "ack" // welcome — qualquer resposta avança
+  | "name" // non-empty string
+  | "age" // integer 3-12
+  | "languages" // comma-split list, ≥1 item
+  | "free_text" // non-empty string
+  | "daily_window_enum" // manhã|tarde|noite (combinações OK)
+  | "boolean_yesno"; // sim|não
+
+export interface Mc10StepDef {
+  stepId: Mc10StepId;
+  promptText: string;
+  expectedShape: Mc10ExpectedShape;
+  nextStep: Mc10StepId;
+}
+
+export const MC10_STEPS: Record<Mc10StepId, Mc10StepDef> = {
+  welcome: {
+    stepId: "welcome",
+    promptText:
+      "Oi! Sou Brota. Posso te perguntar 7 coisas pra entender melhor seu filho? Responde quando puder.",
+    expectedShape: "ack",
+    nextStep: "child_name",
+  },
+  child_name: {
+    stepId: "child_name",
+    promptText: "Como ele/ela se chama?",
+    expectedShape: "name",
+    nextStep: "child_age",
+  },
+  child_age: {
+    stepId: "child_age",
+    promptText: "Quantos anos?",
+    expectedShape: "age",
+    nextStep: "child_languages",
+  },
+  child_languages: {
+    stepId: "child_languages",
+    promptText: "Quais línguas vocês usam em casa? (separe com vírgula)",
+    expectedShape: "languages",
+    nextStep: "parental_telos_short",
+  },
+  parental_telos_short: {
+    stepId: "parental_telos_short",
+    promptText: "Em 1 frase, o que você mais quer pra ele/ela?",
+    expectedShape: "free_text",
+    nextStep: "daily_window",
+  },
+  daily_window: {
+    stepId: "daily_window",
+    promptText:
+      "Que horários do dia você prefere que ele/ela converse comigo? (manhã/tarde/noite)",
+    expectedShape: "daily_window_enum",
+    nextStep: "consent_confirm",
+  },
+  consent_confirm: {
+    stepId: "consent_confirm",
+    promptText: "Posso começar a conversar com ele/ela amanhã? (sim/não)",
+    expectedShape: "boolean_yesno",
+    nextStep: "complete",
+  },
+  complete: {
+    stepId: "complete",
+    promptText: "Obrigado! Vou começar amanhã.",
+    expectedShape: "ack",
+    nextStep: "complete",
+  },
+};
+
+export const FIRST_STEP: Mc10StepId = "welcome";
+
+export type Mc10ParsedValue =
+  | { kind: "ack" }
+  | { kind: "name"; value: string }
+  | { kind: "age"; value: number }
+  | { kind: "languages"; value: string[] }
+  | { kind: "free_text"; value: string }
+  | { kind: "daily_window"; value: string[] }
+  | { kind: "boolean_yesno"; value: boolean };
+
+export interface Mc10ParseError {
+  ok: false;
+  error: string;
+  hint: string;
+}
+
+export type Mc10ParseResult =
+  | { ok: true; parsed: Mc10ParsedValue }
+  | Mc10ParseError;
+
+const DAILY_WINDOW_TOKENS = new Set(["manhã", "manha", "tarde", "noite"]);
+
+function normalize(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+export function parseReply(stepId: Mc10StepId, rawText: string): Mc10ParseResult {
+  const def = MC10_STEPS[stepId];
+  if (!def) {
+    return {
+      ok: false,
+      error: `unknown step ${stepId}`,
+      hint: "estado inválido",
+    };
+  }
+  const trimmed = rawText.trim();
+  switch (def.expectedShape) {
+    case "ack":
+      return { ok: true, parsed: { kind: "ack" } };
+    case "name": {
+      if (trimmed.length === 0) {
+        return {
+          ok: false,
+          error: "name vazio",
+          hint: "Pode me dizer o nome dele/dela?",
+        };
+      }
+      return { ok: true, parsed: { kind: "name", value: trimmed } };
+    }
+    case "age": {
+      const match = trimmed.match(/-?\d+/);
+      if (!match) {
+        return {
+          ok: false,
+          error: "age não numérica",
+          hint: "Pode mandar só o número da idade? Ex: 7",
+        };
+      }
+      const n = parseInt(match[0], 10);
+      if (Number.isNaN(n) || n < 3 || n > 12) {
+        return {
+          ok: false,
+          error: "age fora de range 3-12",
+          hint: "Idade precisa ser entre 3 e 12 anos.",
+        };
+      }
+      return { ok: true, parsed: { kind: "age", value: n } };
+    }
+    case "languages": {
+      const items = trimmed
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (items.length === 0) {
+        return {
+          ok: false,
+          error: "languages vazio",
+          hint: "Pode listar pelo menos 1 língua? Ex: português, japonês",
+        };
+      }
+      return { ok: true, parsed: { kind: "languages", value: items } };
+    }
+    case "free_text": {
+      if (trimmed.length === 0) {
+        return {
+          ok: false,
+          error: "free_text vazio",
+          hint: "Pode escrever em 1 frase o que você mais quer pra ele/ela?",
+        };
+      }
+      return { ok: true, parsed: { kind: "free_text", value: trimmed } };
+    }
+    case "daily_window_enum": {
+      const tokens = normalize(trimmed)
+        .split(/[\s,/]+/)
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0 && t !== "e"); // strip "e" conjunção PT
+      const valid = tokens.filter((t) => DAILY_WINDOW_TOKENS.has(t));
+      if (valid.length === 0) {
+        return {
+          ok: false,
+          error: "daily_window não reconhecido",
+          hint: "Pode escolher: manhã, tarde, noite (ou combinações)?",
+        };
+      }
+      // Normalize "manha" → "manhã"
+      const normalized = valid.map((t) => (t === "manha" ? "manhã" : t));
+      const unique = [...new Set(normalized)];
+      return { ok: true, parsed: { kind: "daily_window", value: unique } };
+    }
+    case "boolean_yesno": {
+      const norm = normalize(trimmed);
+      if (/^(sim|s|yes|y|ok|claro|pode)$/i.test(norm)) {
+        return { ok: true, parsed: { kind: "boolean_yesno", value: true } };
+      }
+      if (/^(não|nao|n|no)$/i.test(norm)) {
+        return { ok: true, parsed: { kind: "boolean_yesno", value: false } };
+      }
+      return {
+        ok: false,
+        error: "consent ambíguo",
+        hint: "Pode responder com sim ou não?",
+      };
+    }
+  }
+}
+
+export interface ValidationOk {
+  ok: true;
+}
+export interface ValidationErr {
+  ok: false;
+  error: string;
+}
+export type ValidationResult = ValidationOk | ValidationErr;
+
+export function validateReply(
+  parsed: Mc10ParsedValue,
+  stepId: Mc10StepId,
+): ValidationResult {
+  const def = MC10_STEPS[stepId];
+  if (!def) {
+    return { ok: false, error: `unknown step ${stepId}` };
+  }
+  // parseReply já carrega validação shape+range. validateReply confirma
+  // que o kind do parsed bate com o expected do step (defesa adicional
+  // contra mismatch caller).
+  const expectKindMap: Record<Mc10ExpectedShape, Mc10ParsedValue["kind"]> = {
+    ack: "ack",
+    name: "name",
+    age: "age",
+    languages: "languages",
+    free_text: "free_text",
+    daily_window_enum: "daily_window",
+    boolean_yesno: "boolean_yesno",
+  };
+  const expected = expectKindMap[def.expectedShape];
+  if (parsed.kind !== expected) {
+    return {
+      ok: false,
+      error: `kind mismatch: esperava ${expected}, recebeu ${parsed.kind}`,
+    };
+  }
+  return { ok: true };
+}
+
+export interface Mc10NextStepResult {
+  nextStep: Mc10StepId;
+  advanced: boolean;
+}
+
+/**
+ * Calcula próximo estado dado o atual + reply do usuário.
+ *
+ * - Se reply não parsea: NÃO avança. Retorna `advanced: false, nextStep =
+ *   currentStep`. Caller deve mostrar `hint` do parse error pro user.
+ * - Se reply parseia OK: avança pra `def.nextStep`. `advanced: true`.
+ * - Se currentStep já é `complete`: nunca avança (idempotente).
+ */
+export function getNextStep(
+  currentStep: Mc10StepId,
+  userReply: string,
+): Mc10NextStepResult {
+  if (currentStep === "complete") {
+    return { nextStep: "complete", advanced: false };
+  }
+  const parsed = parseReply(currentStep, userReply);
+  if (!parsed.ok) {
+    return { nextStep: currentStep, advanced: false };
+  }
+  const def = MC10_STEPS[currentStep];
+  return { nextStep: def.nextStep, advanced: true };
+}
+
+export interface Mc10ReplyHistoryEntry {
+  stepId: Mc10StepId;
+  rawText: string;
+  parsed: Mc10ParsedValue;
+}
+
+export interface Mc10CompletionPayload {
+  childName: string;
+  childAge: number;
+  childLanguages: string[];
+  parentalTelosShort: string;
+  dailyWindow: string[];
+  consentGranted: boolean;
+}
+
+/**
+ * Compõe payload final pra emissão (`OnboardingComplete`) a partir do
+ * histórico de replies. Lança se algum campo obrigatório está faltando
+ * — só deve ser chamado depois de `consent_confirm` validado.
+ */
+export function buildCompletionPayload(
+  history: Mc10ReplyHistoryEntry[],
+): Mc10CompletionPayload {
+  const byStep = new Map<Mc10StepId, Mc10ParsedValue>();
+  for (const entry of history) {
+    byStep.set(entry.stepId, entry.parsed);
+  }
+  const name = byStep.get("child_name");
+  const age = byStep.get("child_age");
+  const langs = byStep.get("child_languages");
+  const telos = byStep.get("parental_telos_short");
+  const window = byStep.get("daily_window");
+  const consent = byStep.get("consent_confirm");
+
+  if (!name || name.kind !== "name") {
+    throw new Error("buildCompletionPayload: child_name ausente");
+  }
+  if (!age || age.kind !== "age") {
+    throw new Error("buildCompletionPayload: child_age ausente");
+  }
+  if (!langs || langs.kind !== "languages") {
+    throw new Error("buildCompletionPayload: child_languages ausente");
+  }
+  if (!telos || telos.kind !== "free_text") {
+    throw new Error("buildCompletionPayload: parental_telos_short ausente");
+  }
+  if (!window || window.kind !== "daily_window") {
+    throw new Error("buildCompletionPayload: daily_window ausente");
+  }
+  if (!consent || consent.kind !== "boolean_yesno") {
+    throw new Error("buildCompletionPayload: consent_confirm ausente");
+  }
+
+  return {
+    childName: name.value,
+    childAge: age.value,
+    childLanguages: langs.value,
+    parentalTelosShort: telos.value,
+    dailyWindow: window.value,
+    consentGranted: consent.value,
+  };
+}

--- a/packages/ebrota-console-bff/src/routes/mc10-routes.ts
+++ b/packages/ebrota-console-bff/src/routes/mc10-routes.ts
@@ -1,0 +1,251 @@
+/**
+ * MC10 Mobile Onboarding routes — wrappa a state machine de
+ * `mc10-mobile-flow.ts` em endpoints HTTP. Cliente final será o webhook
+ * Twilio/WhatsApp (PR futuro); por ora os endpoints existem pra teste
+ * e integração progressiva.
+ *
+ * Feature flag: `MC10_MOBILE_ONBOARDING=true` no env do BFF. Quando
+ * desabilitado, todos endpoints respondem 503.
+ *
+ * Persistence: tabela `mc10_mobile_sessions` no SQLite BFF.
+ *   - session_id, started_at, current_step, replies_json, completed_at,
+ *     completion_payload_json, child_name, child_age.
+ *
+ * Endpoints:
+ *   POST /mc10/mobile/start              → { sessionId, firstPrompt }
+ *   POST /mc10/mobile/:sessionId/reply   → { nextPrompt | completionPayload, complete }
+ *   GET  /mc10/mobile/:sessionId         → status atual (debug)
+ */
+
+import { randomUUID } from "node:crypto";
+import type { FastifyPluginAsync } from "fastify";
+import type { Database as DatabaseType } from "better-sqlite3";
+import {
+  FIRST_STEP,
+  MC10_STEPS,
+  buildCompletionPayload,
+  getNextStep,
+  parseReply,
+  type Mc10CompletionPayload,
+  type Mc10ParsedValue,
+  type Mc10ReplyHistoryEntry,
+  type Mc10StepId,
+} from "../mc10-mobile-flow.js";
+
+export interface Mc10RoutesOptions {
+  db: DatabaseType;
+  /** Process env injetável pra tests. Default `process.env`. */
+  env?: NodeJS.ProcessEnv;
+}
+
+interface Mc10SessionRow {
+  session_id: string;
+  started_at: string;
+  current_step: string;
+  replies_json: string;
+  completed_at: string | null;
+  completion_payload_json: string | null;
+  child_name: string | null;
+  child_age: number | null;
+}
+
+function isEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env.MC10_MOBILE_ONBOARDING === "true";
+}
+
+function loadHistory(row: Mc10SessionRow): Mc10ReplyHistoryEntry[] {
+  try {
+    const arr = JSON.parse(row.replies_json) as Mc10ReplyHistoryEntry[];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+const mc10Routes: FastifyPluginAsync<Mc10RoutesOptions> = async (fastify, opts) => {
+  const { db } = opts;
+  const env = opts.env ?? process.env;
+
+  const guard = (
+    reply: { code: (n: number) => { send: (body: unknown) => unknown } },
+  ): unknown | null => {
+    if (!isEnabled(env)) {
+      return reply
+        .code(503)
+        .send({ error: "MC10 mobile onboarding disabled" });
+    }
+    return null;
+  };
+
+  fastify.post("/mc10/mobile/start", async (_req, reply) => {
+    const blocked = guard(reply);
+    if (blocked !== null) return blocked;
+
+    const sessionId = randomUUID();
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO mc10_mobile_sessions
+         (session_id, started_at, current_step, replies_json)
+       VALUES (?, ?, ?, '[]')`,
+    ).run(sessionId, now, FIRST_STEP);
+    return {
+      sessionId,
+      firstPrompt: MC10_STEPS[FIRST_STEP].promptText,
+      currentStep: FIRST_STEP,
+    };
+  });
+
+  fastify.post<{
+    Params: { sessionId: string };
+    Body: { text?: string };
+  }>("/mc10/mobile/:sessionId/reply", async (req, reply) => {
+    const blocked = guard(reply);
+    if (blocked !== null) return blocked;
+
+    const { sessionId } = req.params;
+    const text = req.body?.text;
+    if (typeof text !== "string") {
+      return reply.code(400).send({ error: "body.text obrigatório (string)" });
+    }
+
+    const row = db
+      .prepare(
+        `SELECT session_id, started_at, current_step, replies_json,
+                completed_at, completion_payload_json, child_name, child_age
+         FROM mc10_mobile_sessions WHERE session_id = ?`,
+      )
+      .get(sessionId) as Mc10SessionRow | undefined;
+    if (!row) {
+      return reply.code(404).send({ error: `session ${sessionId} não encontrada` });
+    }
+
+    // Idempotency: se já completa, retorna payload sem mudar estado.
+    if (row.completed_at !== null && row.completion_payload_json) {
+      return {
+        sessionId,
+        complete: true,
+        completionPayload: JSON.parse(
+          row.completion_payload_json,
+        ) as Mc10CompletionPayload,
+        currentStep: row.current_step as Mc10StepId,
+      };
+    }
+
+    const currentStep = row.current_step as Mc10StepId;
+    const parsed = parseReply(currentStep, text);
+    if (!parsed.ok) {
+      return reply.code(400).send({
+        sessionId,
+        error: parsed.error,
+        hint: parsed.hint,
+        currentStep,
+        retryPrompt: MC10_STEPS[currentStep].promptText,
+      });
+    }
+
+    const transition = getNextStep(currentStep, text);
+    const history = loadHistory(row);
+    history.push({
+      stepId: currentStep,
+      rawText: text,
+      parsed: parsed.parsed,
+    });
+
+    const nextStep = transition.nextStep;
+    const isComplete = nextStep === "complete";
+
+    let completionPayload: Mc10CompletionPayload | null = null;
+    let childName: string | null = row.child_name;
+    let childAge: number | null = row.child_age;
+
+    if (parsed.parsed.kind === "name") {
+      childName = parsed.parsed.value;
+    }
+    if (parsed.parsed.kind === "age") {
+      childAge = parsed.parsed.value;
+    }
+
+    if (isComplete) {
+      // Só compõe payload se consent foi sim. Se sim/não veio falso, ainda
+      // marca como complete (terminou o fluxo) mas consentGranted=false.
+      completionPayload = buildCompletionPayload(history);
+    }
+
+    const now = new Date().toISOString();
+    db.prepare(
+      `UPDATE mc10_mobile_sessions
+       SET current_step = ?,
+           replies_json = ?,
+           completed_at = ?,
+           completion_payload_json = ?,
+           child_name = ?,
+           child_age = ?
+       WHERE session_id = ?`,
+    ).run(
+      nextStep,
+      JSON.stringify(history),
+      isComplete ? now : null,
+      completionPayload ? JSON.stringify(completionPayload) : null,
+      childName,
+      childAge,
+      sessionId,
+    );
+
+    if (isComplete && completionPayload) {
+      return {
+        sessionId,
+        complete: true,
+        completionPayload,
+        currentStep: nextStep,
+      };
+    }
+    return {
+      sessionId,
+      complete: false,
+      nextPrompt: MC10_STEPS[nextStep].promptText,
+      currentStep: nextStep,
+    };
+  });
+
+  fastify.get<{ Params: { sessionId: string } }>(
+    "/mc10/mobile/:sessionId",
+    async (req, reply) => {
+      const blocked = guard(reply);
+      if (blocked !== null) return blocked;
+
+      const { sessionId } = req.params;
+      const row = db
+        .prepare(
+          `SELECT session_id, started_at, current_step, replies_json,
+                  completed_at, completion_payload_json, child_name, child_age
+           FROM mc10_mobile_sessions WHERE session_id = ?`,
+        )
+        .get(sessionId) as Mc10SessionRow | undefined;
+      if (!row) {
+        return reply
+          .code(404)
+          .send({ error: `session ${sessionId} não encontrada` });
+      }
+      const history = loadHistory(row);
+      const replies: Record<string, Mc10ParsedValue> = {};
+      for (const h of history) {
+        replies[h.stepId] = h.parsed;
+      }
+      return {
+        sessionId,
+        startedAt: row.started_at,
+        currentStep: row.current_step as Mc10StepId,
+        complete: row.completed_at !== null,
+        completedAt: row.completed_at,
+        completionPayload: row.completion_payload_json
+          ? (JSON.parse(row.completion_payload_json) as Mc10CompletionPayload)
+          : null,
+        replies,
+        childName: row.child_name,
+        childAge: row.child_age,
+      };
+    },
+  );
+};
+
+export default mc10Routes;

--- a/packages/ebrota-console-bff/src/server.ts
+++ b/packages/ebrota-console-bff/src/server.ts
@@ -89,6 +89,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import b1RoutesPlugin from "./routes/b1-routes.js";
 import b2RoutesPlugin from "./routes/b2-routes.js";
+import mc10MobileRoutes from "./routes/mc10-routes.js";
 
 export interface CreateBffServerOptions {
   daemon: OrchestratorDaemonClient;
@@ -188,6 +189,11 @@ export function createBffServer(opts: CreateBffServerOptions): BffServer {
 
   // Parental Engaged Dashboard (US-PE-01..09) — plugin Fastify isolado.
   void fastify.register(parentalDashboardRoutes, {});
+
+  // MC10 mobile onboarding (alternativa mobile-first ao wizard web).
+  // Feature flag MC10_MOBILE_ONBOARDING=true habilita os endpoints; sem
+  // flag, retornam 503. Twilio webhook wiring é outro PR.
+  void fastify.register(mc10MobileRoutes, { db: opts.db });
 
   // In-memory set de sessionIds ativos (iniciados via /sessions/start-card,
   // removidos via /sessions/:id/end). Permite que App.svelte faça polling

--- a/packages/ebrota-console-bff/tests/mc10-mobile-flow.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/mc10-mobile-flow.unit.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import {
+  FIRST_STEP,
+  MC10_STEPS,
+  buildCompletionPayload,
+  getNextStep,
+  parseReply,
+  validateReply,
+  type Mc10ReplyHistoryEntry,
+} from "../src/mc10-mobile-flow.js";
+
+describe("MC10 state machine — step transitions", () => {
+  it("FIRST_STEP é welcome com prompt apresentando Brota", () => {
+    expect(FIRST_STEP).toBe("welcome");
+    expect(MC10_STEPS.welcome.promptText).toContain("Brota");
+    expect(MC10_STEPS.welcome.promptText).toContain("7 coisas");
+  });
+
+  it("welcome → child_name avança com qualquer ack", () => {
+    const r = getNextStep("welcome", "ok");
+    expect(r.advanced).toBe(true);
+    expect(r.nextStep).toBe("child_name");
+  });
+
+  it("cada step não-complete aponta pro próximo correto", () => {
+    expect(MC10_STEPS.welcome.nextStep).toBe("child_name");
+    expect(MC10_STEPS.child_name.nextStep).toBe("child_age");
+    expect(MC10_STEPS.child_age.nextStep).toBe("child_languages");
+    expect(MC10_STEPS.child_languages.nextStep).toBe("parental_telos_short");
+    expect(MC10_STEPS.parental_telos_short.nextStep).toBe("daily_window");
+    expect(MC10_STEPS.daily_window.nextStep).toBe("consent_confirm");
+    expect(MC10_STEPS.consent_confirm.nextStep).toBe("complete");
+  });
+
+  it("complete é estado terminal (idempotente)", () => {
+    const r = getNextStep("complete", "sim");
+    expect(r.advanced).toBe(false);
+    expect(r.nextStep).toBe("complete");
+  });
+
+  it("reply inválido NÃO avança — currentStep preservado", () => {
+    const r = getNextStep("child_age", "não sei");
+    expect(r.advanced).toBe(false);
+    expect(r.nextStep).toBe("child_age");
+  });
+});
+
+describe("MC10 parseReply — válidos", () => {
+  it("name: trim e accept non-empty", () => {
+    const r = parseReply("child_name", "  Ryo  ");
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "name") {
+      expect(r.parsed.value).toBe("Ryo");
+    }
+  });
+
+  it("age: 7 dentro de range 3-12", () => {
+    const r = parseReply("child_age", "7");
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "age") {
+      expect(r.parsed.value).toBe(7);
+    }
+  });
+
+  it("age: extrai número de texto livre ('tem 8 anos')", () => {
+    const r = parseReply("child_age", "tem 8 anos");
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "age") {
+      expect(r.parsed.value).toBe(8);
+    }
+  });
+
+  it("languages: comma split e trim", () => {
+    const r = parseReply(
+      "child_languages",
+      "português, japonês ,  inglês",
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "languages") {
+      expect(r.parsed.value).toEqual(["português", "japonês", "inglês"]);
+    }
+  });
+
+  it("free_text: aceita frase de telos", () => {
+    const r = parseReply(
+      "parental_telos_short",
+      "Quero que ele seja curioso e gentil.",
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "free_text") {
+      expect(r.parsed.value).toContain("curioso");
+    }
+  });
+
+  it("daily_window: 'manhã e tarde' → ['manhã', 'tarde']", () => {
+    const r = parseReply("daily_window", "manhã e tarde");
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "daily_window") {
+      expect(r.parsed.value).toEqual(["manhã", "tarde"]);
+    }
+  });
+
+  it("daily_window: 'manha' sem til normaliza pra 'manhã'", () => {
+    const r = parseReply("daily_window", "manha");
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "daily_window") {
+      expect(r.parsed.value).toEqual(["manhã"]);
+    }
+  });
+
+  it("consent: 'sim' → true", () => {
+    const r = parseReply("consent_confirm", "sim");
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "boolean_yesno") {
+      expect(r.parsed.value).toBe(true);
+    }
+  });
+
+  it("consent: 'Não' (case-insensitive) → false", () => {
+    const r = parseReply("consent_confirm", "Não");
+    expect(r.ok).toBe(true);
+    if (r.ok && r.parsed.kind === "boolean_yesno") {
+      expect(r.parsed.value).toBe(false);
+    }
+  });
+});
+
+describe("MC10 parseReply — inválidos retornam hint", () => {
+  it("name vazio → erro com hint", () => {
+    const r = parseReply("child_name", "   ");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.hint).toBeTruthy();
+    }
+  });
+
+  it("age não numérica → erro", () => {
+    const r = parseReply("child_age", "sei lá");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.hint).toContain("número");
+  });
+
+  it("age fora de range (2) → erro", () => {
+    const r = parseReply("child_age", "2");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("range");
+  });
+
+  it("age fora de range (15) → erro", () => {
+    const r = parseReply("child_age", "15");
+    expect(r.ok).toBe(false);
+  });
+
+  it("languages vazio → erro", () => {
+    const r = parseReply("child_languages", "   ,  ,  ");
+    expect(r.ok).toBe(false);
+  });
+
+  it("free_text vazio (telos) → erro", () => {
+    const r = parseReply("parental_telos_short", "");
+    expect(r.ok).toBe(false);
+  });
+
+  it("daily_window 'meio-dia' → erro com hint dos válidos", () => {
+    const r = parseReply("daily_window", "meio-dia");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.hint).toMatch(/manhã|tarde|noite/);
+  });
+
+  it("consent ambíguo ('talvez') → erro", () => {
+    const r = parseReply("consent_confirm", "talvez");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("ambíguo");
+  });
+});
+
+describe("MC10 validateReply — kind alinhado ao step", () => {
+  it("kind name no step child_name → ok", () => {
+    const v = validateReply({ kind: "name", value: "Ryo" }, "child_name");
+    expect(v.ok).toBe(true);
+  });
+
+  it("kind age no step child_name → erro mismatch", () => {
+    const v = validateReply({ kind: "age", value: 7 }, "child_name");
+    expect(v.ok).toBe(false);
+  });
+});
+
+describe("MC10 buildCompletionPayload", () => {
+  const fullHistory = (): Mc10ReplyHistoryEntry[] => [
+    { stepId: "welcome", rawText: "ok", parsed: { kind: "ack" } },
+    {
+      stepId: "child_name",
+      rawText: "Ryo",
+      parsed: { kind: "name", value: "Ryo" },
+    },
+    {
+      stepId: "child_age",
+      rawText: "8",
+      parsed: { kind: "age", value: 8 },
+    },
+    {
+      stepId: "child_languages",
+      rawText: "pt, jp",
+      parsed: { kind: "languages", value: ["pt", "jp"] },
+    },
+    {
+      stepId: "parental_telos_short",
+      rawText: "curioso",
+      parsed: { kind: "free_text", value: "curioso" },
+    },
+    {
+      stepId: "daily_window",
+      rawText: "tarde",
+      parsed: { kind: "daily_window", value: ["tarde"] },
+    },
+    {
+      stepId: "consent_confirm",
+      rawText: "sim",
+      parsed: { kind: "boolean_yesno", value: true },
+    },
+  ];
+
+  it("payload completo com todos campos", () => {
+    const p = buildCompletionPayload(fullHistory());
+    expect(p).toEqual({
+      childName: "Ryo",
+      childAge: 8,
+      childLanguages: ["pt", "jp"],
+      parentalTelosShort: "curioso",
+      dailyWindow: ["tarde"],
+      consentGranted: true,
+    });
+  });
+
+  it("consentGranted=false quando pai disse não", () => {
+    const h = fullHistory();
+    h[6]!.parsed = { kind: "boolean_yesno", value: false };
+    const p = buildCompletionPayload(h);
+    expect(p.consentGranted).toBe(false);
+  });
+
+  it("histórico incompleto → lança", () => {
+    const h = fullHistory().slice(0, 4);
+    expect(() => buildCompletionPayload(h)).toThrow();
+  });
+});
+
+describe("MC10 idempotency — reply 2x mesmo step", () => {
+  it("getNextStep com mesma reply duas vezes avança apenas se válida; complete não avança nunca", () => {
+    const first = getNextStep("child_name", "Ryo");
+    expect(first.advanced).toBe(true);
+    expect(first.nextStep).toBe("child_age");
+    // Caller mantém estado em child_age; reapply same name não é
+    // chamado de novo, mas se for chamado em child_name, avança igual.
+    const second = getNextStep("child_name", "Ryo");
+    expect(second.advanced).toBe(true);
+    // Estado complete nunca avança.
+    const term1 = getNextStep("complete", "Ryo");
+    const term2 = getNextStep("complete", "Ryo");
+    expect(term1.advanced).toBe(false);
+    expect(term2.advanced).toBe(false);
+  });
+});

--- a/packages/ebrota-console-bff/tests/mc10-routes.unit.test.ts
+++ b/packages/ebrota-console-bff/tests/mc10-routes.unit.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb } from "../src/db.js";
+import { createBffServer, type BffServer } from "../src/server.js";
+import { createMockDaemonClient } from "../src/daemon-client.js";
+
+const FLAG = "MC10_MOBILE_ONBOARDING";
+const previousFlag = process.env[FLAG];
+
+let server: BffServer;
+
+const inject = async (
+  method: "GET" | "POST",
+  url: string,
+  payload?: unknown,
+) => {
+  const res = await server.fastify.inject({
+    method,
+    url,
+    ...(payload !== undefined ? { payload } : {}),
+  });
+  return {
+    status: res.statusCode,
+    body: res.body ? (JSON.parse(res.body) as Record<string, unknown>) : null,
+  };
+};
+
+const newServer = () => {
+  const db = initDb({ dbPath: ":memory:" });
+  const daemon = createMockDaemonClient();
+  return createBffServer({ daemon, db, logger: false });
+};
+
+describe("MC10 routes — feature flag enabled", () => {
+  beforeEach(() => {
+    process.env[FLAG] = "true";
+    server = newServer();
+  });
+  afterEach(async () => {
+    await server.close();
+    if (previousFlag === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = previousFlag;
+  });
+
+  it("POST /mc10/mobile/start cria session + retorna firstPrompt", async () => {
+    const res = await inject("POST", "/mc10/mobile/start");
+    expect(res.status).toBe(200);
+    expect(typeof res.body?.sessionId).toBe("string");
+    expect(res.body?.currentStep).toBe("welcome");
+    expect(res.body?.firstPrompt).toContain("Brota");
+  });
+
+  it("reply válido avança step (welcome → child_name)", async () => {
+    const start = await inject("POST", "/mc10/mobile/start");
+    const sid = start.body?.sessionId as string;
+    const r = await inject("POST", `/mc10/mobile/${sid}/reply`, {
+      text: "ok",
+    });
+    expect(r.status).toBe(200);
+    expect(r.body?.complete).toBe(false);
+    expect(r.body?.currentStep).toBe("child_name");
+    expect(r.body?.nextPrompt).toContain("chama");
+  });
+
+  it("reply inválido retorna 400 com hint + currentStep preservado", async () => {
+    const start = await inject("POST", "/mc10/mobile/start");
+    const sid = start.body?.sessionId as string;
+    // avança até child_age
+    await inject("POST", `/mc10/mobile/${sid}/reply`, { text: "ok" }); // welcome
+    await inject("POST", `/mc10/mobile/${sid}/reply`, { text: "Ryo" }); // child_name
+    const bad = await inject("POST", `/mc10/mobile/${sid}/reply`, {
+      text: "sei lá",
+    });
+    expect(bad.status).toBe(400);
+    expect(bad.body?.currentStep).toBe("child_age");
+    expect(bad.body?.hint).toBeTruthy();
+    expect(bad.body?.retryPrompt).toContain("anos");
+  });
+
+  it("completion → completionPayload retornado, session marked complete", async () => {
+    const start = await inject("POST", "/mc10/mobile/start");
+    const sid = start.body?.sessionId as string;
+    const replies = [
+      "ok", // welcome
+      "Ryo", // child_name
+      "8", // child_age
+      "português, japonês", // child_languages
+      "Quero que seja curioso e gentil.", // telos
+      "tarde e noite", // daily_window
+      "sim", // consent
+    ];
+    let last: Record<string, unknown> | null = null;
+    for (const text of replies) {
+      const r = await inject("POST", `/mc10/mobile/${sid}/reply`, { text });
+      expect(r.status).toBe(200);
+      last = r.body;
+    }
+    expect(last?.complete).toBe(true);
+    const payload = last?.completionPayload as Record<string, unknown>;
+    expect(payload.childName).toBe("Ryo");
+    expect(payload.childAge).toBe(8);
+    expect(payload.childLanguages).toEqual(["português", "japonês"]);
+    expect(payload.dailyWindow).toEqual(["tarde", "noite"]);
+    expect(payload.consentGranted).toBe(true);
+  });
+
+  it("GET status retorna current step + replies acumulados", async () => {
+    const start = await inject("POST", "/mc10/mobile/start");
+    const sid = start.body?.sessionId as string;
+    await inject("POST", `/mc10/mobile/${sid}/reply`, { text: "ok" });
+    await inject("POST", `/mc10/mobile/${sid}/reply`, { text: "Kei" });
+
+    const status = await inject("GET", `/mc10/mobile/${sid}`);
+    expect(status.status).toBe(200);
+    expect(status.body?.currentStep).toBe("child_age");
+    expect(status.body?.complete).toBe(false);
+    expect(status.body?.childName).toBe("Kei");
+    const replies = status.body?.replies as Record<string, unknown>;
+    expect(replies.child_name).toBeDefined();
+    expect(replies.welcome).toBeDefined();
+  });
+
+  it("GET status 404 quando session inexistente", async () => {
+    const status = await inject("GET", `/mc10/mobile/does-not-exist`);
+    expect(status.status).toBe(404);
+  });
+
+  it("idempotency: replies após complete retornam mesmo payload sem avançar", async () => {
+    const start = await inject("POST", "/mc10/mobile/start");
+    const sid = start.body?.sessionId as string;
+    const replies = [
+      "ok",
+      "Ryo",
+      "8",
+      "português",
+      "telos curto",
+      "manhã",
+      "sim",
+    ];
+    for (const text of replies) {
+      await inject("POST", `/mc10/mobile/${sid}/reply`, { text });
+    }
+    const status1 = await inject("GET", `/mc10/mobile/${sid}`);
+    expect(status1.body?.complete).toBe(true);
+
+    // re-reply após complete: retorna payload sem mudar estado
+    const replay = await inject("POST", `/mc10/mobile/${sid}/reply`, {
+      text: "qualquer coisa",
+    });
+    expect(replay.status).toBe(200);
+    expect(replay.body?.complete).toBe(true);
+    expect(replay.body?.completionPayload).toBeDefined();
+  });
+
+  it("POST /reply body sem text → 400", async () => {
+    const start = await inject("POST", "/mc10/mobile/start");
+    const sid = start.body?.sessionId as string;
+    const r = await inject("POST", `/mc10/mobile/${sid}/reply`, {});
+    expect(r.status).toBe(400);
+  });
+});
+
+describe("MC10 routes — feature flag OFF", () => {
+  beforeEach(() => {
+    delete process.env[FLAG];
+    server = newServer();
+  });
+  afterEach(async () => {
+    await server.close();
+    if (previousFlag !== undefined) process.env[FLAG] = previousFlag;
+  });
+
+  it("503 em /mc10/mobile/start", async () => {
+    const r = await inject("POST", "/mc10/mobile/start");
+    expect(r.status).toBe(503);
+    expect(r.body?.error).toContain("disabled");
+  });
+
+  it("503 em /mc10/mobile/:sessionId/reply", async () => {
+    const r = await inject("POST", "/mc10/mobile/whatever/reply", {
+      text: "x",
+    });
+    expect(r.status).toBe(503);
+  });
+
+  it("503 em GET /mc10/mobile/:sessionId", async () => {
+    const r = await inject("GET", "/mc10/mobile/whatever");
+    expect(r.status).toBe(503);
+  });
+});


### PR DESCRIPTION
## Contexto

MC10 mobile onboarding via WhatsApp — 7 mensagens canônicas pra coletar parental_telos antes do piloto. Alternativa mobile-first ao wizard web do #250.

Cross-repo: ascendimacy/ascendimacy-ops Agent E6-N do batch 6.

## Mudanças

**Novo módulo** `packages/ebrota-console-bff/src/mc10-mobile-flow.ts`:
- Pure functions sem side effects de framework
- State machine de 7 estados sequenciais (welcome → child_name → child_age → child_languages → parental_telos_short → daily_window → consent_confirm → complete)
- Exports: `getNextStep`, `parseReply`, `validateReply`, `buildCompletionPayload`, `MC10_STEPS`, `FIRST_STEP`

**Novo plugin Fastify** `packages/ebrota-console-bff/src/routes/mc10-routes.ts`:
- `POST /mc10/mobile/start` → cria session + retorna firstPrompt
- `POST /mc10/mobile/:sessionId/reply` → processa via state machine, retorna `nextPrompt` ou `completionPayload`
- `GET  /mc10/mobile/:sessionId` → status atual (debug)
- Feature flag: `MC10_MOBILE_ONBOARDING=true` no env do BFF; sem flag, todos endpoints retornam 503

**Schema SQLite**: tabela `mc10_mobile_sessions` em `db.ts` (DDL idempotente). Pre-bakeados child_name/child_age pra futura search.

**Out-of-scope**: Twilio webhook integration. Outro PR conecta esses endpoints ao webhook real.

**Frontend**: nada. MC10 é mobile-first WhatsApp — sem UI no console.

## State machine flow (texts dos 7 prompts)

1. **welcome**: "Oi! Sou Brota. Posso te perguntar 7 coisas pra entender melhor seu filho? Responde quando puder."
2. **child_name**: "Como ele/ela se chama?"
3. **child_age**: "Quantos anos?" (3-12)
4. **child_languages**: "Quais línguas vocês usam em casa? (separe com vírgula)"
5. **parental_telos_short**: "Em 1 frase, o que você mais quer pra ele/ela?"
6. **daily_window**: "Que horários do dia você prefere que ele/ela converse comigo? (manhã/tarde/noite)"
7. **consent_confirm**: "Posso começar a conversar com ele/ela amanhã? (sim/não)"

## Tests

```
✓ tests/mc10-mobile-flow.unit.test.ts  (28 tests)
✓ tests/mc10-routes.unit.test.ts       (11 tests)
```

- Estado machine: transições corretas + complete idempotente
- Parse: name trim, age range 3-12 + extração de texto livre, languages comma-split, daily_window com 'manhã e tarde' + 'manha' sem til, consent sim/não case-insensitive
- Validation errors: age não numérica/fora de range, languages vazio, telos vazio, consent ambíguo, daily_window não reconhecido
- Completion payload: shape correto + lança em histórico incompleto + consentGranted=false respeitado
- Routes: start cria session, reply válido avança, reply inválido 400 com hint + currentStep preservado, completion retorna payload, GET status retorna replies acumulados, 404 inexistente, idempotency post-complete, feature flag OFF → 503 em todas rotas

**Full BFF suite**: 319/319 passing.

## Não mergear

Per spec do agent task.