### PR TITLE
[fix] B2 panel test — mock listDrillAttempts (unblocks CI)

### DIFF
--- a/packages/ebrota-console-ui/tests/b2-drilling-panel.test.ts
+++ b/packages/ebrota-console-ui/tests/b2-drilling-panel.test.ts
@@ -19,6 +19,7 @@ function buildApi(over: Partial<ApiClient> = {}): ApiClient {
     listDrillStates: vi.fn().mockResolvedValue({ states: [] }),
     listDrillDue: vi.fn().mockResolvedValue({ states: [] }),
     listDrillMastered: vi.fn().mockResolvedValue({ states: [] }),
+    listDrillAttempts: vi.fn().mockResolvedValue({ attempts: [] }),
   };
   return { ...base, ...over } as ApiClient;
 }


### PR DESCRIPTION
## Bug

`tests/b2-drilling-panel.test.ts` `buildApi()` factory only mocks 4 methods, but `B2DrillingPanel.svelte` consumer calls 5 (including `listDrillAttempts`). Result: any PR against main fails CI with `api.listDrillAttempts is not a function`.

## Root cause

PR #259 (B2 drilling pipeline) added the consumer call but did not update the mock fixture. Bug entered main; affects every open PR (#265, #266) that runs CI against main.

## Fix

One line: add `listDrillAttempts: vi.fn().mockResolvedValue({ attempts: [] })` to the mock factory.

## Verification

- `npm test -w packages/ebrota-console-ui -- b2-drilling-panel` → 4/4 ✓
- `npm test -w packages/ebrota-console-ui` (full suite) → 236/236 ✓

After merge, #265 and #266 CI should re-run green.