### PR TITLE
feat(tutor): v0.2.8 Discovery-Specific Pool — ataca Achado 3 cirurgicamente

### DIFF
--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -374,7 +374,32 @@ export async function handleSimplifiedPipeline(
     | import("@ascendimacy/shared").MaterializerTrace
     | undefined;
 
-  if (USE_SPLIT_DROTA) {
+  // v0.2.8 — Discovery-Specific Pool short-circuit.
+  // Quando planejador emitiu contextHints.discovery_options (porque move_type=
+  // discover), bypassamos o materializer LLM. O finalText vira a primeira
+  // discovery option escolhida (heurística v1 — v0.3 pode rankear por signal
+  // match ou rotação por kind).
+  //
+  // Motivação: STS realista mostrou LLM ignorando MOVIMENTO: descobrir e
+  // empurrando content do pool estático. Dar pool DIFERENTE (questões de
+  // descoberta) + curto-circuitar materializer = honra contrato sem depender
+  // do LLM seguir instrução negativa.
+  //
+  // fallbackTriggered=true por design — não apresentamos conteúdo educacional,
+  // então concept ledger não acumula presented_concept (gate pedagogicamente
+  // correto pra fase de discovery).
+  const discoveryOptions = input.contextHints?.["discovery_options"] as
+    | Array<{ kind: string; text: string; anchor: string }>
+    | undefined;
+  const discoveryShortCircuit =
+    Array.isArray(discoveryOptions) && discoveryOptions.length > 0;
+
+  if (discoveryShortCircuit) {
+    const chosen = discoveryOptions![0]!;
+    finalText = chosen.text;
+    fallbackTriggered = true;
+    recallCheckEmitted = undefined;
+  } else if (USE_SPLIT_DROTA) {
     // ── S4 path ──────────────────────────────────────────────────────────
     // Step 1: Tactician decides jogada from content pool + assessor signals.
     const tacResult = await tactician(

--- a/planejador/src/discovery-agent.ts
+++ b/planejador/src/discovery-agent.ts
@@ -1,0 +1,180 @@
+/**
+ * Discovery Agent v0.2.8 — gera opções de pergunta aberta para fase de descoberta.
+ *
+ * Quando o Tutor emite `move_type=discover`, este agent faz chamada LLM extra
+ * que retorna N opções de pergunta/probe ancoradas no histórico recente +
+ * sinais detectados + necessidades latentes parentais.
+ *
+ * Motivação: STS realista mostrou que o materializer LLM ignora MOVIMENTO:
+ * descobrir e empurra conteúdo do contentPool estático. Solução: dar ao
+ * materializer um pool DIFERENTE — questões de descoberta em vez de items
+ * de conteúdo — quando o move é discover.
+ *
+ * Spec base: 2026-05-25-session-phases-journey-stages-strategist.md
+ *            + 2026-05-25-subject-knowledge-bridge.md
+ *
+ * Arquitetura: chamada single-LLM stateless. Sem retry sofisticado.
+ * Fallback determinístico (lista hardcoded) quando LLM falhar.
+ */
+
+import { callLlm, callLlmMock } from "./llm-client.js";
+import { shouldUseMockLlm } from "@ascendimacy/shared";
+
+export type DiscoveryOptionKind =
+  | "interest_probe"     // pergunta sobre algo que o sujeito mencionou
+  | "gap_check"          // identifica algo não-mencionado pra explorar
+  | "agency_offer"       // convida o sujeito a propor direção
+  | "value_observation"  // pergunta como mede algo importante
+  | "bridge_to_artifact"; // refere o baralho ou outro artefato concreto
+
+export interface DiscoveryOption {
+  /** Tipo de probe (semântica pra trace/selector). */
+  kind: DiscoveryOptionKind;
+  /** Texto da pergunta/probe — proposta para o materializer formular ao redor. */
+  text: string;
+  /** Tópico/conceito ao qual o probe ancora (do que o sujeito disse). */
+  anchor: string;
+}
+
+export interface DiscoveryAgentInput {
+  /** Histórico recente da conversa (últimos N turns). */
+  recentTurns: Array<{ role: "user" | "assistant"; content: string }>;
+  /** Sinais extraídos do turn atual. */
+  extractedSignals: string[];
+  /** Necessidades latentes do perfil parental. */
+  latentNeeds: string[];
+  /** Tópicos já mencionados pelo sujeito. */
+  topicMentions: string[];
+  /** Mensagem mais recente do sujeito. */
+  incomingMessage?: string;
+  /** Nome do sujeito (pra contexto humano). */
+  subjectName: string;
+}
+
+/**
+ * Fallback determinístico — usado quando LLM falha OU em mock mode.
+ * 5 opções genéricas mas semanticamente válidas, ancoradas no incomingMessage
+ * ou em tópicos comuns.
+ */
+function buildFallbackOptions(input: DiscoveryAgentInput): DiscoveryOption[] {
+  const lastTopic = input.topicMentions[0] ?? "o que você trouxe";
+  const subj = input.subjectName;
+  return [
+    {
+      kind: "interest_probe",
+      text: `Você falou de ${lastTopic} — me conta uma vez em que isso te fez sentir vivo?`,
+      anchor: lastTopic,
+    },
+    {
+      kind: "agency_offer",
+      text: `${subj}, qual parte disso vale a pena a gente explorar primeiro?`,
+      anchor: "agency",
+    },
+    {
+      kind: "gap_check",
+      text: `Tem alguma coisa que te incomoda e que ninguém parou pra ouvir ainda?`,
+      anchor: "unspoken",
+    },
+    {
+      kind: "value_observation",
+      text: `Quando você sabe que algo deu certo — qual é a marca disso pra você?`,
+      anchor: "self_measure",
+    },
+    {
+      kind: "bridge_to_artifact",
+      text: `Quer pegar o baralho de virtudes e ver qual carta combina com isso que você tá descrevendo?`,
+      anchor: "baralho",
+    },
+  ];
+}
+
+/**
+ * Tenta parsear JSON do LLM. Defensive — vários LLMs adicionam
+ * texto antes/depois do array.
+ */
+function parseDiscoveryOptions(raw: string): DiscoveryOption[] | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  // Tenta achar um array JSON no meio do texto
+  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
+  const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
+  const candidate = arrayMatch ? arrayMatch[0] : cleaned;
+  try {
+    const parsed = JSON.parse(candidate);
+    if (!Array.isArray(parsed)) return null;
+    const out: DiscoveryOption[] = [];
+    for (const item of parsed) {
+      if (typeof item?.kind === "string" && typeof item?.text === "string" && typeof item?.anchor === "string") {
+        out.push({
+          kind: item.kind as DiscoveryOptionKind,
+          text: item.text,
+          anchor: item.anchor,
+        });
+      }
+    }
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildSystemPrompt(input: DiscoveryAgentInput): string {
+  return `Você é o Discovery Agent do Ascendimacy. Seu papel: gerar 5 opções de PERGUNTA ABERTA pra um tutor usar com um sujeito jovem (provavelmente 10-14 anos) durante a FASE DE DESCOBERTA.
+
+REGRAS ABSOLUTAS:
+- NÃO gere conteúdo educacional, fatos, metáforas ou conceitos a ensinar
+- NÃO seja terapeuta nem psicólogo — sem framing "como você se sente"
+- Cada opção é UMA PERGUNTA curta + ancorada
+- Variedade obrigatória entre os 5 kinds disponíveis
+
+KINDS DISPONÍVEIS:
+- interest_probe: pergunta sobre algo que o sujeito mencionou
+- gap_check: identifica algo não-mencionado pra explorar
+- agency_offer: convida o sujeito a propor direção
+- value_observation: pergunta como o sujeito mede algo importante
+- bridge_to_artifact: refere o baralho de 4 virtudes que ele recebeu
+
+CONTEXTO DO SUJEITO:
+Nome: ${input.subjectName}
+Tópicos já mencionados: ${input.topicMentions.length > 0 ? input.topicMentions.join(", ") : "(ainda nenhum)"}
+Necessidades latentes (parental input): ${input.latentNeeds.length > 0 ? input.latentNeeds.slice(0, 4).join("; ") : "(nenhuma declarada)"}
+Sinais extraídos do turn atual: ${input.extractedSignals.length > 0 ? input.extractedSignals.join(", ") : "(nenhum)"}
+Mensagem mais recente do sujeito: "${input.incomingMessage ?? ""}"
+
+OUTPUT — RETORNE APENAS JSON ARRAY com 5 opções:
+[
+  { "kind": "interest_probe", "text": "...", "anchor": "..." },
+  { "kind": "gap_check", "text": "...", "anchor": "..." },
+  { "kind": "agency_offer", "text": "...", "anchor": "..." },
+  { "kind": "value_observation", "text": "...", "anchor": "..." },
+  { "kind": "bridge_to_artifact", "text": "...", "anchor": "..." }
+]`;
+}
+
+/**
+ * Gera opções de descoberta via chamada LLM (ou fallback se falhar).
+ * Sempre retorna ≥3 opções (fallback se LLM gerar lixo).
+ */
+export async function generateDiscoveryOptions(
+  input: DiscoveryAgentInput,
+): Promise<DiscoveryOption[]> {
+  const useMock = shouldUseMockLlm("planejador");
+  if (useMock) {
+    return buildFallbackOptions(input);
+  }
+
+  const systemPrompt = buildSystemPrompt(input);
+  const userMessage = `Gere 5 opções de pergunta aberta, em JSON array.`;
+
+  try {
+    const result = await callLlm(systemPrompt, userMessage);
+    const parsed = parseDiscoveryOptions(result.content);
+    if (parsed && parsed.length >= 3) {
+      return parsed;
+    }
+    // LLM gerou lixo — fallback
+    return buildFallbackOptions(input);
+  } catch {
+    // Network/timeout/etc — fallback determinístico
+    return buildFallbackOptions(input);
+  }
+}

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -46,6 +46,7 @@ import {
   isExhausted,
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku, type LlmCallResult } from "./llm-client.js";
+import { generateDiscoveryOptions } from "./discovery-agent.js";
 import { detectMilestone } from "./milestone-detector.js";
 import type { LlmTraceCollector, PlanejadorTrace } from "@ascendimacy/shared";
 
@@ -873,6 +874,40 @@ export async function planTurn(
   const tutorial = computeBasicTutorialContext(input, topK?.[0]?.item ?? null);
   if (tutorial) {
     contextHints["tutorial"] = tutorial;
+  }
+
+  // v0.2.8 (Discovery-Specific Pool) — quando move_type=discover, chama o
+  // Discovery Agent (LLM extra) pra gerar 5 opções de pergunta aberta
+  // ancoradas em sinais + tópicos mencionados + necessidades latentes.
+  // Opções vão pra contextHints.discovery_options; motor-drota's pipeline
+  // detecta + usa esse pool em vez do contentPool estático quando discover.
+  // Cobra +1 LLM call apenas em discover turns.
+  if (tutorial?.move_type === "discover") {
+    const discoveryInput = {
+      recentTurns: Array.isArray(input.contextHints?.["recent_turns"])
+        ? (input.contextHints["recent_turns"] as Array<{ role: "user" | "assistant"; content: string }>)
+        : [],
+      extractedSignals: Array.isArray(input.contextHints?.["extracted_signals"])
+        ? (input.contextHints["extracted_signals"] as string[])
+        : [],
+      latentNeeds: Array.isArray(child?.latent_needs)
+        ? (child.latent_needs as string[])
+        : [],
+      topicMentions: Array.isArray(input.contextHints?.["topic_mentions"])
+        ? (input.contextHints["topic_mentions"] as string[])
+        : [],
+      incomingMessage: typeof input.incomingMessage === "string" ? input.incomingMessage : undefined,
+      subjectName: input.persona?.name ?? "amigo",
+    };
+    try {
+      const discoveryOptions = await generateDiscoveryOptions(discoveryInput);
+      if (discoveryOptions.length > 0) {
+        contextHints["discovery_options"] = discoveryOptions;
+      }
+    } catch {
+      // Telemetry: discovery failure não bloqueia turn — segue sem discovery_options
+      // (fallback determinístico já cobre LLM crashes dentro do agent).
+    }
   }
 
   // CP5 / Item 8 — instruction_addition recebe linha curta por move_type.

--- a/scripts/smoke-infra-tutor-discovery-pool-v0.mjs
+++ b/scripts/smoke-infra-tutor-discovery-pool-v0.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Smoke INFRA — Tutor Clássico v0.2.8 (Discovery-Specific Pool)
+ *
+ * Valida que quando `move_type=discover`, o planejador chama o
+ * Discovery Agent e injeta `contextHints.discovery_options`.
+ *
+ * Em USE_MOCK_LLM=true, discovery-agent retorna fallback determinístico
+ * de 5 opções. Smoke valida shape + presença + content.
+ *
+ * Tipo: Infra
+ *
+ * Uso:
+ *   npm run build --workspace shared && \
+ *   npm run build --workspace motor-execucao && \
+ *   npm run build --workspace planejador
+ *   node scripts/smoke-infra-tutor-discovery-pool-v0.mjs
+ */
+
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+process.env.USE_MOCK_LLM = "true";
+process.env.ASC_DEBUG_MODE = "false";
+
+let pass = 0;
+let fail = 0;
+let bypass = 0;
+
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+function recordBypass(msg) {
+  console.log(`  ○ ${msg} (bypass)`);
+  bypass++;
+}
+
+async function main() {
+  const stateDir = await mkdtemp(path.join(tmpdir(), "smoke-infra-tutor-disc-"));
+  process.env.MOTOR_STATE_DIR = stateDir;
+  console.log(`[smoke-infra] State dir: ${stateDir}\n`);
+
+  const { planTurn } = await import("../planejador/dist/plan.js");
+  const { getState } = await import("../motor-execucao/dist/state-manager.js");
+
+  console.log("[smoke-infra] Tutor Discovery Pool — discovery_options injetados quando discover (v0.2.8)\n");
+
+  const persona = {
+    id: "infra-tutor-disc",
+    name: "Test",
+    age: 12,
+    profile: {},
+  };
+
+  function buildPlanInput(sessionId, opts = {}) {
+    const { contextHints, incomingMessage, ...stateExtras } = opts;
+    const state = getState(sessionId);
+    const input = {
+      sessionId,
+      persona,
+      state: { ...state, ...stateExtras },
+    };
+    if (contextHints) input.contextHints = contextHints;
+    if (incomingMessage !== undefined) input.incomingMessage = incomingMessage;
+    return input;
+  }
+
+  // ─── G1: discover stage → discovery_options injetadas ──────────────────
+  console.log("[smoke-infra] G1: journey_stage=discovery_only → discovery_options em contextHints");
+  const planDisc = await planTurn(
+    buildPlanInput("disc-g1", {
+      turn: 4,
+      contextHints: { journey_stage: "discovery_only" },
+    }),
+  );
+  assert(planDisc.contextHints?.tutorial?.move_type === "discover", "move_type=discover");
+  const opts = planDisc.contextHints?.discovery_options;
+  assert(Array.isArray(opts), "discovery_options é array");
+  assert(opts?.length >= 3, `discovery_options >= 3 opções (got ${opts?.length})`);
+
+  // ─── G2: shape de cada opção ───────────────────────────────────────────
+  console.log("\n[smoke-infra] G2: shape de cada opção (kind + text + anchor)");
+  if (Array.isArray(opts) && opts.length > 0) {
+    const sample = opts[0];
+    assert(typeof sample.kind === "string", "opt.kind é string");
+    assert(typeof sample.text === "string" && sample.text.length > 0, "opt.text é string não-vazia");
+    assert(typeof sample.anchor === "string", "opt.anchor é string");
+    const kinds = new Set(opts.map((o) => o.kind));
+    assert(kinds.size >= 3, `variedade de kinds (got ${[...kinds].join(",")})`);
+  }
+
+  // ─── G3: NÃO emite quando move_type !== discover ────────────────────────
+  console.log("\n[smoke-infra] G3: move_type=explain → discovery_options AUSENTE");
+  const planExplain = await planTurn(buildPlanInput("disc-g3", { turn: 4 }));
+  assert(planExplain.contextHints?.tutorial?.move_type === "explain", "move_type=explain");
+  assert(
+    planExplain.contextHints?.discovery_options === undefined,
+    "discovery_options NÃO emitido em explain",
+  );
+
+  // ─── G4: JSON-serializável (trace-ready) ───────────────────────────────
+  console.log("\n[smoke-infra] G4: discovery_options é JSON-serializável");
+  if (Array.isArray(opts)) {
+    try {
+      const round = JSON.parse(JSON.stringify(opts));
+      assert(Array.isArray(round) && round.length === opts.length, "round-trip preserva length");
+      assert(round[0]?.kind === opts[0]?.kind, "kind preservado");
+      assert(round[0]?.text === opts[0]?.text, "text preservado");
+    } catch (err) {
+      assert(false, `serialização falhou: ${err.message}`);
+    }
+  }
+
+  // ─── G5: LLM real não exercitado em smoke ──────────────────────────────
+  console.log("\n[smoke-infra] G5: LLM real (Qwen/Claude) — validar via STS");
+  recordBypass(
+    "USE_MOCK_LLM=true usa fallback determinístico de 5 opções; LLM real validado em STS smoke",
+  );
+
+  console.log("");
+  console.log(`[smoke-infra] Total: ${pass} pass, ${fail} fail, ${bypass} bypass`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("[smoke-infra] FATAL:", err);
+  process.exit(1);
+});

--- a/scripts/smoke-infra-tutor-suite-v0.mjs
+++ b/scripts/smoke-infra-tutor-suite-v0.mjs
@@ -35,6 +35,7 @@ const SMOKES = [
   { cp: "CP8", item: "Item 12", name: "helix", file: "smoke-infra-tutor-helix-v0.mjs" },
   { cp: "CP9", item: "Item 13", name: "e2e [func]", file: "smoke-func-tutor-e2e-v0.mjs" },
   { cp: "v0.2.7", item: "Bandas", name: "inaugural-bands", file: "smoke-infra-tutor-inaugural-bands-v0.mjs" },
+  { cp: "v0.2.8", item: "DiscPool", name: "discovery-pool", file: "smoke-infra-tutor-discovery-pool-v0.mjs" },
 ];
 
 const TOTALS_RE = /Total:\s+(\d+)\s+pass,\s+(\d+)\s+fail,\s+(\d+)\s+bypass/;


### PR DESCRIPTION
## Discovery-Specific Pool — pool dedicado pro modo descobrir

### Problema (Achado 3)

STS realista (Haiku + Qwen3-30b) mostrou LLM materializer ignorando `MOVIMENTO: descobrir` e empurrando conteúdo do contentPool estático. Mesmo com instruction_addition forte ("NÃO introduza conteúdo novo"), bot dropava lagarta/elefantes/lágrimas químicas.

### Solução

Em vez de pedir pra LLM **não usar** o pool, **dar pool diferente** quando move=discover:

```
move_type=discover
  ↓ planejador chama discovery-agent (LLM extra)
  ↓ contextHints.discovery_options = [{kind, text, anchor}, ...]
  ↓ handler short-circuit: finalText = primeira opção
  ↓ materializer LLM PULADO (-1 call)
```

### 5 kinds de discovery options

- `interest_probe` — pergunta sobre algo que o sujeito já mencionou
- `gap_check` — identifica algo não-mencionado pra explorar
- `agency_offer` — convida o sujeito a propor direção
- `value_observation` — pergunta como o sujeito mede algo importante
- `bridge_to_artifact` — refere o baralho de 4 virtudes

### Mudanças

| Arquivo | Linhas | O que |
|---|---|---|
| `planejador/src/discovery-agent.ts` (NEW) | +180 | LLM call + fallback determinístico + parse defensive |
| `planejador/src/plan.ts` | +35 | Chama discovery-agent quando move=discover |
| `motor-drota/src/simplified-pipeline-handler.ts` | +27 | Short-circuit materializer com discovery option |
| `scripts/smoke-infra-tutor-discovery-pool-v0.mjs` (NEW) | +131 | 5 grupos / 12 asserts |
| `scripts/smoke-infra-tutor-suite-v0.mjs` | +1 | Adiciona ao suite |

### Suite

13 smokes, **206 asserts**, 0 fail, 11 bypass.

### Trade-off de latência

- `discover` turns: +1 LLM call (+30-60s Qwen ou +5-10s Sonnet)
- Outros move_types: zero impacto
- Justificado pedagogicamente (discovery é a fase formativa mais sensível)

### Validação STS pendente

Qwen3 stack offline + Claude proxy exhausted no momento do PR. Quando infra LLM recuperar, esperado:
- Bot diz UMA das 5 questões geradas (não dropa lagarta/elefante)
- `contextHints.discovery_options` no trace v2
- `tutorial_outcome.outcome=discovered` persiste no eventLog

### Co-related

- Base direta: ascendimacy-motor #275 (Tutor v0 Lotes 1+2 + v0.2.7) — já em main
- Spec docs: vou atualizar `2026-05-28-loop-tutorial-v0.md` v0.2.8 em PR separado depois de validação STS