### PR TITLE
feat(tutor): v0.3-B explain dynamic pool pattern

### DIFF
--- a/motor-drota/src/explain-agent.ts
+++ b/motor-drota/src/explain-agent.ts
@@ -1,0 +1,175 @@
+/**
+ * Explain Agent v0.3-B — gera opções de framing explicativo para um item
+ * pedagógico já selecionado.
+ *
+ * Padrão mirrored do Discovery Agent, mas roda em motor-drota DEPOIS do
+ * Pragmatic Selector picar o item (porque precisa do item específico).
+ * Saída vai pra explain-option-selector que escolhe um framing baseado
+ * em signals e o materializer é curto-circuitado.
+ *
+ * Diferente de discover, aqui geramos CONTEÚDO PEDAGÓGICO (não pergunta
+ * aberta) ancorado em fact/bridge/quest do item já validado. O LLM faz
+ * reformulação, NÃO invenção — anti-hallucination via anchor explícito
+ * no prompt.
+ *
+ * 4 kinds:
+ *   concrete_example  — caso específico, narrativa curta
+ *   metaphor          — ponte analógica
+ *   contrast          — o que NÃO é, anti-exemplo
+ *   lineage_anchor    — referência à tradição/cultura do item
+ *
+ * Mock mode + fallback determinístico: deriva 4 framings do item sem LLM.
+ */
+
+import { callGateway, shouldUseMockLlm } from "@ascendimacy/shared";
+import type { ExplainOption } from "./explain-option-selector.js";
+
+export interface ExplainAgentItem {
+  id: string;
+  fact?: string;
+  bridge?: string;
+  quest?: string;
+  keywords?: readonly string[];
+  /** "tradicao/complemento" — ex: "estoica/dicotomia_controle" */
+  lineage_anchor?: string;
+}
+
+export interface ExplainAgentInput {
+  item: ExplainAgentItem;
+  recentTurns: Array<{ role: "user" | "assistant"; content: string }>;
+  subjectName: string;
+  signals: string[];
+  /** run_id pra trace correlation. */
+  runId?: string;
+}
+
+const FALLBACK_LINEAGE = "tradição";
+
+function deriveAnchor(item: ExplainAgentItem): string {
+  return (
+    item.keywords?.[0] ??
+    item.lineage_anchor ??
+    item.id
+  );
+}
+
+function buildFallbackOptions(input: ExplainAgentInput): ExplainOption[] {
+  const it = input.item;
+  const anchor = deriveAnchor(it);
+  const factOrId = it.fact ?? it.id;
+  const lineage = it.lineage_anchor?.split("/")[0] ?? FALLBACK_LINEAGE;
+
+  return [
+    {
+      kind: "concrete_example",
+      text: `${input.subjectName}, ${factOrId}. Pensa numa vez em que você viu isso acontecer.`,
+      anchor,
+    },
+    {
+      kind: "metaphor",
+      text: `É como se ${anchor} fosse a chave de uma porta que você ainda não tinha visto.`,
+      anchor,
+    },
+    {
+      kind: "contrast",
+      text: `O contrário disso é ignorar ${anchor} — e a maioria faz exatamente isso.`,
+      anchor,
+    },
+    {
+      kind: "lineage_anchor",
+      text: `Na ${lineage}, isso era visto como um dos princípios essenciais.`,
+      anchor,
+    },
+  ];
+}
+
+function parseExplainOptions(raw: string): ExplainOption[] | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
+  const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
+  const candidate = arrayMatch ? arrayMatch[0] : cleaned;
+  try {
+    const parsed = JSON.parse(candidate);
+    if (!Array.isArray(parsed)) return null;
+    const out: ExplainOption[] = [];
+    for (const x of parsed) {
+      if (
+        typeof x?.kind === "string" &&
+        typeof x?.text === "string" &&
+        typeof x?.anchor === "string"
+      ) {
+        out.push({ kind: x.kind, text: x.text, anchor: x.anchor });
+      }
+    }
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildSystemPrompt(input: ExplainAgentInput): string {
+  const it = input.item;
+  const anchorFact = it.fact ?? `(sem fato textual — use id "${it.id}")`;
+  const lineage = it.lineage_anchor ?? "(nenhuma)";
+  const keywords = it.keywords?.join(", ") ?? "(nenhuma)";
+
+  return `Você é o Explain Agent do Ascendimacy. Seu papel: gerar 4 FRAMINGS de explicação curta (1-2 frases cada) para um conceito pedagógico já validado.
+
+ITEM A EXPLICAR (use estes ÂNCORAS — não invente fatos novos):
+- id: ${it.id}
+- fato: ${anchorFact}
+- bridge: ${it.bridge ?? "(nenhum)"}
+- quest: ${it.quest ?? "(nenhum)"}
+- linhagem: ${lineage}
+- palavras-chave: ${keywords}
+
+REGRAS ABSOLUTAS:
+- Cada framing tem 1-2 frases (curto, falável)
+- NÃO invente fatos — reformule o âncora acima
+- NÃO faça pergunta — explain ensina, não pergunta
+- 4 kinds OBRIGATÓRIOS, um por opção:
+  * concrete_example: caso/narrativa específica
+  * metaphor: ponte analógica
+  * contrast: o que NÃO é (anti-exemplo)
+  * lineage_anchor: referência à tradição/cultura do item
+
+CONTEXTO:
+Sujeito: ${input.subjectName}
+Signals: ${input.signals.length > 0 ? input.signals.join(", ") : "(nenhum)"}
+
+OUTPUT — RETORNE APENAS JSON ARRAY com 4 opções nessa ORDEM:
+[
+  { "kind": "concrete_example", "text": "...", "anchor": "..." },
+  { "kind": "metaphor", "text": "...", "anchor": "..." },
+  { "kind": "contrast", "text": "...", "anchor": "..." },
+  { "kind": "lineage_anchor", "text": "...", "anchor": "..." }
+]`;
+}
+
+export async function generateExplainOptions(
+  input: ExplainAgentInput,
+): Promise<ExplainOption[]> {
+  if (shouldUseMockLlm("drota")) {
+    return buildFallbackOptions(input);
+  }
+
+  const systemPrompt = buildSystemPrompt(input);
+  const userMessage = `Gere 4 framings de explicação, em JSON array.`;
+
+  try {
+    const result = await callGateway({
+      step: "drota",
+      systemPrompt,
+      userMessage,
+      maxTokens: 600,
+      ...(input.runId ? { run_id: input.runId } : {}),
+    });
+    const parsed = parseExplainOptions(result.content);
+    if (parsed && parsed.length >= 2) {
+      return parsed;
+    }
+    return buildFallbackOptions(input);
+  } catch {
+    return buildFallbackOptions(input);
+  }
+}

--- a/motor-drota/src/explain-option-selector.ts
+++ b/motor-drota/src/explain-option-selector.ts
@@ -1,0 +1,88 @@
+/**
+ * Explain option selection heuristic — v0.3-B.
+ *
+ * Mesma família do discovery-option-selector mas pra move_type=explain.
+ * Recebe pool de framings explicativos (gerados pelo explain-agent) e
+ * escolhe um deles baseado em signals + (opcional) engagement.
+ *
+ * Mapeamento signal → kind preferido:
+ *   frame_rejection, authority_questioning → contrast        (devolve com oposto)
+ *   voluntary_topic_deepening, mood_drift_up → metaphor      (sujeito em fluxo)
+ *   distress_marker_*, mood_drift_down → lineage_anchor      (ancora em tradição)
+ *   default                                → concrete_example (carga cognitiva baixa)
+ *
+ * Diferente de discover, explain NÃO tem fallback de "late_turn" — todo
+ * explain turn é uma oportunidade de teach, sem variação artificial por turno.
+ */
+
+export type ExplainOptionKind =
+  | "concrete_example"
+  | "metaphor"
+  | "contrast"
+  | "lineage_anchor";
+
+export interface ExplainOption {
+  kind: string;
+  text: string;
+  anchor: string;
+}
+
+export interface SelectExplainOptionInput {
+  options: ExplainOption[];
+  signals?: string[];
+}
+
+export interface ExplainOptionSelection {
+  chosen: ExplainOption;
+  reason: string;
+}
+
+export function selectExplainOption(
+  input: SelectExplainOptionInput,
+): ExplainOptionSelection {
+  const { options, signals = [] } = input;
+
+  if (!options || options.length === 0) {
+    throw new Error("selectExplainOption requires non-empty options");
+  }
+
+  if (options.length === 1) {
+    return { chosen: options[0]!, reason: "single_option" };
+  }
+
+  const priorities: ExplainOptionKind[] = [];
+  const reasons: string[] = [];
+
+  const has = (s: string): boolean => signals.includes(s);
+
+  if (has("frame_rejection") || has("authority_questioning")) {
+    priorities.push("contrast");
+    reasons.push("signal:frame_rejection/authority→contrast");
+  }
+
+  if (has("voluntary_topic_deepening") || has("mood_drift_up")) {
+    priorities.push("metaphor");
+    reasons.push("signal:engagement_up→metaphor");
+  }
+
+  if (
+    has("distress_marker_low") ||
+    has("distress_marker_high") ||
+    has("mood_drift_down")
+  ) {
+    priorities.push("lineage_anchor");
+    reasons.push("signal:distress/mood→lineage_anchor");
+  }
+
+  priorities.push("concrete_example");
+  if (reasons.length === 0) reasons.push("default:concrete_example");
+
+  for (const kind of priorities) {
+    const match = options.find((o) => o.kind === kind);
+    if (match) {
+      return { chosen: match, reason: reasons.join(",") };
+    }
+  }
+
+  return { chosen: options[0]!, reason: "fallback_no_match" };
+}

--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -124,6 +124,8 @@ import { resolveInauguralTemplate } from "./inaugural-template.js";
 import { tactician } from "./tactician.js";
 import { speak } from "./speaker.js";
 import { selectDiscoveryOption } from "./discovery-option-selector.js";
+import { selectExplainOption } from "./explain-option-selector.js";
+import { generateExplainOptions } from "./explain-agent.js";
 import type { TacticDecision } from "@ascendimacy/shared";
 
 export interface SimplifiedPipelineOpts {
@@ -412,6 +414,56 @@ export async function handleSimplifiedPipeline(
       recoverable: true,
     });
     fallbackTriggered = true;
+    recallCheckEmitted = undefined;
+  } else if (tutorialMoveType === "explain" && selectionResult.selected) {
+    // v0.3-B — Explain Dynamic Pool short-circuit.
+    // Quando tutorial.move_type=explain, geramos 4 framings (concrete_example,
+    // metaphor, contrast, lineage_anchor) ancorados no item já selecionado,
+    // selector escolhe por signals, materializer é curto-circuitado.
+    //
+    // fallbackTriggered=false por design — explain APRESENTA conceito, então
+    // o ledger DEVE contabilizar presented_concept (gate pedagógico correto).
+    const item = selectionResult.selected.item;
+    // ContentItem é union discriminada; fact/bridge/quest existem em curiosity_hook
+    // e cultural_diamond (não em card_catalog). Acesso narrowing-safe via cast.
+    const itemAny = item as {
+      id: string;
+      fact?: string;
+      bridge?: string;
+      quest?: string;
+      extracted_keywords?: readonly string[];
+      lineage_anchor?: string;
+    };
+    const explainOptions = await generateExplainOptions({
+      item: {
+        id: itemAny.id,
+        ...(itemAny.fact ? { fact: itemAny.fact } : {}),
+        ...(itemAny.bridge ? { bridge: itemAny.bridge } : {}),
+        ...(itemAny.quest ? { quest: itemAny.quest } : {}),
+        ...(itemAny.extracted_keywords ? { keywords: itemAny.extracted_keywords } : {}),
+        ...(itemAny.lineage_anchor ? { lineage_anchor: itemAny.lineage_anchor } : {}),
+      },
+      recentTurns,
+      subjectName: input.persona.name,
+      signals: assessment.signals,
+      runId: input.sessionId,
+    });
+    const extractedSignals =
+      (input.contextHints?.["extracted_signals"] as string[] | undefined) ?? [];
+    const combinedSignals = Array.from(
+      new Set([...extractedSignals, ...assessment.signals]),
+    );
+    const selection = selectExplainOption({
+      options: explainOptions,
+      signals: combinedSignals,
+    });
+    finalText = selection.chosen.text;
+    warnings.push({
+      component: "explain_option_selector",
+      message: `kind=${selection.chosen.kind} reason=${selection.reason}`,
+      recoverable: true,
+    });
+    fallbackTriggered = false;
     recallCheckEmitted = undefined;
   } else if (USE_SPLIT_DROTA) {
     // ── S4 path ──────────────────────────────────────────────────────────

--- a/motor-drota/tests/explain-option-selector.test.ts
+++ b/motor-drota/tests/explain-option-selector.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectExplainOption,
+  type ExplainOption,
+} from "../src/explain-option-selector.js";
+
+const FULL_POOL: ExplainOption[] = [
+  { kind: "concrete_example", text: "ex q", anchor: "a1" },
+  { kind: "metaphor", text: "metaphor q", anchor: "a2" },
+  { kind: "contrast", text: "contrast q", anchor: "a3" },
+  { kind: "lineage_anchor", text: "lineage q", anchor: "a4" },
+];
+
+describe("selectExplainOption — v0.3-B heuristic", () => {
+  it("default sem signals → concrete_example", () => {
+    const { chosen, reason } = selectExplainOption({
+      options: FULL_POOL,
+      signals: [],
+    });
+    expect(chosen.kind).toBe("concrete_example");
+    expect(reason).toContain("default:concrete_example");
+  });
+
+  it("frame_rejection → contrast", () => {
+    const { chosen, reason } = selectExplainOption({
+      options: FULL_POOL,
+      signals: ["frame_rejection"],
+    });
+    expect(chosen.kind).toBe("contrast");
+    expect(reason).toContain("frame_rejection/authority→contrast");
+  });
+
+  it("authority_questioning → contrast", () => {
+    const { chosen } = selectExplainOption({
+      options: FULL_POOL,
+      signals: ["authority_questioning"],
+    });
+    expect(chosen.kind).toBe("contrast");
+  });
+
+  it("voluntary_topic_deepening → metaphor", () => {
+    const { chosen } = selectExplainOption({
+      options: FULL_POOL,
+      signals: ["voluntary_topic_deepening"],
+    });
+    expect(chosen.kind).toBe("metaphor");
+  });
+
+  it("mood_drift_up → metaphor", () => {
+    const { chosen } = selectExplainOption({
+      options: FULL_POOL,
+      signals: ["mood_drift_up"],
+    });
+    expect(chosen.kind).toBe("metaphor");
+  });
+
+  it("distress_marker_low → lineage_anchor", () => {
+    const { chosen } = selectExplainOption({
+      options: FULL_POOL,
+      signals: ["distress_marker_low"],
+    });
+    expect(chosen.kind).toBe("lineage_anchor");
+  });
+
+  it("mood_drift_down → lineage_anchor", () => {
+    const { chosen } = selectExplainOption({
+      options: FULL_POOL,
+      signals: ["mood_drift_down"],
+    });
+    expect(chosen.kind).toBe("lineage_anchor");
+  });
+
+  it("multi-signal: frame_rejection vence sobre metaphor signal", () => {
+    const { chosen } = selectExplainOption({
+      options: FULL_POOL,
+      signals: ["voluntary_topic_deepening", "frame_rejection"],
+    });
+    expect(chosen.kind).toBe("contrast");
+  });
+
+  it("kind preferido ausente do pool → próximo fallback", () => {
+    const pool = FULL_POOL.filter((o) => o.kind !== "contrast");
+    const { chosen } = selectExplainOption({
+      options: pool,
+      signals: ["frame_rejection"],
+    });
+    expect(chosen.kind).toBe("concrete_example");
+  });
+
+  it("single option pool → retorna single", () => {
+    const single = [FULL_POOL[0]!];
+    const { chosen, reason } = selectExplainOption({
+      options: single,
+      signals: ["frame_rejection"],
+    });
+    expect(chosen).toBe(single[0]);
+    expect(reason).toBe("single_option");
+  });
+
+  it("empty pool → throws", () => {
+    expect(() => selectExplainOption({ options: [], signals: [] })).toThrow(
+      /non-empty options/,
+    );
+  });
+
+  it("nenhum kind do pool casa preferência → fallback options[0]", () => {
+    const pool: ExplainOption[] = [
+      { kind: "weird_a", text: "x", anchor: "y" },
+      { kind: "weird_b", text: "x2", anchor: "y2" },
+    ];
+    const { chosen, reason } = selectExplainOption({
+      options: pool,
+      signals: ["frame_rejection"],
+    });
+    expect(chosen).toBe(pool[0]);
+    expect(reason).toBe("fallback_no_match");
+  });
+});


### PR DESCRIPTION
## Contexto

Item #2 do plano de qualidade Tutor Clássico v0 (sequência 5→1→2 aprovada).

Estende o padrão **dynamic pool + signal-driven selector + short-circuit** (introduzido no PR #278 para `discover`) ao `move_type=explain`. Stacked sobre #279 (v0.3-A discovery selector).

## Arquitetura

| Componente | Arquivo | Função |
|------------|---------|--------|
| Agent | `motor-drota/src/explain-agent.ts` | Chama LLM (step=drota) com item selecionado como âncora; gera 4 framings curtos |
| Selector | `motor-drota/src/explain-option-selector.ts` | Heurística signal→kind |
| Wiring | `motor-drota/src/simplified-pipeline-handler.ts` | Branch após discovery short-circuit |

**Diferente de discover:** o agent roda em **motor-drota** (não planejador) porque precisa do item específico que o Pragmatic Selector picou. Discover gera questões content-free; explain precisa de conteúdo ancorado.

## Heurística signal→kind

| Signal | Kind preferido | Racional |
|--------|---------------|----------|
| frame_rejection, authority_questioning | **contrast** | devolve com oposto/anti-exemplo |
| voluntary_topic_deepening, mood_drift_up | **metaphor** | sujeito em fluxo, recebe rico simbólico |
| distress_marker_*, mood_drift_down | **lineage_anchor** | ancora em tradição pra segurança |
| (default) | **concrete_example** | carga cognitiva baixa |

## fallbackTriggered policy

Discover usa `fallbackTriggered=true` (não apresenta conteúdo). Explain usa `fallbackTriggered=false` porque ESTÁ apresentando conceito — o ledger DEVE contabilizar `presented_concept` (`extractPresentedConcepts` roda normalmente no path explain).

## Validação

- **12 unit tests novos** (explain-option-selector): cobertura por signal, fallback de kind ausente, single-option, multi-signal priority.
- **Suite motor-drota full**: 484 PASS + 1 pre-existing failure (inaugural.unit.test.ts — bug pré-existente da v0.2.7).
- **STS mock smoke**: discover path 100% inalterado (rubric_v2 PASS ryo + kei).

## Limitação validação STS real LLM

`journey_stage=discovery_only` está hardcoded em `sts/orchestrator/src/motor-client.ts` (sts#30) — impede `move_type=explain` de disparar em smokes atuais. Wiring + unit tests cobrem a integração; validação end-to-end com Qwen real fica para quando journey progression for habilitada (provavelmente `mapping_ready` ou `applied_double_helix`).

## Próximos move_types

Padrão agora replicável para os 5 restantes (check, correct, recall, apply, close). Recall continua o candidato mais alto-valor (risco de hallucination).