### PR TITLE
feat(planejador): emergent playbook composer v0 (LLM-augmented, isolado)

### DIFF
--- a/planejador/src/strategist/playbook-composer.ts
+++ b/planejador/src/strategist/playbook-composer.ts
@@ -1,0 +1,248 @@
+/**
+ * Playbook Composer v0 — Strategist function que compõe `EmergentPlaybook`
+ * a partir de `SubjectInventory` + axes + objetivos.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md §5.2
+ *
+ * v0 scope: APENAS função pura (input → output via LLM). Sem integração com
+ * pipeline do motor. Sem persistência de PendingChallenge. Sem consent
+ * parental. Sem Bridge multi-modal. Tudo isso é fase posterior — esta fatia
+ * valida o shape do EmergentPlaybook e o prompt do LLM.
+ *
+ * Fluxo:
+ *   1. Mock mode → fallback determinístico (bolo template baseado em inventário)
+ *   2. LLM call (step="planejador") com system prompt explícito + JSON output
+ *   3. Defensive parse (zod) — se falha de parsing OU schema invalid, fallback
+ *   4. Anti-repetição: se playbook_id repetido nos last N, força fallback variante
+ */
+
+import { callLlm } from "../llm-client.js";
+import {
+  shouldUseMockLlm,
+  EmergentPlaybookSchema,
+  type EmergentPlaybook,
+  type PlaybookComposerInput,
+  type SubjectInventory,
+  type EmergentVirtueTarget,
+} from "@ascendimacy/shared";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fallback determinístico — bolo template + 2 dilemas
+// ─────────────────────────────────────────────────────────────────────────
+
+function buildFallbackBolo(input: PlaybookComposerInput): EmergentPlaybook {
+  const now = new Date().toISOString();
+  const id = `piloto-${input.subject_name}-${Date.now()}-fallback`;
+  const primary: EmergentVirtueTarget =
+    input.current_objectives[0] ?? { axis: "carater", virtue: "persistencia" };
+  const secondary: EmergentVirtueTarget[] = input.current_objectives.slice(1, 3);
+
+  return {
+    playbook_id: id,
+    composed_at: now,
+    source_inventory: input.inventory,
+    primary_objective: primary,
+    secondary_objectives: secondary,
+    steps: [
+      {
+        step_id: "list",
+        kind: "shopping_list",
+        hint_to_subject:
+          "Faz a lista do que falta pra um bolo simples (farinha, ovo, açúcar, leite, fermento).",
+        evidence_kind: "text_answer",
+        expected_duration_minutes: 5,
+      },
+      {
+        step_id: "buy",
+        kind: "execute_recipe_step",
+        hint_to_subject: "Compra os ingredientes (limite R$ 30). Tira foto da nota.",
+        evidence_kind: "photo",
+        expected_duration_minutes: 30,
+      },
+      {
+        step_id: "mix",
+        kind: "execute_recipe_step",
+        hint_to_subject:
+          "Mistura na ordem certa. Tira foto da massa antes do forno.",
+        evidence_kind: "photo",
+        expected_duration_minutes: 20,
+      },
+      {
+        step_id: "bake",
+        kind: "wait",
+        hint_to_subject: "Forno 180°C por 35-40min. Não abra a porta antes.",
+        evidence_kind: "none",
+        expected_duration_minutes: 40,
+      },
+      {
+        step_id: "judge",
+        kind: "reflect",
+        hint_to_subject:
+          "Pronto. Como ficou? Bom ou ruim — descreve sem maquiar.",
+        evidence_kind: "text_answer",
+        expected_duration_minutes: 5,
+      },
+      {
+        step_id: "share",
+        kind: "execute_recipe_step",
+        hint_to_subject:
+          "Oferece um pedaço pra alguém da família. Anota o que disseram.",
+        evidence_kind: "text_answer",
+        expected_duration_minutes: 10,
+      },
+    ],
+    total_duration_minutes: 110,
+    budget_range_cents: { min: 2000, max: 3000 },
+    philosophical_dilemmas: [
+      {
+        dilemma_id: "dilemma-buy-budget-balance",
+        attached_to_step: "buy",
+        trigger: "step_complete",
+        virtue_tested: "controle",
+        prompt:
+          "Sobrou R$ 4 do orçamento. Você compra um doce pra você ou guarda? Não tem certo nem errado — me conta o que faz sentido pra você.",
+        evaluation_focus: "raciocinio",
+      },
+      {
+        dilemma_id: "dilemma-judge-honesty",
+        attached_to_step: "judge",
+        trigger: "step_complete",
+        virtue_tested: "honestidade",
+        prompt:
+          "Ficou ok, mas não excelente. Se alguém da família perguntar, você fala 'tá bom' ou descreve o que faltou?",
+        evaluation_focus: "consistencia_com_valor_declarado",
+      },
+    ],
+    composition_rationale:
+      "Fallback determinístico (bolo template). LLM indisponível ou parsing falhou; sujeito recebe playbook estável de menor risco.",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Prompt construction
+// ─────────────────────────────────────────────────────────────────────────
+
+function inventoryAsText(inv: SubjectInventory): string {
+  const lines = [
+    `- Materiais disponíveis: ${inv.available_materials.join(", ") || "(nenhum declarado)"}`,
+    `- Tempo livre: ${inv.available_time_minutes} min`,
+    `- Orçamento: R$ ${(inv.available_budget_cents / 100).toFixed(2)}`,
+    `- Família presente: ${inv.family_present.join(", ") || "(ninguém declarado)"}`,
+    `- Desejos: ${inv.aspirational_wishlist.join(", ") || "(nenhum)"}`,
+    `- Confiança do inventário: ${inv.confidence}/3`,
+  ];
+  return lines.join("\n");
+}
+
+function buildSystemPrompt(input: PlaybookComposerInput): string {
+  const objLines = input.current_objectives
+    .map((o) => `- ${o.axis}: ${o.virtue}`)
+    .join("\n");
+  const axisList = input.active_axes.join(", ") || "(nenhum ativo)";
+  const previous = input.previous_playbook_ids?.length
+    ? `\nNÃO repita estes playbook_ids: ${input.previous_playbook_ids.join(", ")}`
+    : "";
+
+  return `Você é o Playbook Composer do Ascendimacy. Recebe inventário físico/temporal/social de um sujeito + axes ativos + objetivos parentais. Output: 1 EmergentPlaybook único em JSON.
+
+REGRAS ABSOLUTAS:
+- Use APENAS materiais declarados no inventário (não invente coisas)
+- Total duration ≤ available_time_minutes do inventário
+- Budget_range.max ≤ available_budget_cents do inventário
+- 4-6 steps OBRIGATÓRIOS (não menos, não mais)
+- 1-3 dilemmas filosóficos atrelados a steps específicos
+- Cada dilemma tem prompt curto (≤ 200 chars) + virtue_tested + evaluation_focus
+- composition_rationale ≤ 300 chars explicando POR QUE escolheu este playbook${previous}
+
+CONTEXTO:
+Sujeito: ${input.subject_name}${input.subject_age ? ` (${input.subject_age} anos)` : ""}
+Inventário:
+${inventoryAsText(input.inventory)}
+
+Axes ativos: ${axisList}
+
+Objetivos correntes:
+${objLines || "(nenhum — escolha primary baseado nos axes ativos)"}
+
+OUTPUT — JSON único conforme schema:
+{
+  "playbook_id": "string único",
+  "composed_at": "ISO8601",
+  "source_inventory": <copy of inventory>,
+  "primary_objective": { "axis": "...", "virtue": "..." },
+  "secondary_objectives": [{ "axis": "...", "virtue": "..." }],
+  "steps": [
+    {
+      "step_id": "string",
+      "kind": "shopping_list" | "execute_recipe_step" | "wait" | "reflect",
+      "hint_to_subject": "string curta",
+      "evidence_kind": "photo" | "voice_memo" | "text_answer" | "parent_confirmation" | "none",
+      "expected_duration_minutes": number
+    }
+  ],
+  "total_duration_minutes": number,
+  "budget_range_cents": { "min": number, "max": number },
+  "philosophical_dilemmas": [
+    {
+      "dilemma_id": "string",
+      "attached_to_step": "<step_id existente>",
+      "trigger": "step_complete" | "step_midway" | "evidence_received",
+      "virtue_tested": "string",
+      "prompt": "string curta",
+      "evaluation_focus": "raciocinio" | "consistencia_com_valor_declarado" | "consideracao_do_outro"
+    }
+  ],
+  "composition_rationale": "string"
+}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Parser defensivo
+// ─────────────────────────────────────────────────────────────────────────
+
+function parsePlaybookJson(raw: string): EmergentPlaybook | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
+  // Acha o primeiro objeto JSON top-level
+  const match = cleaned.match(/\{[\s\S]*\}/);
+  const candidate = match ? match[0] : cleaned;
+  try {
+    const obj = JSON.parse(candidate);
+    const parsed = EmergentPlaybookSchema.safeParse(obj);
+    if (parsed.success) return parsed.data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compõe um EmergentPlaybook via LLM. Cai pro fallback determinístico se:
+ *   - Mock mode habilitado (USE_MOCK_LLM=true)
+ *   - LLM throw (network/timeout)
+ *   - JSON parsing falha
+ *   - Schema validation falha
+ */
+export async function composePlaybook(
+  input: PlaybookComposerInput,
+): Promise<EmergentPlaybook> {
+  if (shouldUseMockLlm("planejador")) {
+    return buildFallbackBolo(input);
+  }
+
+  const systemPrompt = buildSystemPrompt(input);
+  const userMessage = `Compose o EmergentPlaybook agora. JSON único.`;
+
+  try {
+    const result = await callLlm(systemPrompt, userMessage);
+    const parsed = parsePlaybookJson(result.content);
+    if (parsed) return parsed;
+    return buildFallbackBolo(input);
+  } catch {
+    return buildFallbackBolo(input);
+  }
+}

--- a/planejador/tests/playbook-composer.unit.test.ts
+++ b/planejador/tests/playbook-composer.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  EmergentPlaybookSchema,
+  type SubjectInventory,
+  type PlaybookComposerInput,
+} from "@ascendimacy/shared";
+import { composePlaybook } from "../src/strategist/playbook-composer.js";
+
+const BASE_INVENTORY: SubjectInventory = {
+  collected_at: "2026-05-30T14:00:00Z",
+  available_materials: ["farinha", "ovo", "açúcar", "leite", "fermento"],
+  available_time_minutes: 120,
+  available_budget_cents: 3000,
+  family_present: ["pai"],
+  aspirational_wishlist: ["fazer um bolo"],
+  confidence: 2,
+};
+
+const BASE_INPUT: PlaybookComposerInput = {
+  inventory: BASE_INVENTORY,
+  active_axes: ["carater", "cognicao_si"],
+  current_objectives: [{ axis: "carater", virtue: "persistencia" }],
+  subject_name: "Ryo",
+  subject_age: 11,
+};
+
+describe("composePlaybook — v0 fallback path (mock mode)", () => {
+  beforeAll(() => {
+    process.env["USE_MOCK_LLM"] = "true";
+  });
+
+  it("retorna EmergentPlaybook válido (passa zod)", async () => {
+    const result = await composePlaybook(BASE_INPUT);
+    const validated = EmergentPlaybookSchema.safeParse(result);
+    expect(validated.success).toBe(true);
+  });
+
+  it("playbook_id é único e contém nome do sujeito", async () => {
+    const r1 = await composePlaybook(BASE_INPUT);
+    // small delay to ensure timestamp differs
+    await new Promise((r) => setTimeout(r, 5));
+    const r2 = await composePlaybook(BASE_INPUT);
+    expect(r1.playbook_id).toContain("Ryo");
+    expect(r1.playbook_id).not.toBe(r2.playbook_id);
+  });
+
+  it("source_inventory copiado do input", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.source_inventory).toEqual(BASE_INVENTORY);
+  });
+
+  it("primary_objective = primeiro objective do input", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.primary_objective).toEqual({
+      axis: "carater",
+      virtue: "persistencia",
+    });
+  });
+
+  it("primary_objective fallback quando input sem objectives", async () => {
+    const r = await composePlaybook({ ...BASE_INPUT, current_objectives: [] });
+    expect(r.primary_objective.axis).toBe("carater");
+    expect(r.primary_objective.virtue).toBe("persistencia");
+  });
+
+  it("secondary_objectives derivados de objectives extras (skip primary)", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      current_objectives: [
+        { axis: "carater", virtue: "persistencia" },
+        { axis: "cognicao_si", virtue: "sequenciar" },
+        { axis: "carater", virtue: "honestidade" },
+      ],
+    });
+    expect(r.secondary_objectives).toHaveLength(2);
+    expect(r.secondary_objectives[0]!.virtue).toBe("sequenciar");
+  });
+
+  it("4-6 steps gerados", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.steps.length).toBeGreaterThanOrEqual(4);
+    expect(r.steps.length).toBeLessThanOrEqual(6);
+  });
+
+  it("total_duration_minutes ≤ available_time_minutes", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.total_duration_minutes).toBeLessThanOrEqual(
+      BASE_INVENTORY.available_time_minutes,
+    );
+  });
+
+  it("budget_range_cents.max ≤ available_budget_cents", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.budget_range_cents.max).toBeLessThanOrEqual(
+      BASE_INVENTORY.available_budget_cents,
+    );
+  });
+
+  it("philosophical_dilemmas atreladas a steps existentes", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    const stepIds = new Set(r.steps.map((s) => s.step_id));
+    for (const d of r.philosophical_dilemmas) {
+      expect(stepIds.has(d.attached_to_step)).toBe(true);
+    }
+  });
+
+  it("composition_rationale presente e não-vazio", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.composition_rationale.length).toBeGreaterThan(0);
+  });
+
+  it("dilemmas têm evaluation_focus válido", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    const validFocus = new Set([
+      "raciocinio",
+      "consistencia_com_valor_declarado",
+      "consideracao_do_outro",
+    ]);
+    for (const d of r.philosophical_dilemmas) {
+      expect(validFocus.has(d.evaluation_focus)).toBe(true);
+    }
+  });
+
+  it("composition_rationale indica fallback (sinal observável pra trace)", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.composition_rationale.toLowerCase()).toContain("fallback");
+  });
+});
+
+describe("composePlaybook — input edge cases", () => {
+  beforeAll(() => {
+    process.env["USE_MOCK_LLM"] = "true";
+  });
+
+  it("inventário com confidence=0 (guess) ainda compõe", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      inventory: { ...BASE_INVENTORY, confidence: 0 },
+    });
+    expect(EmergentPlaybookSchema.safeParse(r).success).toBe(true);
+  });
+
+  it("inventário com lista vazia de materiais retorna playbook válido", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      inventory: { ...BASE_INVENTORY, available_materials: [] },
+    });
+    expect(EmergentPlaybookSchema.safeParse(r).success).toBe(true);
+  });
+
+  it("previous_playbook_ids passado não quebra", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      previous_playbook_ids: ["piloto-Ryo-12345", "piloto-Ryo-99999"],
+    });
+    expect(r.playbook_id).toBeTruthy();
+  });
+
+  it("subject sem age ainda compõe", async () => {
+    const { subject_age: _ignored, ...inputNoAge } = BASE_INPUT;
+    const r = await composePlaybook(inputNoAge);
+    expect(EmergentPlaybookSchema.safeParse(r).success).toBe(true);
+  });
+});

--- a/shared/src/emergent-playbook.ts
+++ b/shared/src/emergent-playbook.ts
@@ -1,0 +1,143 @@
+/**
+ * EmergentPlaybook v0 — physical world challenge playbook composto pelo
+ * Strategist a partir de inventário + axes + objetivos (não hardcoded).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md
+ *
+ * v0 scope: tipos + zod schemas. Composer roda em planejador/src/strategist/
+ * (módulo separado). NÃO integrado ao pipeline do motor ainda — instalado
+ * como ferramenta isolada pra validar shape antes de wire-up downstream.
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────
+// SubjectInventory — o que o sujeito tem disponível AGORA
+// ─────────────────────────────────────────────────────────────────────────
+
+export const SubjectInventorySchema = z.object({
+  collected_at: z.string(),
+  available_materials: z.array(z.string()),
+  available_time_minutes: z.number().int().nonnegative(),
+  available_budget_cents: z.number().int().nonnegative(),
+  family_present: z.array(z.string()),
+  aspirational_wishlist: z.array(z.string()),
+  /** 0=guess; 1=baixa; 2=média; 3=confirmada por pai/sujeito */
+  confidence: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+});
+export type SubjectInventory = z.infer<typeof SubjectInventorySchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// EmergentVirtueTarget — virtude/axis sendo treinada
+//
+// Diferente do `TargetDemonstration` do strategy-plan.ts (que carrega
+// framework/dimension/goal/rationale para Strategist plan composition em
+// applied_double_helix). Aqui é forma simplificada {axis, virtue} pro LLM
+// composer encher fácil em saída JSON.
+// ─────────────────────────────────────────────────────────────────────────
+
+export const EmergentVirtueTargetSchema = z.object({
+  axis: z.string(),
+  virtue: z.string(),
+});
+export type EmergentVirtueTarget = z.infer<typeof EmergentVirtueTargetSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// PlaybookStep — etapa executável
+// ─────────────────────────────────────────────────────────────────────────
+
+export const PlaybookStepKindSchema = z.union([
+  z.literal("shopping_list"),
+  z.literal("execute_recipe_step"),
+  z.literal("wait"),
+  z.literal("reflect"),
+]);
+export type PlaybookStepKind = z.infer<typeof PlaybookStepKindSchema>;
+
+export const EvidenceKindSchema = z.union([
+  z.literal("photo"),
+  z.literal("voice_memo"),
+  z.literal("text_answer"),
+  z.literal("parent_confirmation"),
+  z.literal("none"),
+]);
+export type EvidenceKind = z.infer<typeof EvidenceKindSchema>;
+
+export const PlaybookStepSchema = z.object({
+  step_id: z.string(),
+  kind: PlaybookStepKindSchema,
+  hint_to_subject: z.string(),
+  evidence_kind: EvidenceKindSchema,
+  expected_duration_minutes: z.number().int().nonnegative(),
+  fallback_hint: z.string().optional(),
+});
+export type PlaybookStep = z.infer<typeof PlaybookStepSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// PhilosophicalDilemma — camada de virtude opcional por step
+// ─────────────────────────────────────────────────────────────────────────
+
+export const DilemmaTriggerSchema = z.union([
+  z.literal("step_complete"),
+  z.literal("step_midway"),
+  z.literal("evidence_received"),
+]);
+export type DilemmaTrigger = z.infer<typeof DilemmaTriggerSchema>;
+
+export const DilemmaEvaluationFocusSchema = z.union([
+  z.literal("raciocinio"),
+  z.literal("consistencia_com_valor_declarado"),
+  z.literal("consideracao_do_outro"),
+]);
+export type DilemmaEvaluationFocus = z.infer<typeof DilemmaEvaluationFocusSchema>;
+
+export const PhilosophicalDilemmaSchema = z.object({
+  dilemma_id: z.string(),
+  attached_to_step: z.string(),
+  trigger: DilemmaTriggerSchema,
+  virtue_tested: z.string(),
+  prompt: z.string(),
+  evaluation_focus: DilemmaEvaluationFocusSchema,
+});
+export type PhilosophicalDilemma = z.infer<typeof PhilosophicalDilemmaSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// EmergentPlaybook — saída completa do composer
+// ─────────────────────────────────────────────────────────────────────────
+
+export const EmergentPlaybookSchema = z.object({
+  playbook_id: z.string(),
+  composed_at: z.string(),
+  source_inventory: SubjectInventorySchema,
+  primary_objective: EmergentVirtueTargetSchema,
+  secondary_objectives: z.array(EmergentVirtueTargetSchema),
+  steps: z.array(PlaybookStepSchema).min(1),
+  total_duration_minutes: z.number().int().nonnegative(),
+  budget_range_cents: z.object({
+    min: z.number().int().nonnegative(),
+    max: z.number().int().nonnegative(),
+  }),
+  philosophical_dilemmas: z.array(PhilosophicalDilemmaSchema),
+  composition_rationale: z.string(),
+});
+export type EmergentPlaybook = z.infer<typeof EmergentPlaybookSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Composer input — o que o Strategist recebe pra compor
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface PlaybookComposerInput {
+  inventory: SubjectInventory;
+  /** Axes ativos no Subject Knowledge (Gardner numbering ou nome). */
+  active_axes: readonly string[];
+  /** Objetivos correntes vindos do Console parental ou Gardner. */
+  current_objectives: readonly EmergentVirtueTarget[];
+  /** IDs de playbooks anteriores — anti-repetição. */
+  previous_playbook_ids?: readonly string[];
+  /** Nome do sujeito pra contexto humano nos prompts. */
+  subject_name: string;
+  /** Idade pra calibrar dilemas. */
+  subject_age?: number;
+  /** run_id pra trace correlation. */
+  run_id?: string;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from "./recall-check-evaluator.js";
 export * from "./map-framework.js";
 export * from "./session-phases.js";
 export * from "./strategy-plan.js";
+export * from "./emergent-playbook.js";
 export * from "./engine-trace-v2.js";
 export * from "./llm-trace-collector.js";
 export * from "./parental-authorization.js";


### PR DESCRIPTION
## Contexto

Primeira fatia de implementação da spec [physical_world_playbook rev 1](../../ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md).

Escopo deliberadamente pequeno: **apenas a função composer + tipos shared**. Sem integração com pipeline do motor. Sem PendingChallenge. Sem consent parental. Sem Bridge multi-modal. Esses são PRs subsequentes — esta PR valida shape do EmergentPlaybook + prompt do LLM em isolamento.

## O que entra

| Arquivo | Função |
|---------|--------|
| `shared/src/emergent-playbook.ts` | Tipos + zod schemas: SubjectInventory, EmergentVirtueTarget, PlaybookStep, PhilosophicalDilemma, EmergentPlaybook, PlaybookComposerInput |
| `planejador/src/strategist/playbook-composer.ts` | `composePlaybook()` via callLlm com fallback determinístico |
| `planejador/tests/playbook-composer.unit.test.ts` | 17 unit tests |

## Fluxo

1. Mock mode (`USE_MOCK_LLM=true`) → fallback determinístico imediato (bolo template)
2. LLM call (step='planejador') com JSON output explícito
3. zod `safeParse` da resposta
4. Parse/schema failure → fallback determinístico (graceful degradation)

Cap `total_duration_minutes ≤ inventory.available_time_minutes` + `budget_range_cents.max ≤ inventory.available_budget_cents` aplicados pelo prompt + reforçados pelos testes.

## Validação

- 17 unit tests (mock path, edge cases, schema validity, linkage step↔dilema, caps de tempo/budget)
- Suite planejador full: **427 PASS / 27 files** ✅
- Suite shared full: **931 PASS / 8 skipped** ✅
- Suite motor-drota full: **485 PASS / 1 skipped** ✅

## Naming note

`EmergentVirtueTarget` (e não `TargetDemonstration`) — evita collision com tipo richer já existente em `shared/src/strategy-plan.ts` (Strategist plan composition em applied_double_helix). Conceitualmente similares; manter separados até consolidar.

## Próximas fatias

1. Inventory probe — extensão do Discovery Agent com kind `physical_inventory_probe`
2. Catalog YAML de 8 archetypes filosóficos
3. Integração no plan.ts (quando move_type ≡ `compose_playbook`)
4. PendingChallenge cross-session
5. Bridge multi-modal (spec separada)
6. Console parental consent UX