### PR TITLE
feat(planejador): philosophical dilemma archetype catalog v1 (8 archetypes)

### DIFF
--- a/planejador/data/dilemma-archetypes.yaml
+++ b/planejador/data/dilemma-archetypes.yaml
@@ -1,0 +1,119 @@
+# Philosophical Dilemma Archetype Catalog v1
+#
+# Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md §5.4
+#
+# 8 archetypes iniciais — cada um testa uma virtude específica via case
+# curto com tensão real. NÃO há resposta "certa": o motor avalia o
+# RACIOCÍNIO explicitado (0-3), não a escolha.
+#
+# Strategist consome este catálogo no `composePlaybook` e injeta no máximo
+# 1 dilema por step. `applicable_triggers` indica em qual ponto do step
+# o dilema disparou (step_complete / step_midway / evidence_received).
+#
+# `prompt_template` usa placeholders { context_X } que o composer substitui
+# por valores derivados do playbook (e.g. nome de pessoa, item, valor).
+
+version: 1
+
+archetypes:
+  - id: temptation_to_skip
+    virtue_tested: persistencia
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_midway
+    prompt_template: >-
+      Você está {context_what_doing} e tá cansativo agora.
+      Para de fazer ou continua? Não tem resposta certa — me
+      conta o que faz mais sentido pra você e por quê.
+    description: >-
+      Plantar tentação de desistir no meio do step. Cabe em qualquer
+      execute_recipe_step ou wait com expected_duration > 15min.
+
+  - id: silent_error
+    virtue_tested: honestidade
+    evaluation_focus: consistencia_com_valor_declarado
+    applicable_triggers:
+      - step_complete
+      - evidence_received
+    prompt_template: >-
+      Você cometeu {context_error} e ninguém viu. Você conta pra
+      {context_audience} agora ou guarda pra você?
+    description: >-
+      Quando evidência mostra erro (sujeito errou medida, passo, etc).
+      Testa se honestidade é declarada vs vivida.
+
+  - id: share_vs_keep
+    virtue_tested: generosidade
+    evaluation_focus: consideracao_do_outro
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Você tem {context_quantity} de {context_thing}. Você divide com
+      {context_other} ou guarda? O que pesa mais na sua decisão?
+    description: >-
+      Plantar no step final de qualquer playbook com resultado físico
+      compartilhável. Testa generosidade vs apego.
+
+  - id: cheap_vs_quality
+    virtue_tested: discernimento
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Você pode pagar mais por {context_better} ou economizar com
+      {context_worse}. Você nem sempre tem que escolher o mais barato.
+      Como você decide aqui?
+    description: >-
+      Plantar em shopping_list ou buy step quando há opções de preço.
+      Testa julgamento sob restrição econômica.
+
+  - id: give_credit
+    virtue_tested: humildade
+    evaluation_focus: consistencia_com_valor_declarado
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Foi sua ideia mas {context_helper} ajudou no caminho. Quando
+      você conta o que fez, fala 'eu' ou 'a gente'?
+    description: >-
+      Plantar em reflect step quando família/parceiro contribuiu.
+      Testa reconhecimento da contribuição alheia.
+
+  - id: early_quit
+    virtue_tested: paciencia
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_midway
+      - evidence_received
+    prompt_template: >-
+      Tá dando errado — {context_problem}. Você para por aqui ou
+      ajusta e continua? Como você sabe a diferença entre "ajustar"
+      e "teimar"?
+    description: >-
+      Plantar quando evidência sugere problema (foto mostra erro,
+      tempo estourou). Testa discernimento entre persistência
+      sábia e cabeça-dura.
+
+  - id: judge_yourself
+    virtue_tested: honestidade_auto
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Ficou {context_result} — não excelente, não ruim. {context_audience}
+      pergunta como foi. Você fala "tá bom" ou descreve o que faltou?
+    description: >-
+      Plantar em judge step quando resultado é mediano. Testa auto-
+      avaliação honesta (resiste à tentação de embelezar).
+
+  - id: prioritize_who
+    virtue_tested: justica
+    evaluation_focus: consideracao_do_outro
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Tem {context_constraint} e dois lados afetados ({context_side_a}
+      vs {context_side_b}). Como você escolhe quem fica com o quê?
+    description: >-
+      Plantar quando há recurso finito a distribuir (último pedaço,
+      última peça, tempo limitado). Testa critério de justiça.

--- a/planejador/package.json
+++ b/planejador/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/server.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "postbuild": "mkdir -p dist/data && cp data/*.yaml dist/data/",
     "test": "vitest run",
     "start": "node dist/server.js",
     "clean": "rm -rf dist"

--- a/planejador/src/dilemma-archetype-loader.ts
+++ b/planejador/src/dilemma-archetype-loader.ts
@@ -1,0 +1,253 @@
+/**
+ * Loader do Philosophical Dilemma Archetype Catalog v1.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md §5.4
+ *
+ * Carrega planejador/data/dilemma-archetypes.yaml, valida estrutura,
+ * oferece consulta filtrada por virtude / trigger. Strategist composer
+ * consome este loader pra escolher quais dilemas plantar em quais steps.
+ *
+ * Padrão idêntico ao playbook-moves-loader.ts (motor-drota).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const DEFAULT_DILEMMA_CATALOG_PATH = join(
+  __dirname,
+  "..",
+  "data",
+  "dilemma-archetypes.yaml",
+);
+
+// ─────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────
+
+export type DilemmaTrigger =
+  | "step_complete"
+  | "step_midway"
+  | "evidence_received";
+
+export type DilemmaEvaluationFocus =
+  | "raciocinio"
+  | "consistencia_com_valor_declarado"
+  | "consideracao_do_outro";
+
+export interface DilemmaArchetype {
+  id: string;
+  virtue_tested: string;
+  evaluation_focus: DilemmaEvaluationFocus;
+  applicable_triggers: DilemmaTrigger[];
+  prompt_template: string;
+  description: string;
+}
+
+export interface DilemmaCatalog {
+  version: number;
+  archetypes: DilemmaArchetype[];
+}
+
+export interface LoadOptions {
+  path?: string;
+  strict?: boolean;
+}
+
+export interface ValidationIssue {
+  level: "error" | "warning";
+  archetype_id?: string;
+  message: string;
+}
+
+export interface LoadCatalogResult {
+  catalog: DilemmaCatalog;
+  issues: ValidationIssue[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Validators
+// ─────────────────────────────────────────────────────────────────────────
+
+const VALID_FOCUS = new Set<DilemmaEvaluationFocus>([
+  "raciocinio",
+  "consistencia_com_valor_declarado",
+  "consideracao_do_outro",
+]);
+
+const VALID_TRIGGERS = new Set<DilemmaTrigger>([
+  "step_complete",
+  "step_midway",
+  "evidence_received",
+]);
+
+function validateArchetype(
+  raw: unknown,
+  index: number,
+): { ok: DilemmaArchetype | null; issues: ValidationIssue[] } {
+  const issues: ValidationIssue[] = [];
+  if (!raw || typeof raw !== "object") {
+    issues.push({
+      level: "error",
+      message: `archetype[${index}] não é um objeto`,
+    });
+    return { ok: null, issues };
+  }
+  const r = raw as Record<string, unknown>;
+  const id = typeof r["id"] === "string" ? (r["id"] as string) : "";
+  if (!id) {
+    issues.push({
+      level: "error",
+      message: `archetype[${index}] sem 'id'`,
+    });
+    return { ok: null, issues };
+  }
+  const virtue = typeof r["virtue_tested"] === "string" ? r["virtue_tested"] : "";
+  if (!virtue) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' sem 'virtue_tested'`,
+    });
+    return { ok: null, issues };
+  }
+  const focus = r["evaluation_focus"];
+  if (typeof focus !== "string" || !VALID_FOCUS.has(focus as DilemmaEvaluationFocus)) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' tem 'evaluation_focus' inválido: ${focus}`,
+    });
+    return { ok: null, issues };
+  }
+  const triggersRaw = r["applicable_triggers"];
+  if (!Array.isArray(triggersRaw) || triggersRaw.length === 0) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' sem 'applicable_triggers' (array não-vazio)`,
+    });
+    return { ok: null, issues };
+  }
+  const triggers: DilemmaTrigger[] = [];
+  for (const t of triggersRaw) {
+    if (typeof t !== "string" || !VALID_TRIGGERS.has(t as DilemmaTrigger)) {
+      issues.push({
+        level: "error",
+        archetype_id: id,
+        message: `'${id}' tem trigger inválido: ${t}`,
+      });
+      return { ok: null, issues };
+    }
+    triggers.push(t as DilemmaTrigger);
+  }
+  const tpl = typeof r["prompt_template"] === "string" ? r["prompt_template"].trim() : "";
+  if (!tpl) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' sem 'prompt_template'`,
+    });
+    return { ok: null, issues };
+  }
+  const desc = typeof r["description"] === "string" ? r["description"].trim() : "";
+  if (!desc) {
+    issues.push({
+      level: "warning",
+      archetype_id: id,
+      message: `'${id}' sem 'description' (recomendado)`,
+    });
+  }
+  return {
+    ok: {
+      id,
+      virtue_tested: virtue,
+      evaluation_focus: focus as DilemmaEvaluationFocus,
+      applicable_triggers: triggers,
+      prompt_template: tpl,
+      description: desc,
+    },
+    issues,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+export function loadDilemmaCatalog(
+  opts: LoadOptions = {},
+): LoadCatalogResult {
+  const path = opts.path ?? DEFAULT_DILEMMA_CATALOG_PATH;
+  const raw = readFileSync(path, "utf8");
+  const parsed = yaml.load(raw);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`dilemma-archetypes: YAML root inválido em ${path}`);
+  }
+  const root = parsed as Record<string, unknown>;
+  const version = typeof root["version"] === "number" ? (root["version"] as number) : 0;
+  const archetypesRaw = root["archetypes"];
+  if (!Array.isArray(archetypesRaw)) {
+    throw new Error(
+      `dilemma-archetypes: campo 'archetypes' obrigatório (array) em ${path}`,
+    );
+  }
+
+  const archetypes: DilemmaArchetype[] = [];
+  const issues: ValidationIssue[] = [];
+  const seenIds = new Set<string>();
+
+  for (let i = 0; i < archetypesRaw.length; i++) {
+    const { ok, issues: archIssues } = validateArchetype(archetypesRaw[i], i);
+    issues.push(...archIssues);
+    if (!ok) continue;
+    if (seenIds.has(ok.id)) {
+      issues.push({
+        level: "error",
+        archetype_id: ok.id,
+        message: `id duplicado: '${ok.id}'`,
+      });
+      continue;
+    }
+    seenIds.add(ok.id);
+    archetypes.push(ok);
+  }
+
+  if (opts.strict) {
+    const errors = issues.filter((i) => i.level === "error");
+    if (errors.length > 0) {
+      throw new Error(
+        `dilemma-archetypes: ${errors.length} erros no catálogo:\n${errors
+          .map((e) => `  - ${e.message}`)
+          .join("\n")}`,
+      );
+    }
+  }
+
+  return {
+    catalog: { version, archetypes },
+    issues,
+  };
+}
+
+/** Filtra archetypes por virtude testada. */
+export function findArchetypesByVirtue(
+  catalog: DilemmaCatalog,
+  virtue: string,
+): DilemmaArchetype[] {
+  return catalog.archetypes.filter((a) => a.virtue_tested === virtue);
+}
+
+/** Filtra archetypes que aplicam num trigger específico. */
+export function findArchetypesByTrigger(
+  catalog: DilemmaCatalog,
+  trigger: DilemmaTrigger,
+): DilemmaArchetype[] {
+  return catalog.archetypes.filter((a) =>
+    a.applicable_triggers.includes(trigger),
+  );
+}

--- a/planejador/tests/dilemma-archetype-loader.unit.test.ts
+++ b/planejador/tests/dilemma-archetype-loader.unit.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadDilemmaCatalog,
+  findArchetypesByVirtue,
+  findArchetypesByTrigger,
+} from "../src/dilemma-archetype-loader.js";
+
+describe("loadDilemmaCatalog — produção (data/dilemma-archetypes.yaml)", () => {
+  it("carrega catálogo default sem erros", () => {
+    const { catalog, issues } = loadDilemmaCatalog();
+    const errors = issues.filter((i) => i.level === "error");
+    expect(errors).toEqual([]);
+    expect(catalog.version).toBeGreaterThanOrEqual(1);
+  });
+
+  it("catálogo tem os 8 archetypes esperados (spec §5.4)", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const ids = catalog.archetypes.map((a) => a.id).sort();
+    expect(ids).toEqual([
+      "cheap_vs_quality",
+      "early_quit",
+      "give_credit",
+      "judge_yourself",
+      "prioritize_who",
+      "share_vs_keep",
+      "silent_error",
+      "temptation_to_skip",
+    ]);
+  });
+
+  it("todos archetypes têm prompt_template não-vazio", () => {
+    const { catalog } = loadDilemmaCatalog();
+    for (const a of catalog.archetypes) {
+      expect(a.prompt_template.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("todos archetypes têm pelo menos 1 applicable_trigger", () => {
+    const { catalog } = loadDilemmaCatalog();
+    for (const a of catalog.archetypes) {
+      expect(a.applicable_triggers.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("evaluation_focus é sempre um dos 3 valores válidos", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const valid = new Set([
+      "raciocinio",
+      "consistencia_com_valor_declarado",
+      "consideracao_do_outro",
+    ]);
+    for (const a of catalog.archetypes) {
+      expect(valid.has(a.evaluation_focus)).toBe(true);
+    }
+  });
+
+  it("strict mode passa sem throw", () => {
+    expect(() => loadDilemmaCatalog({ strict: true })).not.toThrow();
+  });
+});
+
+describe("findArchetypesByVirtue", () => {
+  it("retorna archetypes correspondentes", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const honesty = findArchetypesByVirtue(catalog, "honestidade");
+    expect(honesty.length).toBeGreaterThan(0);
+    for (const a of honesty) {
+      expect(a.virtue_tested).toBe("honestidade");
+    }
+  });
+
+  it("retorna [] quando virtude desconhecida", () => {
+    const { catalog } = loadDilemmaCatalog();
+    expect(findArchetypesByVirtue(catalog, "fake-virtue")).toEqual([]);
+  });
+});
+
+describe("findArchetypesByTrigger", () => {
+  it("retorna archetypes que aplicam em step_complete", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const stepComplete = findArchetypesByTrigger(catalog, "step_complete");
+    expect(stepComplete.length).toBeGreaterThan(0);
+    for (const a of stepComplete) {
+      expect(a.applicable_triggers).toContain("step_complete");
+    }
+  });
+
+  it("retorna archetypes que aplicam em step_midway", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const midway = findArchetypesByTrigger(catalog, "step_midway");
+    expect(midway.length).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Loader edge cases — usa arquivos temporários
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("loadDilemmaCatalog — validation edge cases", () => {
+  function withTempCatalog<T>(content: string, fn: (path: string) => T): T {
+    const dir = mkdtempSync(join(tmpdir(), "dilemma-catalog-"));
+    const path = join(dir, "test.yaml");
+    writeFileSync(path, content, "utf8");
+    try {
+      return fn(path);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("YAML root inválido → throw", () => {
+    withTempCatalog("just a string", (path) => {
+      expect(() => loadDilemmaCatalog({ path })).toThrow(/root inválido/);
+    });
+  });
+
+  it("falta campo 'archetypes' → throw", () => {
+    withTempCatalog("version: 1\n", (path) => {
+      expect(() => loadDilemmaCatalog({ path })).toThrow(/'archetypes' obrigatório/);
+    });
+  });
+
+  it("archetype sem id → issue error, archetype dropado", () => {
+    const yaml = `version: 1
+archetypes:
+  - virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(0);
+      expect(issues.some((i) => i.level === "error" && /sem 'id'/.test(i.message))).toBe(true);
+    });
+  });
+
+  it("evaluation_focus inválido → error", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: bad_focus
+    virtue_tested: x
+    evaluation_focus: fake-focus
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(0);
+      expect(
+        issues.some((i) => i.level === "error" && /'evaluation_focus' inválido/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("trigger inválido → error", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: bad_trigger
+    virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [fake_trigger]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(0);
+      expect(
+        issues.some((i) => i.level === "error" && /trigger inválido/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("id duplicado → error, segundo dropado", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: dup
+    virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+  - id: dup
+    virtue_tested: y
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "outro prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(1);
+      expect(
+        issues.some((i) => i.level === "error" && /duplicado/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("description ausente → warning, archetype mantido", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: no_desc
+    virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(1);
+      expect(
+        issues.some((i) => i.level === "warning" && /sem 'description'/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("strict mode com errors → throw", () => {
+    const yaml = `version: 1
+archetypes:
+  - virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+`;
+    withTempCatalog(yaml, (path) => {
+      expect(() => loadDilemmaCatalog({ path, strict: true })).toThrow(/erros no catálogo/);
+    });
+  });
+});


### PR DESCRIPTION
## Contexto

Terceira fatia da spec [physical_world_playbook rev 1 §5.4](../../ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md). **Standalone** — off main, sem dependência das fatias 1 (#282 composer) e 2 (#283 inventory probe).

Adiciona catálogo + loader dos 8 archetypes filosóficos que o Strategist vai injetar como dilemma layer em playbooks emergentes.

## Catálogo (planejador/data/dilemma-archetypes.yaml)

| ID | Virtude |
|----|---------|
| temptation_to_skip | persistencia |
| silent_error | honestidade |
| share_vs_keep | generosidade |
| cheap_vs_quality | discernimento |
| give_credit | humildade |
| early_quit | paciencia |
| judge_yourself | honestidade_auto |
| prioritize_who | justica |

Cada archetype: `id`, `virtue_tested`, `evaluation_focus`, `applicable_triggers`, `prompt_template` (com placeholders `{context_X}` que o composer substitui), `description`.

## Loader (planejador/src/dilemma-archetype-loader.ts)

`loadDilemmaCatalog({ path?, strict? }) → { catalog, issues }`

Padrão idêntico ao `motor-drota/src/playbook-moves-loader.ts`. Helpers `findArchetypesByVirtue` + `findArchetypesByTrigger` pro Strategist filtrar.

Validação cobre: id único + não-vazio, virtue não-vazia, evaluation_focus + triggers do enum, prompt_template não-vazio, description warning se ausente. Strict mode throw em qualquer error issue.

## Wiring necessário

`planejador/package.json`: novo postbuild step `mkdir -p dist/data && cp data/*.yaml dist/data/` (motor-drota já fazia isso). Necessário pra que `__dirname/../data/` resolva tanto em src/ quanto em dist/.

## Validação

- **18 unit tests** cobrindo: 8 archetypes default OK, YAML inválido rejeitado, drop de archetype sem id, error em focus/trigger inválidos, warning em description ausente, dedupe de id duplicado, strict throw, helpers de filtro
- Suite planejador full: **428 PASS / 27 files** ✅
- Sem regressão

## Próximas fatias

4. Integração (move_type=compose_playbook no plan.ts) — depende de #282, #283 e desta
5. PendingChallenge cross-session state machine
6. Bridge multi-modal spec
7. Console parental consent UX