### PR TITLE
feat(planejador): compose_playbook integration v0 (fatia 4)

### DIFF
--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -268,6 +268,7 @@ export async function handleSimplifiedPipeline(
     | "apply"
     | "recall"
     | "close"
+    | "compose_playbook"
     | undefined;
   const selectionResult = selectAction(
     {

--- a/planejador/data/dilemma-archetypes.yaml
+++ b/planejador/data/dilemma-archetypes.yaml
@@ -1,0 +1,119 @@
+# Philosophical Dilemma Archetype Catalog v1
+#
+# Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md §5.4
+#
+# 8 archetypes iniciais — cada um testa uma virtude específica via case
+# curto com tensão real. NÃO há resposta "certa": o motor avalia o
+# RACIOCÍNIO explicitado (0-3), não a escolha.
+#
+# Strategist consome este catálogo no `composePlaybook` e injeta no máximo
+# 1 dilema por step. `applicable_triggers` indica em qual ponto do step
+# o dilema disparou (step_complete / step_midway / evidence_received).
+#
+# `prompt_template` usa placeholders { context_X } que o composer substitui
+# por valores derivados do playbook (e.g. nome de pessoa, item, valor).
+
+version: 1
+
+archetypes:
+  - id: temptation_to_skip
+    virtue_tested: persistencia
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_midway
+    prompt_template: >-
+      Você está {context_what_doing} e tá cansativo agora.
+      Para de fazer ou continua? Não tem resposta certa — me
+      conta o que faz mais sentido pra você e por quê.
+    description: >-
+      Plantar tentação de desistir no meio do step. Cabe em qualquer
+      execute_recipe_step ou wait com expected_duration > 15min.
+
+  - id: silent_error
+    virtue_tested: honestidade
+    evaluation_focus: consistencia_com_valor_declarado
+    applicable_triggers:
+      - step_complete
+      - evidence_received
+    prompt_template: >-
+      Você cometeu {context_error} e ninguém viu. Você conta pra
+      {context_audience} agora ou guarda pra você?
+    description: >-
+      Quando evidência mostra erro (sujeito errou medida, passo, etc).
+      Testa se honestidade é declarada vs vivida.
+
+  - id: share_vs_keep
+    virtue_tested: generosidade
+    evaluation_focus: consideracao_do_outro
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Você tem {context_quantity} de {context_thing}. Você divide com
+      {context_other} ou guarda? O que pesa mais na sua decisão?
+    description: >-
+      Plantar no step final de qualquer playbook com resultado físico
+      compartilhável. Testa generosidade vs apego.
+
+  - id: cheap_vs_quality
+    virtue_tested: discernimento
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Você pode pagar mais por {context_better} ou economizar com
+      {context_worse}. Você nem sempre tem que escolher o mais barato.
+      Como você decide aqui?
+    description: >-
+      Plantar em shopping_list ou buy step quando há opções de preço.
+      Testa julgamento sob restrição econômica.
+
+  - id: give_credit
+    virtue_tested: humildade
+    evaluation_focus: consistencia_com_valor_declarado
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Foi sua ideia mas {context_helper} ajudou no caminho. Quando
+      você conta o que fez, fala 'eu' ou 'a gente'?
+    description: >-
+      Plantar em reflect step quando família/parceiro contribuiu.
+      Testa reconhecimento da contribuição alheia.
+
+  - id: early_quit
+    virtue_tested: paciencia
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_midway
+      - evidence_received
+    prompt_template: >-
+      Tá dando errado — {context_problem}. Você para por aqui ou
+      ajusta e continua? Como você sabe a diferença entre "ajustar"
+      e "teimar"?
+    description: >-
+      Plantar quando evidência sugere problema (foto mostra erro,
+      tempo estourou). Testa discernimento entre persistência
+      sábia e cabeça-dura.
+
+  - id: judge_yourself
+    virtue_tested: honestidade_auto
+    evaluation_focus: raciocinio
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Ficou {context_result} — não excelente, não ruim. {context_audience}
+      pergunta como foi. Você fala "tá bom" ou descreve o que faltou?
+    description: >-
+      Plantar em judge step quando resultado é mediano. Testa auto-
+      avaliação honesta (resiste à tentação de embelezar).
+
+  - id: prioritize_who
+    virtue_tested: justica
+    evaluation_focus: consideracao_do_outro
+    applicable_triggers:
+      - step_complete
+    prompt_template: >-
+      Tem {context_constraint} e dois lados afetados ({context_side_a}
+      vs {context_side_b}). Como você escolhe quem fica com o quê?
+    description: >-
+      Plantar quando há recurso finito a distribuir (último pedaço,
+      última peça, tempo limitado). Testa critério de justiça.

--- a/planejador/package.json
+++ b/planejador/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/server.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "postbuild": "mkdir -p dist/data && cp data/*.yaml dist/data/",
     "test": "vitest run",
     "start": "node dist/server.js",
     "clean": "rm -rf dist"

--- a/planejador/src/dilemma-archetype-loader.ts
+++ b/planejador/src/dilemma-archetype-loader.ts
@@ -1,0 +1,253 @@
+/**
+ * Loader do Philosophical Dilemma Archetype Catalog v1.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md §5.4
+ *
+ * Carrega planejador/data/dilemma-archetypes.yaml, valida estrutura,
+ * oferece consulta filtrada por virtude / trigger. Strategist composer
+ * consome este loader pra escolher quais dilemas plantar em quais steps.
+ *
+ * Padrão idêntico ao playbook-moves-loader.ts (motor-drota).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const DEFAULT_DILEMMA_CATALOG_PATH = join(
+  __dirname,
+  "..",
+  "data",
+  "dilemma-archetypes.yaml",
+);
+
+// ─────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────
+
+export type DilemmaTrigger =
+  | "step_complete"
+  | "step_midway"
+  | "evidence_received";
+
+export type DilemmaEvaluationFocus =
+  | "raciocinio"
+  | "consistencia_com_valor_declarado"
+  | "consideracao_do_outro";
+
+export interface DilemmaArchetype {
+  id: string;
+  virtue_tested: string;
+  evaluation_focus: DilemmaEvaluationFocus;
+  applicable_triggers: DilemmaTrigger[];
+  prompt_template: string;
+  description: string;
+}
+
+export interface DilemmaCatalog {
+  version: number;
+  archetypes: DilemmaArchetype[];
+}
+
+export interface LoadOptions {
+  path?: string;
+  strict?: boolean;
+}
+
+export interface ValidationIssue {
+  level: "error" | "warning";
+  archetype_id?: string;
+  message: string;
+}
+
+export interface LoadCatalogResult {
+  catalog: DilemmaCatalog;
+  issues: ValidationIssue[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Validators
+// ─────────────────────────────────────────────────────────────────────────
+
+const VALID_FOCUS = new Set<DilemmaEvaluationFocus>([
+  "raciocinio",
+  "consistencia_com_valor_declarado",
+  "consideracao_do_outro",
+]);
+
+const VALID_TRIGGERS = new Set<DilemmaTrigger>([
+  "step_complete",
+  "step_midway",
+  "evidence_received",
+]);
+
+function validateArchetype(
+  raw: unknown,
+  index: number,
+): { ok: DilemmaArchetype | null; issues: ValidationIssue[] } {
+  const issues: ValidationIssue[] = [];
+  if (!raw || typeof raw !== "object") {
+    issues.push({
+      level: "error",
+      message: `archetype[${index}] não é um objeto`,
+    });
+    return { ok: null, issues };
+  }
+  const r = raw as Record<string, unknown>;
+  const id = typeof r["id"] === "string" ? (r["id"] as string) : "";
+  if (!id) {
+    issues.push({
+      level: "error",
+      message: `archetype[${index}] sem 'id'`,
+    });
+    return { ok: null, issues };
+  }
+  const virtue = typeof r["virtue_tested"] === "string" ? r["virtue_tested"] : "";
+  if (!virtue) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' sem 'virtue_tested'`,
+    });
+    return { ok: null, issues };
+  }
+  const focus = r["evaluation_focus"];
+  if (typeof focus !== "string" || !VALID_FOCUS.has(focus as DilemmaEvaluationFocus)) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' tem 'evaluation_focus' inválido: ${focus}`,
+    });
+    return { ok: null, issues };
+  }
+  const triggersRaw = r["applicable_triggers"];
+  if (!Array.isArray(triggersRaw) || triggersRaw.length === 0) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' sem 'applicable_triggers' (array não-vazio)`,
+    });
+    return { ok: null, issues };
+  }
+  const triggers: DilemmaTrigger[] = [];
+  for (const t of triggersRaw) {
+    if (typeof t !== "string" || !VALID_TRIGGERS.has(t as DilemmaTrigger)) {
+      issues.push({
+        level: "error",
+        archetype_id: id,
+        message: `'${id}' tem trigger inválido: ${t}`,
+      });
+      return { ok: null, issues };
+    }
+    triggers.push(t as DilemmaTrigger);
+  }
+  const tpl = typeof r["prompt_template"] === "string" ? r["prompt_template"].trim() : "";
+  if (!tpl) {
+    issues.push({
+      level: "error",
+      archetype_id: id,
+      message: `'${id}' sem 'prompt_template'`,
+    });
+    return { ok: null, issues };
+  }
+  const desc = typeof r["description"] === "string" ? r["description"].trim() : "";
+  if (!desc) {
+    issues.push({
+      level: "warning",
+      archetype_id: id,
+      message: `'${id}' sem 'description' (recomendado)`,
+    });
+  }
+  return {
+    ok: {
+      id,
+      virtue_tested: virtue,
+      evaluation_focus: focus as DilemmaEvaluationFocus,
+      applicable_triggers: triggers,
+      prompt_template: tpl,
+      description: desc,
+    },
+    issues,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+export function loadDilemmaCatalog(
+  opts: LoadOptions = {},
+): LoadCatalogResult {
+  const path = opts.path ?? DEFAULT_DILEMMA_CATALOG_PATH;
+  const raw = readFileSync(path, "utf8");
+  const parsed = yaml.load(raw);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`dilemma-archetypes: YAML root inválido em ${path}`);
+  }
+  const root = parsed as Record<string, unknown>;
+  const version = typeof root["version"] === "number" ? (root["version"] as number) : 0;
+  const archetypesRaw = root["archetypes"];
+  if (!Array.isArray(archetypesRaw)) {
+    throw new Error(
+      `dilemma-archetypes: campo 'archetypes' obrigatório (array) em ${path}`,
+    );
+  }
+
+  const archetypes: DilemmaArchetype[] = [];
+  const issues: ValidationIssue[] = [];
+  const seenIds = new Set<string>();
+
+  for (let i = 0; i < archetypesRaw.length; i++) {
+    const { ok, issues: archIssues } = validateArchetype(archetypesRaw[i], i);
+    issues.push(...archIssues);
+    if (!ok) continue;
+    if (seenIds.has(ok.id)) {
+      issues.push({
+        level: "error",
+        archetype_id: ok.id,
+        message: `id duplicado: '${ok.id}'`,
+      });
+      continue;
+    }
+    seenIds.add(ok.id);
+    archetypes.push(ok);
+  }
+
+  if (opts.strict) {
+    const errors = issues.filter((i) => i.level === "error");
+    if (errors.length > 0) {
+      throw new Error(
+        `dilemma-archetypes: ${errors.length} erros no catálogo:\n${errors
+          .map((e) => `  - ${e.message}`)
+          .join("\n")}`,
+      );
+    }
+  }
+
+  return {
+    catalog: { version, archetypes },
+    issues,
+  };
+}
+
+/** Filtra archetypes por virtude testada. */
+export function findArchetypesByVirtue(
+  catalog: DilemmaCatalog,
+  virtue: string,
+): DilemmaArchetype[] {
+  return catalog.archetypes.filter((a) => a.virtue_tested === virtue);
+}
+
+/** Filtra archetypes que aplicam num trigger específico. */
+export function findArchetypesByTrigger(
+  catalog: DilemmaCatalog,
+  trigger: DilemmaTrigger,
+): DilemmaArchetype[] {
+  return catalog.archetypes.filter((a) =>
+    a.applicable_triggers.includes(trigger),
+  );
+}

--- a/planejador/src/inventory-probe-agent.ts
+++ b/planejador/src/inventory-probe-agent.ts
@@ -1,0 +1,270 @@
+/**
+ * Inventory Probe Agent v0 — gera perguntas curtas que mapeiam o que o
+ * sujeito TEM DISPONÍVEL agora (materiais, tempo, família presente, orçamento,
+ * desejos) — input para o Strategist compor um EmergentPlaybook.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md §5.1
+ *
+ * v0 scope: APENAS função de geração de perguntas — sem extrator de respostas
+ * (extrair SubjectInventory das mensagens do sujeito é PR separada). Sem
+ * integração com pipeline do motor. Output paralelo ao DiscoveryOption mas
+ * com kind específico.
+ *
+ * Padrão idêntico ao Discovery Agent: LLM-augmented com fallback determinístico.
+ *
+ * Quando perguntar:
+ *   - 5 perguntas-base cobrem inventário completo (1 por dimensão)
+ *   - Agent pula dimensões já no `partial_inventory` — só pergunta o que falta
+ *   - Output máximo 5 perguntas; mínimo 1 (se inventário quase completo)
+ */
+
+import { callLlm } from "./llm-client.js";
+import {
+  shouldUseMockLlm,
+  type SubjectInventory,
+} from "@ascendimacy/shared";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────
+
+export type InventoryQuestionKind =
+  | "materials_around"      // o que tem por perto
+  | "time_window"           // quanto tempo livre
+  | "family_presence"       // quem tá em casa
+  | "budget_capacity"       // quanto dinheiro
+  | "aspirational";         // o que sempre quis fazer
+
+export interface InventoryProbeQuestion {
+  kind: InventoryQuestionKind;
+  text: string;
+  /** Hint para extrator (PR futura) — qual campo de SubjectInventory popular. */
+  expected_extraction_target:
+    | "available_materials"
+    | "available_time_minutes"
+    | "family_present"
+    | "available_budget_cents"
+    | "aspirational_wishlist";
+}
+
+export interface InventoryProbeInput {
+  recentTurns: Array<{ role: "user" | "assistant"; content: string }>;
+  subjectName: string;
+  subjectAge?: number;
+  /** Inventário já parcial — agent pula perguntas dessas dimensões. */
+  partial_inventory?: Partial<SubjectInventory>;
+  run_id?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Kind → extraction target mapping (estável; cada kind sempre puxa o mesmo
+// campo do SubjectInventory)
+// ─────────────────────────────────────────────────────────────────────────
+
+const KIND_TO_TARGET: Record<
+  InventoryQuestionKind,
+  InventoryProbeQuestion["expected_extraction_target"]
+> = {
+  materials_around: "available_materials",
+  time_window: "available_time_minutes",
+  family_presence: "family_present",
+  budget_capacity: "available_budget_cents",
+  aspirational: "aspirational_wishlist",
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Detecta dimensões já preenchidas no partial_inventory
+// ─────────────────────────────────────────────────────────────────────────
+
+function isFilled(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === "number") return value > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "string") return value.length > 0;
+  return false;
+}
+
+function missingKinds(
+  partial: Partial<SubjectInventory> | undefined,
+): InventoryQuestionKind[] {
+  if (!partial) {
+    return [
+      "materials_around",
+      "time_window",
+      "family_presence",
+      "budget_capacity",
+      "aspirational",
+    ];
+  }
+  const out: InventoryQuestionKind[] = [];
+  if (!isFilled(partial.available_materials)) out.push("materials_around");
+  if (!isFilled(partial.available_time_minutes)) out.push("time_window");
+  if (!isFilled(partial.family_present)) out.push("family_presence");
+  if (!isFilled(partial.available_budget_cents)) out.push("budget_capacity");
+  if (!isFilled(partial.aspirational_wishlist)) out.push("aspirational");
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fallback determinístico — 5 perguntas-base ajustadas por idade
+// ─────────────────────────────────────────────────────────────────────────
+
+function buildFallbackQuestions(
+  input: InventoryProbeInput,
+): InventoryProbeQuestion[] {
+  const kinds = missingKinds(input.partial_inventory);
+  // Tom mais infantil para < 10, mais direto para 10+
+  const isLudic = (input.subjectAge ?? 12) < 10;
+  const subj = input.subjectName;
+
+  const BASE: Record<InventoryQuestionKind, string> = isLudic
+    ? {
+        materials_around: `${subj}, olha em volta — vê alguma coisa legal pra mexer com a mão? Pode ser comida, brinquedo, ferramenta.`,
+        time_window: "Quanto tempo você tem antes de ter que fazer outra coisa hoje?",
+        family_presence: "Quem tá em casa contigo agora?",
+        budget_capacity:
+          "Se valer a pena, dá pra usar um pouquinho de dinheiro? Quanto?",
+        aspirational:
+          "Tem alguma coisa que você sempre quis fazer mas nunca rolou?",
+      }
+    : {
+        materials_around: `${subj}, olha em volta — tem algo útil pra construir, cozinhar ou montar alguma coisa? Pode ser cozinha, ferramenta, qualquer coisa concreta.`,
+        time_window:
+          "Quanto tempo de hoje você tem livre, sem ninguém te chamar?",
+        family_presence: "Tem alguém em casa agora? Quem?",
+        budget_capacity:
+          "Quanto dinheiro você poderia gastar se valesse a pena pra algo real?",
+        aspirational:
+          "Tem uma coisa que você sempre quis fazer mas nunca teve tempo ou material?",
+      };
+
+  return kinds.map((k) => ({
+    kind: k,
+    text: BASE[k],
+    expected_extraction_target: KIND_TO_TARGET[k],
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Parser defensivo
+// ─────────────────────────────────────────────────────────────────────────
+
+const VALID_KINDS = new Set<string>([
+  "materials_around",
+  "time_window",
+  "family_presence",
+  "budget_capacity",
+  "aspirational",
+]);
+
+function parseInventoryQuestions(
+  raw: string,
+): InventoryProbeQuestion[] | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
+  const match = cleaned.match(/\[[\s\S]*\]/);
+  const candidate = match ? match[0] : cleaned;
+  try {
+    const arr = JSON.parse(candidate);
+    if (!Array.isArray(arr)) return null;
+    const out: InventoryProbeQuestion[] = [];
+    for (const x of arr) {
+      if (
+        typeof x?.kind === "string" &&
+        VALID_KINDS.has(x.kind) &&
+        typeof x?.text === "string" &&
+        x.text.length > 0
+      ) {
+        const kind = x.kind as InventoryQuestionKind;
+        out.push({
+          kind,
+          text: x.text,
+          expected_extraction_target: KIND_TO_TARGET[kind],
+        });
+      }
+    }
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Prompt
+// ─────────────────────────────────────────────────────────────────────────
+
+function buildSystemPrompt(input: InventoryProbeInput): string {
+  const missing = missingKinds(input.partial_inventory);
+  const missingList =
+    missing.length > 0 ? missing.join(", ") : "(inventário completo)";
+  const ageHint = input.subjectAge
+    ? `${input.subjectAge} anos`
+    : "(idade não declarada)";
+  const recent = input.recentTurns
+    .slice(-3)
+    .map((t) => `${t.role}: "${t.content.slice(0, 100)}"`)
+    .join("\n");
+
+  return `Você é o Inventory Probe Agent do Ascendimacy. Gere perguntas curtas pra mapear o que o sujeito TEM DISPONÍVEL agora (materiais físicos, tempo, família presente, dinheiro, desejos não realizados). Esse inventário vai virar input pro Strategist compor um desafio físico real.
+
+REGRAS ABSOLUTAS:
+- 1 pergunta por dimensão (nunca duas pra mesma)
+- APENAS pra dimensões na lista de FALTANTES abaixo
+- Pergunta curta, concreta, sem teoria
+- NÃO faça pergunta sobre sentimento ou abstração
+- Cada pergunta tem o "kind" exato da lista abaixo
+
+KINDS DISPONÍVEIS (use APENAS estes):
+- materials_around: o que tem fisicamente disponível pra usar
+- time_window: quanto tempo livre tem hoje
+- family_presence: quem está em casa agora
+- budget_capacity: quanto dinheiro pode usar se valer a pena
+- aspirational: o que sempre quis fazer mas nunca rolou
+
+CONTEXTO:
+Sujeito: ${input.subjectName} (${ageHint})
+Conversa recente:
+${recent || "(início da conversa)"}
+
+DIMENSÕES FALTANTES (gere 1 pergunta pra CADA): ${missingList}
+
+OUTPUT — APENAS JSON ARRAY:
+[
+  { "kind": "materials_around", "text": "..." },
+  { "kind": "time_window", "text": "..." }
+]`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+export async function generateInventoryProbeQuestions(
+  input: InventoryProbeInput,
+): Promise<InventoryProbeQuestion[]> {
+  const missing = missingKinds(input.partial_inventory);
+  if (missing.length === 0) {
+    return [];
+  }
+
+  if (shouldUseMockLlm("planejador")) {
+    return buildFallbackQuestions(input);
+  }
+
+  const systemPrompt = buildSystemPrompt(input);
+  const userMessage = `Gere as perguntas em JSON array. Apenas para as dimensões faltantes.`;
+
+  try {
+    const result = await callLlm(systemPrompt, userMessage);
+    const parsed = parseInventoryQuestions(result.content);
+    if (parsed && parsed.length >= 1) {
+      // Filtra pra garantir que não veio kind já preenchido (LLM pode ignorar instruction)
+      const missingSet = new Set(missing);
+      const filtered = parsed.filter((q) => missingSet.has(q.kind));
+      if (filtered.length > 0) return filtered;
+    }
+    return buildFallbackQuestions(input);
+  } catch {
+    return buildFallbackQuestions(input);
+  }
+}

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -47,6 +47,9 @@ import {
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku, type LlmCallResult } from "./llm-client.js";
 import { generateDiscoveryOptions } from "./discovery-agent.js";
+import { generateInventoryProbeQuestions } from "./inventory-probe-agent.js";
+import { composePlaybook } from "./strategist/playbook-composer.js";
+import type { SubjectInventory, EmergentVirtueTarget } from "@ascendimacy/shared";
 import { detectMilestone } from "./milestone-detector.js";
 import type { LlmTraceCollector, PlanejadorTrace } from "@ascendimacy/shared";
 
@@ -230,12 +233,22 @@ function computeBasicTutorialContext(
   const shouldRecall =
     !recallCooldownActive && lastExecutedId != null && topItem?.id !== lastExecutedId;
 
+  // Fatia 4 (physical_world_playbook spec §5 — emergent composition):
+  // Console parental seta `contextHints.compose_playbook_request=true`
+  // depois de aprovar um piloto de desafio físico real. Highest priority
+  // — sobrepõe close/discover/etc. Default ausente → comportamento atual.
+  const composePlaybookRequested =
+    input.contextHints?.["compose_playbook_request"] === true;
+
   let moveType: TutorialMove = "explain";
   let goal = input.incomingMessage
     ? "Trabalhar a mensagem atual do sujeito"
     : "Avançar no objetivo formativo da sessão";
 
-  if (hasExitSignal) {
+  if (composePlaybookRequested) {
+    moveType = "compose_playbook";
+    goal = "Coletar inventário + compor desafio físico real para o sujeito";
+  } else if (hasExitSignal) {
     moveType = "close";
     goal = "Fechar respeitando sinal de saída do sujeito";
   } else if (isDiscoveryStage) {
@@ -305,6 +318,12 @@ function computeBasicTutorialContext(
       ctx.failure_policy = "re_explain";
       break;
     case "close":
+      ctx.advance_policy = "can_move_on";
+      break;
+    case "compose_playbook":
+      // Pode avançar sem requerer correct/attempted — a decisão de seguir
+      // pra próximo step do playbook é responsabilidade do PendingChallenge
+      // state machine (fatia futura), não do tutorial flow.
       ctx.advance_policy = "can_move_on";
       break;
   }
@@ -907,6 +926,74 @@ export async function planTurn(
     } catch {
       // Telemetry: discovery failure não bloqueia turn — segue sem discovery_options
       // (fallback determinístico já cobre LLM crashes dentro do agent).
+    }
+  }
+
+  // Fatia 4 (physical_world_playbook §5.1+5.2) — quando move_type=compose_playbook,
+  // roda probe (questões de inventário) E composer (gera EmergentPlaybook) em
+  // sequência. Probe primeiro: se inventário já completo, retorna [] e composer
+  // usa o que tem; senão, composer roda com fallback determinístico (bolo template).
+  //
+  // Outputs em contextHints:
+  //   - inventory_probe_options: questões que faltam perguntar
+  //   - emergent_playbook: instância composta (presente sempre quando flag setado)
+  //
+  // Motor-drota não consome ainda (integração materializer = fatia futura). Por
+  // ora é apenas wiring planejador-side validado por testes de planTurn.
+  if (tutorial?.move_type === "compose_playbook") {
+    const partialInventory = input.contextHints?.["subject_inventory"] as
+      | Partial<SubjectInventory>
+      | undefined;
+    const recentTurns = Array.isArray(input.contextHints?.["recent_turns"])
+      ? (input.contextHints!["recent_turns"] as Array<{ role: "user" | "assistant"; content: string }>)
+      : [];
+    const subjectName = input.persona?.name ?? "amigo";
+    const subjectAge = typeof input.persona?.age === "number" ? input.persona.age : undefined;
+
+    try {
+      const probeInput: Parameters<typeof generateInventoryProbeQuestions>[0] = {
+        recentTurns,
+        subjectName,
+      };
+      if (subjectAge !== undefined) probeInput.subjectAge = subjectAge;
+      if (partialInventory) probeInput.partial_inventory = partialInventory;
+      const probeOptions = await generateInventoryProbeQuestions(probeInput);
+      if (probeOptions.length > 0) {
+        contextHints["inventory_probe_options"] = probeOptions;
+      }
+    } catch {
+      // Probe failure não bloqueia composer abaixo.
+    }
+
+    try {
+      // Inventário pra composer: completa partial com defaults razoáveis pra
+      // permitir fallback determinístico. v0 não exige inventário completo;
+      // fatia futura adiciona gate "só compõe se confidence >= 2".
+      const inventoryForCompose: SubjectInventory = {
+        collected_at: partialInventory?.collected_at ?? new Date().toISOString(),
+        available_materials: partialInventory?.available_materials ?? [],
+        available_time_minutes: partialInventory?.available_time_minutes ?? 0,
+        available_budget_cents: partialInventory?.available_budget_cents ?? 0,
+        family_present: partialInventory?.family_present ?? [],
+        aspirational_wishlist: partialInventory?.aspirational_wishlist ?? [],
+        confidence: partialInventory?.confidence ?? 0,
+      };
+      const currentObjectives = Array.isArray(input.contextHints?.["playbook_objectives"])
+        ? (input.contextHints!["playbook_objectives"] as readonly EmergentVirtueTarget[])
+        : [];
+      const playbookInput: Parameters<typeof composePlaybook>[0] = {
+        inventory: inventoryForCompose,
+        active_axes: Array.isArray(input.contextHints?.["axes_active"])
+          ? (input.contextHints!["axes_active"] as readonly string[])
+          : [],
+        current_objectives: currentObjectives,
+        subject_name: subjectName,
+      };
+      if (subjectAge !== undefined) playbookInput.subject_age = subjectAge;
+      const playbook = await composePlaybook(playbookInput);
+      contextHints["emergent_playbook"] = playbook;
+    } catch {
+      // Composer failure não bloqueia turn — segue sem playbook.
     }
   }
 

--- a/planejador/src/strategist/playbook-composer.ts
+++ b/planejador/src/strategist/playbook-composer.ts
@@ -1,0 +1,248 @@
+/**
+ * Playbook Composer v0 — Strategist function que compõe `EmergentPlaybook`
+ * a partir de `SubjectInventory` + axes + objetivos.
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md §5.2
+ *
+ * v0 scope: APENAS função pura (input → output via LLM). Sem integração com
+ * pipeline do motor. Sem persistência de PendingChallenge. Sem consent
+ * parental. Sem Bridge multi-modal. Tudo isso é fase posterior — esta fatia
+ * valida o shape do EmergentPlaybook e o prompt do LLM.
+ *
+ * Fluxo:
+ *   1. Mock mode → fallback determinístico (bolo template baseado em inventário)
+ *   2. LLM call (step="planejador") com system prompt explícito + JSON output
+ *   3. Defensive parse (zod) — se falha de parsing OU schema invalid, fallback
+ *   4. Anti-repetição: se playbook_id repetido nos last N, força fallback variante
+ */
+
+import { callLlm } from "../llm-client.js";
+import {
+  shouldUseMockLlm,
+  EmergentPlaybookSchema,
+  type EmergentPlaybook,
+  type PlaybookComposerInput,
+  type SubjectInventory,
+  type EmergentVirtueTarget,
+} from "@ascendimacy/shared";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fallback determinístico — bolo template + 2 dilemas
+// ─────────────────────────────────────────────────────────────────────────
+
+function buildFallbackBolo(input: PlaybookComposerInput): EmergentPlaybook {
+  const now = new Date().toISOString();
+  const id = `piloto-${input.subject_name}-${Date.now()}-fallback`;
+  const primary: EmergentVirtueTarget =
+    input.current_objectives[0] ?? { axis: "carater", virtue: "persistencia" };
+  const secondary: EmergentVirtueTarget[] = input.current_objectives.slice(1, 3);
+
+  return {
+    playbook_id: id,
+    composed_at: now,
+    source_inventory: input.inventory,
+    primary_objective: primary,
+    secondary_objectives: secondary,
+    steps: [
+      {
+        step_id: "list",
+        kind: "shopping_list",
+        hint_to_subject:
+          "Faz a lista do que falta pra um bolo simples (farinha, ovo, açúcar, leite, fermento).",
+        evidence_kind: "text_answer",
+        expected_duration_minutes: 5,
+      },
+      {
+        step_id: "buy",
+        kind: "execute_recipe_step",
+        hint_to_subject: "Compra os ingredientes (limite R$ 30). Tira foto da nota.",
+        evidence_kind: "photo",
+        expected_duration_minutes: 30,
+      },
+      {
+        step_id: "mix",
+        kind: "execute_recipe_step",
+        hint_to_subject:
+          "Mistura na ordem certa. Tira foto da massa antes do forno.",
+        evidence_kind: "photo",
+        expected_duration_minutes: 20,
+      },
+      {
+        step_id: "bake",
+        kind: "wait",
+        hint_to_subject: "Forno 180°C por 35-40min. Não abra a porta antes.",
+        evidence_kind: "none",
+        expected_duration_minutes: 40,
+      },
+      {
+        step_id: "judge",
+        kind: "reflect",
+        hint_to_subject:
+          "Pronto. Como ficou? Bom ou ruim — descreve sem maquiar.",
+        evidence_kind: "text_answer",
+        expected_duration_minutes: 5,
+      },
+      {
+        step_id: "share",
+        kind: "execute_recipe_step",
+        hint_to_subject:
+          "Oferece um pedaço pra alguém da família. Anota o que disseram.",
+        evidence_kind: "text_answer",
+        expected_duration_minutes: 10,
+      },
+    ],
+    total_duration_minutes: 110,
+    budget_range_cents: { min: 2000, max: 3000 },
+    philosophical_dilemmas: [
+      {
+        dilemma_id: "dilemma-buy-budget-balance",
+        attached_to_step: "buy",
+        trigger: "step_complete",
+        virtue_tested: "controle",
+        prompt:
+          "Sobrou R$ 4 do orçamento. Você compra um doce pra você ou guarda? Não tem certo nem errado — me conta o que faz sentido pra você.",
+        evaluation_focus: "raciocinio",
+      },
+      {
+        dilemma_id: "dilemma-judge-honesty",
+        attached_to_step: "judge",
+        trigger: "step_complete",
+        virtue_tested: "honestidade",
+        prompt:
+          "Ficou ok, mas não excelente. Se alguém da família perguntar, você fala 'tá bom' ou descreve o que faltou?",
+        evaluation_focus: "consistencia_com_valor_declarado",
+      },
+    ],
+    composition_rationale:
+      "Fallback determinístico (bolo template). LLM indisponível ou parsing falhou; sujeito recebe playbook estável de menor risco.",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Prompt construction
+// ─────────────────────────────────────────────────────────────────────────
+
+function inventoryAsText(inv: SubjectInventory): string {
+  const lines = [
+    `- Materiais disponíveis: ${inv.available_materials.join(", ") || "(nenhum declarado)"}`,
+    `- Tempo livre: ${inv.available_time_minutes} min`,
+    `- Orçamento: R$ ${(inv.available_budget_cents / 100).toFixed(2)}`,
+    `- Família presente: ${inv.family_present.join(", ") || "(ninguém declarado)"}`,
+    `- Desejos: ${inv.aspirational_wishlist.join(", ") || "(nenhum)"}`,
+    `- Confiança do inventário: ${inv.confidence}/3`,
+  ];
+  return lines.join("\n");
+}
+
+function buildSystemPrompt(input: PlaybookComposerInput): string {
+  const objLines = input.current_objectives
+    .map((o) => `- ${o.axis}: ${o.virtue}`)
+    .join("\n");
+  const axisList = input.active_axes.join(", ") || "(nenhum ativo)";
+  const previous = input.previous_playbook_ids?.length
+    ? `\nNÃO repita estes playbook_ids: ${input.previous_playbook_ids.join(", ")}`
+    : "";
+
+  return `Você é o Playbook Composer do Ascendimacy. Recebe inventário físico/temporal/social de um sujeito + axes ativos + objetivos parentais. Output: 1 EmergentPlaybook único em JSON.
+
+REGRAS ABSOLUTAS:
+- Use APENAS materiais declarados no inventário (não invente coisas)
+- Total duration ≤ available_time_minutes do inventário
+- Budget_range.max ≤ available_budget_cents do inventário
+- 4-6 steps OBRIGATÓRIOS (não menos, não mais)
+- 1-3 dilemmas filosóficos atrelados a steps específicos
+- Cada dilemma tem prompt curto (≤ 200 chars) + virtue_tested + evaluation_focus
+- composition_rationale ≤ 300 chars explicando POR QUE escolheu este playbook${previous}
+
+CONTEXTO:
+Sujeito: ${input.subject_name}${input.subject_age ? ` (${input.subject_age} anos)` : ""}
+Inventário:
+${inventoryAsText(input.inventory)}
+
+Axes ativos: ${axisList}
+
+Objetivos correntes:
+${objLines || "(nenhum — escolha primary baseado nos axes ativos)"}
+
+OUTPUT — JSON único conforme schema:
+{
+  "playbook_id": "string único",
+  "composed_at": "ISO8601",
+  "source_inventory": <copy of inventory>,
+  "primary_objective": { "axis": "...", "virtue": "..." },
+  "secondary_objectives": [{ "axis": "...", "virtue": "..." }],
+  "steps": [
+    {
+      "step_id": "string",
+      "kind": "shopping_list" | "execute_recipe_step" | "wait" | "reflect",
+      "hint_to_subject": "string curta",
+      "evidence_kind": "photo" | "voice_memo" | "text_answer" | "parent_confirmation" | "none",
+      "expected_duration_minutes": number
+    }
+  ],
+  "total_duration_minutes": number,
+  "budget_range_cents": { "min": number, "max": number },
+  "philosophical_dilemmas": [
+    {
+      "dilemma_id": "string",
+      "attached_to_step": "<step_id existente>",
+      "trigger": "step_complete" | "step_midway" | "evidence_received",
+      "virtue_tested": "string",
+      "prompt": "string curta",
+      "evaluation_focus": "raciocinio" | "consistencia_com_valor_declarado" | "consideracao_do_outro"
+    }
+  ],
+  "composition_rationale": "string"
+}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Parser defensivo
+// ─────────────────────────────────────────────────────────────────────────
+
+function parsePlaybookJson(raw: string): EmergentPlaybook | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  const cleaned = raw.replace(/^```json\n?/, "").replace(/\n?```$/, "").trim();
+  // Acha o primeiro objeto JSON top-level
+  const match = cleaned.match(/\{[\s\S]*\}/);
+  const candidate = match ? match[0] : cleaned;
+  try {
+    const obj = JSON.parse(candidate);
+    const parsed = EmergentPlaybookSchema.safeParse(obj);
+    if (parsed.success) return parsed.data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compõe um EmergentPlaybook via LLM. Cai pro fallback determinístico se:
+ *   - Mock mode habilitado (USE_MOCK_LLM=true)
+ *   - LLM throw (network/timeout)
+ *   - JSON parsing falha
+ *   - Schema validation falha
+ */
+export async function composePlaybook(
+  input: PlaybookComposerInput,
+): Promise<EmergentPlaybook> {
+  if (shouldUseMockLlm("planejador")) {
+    return buildFallbackBolo(input);
+  }
+
+  const systemPrompt = buildSystemPrompt(input);
+  const userMessage = `Compose o EmergentPlaybook agora. JSON único.`;
+
+  try {
+    const result = await callLlm(systemPrompt, userMessage);
+    const parsed = parsePlaybookJson(result.content);
+    if (parsed) return parsed;
+    return buildFallbackBolo(input);
+  } catch {
+    return buildFallbackBolo(input);
+  }
+}

--- a/planejador/tests/compose-playbook-integration.test.ts
+++ b/planejador/tests/compose-playbook-integration.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import { planTurn } from "../src/plan.js";
+import {
+  EmergentPlaybookSchema,
+  type PersonaDef,
+  type SessionState,
+  type SubjectInventory,
+} from "@ascendimacy/shared";
+
+process.env["USE_MOCK_LLM"] = "true";
+
+function makePersona(overrides: Partial<PersonaDef> = {}): PersonaDef {
+  return {
+    id: "kei",
+    name: "Kei",
+    age: 11,
+    profile: {},
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: "s1",
+    trustLevel: 0.4,
+    budgetRemaining: 100,
+    turn: 2,
+    eventLog: [],
+    statusMatrix: { emotional: "baia" },
+    ...overrides,
+  };
+}
+
+const adquirente = { id: "jun", name: "Jun", defaults: {} };
+const inventory = [
+  {
+    id: "kids.helix.session",
+    title: "Helix",
+    category: "kids",
+    estimatedSacrifice: 1,
+    estimatedConfidenceGain: 4,
+  },
+];
+
+describe("planTurn — compose_playbook integration (fatia 4)", () => {
+  it("default sem flag → move_type NÃO é compose_playbook", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+    });
+    expect(out.contextHints["tutorial"]).toBeTruthy();
+    const tutorial = out.contextHints["tutorial"] as { move_type: string };
+    expect(tutorial.move_type).not.toBe("compose_playbook");
+  });
+
+  it("flag true → move_type=compose_playbook", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const tutorial = out.contextHints["tutorial"] as { move_type: string; teaching_goal: string };
+    expect(tutorial.move_type).toBe("compose_playbook");
+    expect(tutorial.teaching_goal.toLowerCase()).toContain("inventário");
+  });
+
+  it("flag true sem inventory → inventory_probe_options preenchido (5 questões)", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const probe = out.contextHints["inventory_probe_options"] as Array<{ kind: string }>;
+    expect(Array.isArray(probe)).toBe(true);
+    expect(probe.length).toBe(5);
+  });
+
+  it("flag true com partial inventory pula dimensões cobertas", async () => {
+    const partial: Partial<SubjectInventory> = {
+      available_time_minutes: 90,
+      available_materials: ["ovos", "farinha"],
+    };
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: {
+        compose_playbook_request: true,
+        subject_inventory: partial,
+      },
+    });
+    const probe = out.contextHints["inventory_probe_options"] as Array<{ kind: string }>;
+    const kinds = probe.map((q) => q.kind);
+    expect(kinds).not.toContain("time_window");
+    expect(kinds).not.toContain("materials_around");
+    expect(probe.length).toBe(3);
+  });
+
+  it("flag true → emergent_playbook preenchido + zod válido", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const playbook = out.contextHints["emergent_playbook"];
+    expect(playbook).toBeTruthy();
+    const parsed = EmergentPlaybookSchema.safeParse(playbook);
+    expect(parsed.success).toBe(true);
+  });
+
+  it("flag true sobrepõe outros triggers (exit signal não vence)", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "tchau",
+      contextHints: {
+        compose_playbook_request: true,
+        extracted_signals: ["exit_marker_explicit"],
+      },
+    });
+    const tutorial = out.contextHints["tutorial"] as { move_type: string };
+    expect(tutorial.move_type).toBe("compose_playbook");
+  });
+
+  it("advance_policy = can_move_on (configurado em §switch)", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const tutorial = out.contextHints["tutorial"] as { advance_policy?: string };
+    expect(tutorial.advance_policy).toBe("can_move_on");
+  });
+
+  it("flag false (não truthy literal) NÃO dispara", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: false },
+    });
+    const tutorial = out.contextHints["tutorial"] as { move_type: string };
+    expect(tutorial.move_type).not.toBe("compose_playbook");
+    expect(out.contextHints["emergent_playbook"]).toBeUndefined();
+  });
+
+  it("nome do sujeito flui pro playbook_id", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona({ id: "ryo", name: "Ryo", age: 13 }),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const playbook = out.contextHints["emergent_playbook"] as { playbook_id: string };
+    expect(playbook.playbook_id).toContain("Ryo");
+  });
+});

--- a/planejador/tests/dilemma-archetype-loader.unit.test.ts
+++ b/planejador/tests/dilemma-archetype-loader.unit.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadDilemmaCatalog,
+  findArchetypesByVirtue,
+  findArchetypesByTrigger,
+} from "../src/dilemma-archetype-loader.js";
+
+describe("loadDilemmaCatalog — produção (data/dilemma-archetypes.yaml)", () => {
+  it("carrega catálogo default sem erros", () => {
+    const { catalog, issues } = loadDilemmaCatalog();
+    const errors = issues.filter((i) => i.level === "error");
+    expect(errors).toEqual([]);
+    expect(catalog.version).toBeGreaterThanOrEqual(1);
+  });
+
+  it("catálogo tem os 8 archetypes esperados (spec §5.4)", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const ids = catalog.archetypes.map((a) => a.id).sort();
+    expect(ids).toEqual([
+      "cheap_vs_quality",
+      "early_quit",
+      "give_credit",
+      "judge_yourself",
+      "prioritize_who",
+      "share_vs_keep",
+      "silent_error",
+      "temptation_to_skip",
+    ]);
+  });
+
+  it("todos archetypes têm prompt_template não-vazio", () => {
+    const { catalog } = loadDilemmaCatalog();
+    for (const a of catalog.archetypes) {
+      expect(a.prompt_template.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("todos archetypes têm pelo menos 1 applicable_trigger", () => {
+    const { catalog } = loadDilemmaCatalog();
+    for (const a of catalog.archetypes) {
+      expect(a.applicable_triggers.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("evaluation_focus é sempre um dos 3 valores válidos", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const valid = new Set([
+      "raciocinio",
+      "consistencia_com_valor_declarado",
+      "consideracao_do_outro",
+    ]);
+    for (const a of catalog.archetypes) {
+      expect(valid.has(a.evaluation_focus)).toBe(true);
+    }
+  });
+
+  it("strict mode passa sem throw", () => {
+    expect(() => loadDilemmaCatalog({ strict: true })).not.toThrow();
+  });
+});
+
+describe("findArchetypesByVirtue", () => {
+  it("retorna archetypes correspondentes", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const honesty = findArchetypesByVirtue(catalog, "honestidade");
+    expect(honesty.length).toBeGreaterThan(0);
+    for (const a of honesty) {
+      expect(a.virtue_tested).toBe("honestidade");
+    }
+  });
+
+  it("retorna [] quando virtude desconhecida", () => {
+    const { catalog } = loadDilemmaCatalog();
+    expect(findArchetypesByVirtue(catalog, "fake-virtue")).toEqual([]);
+  });
+});
+
+describe("findArchetypesByTrigger", () => {
+  it("retorna archetypes que aplicam em step_complete", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const stepComplete = findArchetypesByTrigger(catalog, "step_complete");
+    expect(stepComplete.length).toBeGreaterThan(0);
+    for (const a of stepComplete) {
+      expect(a.applicable_triggers).toContain("step_complete");
+    }
+  });
+
+  it("retorna archetypes que aplicam em step_midway", () => {
+    const { catalog } = loadDilemmaCatalog();
+    const midway = findArchetypesByTrigger(catalog, "step_midway");
+    expect(midway.length).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Loader edge cases — usa arquivos temporários
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("loadDilemmaCatalog — validation edge cases", () => {
+  function withTempCatalog<T>(content: string, fn: (path: string) => T): T {
+    const dir = mkdtempSync(join(tmpdir(), "dilemma-catalog-"));
+    const path = join(dir, "test.yaml");
+    writeFileSync(path, content, "utf8");
+    try {
+      return fn(path);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("YAML root inválido → throw", () => {
+    withTempCatalog("just a string", (path) => {
+      expect(() => loadDilemmaCatalog({ path })).toThrow(/root inválido/);
+    });
+  });
+
+  it("falta campo 'archetypes' → throw", () => {
+    withTempCatalog("version: 1\n", (path) => {
+      expect(() => loadDilemmaCatalog({ path })).toThrow(/'archetypes' obrigatório/);
+    });
+  });
+
+  it("archetype sem id → issue error, archetype dropado", () => {
+    const yaml = `version: 1
+archetypes:
+  - virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(0);
+      expect(issues.some((i) => i.level === "error" && /sem 'id'/.test(i.message))).toBe(true);
+    });
+  });
+
+  it("evaluation_focus inválido → error", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: bad_focus
+    virtue_tested: x
+    evaluation_focus: fake-focus
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(0);
+      expect(
+        issues.some((i) => i.level === "error" && /'evaluation_focus' inválido/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("trigger inválido → error", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: bad_trigger
+    virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [fake_trigger]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(0);
+      expect(
+        issues.some((i) => i.level === "error" && /trigger inválido/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("id duplicado → error, segundo dropado", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: dup
+    virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+    description: "test"
+  - id: dup
+    virtue_tested: y
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "outro prompt longo o bastante pra passar"
+    description: "test"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(1);
+      expect(
+        issues.some((i) => i.level === "error" && /duplicado/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("description ausente → warning, archetype mantido", () => {
+    const yaml = `version: 1
+archetypes:
+  - id: no_desc
+    virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+`;
+    withTempCatalog(yaml, (path) => {
+      const { catalog, issues } = loadDilemmaCatalog({ path });
+      expect(catalog.archetypes).toHaveLength(1);
+      expect(
+        issues.some((i) => i.level === "warning" && /sem 'description'/.test(i.message)),
+      ).toBe(true);
+    });
+  });
+
+  it("strict mode com errors → throw", () => {
+    const yaml = `version: 1
+archetypes:
+  - virtue_tested: x
+    evaluation_focus: raciocinio
+    applicable_triggers: [step_complete]
+    prompt_template: "test prompt longo o bastante pra passar"
+`;
+    withTempCatalog(yaml, (path) => {
+      expect(() => loadDilemmaCatalog({ path, strict: true })).toThrow(/erros no catálogo/);
+    });
+  });
+});

--- a/planejador/tests/inventory-probe-agent.unit.test.ts
+++ b/planejador/tests/inventory-probe-agent.unit.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import type { SubjectInventory } from "@ascendimacy/shared";
+import {
+  generateInventoryProbeQuestions,
+  type InventoryProbeInput,
+} from "../src/inventory-probe-agent.js";
+
+const BASE_INPUT: InventoryProbeInput = {
+  recentTurns: [],
+  subjectName: "Kei",
+  subjectAge: 11,
+};
+
+describe("generateInventoryProbeQuestions — fallback (mock mode)", () => {
+  beforeAll(() => {
+    process.env["USE_MOCK_LLM"] = "true";
+  });
+
+  it("retorna 5 perguntas quando partial_inventory ausente", async () => {
+    const qs = await generateInventoryProbeQuestions(BASE_INPUT);
+    expect(qs).toHaveLength(5);
+  });
+
+  it("cobre exatamente os 5 kinds esperados", async () => {
+    const qs = await generateInventoryProbeQuestions(BASE_INPUT);
+    const kinds = qs.map((q) => q.kind).sort();
+    expect(kinds).toEqual([
+      "aspirational",
+      "budget_capacity",
+      "family_presence",
+      "materials_around",
+      "time_window",
+    ]);
+  });
+
+  it("cada pergunta tem texto não-vazio", async () => {
+    const qs = await generateInventoryProbeQuestions(BASE_INPUT);
+    for (const q of qs) {
+      expect(q.text.length).toBeGreaterThan(5);
+    }
+  });
+
+  it("expected_extraction_target consistente por kind", async () => {
+    const qs = await generateInventoryProbeQuestions(BASE_INPUT);
+    const map = Object.fromEntries(
+      qs.map((q) => [q.kind, q.expected_extraction_target]),
+    );
+    expect(map["materials_around"]).toBe("available_materials");
+    expect(map["time_window"]).toBe("available_time_minutes");
+    expect(map["family_presence"]).toBe("family_present");
+    expect(map["budget_capacity"]).toBe("available_budget_cents");
+    expect(map["aspirational"]).toBe("aspirational_wishlist");
+  });
+
+  it("pula dimensões já preenchidas no partial_inventory", async () => {
+    const partial: Partial<SubjectInventory> = {
+      available_time_minutes: 60,
+      available_materials: ["farinha"],
+    };
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      partial_inventory: partial,
+    });
+    const kinds = qs.map((q) => q.kind);
+    expect(kinds).not.toContain("time_window");
+    expect(kinds).not.toContain("materials_around");
+    expect(kinds).toContain("family_presence");
+    expect(kinds).toContain("budget_capacity");
+    expect(kinds).toContain("aspirational");
+    expect(qs).toHaveLength(3);
+  });
+
+  it("retorna array vazio quando inventário completo", async () => {
+    const complete: SubjectInventory = {
+      collected_at: "2026-05-30T14:00:00Z",
+      available_materials: ["x"],
+      available_time_minutes: 60,
+      available_budget_cents: 1000,
+      family_present: ["pai"],
+      aspirational_wishlist: ["bolo"],
+      confidence: 2,
+    };
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      partial_inventory: complete,
+    });
+    expect(qs).toEqual([]);
+  });
+
+  it("trata partial vazio como vazio (não pula nada)", async () => {
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      partial_inventory: {
+        available_materials: [],
+        available_time_minutes: 0,
+        family_present: [],
+        available_budget_cents: 0,
+        aspirational_wishlist: [],
+      },
+    });
+    expect(qs).toHaveLength(5);
+  });
+
+  it("variante lúdica para sujeitos < 10 anos", async () => {
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      subjectAge: 8,
+    });
+    const materialsQ = qs.find((q) => q.kind === "materials_around")!;
+    // Texto lúdico contém "legal" ou "mexer com a mão"
+    expect(materialsQ.text.toLowerCase()).toMatch(/legal|mexer com a mão/);
+  });
+
+  it("variante direta para sujeitos 10+", async () => {
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      subjectAge: 13,
+    });
+    const materialsQ = qs.find((q) => q.kind === "materials_around")!;
+    expect(materialsQ.text.toLowerCase()).toContain("construir");
+  });
+
+  it("nome do sujeito aparece em pergunta materials_around", async () => {
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      subjectName: "Ryo",
+    });
+    const materialsQ = qs.find((q) => q.kind === "materials_around")!;
+    expect(materialsQ.text).toContain("Ryo");
+  });
+
+  it("partial com só time_window definido pula apenas essa dimensão", async () => {
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      partial_inventory: { available_time_minutes: 90 },
+    });
+    expect(qs).toHaveLength(4);
+    expect(qs.map((q) => q.kind)).not.toContain("time_window");
+  });
+});
+
+describe("generateInventoryProbeQuestions — input edge cases", () => {
+  beforeAll(() => {
+    process.env["USE_MOCK_LLM"] = "true";
+  });
+
+  it("recentTurns vazio não quebra", async () => {
+    const qs = await generateInventoryProbeQuestions({
+      ...BASE_INPUT,
+      recentTurns: [],
+    });
+    expect(qs.length).toBeGreaterThan(0);
+  });
+
+  it("sem subjectAge default é direto (não lúdico)", async () => {
+    const { subjectAge: _unused, ...inputNoAge } = BASE_INPUT;
+    const qs = await generateInventoryProbeQuestions(inputNoAge);
+    const materialsQ = qs.find((q) => q.kind === "materials_around")!;
+    expect(materialsQ.text.toLowerCase()).toContain("construir");
+  });
+});

--- a/planejador/tests/playbook-composer.unit.test.ts
+++ b/planejador/tests/playbook-composer.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  EmergentPlaybookSchema,
+  type SubjectInventory,
+  type PlaybookComposerInput,
+} from "@ascendimacy/shared";
+import { composePlaybook } from "../src/strategist/playbook-composer.js";
+
+const BASE_INVENTORY: SubjectInventory = {
+  collected_at: "2026-05-30T14:00:00Z",
+  available_materials: ["farinha", "ovo", "açúcar", "leite", "fermento"],
+  available_time_minutes: 120,
+  available_budget_cents: 3000,
+  family_present: ["pai"],
+  aspirational_wishlist: ["fazer um bolo"],
+  confidence: 2,
+};
+
+const BASE_INPUT: PlaybookComposerInput = {
+  inventory: BASE_INVENTORY,
+  active_axes: ["carater", "cognicao_si"],
+  current_objectives: [{ axis: "carater", virtue: "persistencia" }],
+  subject_name: "Ryo",
+  subject_age: 11,
+};
+
+describe("composePlaybook — v0 fallback path (mock mode)", () => {
+  beforeAll(() => {
+    process.env["USE_MOCK_LLM"] = "true";
+  });
+
+  it("retorna EmergentPlaybook válido (passa zod)", async () => {
+    const result = await composePlaybook(BASE_INPUT);
+    const validated = EmergentPlaybookSchema.safeParse(result);
+    expect(validated.success).toBe(true);
+  });
+
+  it("playbook_id é único e contém nome do sujeito", async () => {
+    const r1 = await composePlaybook(BASE_INPUT);
+    // small delay to ensure timestamp differs
+    await new Promise((r) => setTimeout(r, 5));
+    const r2 = await composePlaybook(BASE_INPUT);
+    expect(r1.playbook_id).toContain("Ryo");
+    expect(r1.playbook_id).not.toBe(r2.playbook_id);
+  });
+
+  it("source_inventory copiado do input", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.source_inventory).toEqual(BASE_INVENTORY);
+  });
+
+  it("primary_objective = primeiro objective do input", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.primary_objective).toEqual({
+      axis: "carater",
+      virtue: "persistencia",
+    });
+  });
+
+  it("primary_objective fallback quando input sem objectives", async () => {
+    const r = await composePlaybook({ ...BASE_INPUT, current_objectives: [] });
+    expect(r.primary_objective.axis).toBe("carater");
+    expect(r.primary_objective.virtue).toBe("persistencia");
+  });
+
+  it("secondary_objectives derivados de objectives extras (skip primary)", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      current_objectives: [
+        { axis: "carater", virtue: "persistencia" },
+        { axis: "cognicao_si", virtue: "sequenciar" },
+        { axis: "carater", virtue: "honestidade" },
+      ],
+    });
+    expect(r.secondary_objectives).toHaveLength(2);
+    expect(r.secondary_objectives[0]!.virtue).toBe("sequenciar");
+  });
+
+  it("4-6 steps gerados", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.steps.length).toBeGreaterThanOrEqual(4);
+    expect(r.steps.length).toBeLessThanOrEqual(6);
+  });
+
+  it("total_duration_minutes ≤ available_time_minutes", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.total_duration_minutes).toBeLessThanOrEqual(
+      BASE_INVENTORY.available_time_minutes,
+    );
+  });
+
+  it("budget_range_cents.max ≤ available_budget_cents", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.budget_range_cents.max).toBeLessThanOrEqual(
+      BASE_INVENTORY.available_budget_cents,
+    );
+  });
+
+  it("philosophical_dilemmas atreladas a steps existentes", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    const stepIds = new Set(r.steps.map((s) => s.step_id));
+    for (const d of r.philosophical_dilemmas) {
+      expect(stepIds.has(d.attached_to_step)).toBe(true);
+    }
+  });
+
+  it("composition_rationale presente e não-vazio", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.composition_rationale.length).toBeGreaterThan(0);
+  });
+
+  it("dilemmas têm evaluation_focus válido", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    const validFocus = new Set([
+      "raciocinio",
+      "consistencia_com_valor_declarado",
+      "consideracao_do_outro",
+    ]);
+    for (const d of r.philosophical_dilemmas) {
+      expect(validFocus.has(d.evaluation_focus)).toBe(true);
+    }
+  });
+
+  it("composition_rationale indica fallback (sinal observável pra trace)", async () => {
+    const r = await composePlaybook(BASE_INPUT);
+    expect(r.composition_rationale.toLowerCase()).toContain("fallback");
+  });
+});
+
+describe("composePlaybook — input edge cases", () => {
+  beforeAll(() => {
+    process.env["USE_MOCK_LLM"] = "true";
+  });
+
+  it("inventário com confidence=0 (guess) ainda compõe", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      inventory: { ...BASE_INVENTORY, confidence: 0 },
+    });
+    expect(EmergentPlaybookSchema.safeParse(r).success).toBe(true);
+  });
+
+  it("inventário com lista vazia de materiais retorna playbook válido", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      inventory: { ...BASE_INVENTORY, available_materials: [] },
+    });
+    expect(EmergentPlaybookSchema.safeParse(r).success).toBe(true);
+  });
+
+  it("previous_playbook_ids passado não quebra", async () => {
+    const r = await composePlaybook({
+      ...BASE_INPUT,
+      previous_playbook_ids: ["piloto-Ryo-12345", "piloto-Ryo-99999"],
+    });
+    expect(r.playbook_id).toBeTruthy();
+  });
+
+  it("subject sem age ainda compõe", async () => {
+    const { subject_age: _ignored, ...inputNoAge } = BASE_INPUT;
+    const r = await composePlaybook(inputNoAge);
+    expect(EmergentPlaybookSchema.safeParse(r).success).toBe(true);
+  });
+});

--- a/shared/src/emergent-playbook.ts
+++ b/shared/src/emergent-playbook.ts
@@ -1,0 +1,143 @@
+/**
+ * EmergentPlaybook v0 — physical world challenge playbook composto pelo
+ * Strategist a partir de inventário + axes + objetivos (não hardcoded).
+ *
+ * Spec: ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md
+ *
+ * v0 scope: tipos + zod schemas. Composer roda em planejador/src/strategist/
+ * (módulo separado). NÃO integrado ao pipeline do motor ainda — instalado
+ * como ferramenta isolada pra validar shape antes de wire-up downstream.
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────
+// SubjectInventory — o que o sujeito tem disponível AGORA
+// ─────────────────────────────────────────────────────────────────────────
+
+export const SubjectInventorySchema = z.object({
+  collected_at: z.string(),
+  available_materials: z.array(z.string()),
+  available_time_minutes: z.number().int().nonnegative(),
+  available_budget_cents: z.number().int().nonnegative(),
+  family_present: z.array(z.string()),
+  aspirational_wishlist: z.array(z.string()),
+  /** 0=guess; 1=baixa; 2=média; 3=confirmada por pai/sujeito */
+  confidence: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+});
+export type SubjectInventory = z.infer<typeof SubjectInventorySchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// EmergentVirtueTarget — virtude/axis sendo treinada
+//
+// Diferente do `TargetDemonstration` do strategy-plan.ts (que carrega
+// framework/dimension/goal/rationale para Strategist plan composition em
+// applied_double_helix). Aqui é forma simplificada {axis, virtue} pro LLM
+// composer encher fácil em saída JSON.
+// ─────────────────────────────────────────────────────────────────────────
+
+export const EmergentVirtueTargetSchema = z.object({
+  axis: z.string(),
+  virtue: z.string(),
+});
+export type EmergentVirtueTarget = z.infer<typeof EmergentVirtueTargetSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// PlaybookStep — etapa executável
+// ─────────────────────────────────────────────────────────────────────────
+
+export const PlaybookStepKindSchema = z.union([
+  z.literal("shopping_list"),
+  z.literal("execute_recipe_step"),
+  z.literal("wait"),
+  z.literal("reflect"),
+]);
+export type PlaybookStepKind = z.infer<typeof PlaybookStepKindSchema>;
+
+export const EvidenceKindSchema = z.union([
+  z.literal("photo"),
+  z.literal("voice_memo"),
+  z.literal("text_answer"),
+  z.literal("parent_confirmation"),
+  z.literal("none"),
+]);
+export type EvidenceKind = z.infer<typeof EvidenceKindSchema>;
+
+export const PlaybookStepSchema = z.object({
+  step_id: z.string(),
+  kind: PlaybookStepKindSchema,
+  hint_to_subject: z.string(),
+  evidence_kind: EvidenceKindSchema,
+  expected_duration_minutes: z.number().int().nonnegative(),
+  fallback_hint: z.string().optional(),
+});
+export type PlaybookStep = z.infer<typeof PlaybookStepSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// PhilosophicalDilemma — camada de virtude opcional por step
+// ─────────────────────────────────────────────────────────────────────────
+
+export const DilemmaTriggerSchema = z.union([
+  z.literal("step_complete"),
+  z.literal("step_midway"),
+  z.literal("evidence_received"),
+]);
+export type DilemmaTrigger = z.infer<typeof DilemmaTriggerSchema>;
+
+export const DilemmaEvaluationFocusSchema = z.union([
+  z.literal("raciocinio"),
+  z.literal("consistencia_com_valor_declarado"),
+  z.literal("consideracao_do_outro"),
+]);
+export type DilemmaEvaluationFocus = z.infer<typeof DilemmaEvaluationFocusSchema>;
+
+export const PhilosophicalDilemmaSchema = z.object({
+  dilemma_id: z.string(),
+  attached_to_step: z.string(),
+  trigger: DilemmaTriggerSchema,
+  virtue_tested: z.string(),
+  prompt: z.string(),
+  evaluation_focus: DilemmaEvaluationFocusSchema,
+});
+export type PhilosophicalDilemma = z.infer<typeof PhilosophicalDilemmaSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// EmergentPlaybook — saída completa do composer
+// ─────────────────────────────────────────────────────────────────────────
+
+export const EmergentPlaybookSchema = z.object({
+  playbook_id: z.string(),
+  composed_at: z.string(),
+  source_inventory: SubjectInventorySchema,
+  primary_objective: EmergentVirtueTargetSchema,
+  secondary_objectives: z.array(EmergentVirtueTargetSchema),
+  steps: z.array(PlaybookStepSchema).min(1),
+  total_duration_minutes: z.number().int().nonnegative(),
+  budget_range_cents: z.object({
+    min: z.number().int().nonnegative(),
+    max: z.number().int().nonnegative(),
+  }),
+  philosophical_dilemmas: z.array(PhilosophicalDilemmaSchema),
+  composition_rationale: z.string(),
+});
+export type EmergentPlaybook = z.infer<typeof EmergentPlaybookSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Composer input — o que o Strategist recebe pra compor
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface PlaybookComposerInput {
+  inventory: SubjectInventory;
+  /** Axes ativos no Subject Knowledge (Gardner numbering ou nome). */
+  active_axes: readonly string[];
+  /** Objetivos correntes vindos do Console parental ou Gardner. */
+  current_objectives: readonly EmergentVirtueTarget[];
+  /** IDs de playbooks anteriores — anti-repetição. */
+  previous_playbook_ids?: readonly string[];
+  /** Nome do sujeito pra contexto humano nos prompts. */
+  subject_name: string;
+  /** Idade pra calibrar dilemas. */
+  subject_age?: number;
+  /** run_id pra trace correlation. */
+  run_id?: string;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from "./recall-check-evaluator.js";
 export * from "./map-framework.js";
 export * from "./session-phases.js";
 export * from "./strategy-plan.js";
+export * from "./emergent-playbook.js";
 export * from "./engine-trace-v2.js";
 export * from "./llm-trace-collector.js";
 export * from "./parental-authorization.js";

--- a/shared/src/tutorial.ts
+++ b/shared/src/tutorial.ts
@@ -11,7 +11,15 @@ export type TutorialMove =
   | "correct"
   | "apply"
   | "recall"
-  | "close";
+  | "close"
+  /**
+   * compose_playbook (v0 emergent physical world challenge — fatia 4):
+   * dispara quando `contextHints.compose_playbook_request === true`. Bot
+   * coleta inventário do sujeito + compõe EmergentPlaybook via Strategist.
+   * Saída em contextHints: inventory_probe_options + emergent_playbook.
+   * Integração motor-drota é fatia futura — por ora só wiring planejador.
+   */
+  | "compose_playbook";
 
 export type TutorialAdvancePolicy =
   | "hold_until_attempted"


### PR DESCRIPTION
## Contexto

Quarta fatia da spec [physical_world_playbook rev 1](../../ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md). **Stacked sobre #283** (probe) + #284 (catalog) via merge interno.

Adiciona novo `move_type='compose_playbook'` disparado por flag explícita `contextHints.compose_playbook_request=true` (decisão aprovada na pergunta de design). Default ausente → comportamento atual 100% inalterado.

## Fluxo

Quando flag ativa:
1. `computeBasicTutorialContext` emite `compose_playbook` (highest priority, sobrepõe close/discover/etc)
2. `planTurn` chama `generateInventoryProbeQuestions` — questões pra dimensões faltantes
3. `planTurn` chama `composePlaybook` — gera EmergentPlaybook via Strategist
4. Outputs em `contextHints`: `inventory_probe_options` + `emergent_playbook`

## Mudanças

| Arquivo | Mudança |
|---------|---------|
| `shared/src/tutorial.ts` | `compose_playbook` adicionado a TutorialMove |
| `motor-drota/src/simplified-pipeline-handler.ts` | Cast inline atualizado (sem behaviour) |
| `planejador/src/plan.ts` | Detection no priority chain + switch case + agent calls |

## Limitações v0 (intencional)

- ❌ Motor-drota não consome `inventory_probe_options` nem `emergent_playbook` (sem materializer integration; é fatia 5)
- ❌ Não há extrator turn-a-turn de respostas → `SubjectInventory`
- ❌ Sem PendingChallenge state machine cross-sessão
- ❌ Sem parental consent gate

## Validação

- **9 unit tests novos** (compose-playbook-integration): default inalterado, flag emite move_type, probe + playbook em contextHints, partial inventory pula dimensões cobertas, flag sobrepõe outros triggers, advance_policy correto, flag=false não dispara, nome flui pro playbook_id
- Suite planejador: **467 PASS / 30 files** ✅
- Suite shared: **931 PASS / 8 skipped** ✅
- Suite motor-drota: **485 PASS / 1 skipped** ✅

## Próximas fatias

- **#5** Motor-drota wiring: materializer apresenta inventory_probe_options ou emergent_playbook ao sujeito
- **#6** Extrator de respostas → SubjectInventory (motor-drota signal_extractor variant)
- **#7** PendingChallenge cross-session state machine
- **#8** Bridge multi-modal (foto/voz) — spec própria primeiro
- **#9** Console parental consent UX