### PR TITLE
feat(planejador): compose_playbook integration v0 (fatia 4)

### DIFF
--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -268,6 +268,7 @@ export async function handleSimplifiedPipeline(
     | "apply"
     | "recall"
     | "close"
+    | "compose_playbook"
     | undefined;
   const selectionResult = selectAction(
     {

--- a/planejador/src/plan.ts
+++ b/planejador/src/plan.ts
@@ -47,6 +47,9 @@ import {
 } from "@ascendimacy/shared";
 import { callLlm, callLlmMock, callHaiku, type LlmCallResult } from "./llm-client.js";
 import { generateDiscoveryOptions } from "./discovery-agent.js";
+import { generateInventoryProbeQuestions } from "./inventory-probe-agent.js";
+import { composePlaybook } from "./strategist/playbook-composer.js";
+import type { SubjectInventory, EmergentVirtueTarget } from "@ascendimacy/shared";
 import { detectMilestone } from "./milestone-detector.js";
 import type { LlmTraceCollector, PlanejadorTrace } from "@ascendimacy/shared";
 
@@ -230,12 +233,22 @@ function computeBasicTutorialContext(
   const shouldRecall =
     !recallCooldownActive && lastExecutedId != null && topItem?.id !== lastExecutedId;
 
+  // Fatia 4 (physical_world_playbook spec §5 — emergent composition):
+  // Console parental seta `contextHints.compose_playbook_request=true`
+  // depois de aprovar um piloto de desafio físico real. Highest priority
+  // — sobrepõe close/discover/etc. Default ausente → comportamento atual.
+  const composePlaybookRequested =
+    input.contextHints?.["compose_playbook_request"] === true;
+
   let moveType: TutorialMove = "explain";
   let goal = input.incomingMessage
     ? "Trabalhar a mensagem atual do sujeito"
     : "Avançar no objetivo formativo da sessão";
 
-  if (hasExitSignal) {
+  if (composePlaybookRequested) {
+    moveType = "compose_playbook";
+    goal = "Coletar inventário + compor desafio físico real para o sujeito";
+  } else if (hasExitSignal) {
     moveType = "close";
     goal = "Fechar respeitando sinal de saída do sujeito";
   } else if (isDiscoveryStage) {
@@ -305,6 +318,12 @@ function computeBasicTutorialContext(
       ctx.failure_policy = "re_explain";
       break;
     case "close":
+      ctx.advance_policy = "can_move_on";
+      break;
+    case "compose_playbook":
+      // Pode avançar sem requerer correct/attempted — a decisão de seguir
+      // pra próximo step do playbook é responsabilidade do PendingChallenge
+      // state machine (fatia futura), não do tutorial flow.
       ctx.advance_policy = "can_move_on";
       break;
   }
@@ -907,6 +926,74 @@ export async function planTurn(
     } catch {
       // Telemetry: discovery failure não bloqueia turn — segue sem discovery_options
       // (fallback determinístico já cobre LLM crashes dentro do agent).
+    }
+  }
+
+  // Fatia 4 (physical_world_playbook §5.1+5.2) — quando move_type=compose_playbook,
+  // roda probe (questões de inventário) E composer (gera EmergentPlaybook) em
+  // sequência. Probe primeiro: se inventário já completo, retorna [] e composer
+  // usa o que tem; senão, composer roda com fallback determinístico (bolo template).
+  //
+  // Outputs em contextHints:
+  //   - inventory_probe_options: questões que faltam perguntar
+  //   - emergent_playbook: instância composta (presente sempre quando flag setado)
+  //
+  // Motor-drota não consome ainda (integração materializer = fatia futura). Por
+  // ora é apenas wiring planejador-side validado por testes de planTurn.
+  if (tutorial?.move_type === "compose_playbook") {
+    const partialInventory = input.contextHints?.["subject_inventory"] as
+      | Partial<SubjectInventory>
+      | undefined;
+    const recentTurns = Array.isArray(input.contextHints?.["recent_turns"])
+      ? (input.contextHints!["recent_turns"] as Array<{ role: "user" | "assistant"; content: string }>)
+      : [];
+    const subjectName = input.persona?.name ?? "amigo";
+    const subjectAge = typeof input.persona?.age === "number" ? input.persona.age : undefined;
+
+    try {
+      const probeInput: Parameters<typeof generateInventoryProbeQuestions>[0] = {
+        recentTurns,
+        subjectName,
+      };
+      if (subjectAge !== undefined) probeInput.subjectAge = subjectAge;
+      if (partialInventory) probeInput.partial_inventory = partialInventory;
+      const probeOptions = await generateInventoryProbeQuestions(probeInput);
+      if (probeOptions.length > 0) {
+        contextHints["inventory_probe_options"] = probeOptions;
+      }
+    } catch {
+      // Probe failure não bloqueia composer abaixo.
+    }
+
+    try {
+      // Inventário pra composer: completa partial com defaults razoáveis pra
+      // permitir fallback determinístico. v0 não exige inventário completo;
+      // fatia futura adiciona gate "só compõe se confidence >= 2".
+      const inventoryForCompose: SubjectInventory = {
+        collected_at: partialInventory?.collected_at ?? new Date().toISOString(),
+        available_materials: partialInventory?.available_materials ?? [],
+        available_time_minutes: partialInventory?.available_time_minutes ?? 0,
+        available_budget_cents: partialInventory?.available_budget_cents ?? 0,
+        family_present: partialInventory?.family_present ?? [],
+        aspirational_wishlist: partialInventory?.aspirational_wishlist ?? [],
+        confidence: partialInventory?.confidence ?? 0,
+      };
+      const currentObjectives = Array.isArray(input.contextHints?.["playbook_objectives"])
+        ? (input.contextHints!["playbook_objectives"] as readonly EmergentVirtueTarget[])
+        : [];
+      const playbookInput: Parameters<typeof composePlaybook>[0] = {
+        inventory: inventoryForCompose,
+        active_axes: Array.isArray(input.contextHints?.["axes_active"])
+          ? (input.contextHints!["axes_active"] as readonly string[])
+          : [],
+        current_objectives: currentObjectives,
+        subject_name: subjectName,
+      };
+      if (subjectAge !== undefined) playbookInput.subject_age = subjectAge;
+      const playbook = await composePlaybook(playbookInput);
+      contextHints["emergent_playbook"] = playbook;
+    } catch {
+      // Composer failure não bloqueia turn — segue sem playbook.
     }
   }
 

--- a/planejador/tests/compose-playbook-integration.test.ts
+++ b/planejador/tests/compose-playbook-integration.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import { planTurn } from "../src/plan.js";
+import {
+  EmergentPlaybookSchema,
+  type PersonaDef,
+  type SessionState,
+  type SubjectInventory,
+} from "@ascendimacy/shared";
+
+process.env["USE_MOCK_LLM"] = "true";
+
+function makePersona(overrides: Partial<PersonaDef> = {}): PersonaDef {
+  return {
+    id: "kei",
+    name: "Kei",
+    age: 11,
+    profile: {},
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: "s1",
+    trustLevel: 0.4,
+    budgetRemaining: 100,
+    turn: 2,
+    eventLog: [],
+    statusMatrix: { emotional: "baia" },
+    ...overrides,
+  };
+}
+
+const adquirente = { id: "jun", name: "Jun", defaults: {} };
+const inventory = [
+  {
+    id: "kids.helix.session",
+    title: "Helix",
+    category: "kids",
+    estimatedSacrifice: 1,
+    estimatedConfidenceGain: 4,
+  },
+];
+
+describe("planTurn — compose_playbook integration (fatia 4)", () => {
+  it("default sem flag → move_type NÃO é compose_playbook", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+    });
+    expect(out.contextHints["tutorial"]).toBeTruthy();
+    const tutorial = out.contextHints["tutorial"] as { move_type: string };
+    expect(tutorial.move_type).not.toBe("compose_playbook");
+  });
+
+  it("flag true → move_type=compose_playbook", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const tutorial = out.contextHints["tutorial"] as { move_type: string; teaching_goal: string };
+    expect(tutorial.move_type).toBe("compose_playbook");
+    expect(tutorial.teaching_goal.toLowerCase()).toContain("inventário");
+  });
+
+  it("flag true sem inventory → inventory_probe_options preenchido (5 questões)", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const probe = out.contextHints["inventory_probe_options"] as Array<{ kind: string }>;
+    expect(Array.isArray(probe)).toBe(true);
+    expect(probe.length).toBe(5);
+  });
+
+  it("flag true com partial inventory pula dimensões cobertas", async () => {
+    const partial: Partial<SubjectInventory> = {
+      available_time_minutes: 90,
+      available_materials: ["ovos", "farinha"],
+    };
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: {
+        compose_playbook_request: true,
+        subject_inventory: partial,
+      },
+    });
+    const probe = out.contextHints["inventory_probe_options"] as Array<{ kind: string }>;
+    const kinds = probe.map((q) => q.kind);
+    expect(kinds).not.toContain("time_window");
+    expect(kinds).not.toContain("materials_around");
+    expect(probe.length).toBe(3);
+  });
+
+  it("flag true → emergent_playbook preenchido + zod válido", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const playbook = out.contextHints["emergent_playbook"];
+    expect(playbook).toBeTruthy();
+    const parsed = EmergentPlaybookSchema.safeParse(playbook);
+    expect(parsed.success).toBe(true);
+  });
+
+  it("flag true sobrepõe outros triggers (exit signal não vence)", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "tchau",
+      contextHints: {
+        compose_playbook_request: true,
+        extracted_signals: ["exit_marker_explicit"],
+      },
+    });
+    const tutorial = out.contextHints["tutorial"] as { move_type: string };
+    expect(tutorial.move_type).toBe("compose_playbook");
+  });
+
+  it("advance_policy = can_move_on (configurado em §switch)", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const tutorial = out.contextHints["tutorial"] as { advance_policy?: string };
+    expect(tutorial.advance_policy).toBe("can_move_on");
+  });
+
+  it("flag false (não truthy literal) NÃO dispara", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona(),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: false },
+    });
+    const tutorial = out.contextHints["tutorial"] as { move_type: string };
+    expect(tutorial.move_type).not.toBe("compose_playbook");
+    expect(out.contextHints["emergent_playbook"]).toBeUndefined();
+  });
+
+  it("nome do sujeito flui pro playbook_id", async () => {
+    const out = await planTurn({
+      sessionId: "s1",
+      persona: makePersona({ id: "ryo", name: "Ryo", age: 13 }),
+      adquirente,
+      inventory,
+      state: makeState(),
+      incomingMessage: "oi",
+      contextHints: { compose_playbook_request: true },
+    });
+    const playbook = out.contextHints["emergent_playbook"] as { playbook_id: string };
+    expect(playbook.playbook_id).toContain("Ryo");
+  });
+});

--- a/shared/src/tutorial.ts
+++ b/shared/src/tutorial.ts
@@ -11,7 +11,15 @@ export type TutorialMove =
   | "correct"
   | "apply"
   | "recall"
-  | "close";
+  | "close"
+  /**
+   * compose_playbook (v0 emergent physical world challenge — fatia 4):
+   * dispara quando `contextHints.compose_playbook_request === true`. Bot
+   * coleta inventário do sujeito + compõe EmergentPlaybook via Strategist.
+   * Saída em contextHints: inventory_probe_options + emergent_playbook.
+   * Integração motor-drota é fatia futura — por ora só wiring planejador.
+   */
+  | "compose_playbook";
 
 export type TutorialAdvancePolicy =
   | "hold_until_attempted"


### PR DESCRIPTION
## Contexto

Quarta fatia da spec [physical_world_playbook rev 1](../../ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md). Reaberto após #286 mergear.

Adiciona novo `move_type='compose_playbook'` disparado por flag explícita `contextHints.compose_playbook_request=true`. Default ausente → comportamento atual 100% inalterado.

## Fluxo

Quando flag ativa:
1. `computeBasicTutorialContext` emite `compose_playbook` (highest priority)
2. `planTurn` chama `generateInventoryProbeQuestions` — questões pra dimensões faltantes
3. `planTurn` chama `composePlaybook` — gera EmergentPlaybook via Strategist
4. Outputs em `contextHints`: `inventory_probe_options` + `emergent_playbook`

## Mudanças

- `shared/src/tutorial.ts`: `compose_playbook` adicionado a TutorialMove
- `motor-drota/src/simplified-pipeline-handler.ts`: cast inline atualizado
- `planejador/src/plan.ts`: detection + switch case + agent calls

## Validação

- **9 unit tests novos** (compose-playbook-integration)
- Suite planejador: **467 PASS / 30 files** ✅