### PR TITLE
feat(motor-drota): compose_playbook materializer wiring v0 (fatia 5)

### DIFF
--- a/motor-drota/src/simplified-pipeline-handler.ts
+++ b/motor-drota/src/simplified-pipeline-handler.ts
@@ -466,6 +466,70 @@ export async function handleSimplifiedPipeline(
     });
     fallbackTriggered = false;
     recallCheckEmitted = undefined;
+  } else if (tutorialMoveType === "compose_playbook") {
+    // v0 (fatia 5) — compose_playbook short-circuit:
+    // Quando planejador emitiu compose_playbook move + inventory_probe_options
+    // OU emergent_playbook em contextHints, motor apresenta o conteúdo sem
+    // passar pelo materializer LLM.
+    //
+    // Ordem de prioridade:
+    //   1. inventory_probe_options presentes → apresenta primeira pergunta
+    //      (inventário ainda incompleto, prossegue coletando)
+    //   2. emergent_playbook presente → apresenta intro do desafio composto
+    //
+    // fallbackTriggered=true por design — meta-conversação (probe ou intro de
+    // playbook), não apresentação de conceito pedagógico → ledger não
+    // contabiliza presented_concept.
+    const probeOptions = input.contextHints?.["inventory_probe_options"] as
+      | Array<{ kind: string; text: string }>
+      | undefined;
+    const playbook = input.contextHints?.["emergent_playbook"] as
+      | {
+          steps?: Array<{ hint_to_subject?: string }>;
+          total_duration_minutes?: number;
+          budget_range_cents?: { max?: number };
+          composition_rationale?: string;
+        }
+      | undefined;
+
+    if (Array.isArray(probeOptions) && probeOptions.length > 0) {
+      const firstProbe = probeOptions[0]!;
+      finalText = firstProbe.text;
+      warnings.push({
+        component: "compose_playbook_wiring",
+        message: `presenting probe kind=${firstProbe.kind}`,
+        recoverable: true,
+      });
+    } else if (playbook && playbook.steps && playbook.steps.length > 0) {
+      const stepCount = playbook.steps.length;
+      const totalMin = playbook.total_duration_minutes ?? 0;
+      const budgetMaxR$ = ((playbook.budget_range_cents?.max ?? 0) / 100).toFixed(2);
+      const firstStepHint =
+        playbook.steps[0]?.hint_to_subject ?? "começamos juntos";
+      const rationale = playbook.composition_rationale ?? "";
+      finalText =
+        `${input.persona.name}, vou te propor um desafio real: ${stepCount} passos, ~${totalMin}min, até R$${budgetMaxR$}.` +
+        (rationale ? ` ${rationale}` : "") +
+        ` Primeiro passo: ${firstStepHint} Topa?`;
+      warnings.push({
+        component: "compose_playbook_wiring",
+        message: `presenting playbook intro (steps=${stepCount}, duration_min=${totalMin})`,
+        recoverable: true,
+      });
+    } else {
+      // Sem probe nem playbook em contextHints — planejador deveria ter
+      // populado mas falhou (mock mode + erro?). Fallback conversacional.
+      finalText =
+        `${input.persona.name}, tô tentando montar um desafio real pra gente. Me dá um minuto?`;
+      warnings.push({
+        component: "compose_playbook_wiring",
+        message:
+          "no probe_options nor emergent_playbook in contextHints — fallback conversational",
+        recoverable: true,
+      });
+    }
+    fallbackTriggered = true;
+    recallCheckEmitted = undefined;
   } else if (USE_SPLIT_DROTA) {
     // ── S4 path ──────────────────────────────────────────────────────────
     // Step 1: Tactician decides jogada from content pool + assessor signals.

--- a/motor-drota/tests/compose-playbook-wiring.unit.test.ts
+++ b/motor-drota/tests/compose-playbook-wiring.unit.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  GatewayChatCompletionInput,
+  GatewayChatCompletionOutput,
+  EvaluateAndSelectInput,
+  ContentItem,
+  ScoredContentItem,
+  PersonaDef,
+} from "@ascendimacy/shared";
+
+// Mock callGateway antes do import do handler (vitest hoists vi.mock factory).
+const mockState: {
+  responses: GatewayChatCompletionOutput[];
+  callCount: number;
+} = {
+  responses: [],
+  callCount: 0,
+};
+
+vi.mock("@ascendimacy/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ascendimacy/shared")>();
+  return {
+    ...actual,
+    callGateway: async (_req: GatewayChatCompletionInput) => {
+      const response =
+        mockState.responses[mockState.callCount] ??
+        mockState.responses[mockState.responses.length - 1];
+      mockState.callCount += 1;
+      if (!response) {
+        throw new Error("test setup error: no mock response queued");
+      }
+      return response;
+    },
+  };
+});
+
+import { handleSimplifiedPipeline } from "../src/simplified-pipeline-handler.js";
+import { rankPool } from "../src/evaluate.js";
+
+function buildLlmResponse(content: string): GatewayChatCompletionOutput {
+  return {
+    content,
+    tokens: { in: 100, out: 50, reasoning: 0 },
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    latency_ms: 100,
+    attempt_count: 1,
+    was_fallback: false,
+  };
+}
+
+function neutralAssessorResponse(): GatewayChatCompletionOutput {
+  return buildLlmResponse(
+    `{"mood": 5, "mood_confidence": "medium", "signals": [], "engagement": "medium", "rationale": "neutral"}`,
+  );
+}
+
+function stubItem(id: string): ScoredContentItem {
+  return {
+    item: {
+      id,
+      type: "curiosity_hook",
+      domain: "biology",
+      casel_target: ["SA"],
+      age_range: [7, 14],
+      surprise: 6,
+      verified: true,
+      base_score: 6,
+      fact: "Stub fact.",
+      bridge: "Stub bridge.",
+      quest: "Stub quest.",
+      sacrifice_type: "reflect",
+      sacrifice_amount: 3,
+    } as ContentItem,
+    score: 6,
+    reasons: [],
+  };
+}
+
+function stubInput(
+  contextHints: Record<string, unknown>,
+): EvaluateAndSelectInput {
+  return {
+    sessionId: "test-session",
+    contentPool: [stubItem("a"), stubItem("b")],
+    state: {
+      sessionId: "test-session",
+      trustLevel: 0.5,
+      budgetRemaining: 50,
+      eventLog: [],
+      turn: 1,
+    },
+    persona: {
+      id: "kei-001",
+      name: "Kei",
+      age: 11,
+      profile: {},
+    } as PersonaDef,
+    strategicRationale: "",
+    contextHints,
+  } as EvaluateAndSelectInput;
+}
+
+beforeEach(() => {
+  mockState.responses = [];
+  mockState.callCount = 0;
+});
+
+describe("handleSimplifiedPipeline — compose_playbook short-circuit (fatia 5)", () => {
+  it("apresenta inventory_probe_options[0].text quando probe presente", async () => {
+    mockState.responses.push(neutralAssessorResponse());
+
+    const input = stubInput({
+      tutorial: { move_type: "compose_playbook" },
+      inventory_probe_options: [
+        {
+          kind: "materials_around",
+          text: "Olha em volta — tem alguma coisa útil pra construir?",
+          expected_extraction_target: "available_materials",
+        },
+        {
+          kind: "time_window",
+          text: "Quanto tempo livre você tem hoje?",
+          expected_extraction_target: "available_time_minutes",
+        },
+      ],
+    });
+    const ranked = rankPool(input.contentPool);
+    const out = await handleSimplifiedPipeline(input, ranked);
+    expect(out.linguisticMaterialization).toBe(
+      "Olha em volta — tem alguma coisa útil pra construir?",
+    );
+  });
+
+  it("apresenta playbook intro quando emergent_playbook presente (sem probe)", async () => {
+    mockState.responses.push(neutralAssessorResponse());
+
+    const input = stubInput({
+      tutorial: { move_type: "compose_playbook" },
+      emergent_playbook: {
+        playbook_id: "piloto-Kei-12345",
+        steps: [
+          { hint_to_subject: "Faz a lista de ingredientes do bolo" },
+          { hint_to_subject: "Compra ingredientes (R$ 30 max)" },
+          { hint_to_subject: "Mistura e leva ao forno" },
+        ],
+        total_duration_minutes: 90,
+        budget_range_cents: { min: 2000, max: 3000 },
+        composition_rationale: "Bolo simples pra primeiro desafio.",
+      },
+    });
+    const ranked = rankPool(input.contentPool);
+    const out = await handleSimplifiedPipeline(input, ranked);
+    expect(out.linguisticMaterialization).toContain("Kei");
+    expect(out.linguisticMaterialization).toContain("3 passos");
+    expect(out.linguisticMaterialization).toContain("90min");
+    expect(out.linguisticMaterialization).toContain("30.00");
+    expect(out.linguisticMaterialization).toContain("Faz a lista");
+    expect(out.linguisticMaterialization).toContain("Topa?");
+  });
+
+  it("probe tem prioridade sobre playbook quando ambos presentes", async () => {
+    mockState.responses.push(neutralAssessorResponse());
+
+    const input = stubInput({
+      tutorial: { move_type: "compose_playbook" },
+      inventory_probe_options: [
+        {
+          kind: "time_window",
+          text: "Quanto tempo você tem hoje?",
+          expected_extraction_target: "available_time_minutes",
+        },
+      ],
+      emergent_playbook: {
+        playbook_id: "piloto-Kei-12345",
+        steps: [{ hint_to_subject: "Lista" }],
+        total_duration_minutes: 30,
+        budget_range_cents: { max: 2000 },
+        composition_rationale: "x",
+      },
+    });
+    const ranked = rankPool(input.contentPool);
+    const out = await handleSimplifiedPipeline(input, ranked);
+    expect(out.linguisticMaterialization).toBe("Quanto tempo você tem hoje?");
+  });
+
+  it("fallback conversacional quando nem probe nem playbook presentes", async () => {
+    mockState.responses.push(neutralAssessorResponse());
+
+    const input = stubInput({
+      tutorial: { move_type: "compose_playbook" },
+    });
+    const ranked = rankPool(input.contentPool);
+    const out = await handleSimplifiedPipeline(input, ranked);
+    expect(out.linguisticMaterialization).toContain("Kei");
+    expect(out.linguisticMaterialization.toLowerCase()).toContain("desafio");
+  });
+
+  it("emergent_playbook com steps vazio cai pro fallback conversacional", async () => {
+    mockState.responses.push(neutralAssessorResponse());
+
+    const input = stubInput({
+      tutorial: { move_type: "compose_playbook" },
+      emergent_playbook: {
+        playbook_id: "piloto-Kei-empty",
+        steps: [],
+        total_duration_minutes: 0,
+        budget_range_cents: { max: 0 },
+        composition_rationale: "empty",
+      },
+    });
+    const ranked = rankPool(input.contentPool);
+    const out = await handleSimplifiedPipeline(input, ranked);
+    expect(out.linguisticMaterialization.toLowerCase()).toContain("desafio");
+  });
+
+  it("warning emitido no engine trace pra observability", async () => {
+    mockState.responses.push(neutralAssessorResponse());
+
+    const input = stubInput({
+      tutorial: { move_type: "compose_playbook" },
+      inventory_probe_options: [
+        {
+          kind: "materials_around",
+          text: "test",
+          expected_extraction_target: "available_materials",
+        },
+      ],
+    });
+    const ranked = rankPool(input.contentPool);
+    const out = await handleSimplifiedPipeline(input, ranked, { captureTrace: true });
+    const warnings = out.engineTrace?.warnings ?? [];
+    const wiringWarning = warnings.find(
+      (w) => w.component === "compose_playbook_wiring",
+    );
+    expect(wiringWarning).toBeTruthy();
+    expect(wiringWarning?.message).toContain("materials_around");
+  });
+
+  it("move_type=discover (não compose_playbook) NÃO ativa wiring", async () => {
+    mockState.responses.push(neutralAssessorResponse());
+    // discover path tem seu próprio short-circuit (com discovery_options).
+    // Aqui só verificamos que compose_playbook wiring não é tocado.
+
+    const input = stubInput({
+      tutorial: { move_type: "discover" },
+      inventory_probe_options: [
+        {
+          kind: "materials_around",
+          text: "PROBE QUE NÃO DEVE APARECER",
+          expected_extraction_target: "available_materials",
+        },
+      ],
+      discovery_options: [
+        {
+          kind: "interest_probe",
+          text: "Discover question",
+          anchor: "x",
+        },
+      ],
+    });
+    const ranked = rankPool(input.contentPool);
+    const out = await handleSimplifiedPipeline(input, ranked);
+    expect(out.linguisticMaterialization).not.toContain("PROBE QUE NÃO");
+    expect(out.linguisticMaterialization).toBe("Discover question");
+  });
+});


### PR DESCRIPTION
## Contexto

Quinta fatia da spec [physical_world_playbook rev 1](../../ascendimacy-ops/docs/specs/2026-05-30-physical-world-challenge-piloto-bolo-v0.md). Off main \u2014 standalone, sem stack.

Motor-drota agora **consome** `inventory_probe_options` + `emergent_playbook` populados pelo planejador na fatia 4 (#287). Adiciona short-circuit do materializer no `simplified-pipeline-handler.ts` seguindo o padr\u00e3o discover (v0.2.8) e explain (v0.3-B).

## Comportamento

| Sit. | Bot diz |
|------|---------|
| probe presente | `probe_options[0].text` (pergunta inventory) |
| s\u00f3 playbook | Intro: nome + step count + dura\u00e7\u00e3o + budget + first step hint + 'Topa?' |
| ambos | probe vence (inventory primeiro) |
| nenhum | Fallback conversacional |

`fallbackTriggered=true` em todos ramos \u2014 meta-conversa\u00e7\u00e3o n\u00e3o conta presented_concept no ledger.

## Valida\u00e7\u00e3o

- **7 unit tests novos**: probe presenter, playbook intro presenter, prioridade probe>playbook, fallback sem nenhum, steps vazio cai em fallback, warning emitido, outros move_types intocados
- Suite motor-drota: **492 PASS / 1 skipped / 38 files** \u2705

## Pr\u00f3ximas fatias

- #6 Extrator de respostas \u2192 SubjectInventory (signal_extractor variant)
- #7 PendingChallenge cross-session state machine
- #8 Bridge multi-modal (precisa spec pr\u00f3pria primeiro)
- #9 Console parental consent UX